### PR TITLE
fix(cli): correctly handle valid_until when no expiry is selected

### DIFF
--- a/openvtc-cli/src/interactions/vrc.rs
+++ b/openvtc-cli/src/interactions/vrc.rs
@@ -818,13 +818,11 @@ pub async fn handle_accept_vrcs_request(
         }
     };
 
-    let valid_until = if !Confirm::with_theme(&ColorfulTheme::default())
+    let valid_until = if Confirm::with_theme(&ColorfulTheme::default())
         .with_prompt("Does this VRC have a valid until timestamp?")
         .default(false)
         .interact()?
     {
-        Some(Local::now())
-    } else {
         let now = Local::now();
         println!(
             "{}",
@@ -844,6 +842,8 @@ pub async fn handle_accept_vrcs_request(
             .unwrap();
 
         Some(custom_valid_until.parse().unwrap())
+    } else {
+        None
     };
 
     let mut vrc = DTGCredential::new_vrc(


### PR DESCRIPTION
### Fix: correct handling of `valid_until` when no expiry is selected

This PR fixes a small issue in the VRC issuance flow.

The confirmation prompt asks:

> “Does this VRC have a valid until timestamp?”

Previously, when the user selected **“No”**, the code incorrectly set `valid_until` to `Some(Local::now())`. This could unintentionally create credentials that expire immediately.

This has now been corrected — selecting **“No”** sets `valid_until` to `None`, meaning no expiration, which aligns with the prompt and expected behavior.

* Minimal change (1 line in a single file)
* No API or dependency changes
* “Yes” flow (custom timestamp input and parsing) remains unchanged
* Behavior now correctly reflects user intent

This is a low-risk fix that improves correctness and makes the CLI behavior more intuitive.
