### PR TITLE
fix(service): reject plaintext private key material in config

### DIFF
--- a/openvtc-service/conf/config.json-example
+++ b/openvtc-service/conf/config.json-example
@@ -19,26 +19,5 @@
   ],
   "mediator": "did:webvh:QmetnhxzJXTJ9pyXR1BbZ2h6DomY6SB1ZbzFPrjYyaEq9V:openvtc.storm.ws:public-mediator",
   "our_did": "did:webvh:QmXkYcFCbvFFcYZf2q5gNk8Vp4b4vMbVKWbbc7oivcdZHK:openvtc.storm.ws",
-  "secrets": [
-    {
-      "id": "did:webvh:QmXkYcFCbvFFcYZf2q5gNk8Vp4b4vMbVKWbbc7oivcdZHK:openvtc.storm.ws#key-0",
-      "type": "JsonWebKey2020",
-      "privateKeyJwk": {
-        "crv": "Ed25519",
-        "d": "..",
-        "kty": "OKP",
-        "x": ".."
-      }
-    },
-    {
-      "id": "did:webvh:QmXkYcFCbvFFcYZf2q5gNk8Vp4b4vMbVKWbbc7oivcdZHK:openvtc.storm.ws#key-1",
-      "type": "JsonWebKey2020",
-      "privateKeyJwk": {
-        "crv": "X25519",
-        "d": "..",
-        "kty": "OKP",
-        "x": ".."
-      }
-    }
-  ]
+  "secrets": []
 }

--- a/openvtc-service/src/config.rs
+++ b/openvtc-service/src/config.rs
@@ -2,6 +2,7 @@ use affinidi_tdk::secrets_resolver::secrets::Secret;
 use anyhow::{Context, Result, bail};
 use openvtc::maintainers::Maintainer;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fs;
 use tracing::error;
 
@@ -16,17 +17,124 @@ pub struct Config {
 
 impl Config {
     pub fn load(path: &str) -> Result<Self> {
-        let file = fs::File::open(path).context(format!(
+        let raw = fs::read_to_string(path).context(format!(
             "Couldn't load openvtc configuration file ({}) from disk",
             &path
         ))?;
 
-        match serde_json::from_reader(file) {
+        reject_plaintext_private_keys(&raw)?;
+
+        match serde_json::from_str(&raw) {
             Ok(s) => Ok(s),
             Err(e) => {
                 error!("ERROR: Couldn't Deserialize Config file. Reason: {}", e);
                 bail!("Deserialization error")
             }
         }
+    }
+}
+
+fn reject_plaintext_private_keys(raw: &str) -> Result<()> {
+    if contains_plaintext_private_key_material(raw) {
+        bail!("Refusing to load config containing plaintext private key material")
+    }
+
+    Ok(())
+}
+
+fn contains_plaintext_private_key_material(raw: &str) -> bool {
+    // Fast fail-closed guard for common private-key field names.
+    let lowercase = raw.to_ascii_lowercase();
+    if lowercase.contains("\"privatekeyjwk\"") {
+        return true;
+    }
+
+    let Ok(value) = serde_json::from_str::<Value>(raw) else {
+        return false;
+    };
+
+    contains_jwk_private_components(&value)
+}
+
+fn contains_jwk_private_components(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            if map.contains_key("privateKeyJwk") {
+                return true;
+            }
+
+            if map.contains_key("d") && map.contains_key("kty") {
+                return true;
+            }
+
+            map.values().any(contains_jwk_private_components)
+        }
+        Value::Array(items) => items.iter().any(contains_jwk_private_components),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contains_plaintext_private_key_material;
+
+    #[test]
+    fn detects_private_key_jwk_pattern() {
+        let raw = r#"{
+            "secrets": [
+                {
+                    "privateKeyJwk": {"kty": "OKP", "d": "secret", "x": "public"}
+                }
+            ]
+        }"#;
+
+        assert!(contains_plaintext_private_key_material(raw));
+    }
+
+    #[test]
+    fn detects_d_and_kty_jwk_private_material_pattern() {
+        let raw = r#"{
+            "secrets": [
+                {
+                    "kty": "OKP",
+                    "d": "secret"
+                }
+            ]
+        }"#;
+
+        assert!(contains_plaintext_private_key_material(raw));
+    }
+
+    #[test]
+    fn safe_config_shape_does_not_trigger() {
+        let raw = r#"{
+            "maintainers": [{"alias": "Ada", "did": "did:webvh:example"}],
+            "mediator": "did:webvh:mediator",
+            "our_did": "did:webvh:ours",
+            "secrets": []
+        }"#;
+
+        assert!(!contains_plaintext_private_key_material(raw));
+    }
+
+    #[test]
+    fn nested_secrets_array_case_triggers() {
+        let raw = r#"{
+            "maintainers": [{"alias": "Ada", "did": "did:webvh:example"}],
+            "mediator": "did:webvh:mediator",
+            "our_did": "did:webvh:ours",
+            "secrets": [
+                {
+                    "nested": {
+                        "inner": {
+                            "kty": "OKP",
+                            "d": "secret"
+                        }
+                    }
+                }
+            ]
+        }"#;
+
+        assert!(contains_plaintext_private_key_material(raw));
     }
 }


### PR DESCRIPTION
Adding a fail-closed guard in the service config loader to reject plaintext private key material (privateKeyJwk and JWK d + kty patterns). Also updates the example config to remove plaintext secrets and adds unit tests for detection and safe cases.