### PR TITLE
Fix(UI) : Improve terminal navigation hints and menu rendering.

### DIFF
--- a/openvtc-cli2/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc-cli2/src/ui/pages/main/components/content_panel.rs
@@ -101,14 +101,18 @@ impl ContentPanelState {
                 vec![
                     Line::from(""),
                     Line::from("Managing settings has not been implemented yet").fg(COLOR_ORANGE),
-                    Line::from("Press Enter to select a menu item").fg(COLOR_ORANGE),
+                    Line::from("Press Tab, Left, or Right to return to the menu")
+                        .fg(COLOR_TEXT_DEFAULT),
                 ]
             }
             MainMenu::Help => {
                 vec![
                     Line::from(""),
                     Line::from("Press Up/Down to navigate the menu").fg(COLOR_TEXT_DEFAULT),
-                    Line::from("Press Enter to select a menu item").fg(COLOR_TEXT_DEFAULT),
+                    Line::from("Press Enter to open the selected item").fg(COLOR_TEXT_DEFAULT),
+                    Line::from("Press Tab, Left, or Right to switch panels")
+                        .fg(COLOR_TEXT_DEFAULT),
+                    Line::from("Press F10 to quit from anywhere").fg(COLOR_TEXT_DEFAULT),
                 ]
             }
             MainMenu::Quit => {

--- a/openvtc-cli2/src/ui/pages/main/components/menu_panel.rs
+++ b/openvtc-cli2/src/ui/pages/main/components/menu_panel.rs
@@ -34,13 +34,13 @@ impl MenuPanelState {
         let mut lines = Vec::new();
         for item in MainMenu::iter() {
             if item == self.selected_menu {
-                // make it colorful
+                // Use an ASCII marker for consistent rendering across terminals.
                 lines.push(
-                    Line::from(["• ".to_string(), item.to_string()].concat()).fg(COLOR_SUCCESS),
+                    Line::from(["* ".to_string(), item.to_string()].concat()).fg(COLOR_SUCCESS),
                 );
             } else {
                 lines.push(
-                    Line::from(["• ".to_string(), item.to_string()].concat())
+                    Line::from(["* ".to_string(), item.to_string()].concat())
                         .fg(COLOR_TEXT_DEFAULT),
                 );
             }

--- a/openvtc-cli2/src/ui/pages/main/mod.rs
+++ b/openvtc-cli2/src/ui/pages/main/mod.rs
@@ -218,7 +218,7 @@ impl ComponentRender<()> for MainPage {
             .merge_borders(MergeStrategy::Fuzzy)
             .fg(COLOR_BORDER);
         frame.render_widget(
-            Paragraph::new("<TAB> to change panels")
+            Paragraph::new("<TAB>/<LEFT>/<RIGHT> to change panels, <F10> to quit")
                 .dark_gray()
                 .alignment(Alignment::Left)
                 .block(bottom_block),


### PR DESCRIPTION
## Summary

This PR improves a few small terminal UI issues in `openvtc-cli2`.

## Changes

- replaced the menu bullet marker with an ASCII `*` for more reliable rendering across terminals
- updated the Settings panel hint to reflect the actual navigation keys
- improved the Help panel instructions so they match the implemented key bindings
- updated the footer shortcut text to show supported panel-switching and quit keys

## Details

### Menu rendering
- changed the menu item marker from a Unicode bullet to `*`
- avoids broken character rendering in some terminal environments

### Navigation hints
- Settings no longer incorrectly suggests using `Enter` to return
- Help now documents:
  - `Up/Down` to navigate
  - `Enter` to open the selected item
  - `Tab`, `Left`, or `Right` to switch panels
  - `F10` to quit

### Footer copy
- updated the footer shortcut text to:
  - `<TAB>/<LEFT>/<RIGHT> to change panels, <F10> to quit`

## Files Changed

- `openvtc-cli2/src/ui/pages/main/components/menu_panel.rs`
- `openvtc-cli2/src/ui/pages/main/components/content_panel.rs`
- `openvtc-cli2/src/ui/pages/main/mod.rs`

## Why

These are small usability and compatibility fixes that make the terminal UI clearer and more consistent with the actual controls.

