### PR TITLE
Export only public DID document to did.jsonl

### DIFF
--- a/openvtc-cli/src/setup/did.rs
+++ b/openvtc-cli/src/setup/did.rs
@@ -277,8 +277,17 @@ pub async fn did_setup(
         style(did_id).color256(CLI_PURPLE)
     );
 
-    // save to disk
-    log_entry.log_entry.save_to_file("did.jsonl")?;
+    // Save only the public DID document to disk
+    let did_doc_value = log_entry.get_did_document()?;
+    let did_json = serde_json::to_string_pretty(&did_doc_value)?;
+    std::fs::write("did.jsonl", did_json)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions("did.jsonl", std::fs::Permissions::from_mode(0o600))?;
+    }
+
     println!(
         "{} {}",
         style("DID document saved:").color256(CLI_BLUE),
@@ -315,4 +324,16 @@ pub async fn did_setup(
         )
         .context("Serializing initial DID document state failed.")?,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn did_export_does_not_write_internal_log_entry() {
+        let src = include_str!("did.rs");
+        assert!(
+            !src.contains("log_entry.log_entry.save_to_file(\"did.jsonl\")"),
+            "did.jsonl export must not write internal log entries"
+        );
+    }
 }

--- a/openvtc-lib/src/config/did.rs
+++ b/openvtc-lib/src/config/did.rs
@@ -198,11 +198,31 @@ pub fn create_initial_webvh_did(
     keys.authentication.secret.id = [did_id, "#key-2"].concat();
     keys.decryption.secret.id = [did_id, "#key-3"].concat();
 
-    // Save the DID to local file
-    log_entry.log_entry.save_to_file("did.jsonl")?;
+    // Save only the public DID document to local file
+    let did_doc_value = log_entry.get_did_document()?;
+    let did_json = serde_json::to_string_pretty(&did_doc_value)?;
+    std::fs::write("did.jsonl", did_json)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions("did.jsonl", std::fs::Permissions::from_mode(0o600))?;
+    }
 
     Ok((
         did_id.to_string(),
         serde_json::from_value(log_entry.get_did_document()?)?,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn did_export_does_not_write_internal_log_entry() {
+        let src = include_str!("did.rs");
+        assert!(
+            !src.contains("log_entry.log_entry.save_to_file(\"did.jsonl\")"),
+            "did.jsonl export must not write internal log entries"
+        );
+    }
 }


### PR DESCRIPTION
Previously, setup code exported internal DID log entries directly to `did.jsonl`, which could include sensitive fields if the file became publicly accessible.  
## What changed
- Replaced internal log export with public DID document JSON export in:
  - openvtc-lib/src/config/did.rs
  - openvtc-cli/src/setup/did.rs
- Export now uses:
  - `log_entry.get_did_document()?`
  - `serde_json::to_string_pretty(...)`
  - `std::fs::write("did.jsonl", ...)`
- Added regression checks in both files to prevent reintroducing:
  - `log_entry.log_entry.save_to_file("did.jsonl")`
 
- Prevents accidental exposure of internal DID history/log data.
- Reduces risk of leaking sensitive update/rotation-related material.
- Keeps published `did.jsonl` limited to public DID document content.
 