### PR TITLE
fix(security): replace plain String with SecretString for BIP32 seed and imported key material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5945,6 +5945,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
+ "serde",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,6 +4418,7 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.10.9",
+ "sysinfo",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ pgp = "0.19"
 rand = "0.8"
 ratatui = "0.30"
 regex = "1.12"
-secrecy = "0.10"
+secrecy = { version = "0.10", features = ["serde"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_json_canonicalizer = "0.3"

--- a/openvtc-cli/src/config.rs
+++ b/openvtc-cli/src/config.rs
@@ -94,7 +94,7 @@ impl ConfigExtension for Config {
             .context("Imported config does not contain a BIP32 seed (VTA configs cannot be imported via CLI)")?;
         let bip32_root = ExtendedSigningKey::from_seed(
             BASE64_URL_SAFE_NO_PAD
-                .decode(bip32_seed)
+                .decode(bip32_seed.expose_secret())
                 .context("Couldn't base64 decode BIP32 seed")?
                 .as_slice(),
         )?;

--- a/openvtc-cli/src/main.rs
+++ b/openvtc-cli/src/main.rs
@@ -82,7 +82,7 @@ async fn load(profile: &str) -> Result<(TDK, Config)> {
 
     let public_config = Config::load_step1(profile)?;
 
-    let (user_pin, unlock_passphrase) = match &public_config.protection {
+    let (_user_pin, unlock_passphrase) = match &public_config.protection {
         ConfigProtectionType::Token { .. } => {
             let user_pin = Password::with_theme(&ColorfulTheme::default())
                 .with_prompt("Please enter Token User PIN <blank = default>")
@@ -122,7 +122,7 @@ async fn load(profile: &str) -> Result<(TDK, Config)> {
         public_config,
         unlock_passphrase.as_ref(),
         #[cfg(feature = "openpgp-card")]
-        &user_pin,
+        &_user_pin,
         #[cfg(feature = "openpgp-card")]
         &a,
         None,

--- a/openvtc-cli/src/main.rs
+++ b/openvtc-cli/src/main.rs
@@ -22,11 +22,11 @@ use openvtc::config::TokenInteractions;
 use openvtc::{
     colors::{CLI_BLUE, CLI_GREEN, CLI_ORANGE, CLI_PURPLE, CLI_RED},
     config::{Config, ConfigProtectionType, UnlockCode},
+    process_lock::{check_duplicate_instance, remove_lock_file},
 };
 use secrecy::SecretString;
 use status::print_status;
-use std::{env, fs, path::Path, process, str::FromStr};
-use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
+use std::env;
 use tracing_subscriber::EnvFilter;
 
 mod cli;
@@ -141,114 +141,6 @@ async fn load(profile: &str) -> Result<(TDK, Config)> {
     };
 
     Ok((tdk, config))
-}
-
-/// Checks if another instance of openvtc is running for the same profile
-/// will return an error if a duplicate instance is found
-/// otherwise, creates a lock file to prvent other instances from running
-/// Returns the path to the lock file created
-fn check_duplicate_instance(profile: &str) -> Result<String> {
-    let lock_file = get_lock_file(profile)?;
-
-    // Check if existing lockfile exists
-    // If so, then check if the PID is still running
-    match fs::exists(&lock_file) {
-        Ok(exists) => {
-            if exists {
-                // Check the PID
-                let pid = fs::read_to_string(&lock_file)
-                    .context("Couldn't read from lockfile")?
-                    .trim_end()
-                    .to_string();
-
-                // We want to only refresh processes.
-                let system = System::new_with_specifics(
-                    RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()),
-                );
-                if system.process(Pid::from_str(&pid)?).is_some() {
-                    println!(
-                        "{}{}{} {}",
-                        style("ERROR: Another instance of openvtc is running for this profile (")
-                            .color256(CLI_RED),
-                        style(profile).color256(CLI_PURPLE),
-                        style(")!").color256(CLI_RED),
-                        style(
-                            "Only a single instance of openvtc can run for a given profile at a time!"
-                        )
-                        .color256(CLI_ORANGE)
-                    );
-                    bail!("Duplicate openvtc instance running");
-                }
-            }
-        }
-        Err(e) => {
-            println!(
-                "{} {}",
-                style("ERROR: Couldn't check for lock file! Reason:").color256(CLI_RED),
-                style(e).color256(CLI_ORANGE)
-            );
-            bail!("Lock File Error");
-        }
-    }
-
-    // Create the lock file
-    create_lock_file(&lock_file).context("create_lock_file() failed")?;
-    Ok(lock_file)
-}
-
-/// Returns the path to the lock file for the given profile
-fn get_lock_file(profile: &str) -> Result<String> {
-    let path = if let Ok(config_path) = env::var("OPENVTC_CONFIG_PATH") {
-        if config_path.ends_with('/') {
-            config_path
-        } else {
-            [&config_path, "/"].concat()
-        }
-    } else if let Some(home) = dirs::home_dir()
-        && let Some(home_str) = home.to_str()
-    {
-        [home_str, "/.config/openvtc/"].concat()
-    } else {
-        bail!("Couldn't determine Home directory");
-    };
-
-    if profile == "default" {
-        Ok([&path, "config.lock"].concat())
-    } else {
-        Ok([&path, "config-", profile, ".lock"].concat())
-    }
-}
-
-/// Creates the lock file containg the running process PID
-fn create_lock_file(lock_file: &str) -> Result<()> {
-    let dir_path = Path::new(&lock_file);
-
-    // Check that directory structure exists
-    if let Some(parent_path) = dir_path.parent()
-        && !parent_path.exists()
-    {
-        // Create parent directories
-        fs::create_dir_all(parent_path)?;
-    }
-
-    match fs::write(lock_file, process::id().to_string()) {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            println!(
-                "{}{}{}{}",
-                style("ERROR: Couldn't create lock file: ").color256(CLI_RED),
-                style(lock_file).color256(CLI_PURPLE),
-                style(" Reason: ").color256(CLI_RED),
-                style(e).color256(CLI_ORANGE)
-            );
-            bail!("Couldn't create lock file");
-        }
-    }
-}
-
-/// Removes the lock file for the given profile
-fn remove_lock_file(lock_file: &str) {
-    let _ = fs::remove_file(lock_file);
 }
 
 // ****************************************************************************
@@ -440,7 +332,8 @@ async fn openvtc(term: &Term, profile: &str) -> Result<()> {
 pub fn get_unlock_code() -> Result<[u8; 32]> {
     let unlock_code = Password::with_theme(&ColorfulTheme::default())
         .with_prompt("Please enter your openvtc unlock code")
-        .allow_empty_password(true)
+        // An empty unlock code would produce a deterministic key, providing no security.
+        .allow_empty_password(false)
         .interact()
         .map_err(|e| anyhow::anyhow!("Failed to read unlock code: {e}"))?;
 

--- a/openvtc-cli/src/main.rs
+++ b/openvtc-cli/src/main.rs
@@ -24,7 +24,6 @@ use openvtc::{
     config::{Config, ConfigProtectionType, UnlockCode},
 };
 use secrecy::SecretString;
-use sha2::Digest;
 use status::print_status;
 use std::{env, fs, path::Path, process, str::FromStr};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
@@ -436,8 +435,8 @@ async fn openvtc(term: &Term, profile: &str) -> Result<()> {
     Ok(())
 }
 
-/// Prompts user for their unlock code when not using a hardware token
-/// returns the SHA256 hash of whatever they entered
+/// Prompts user for their unlock code when not using a hardware token.
+/// Derives a 32-byte key via Argon2id (same KDF as `UnlockCode::from_string`).
 pub fn get_unlock_code() -> Result<[u8; 32]> {
     let unlock_code = Password::with_theme(&ColorfulTheme::default())
         .with_prompt("Please enter your openvtc unlock code")
@@ -445,5 +444,8 @@ pub fn get_unlock_code() -> Result<[u8; 32]> {
         .interact()
         .map_err(|e| anyhow::anyhow!("Failed to read unlock code: {e}"))?;
 
-    Ok(sha2::Sha256::digest(unlock_code.as_bytes()).into())
+    Ok(openvtc::config::derive_passphrase_key(
+        unlock_code.as_bytes(),
+        b"openvtc-unlock-code-v1",
+    )?)
 }

--- a/openvtc-cli/src/setup/mod.rs
+++ b/openvtc-cli/src/setup/mod.rs
@@ -31,8 +31,7 @@ use openvtc::{
     },
     logs::{LogFamily, LogMessage, Logs},
 };
-use secrecy::SecretString;
-use sha2::Digest;
+use secrecy::{SecretBox, SecretString};
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
@@ -111,7 +110,7 @@ pub async fn cli_setup(term: &Term, profile: &str) -> Result<()> {
     // If hardware token is not being used, then ask for an unlock code
     let unlock_code = if token_id.is_none() {
         // Check if an unlock code is desired?
-        create_unlock_code()?.map(|c| c.to_vec())
+        create_unlock_code()?.map(|c| SecretBox::new(Box::new(c.to_vec())))
     } else {
         // No need for an unlock code when using hardware token
         None
@@ -341,7 +340,7 @@ fn create_keys(mnemonic: &Mnemonic, imported_keys: &PGPKeys) -> Result<PersonaDI
     })
 }
 
-/// Generates a sha256 hash of an unlock code if required
+/// Derives an unlock code via Argon2id from a user-provided passphrase.
 pub fn create_unlock_code() -> Result<Option<[u8; 32]>> {
     println!("{}", style("NOTE: You are not using any hardware token. While secret information will be stored in your OS secure store where possible, it is best practice to protect this data with an unlock code.").color256(CLI_BLUE));
     println!("  {}", style("This unlock code is asked on application start so it can unlock secret configuration data required.").color256(CLI_BLUE));
@@ -359,8 +358,10 @@ pub fn create_unlock_code() -> Result<Option<[u8; 32]>> {
             .interact()
             .context("Failed to read unlock code")?;
 
-        // Create SHA2-256 hash of the unlock code
-        Ok(Some(sha2::Sha256::digest(unlock_code.as_bytes()).into()))
+        Ok(Some(openvtc::config::derive_passphrase_key(
+            unlock_code.as_bytes(),
+            b"openvtc-unlock-code-v1",
+        )?))
     } else {
         Ok(None)
     }

--- a/openvtc-cli/src/setup/pgp_import.rs
+++ b/openvtc-cli/src/setup/pgp_import.rs
@@ -22,6 +22,7 @@ use pgp::{
 };
 use regex::Regex;
 use secrecy::SecretString;
+use std::time::SystemTime;
 use zeroize::Zeroize;
 
 /// Holds imported PGP Keys
@@ -147,7 +148,7 @@ impl PGPKeys {
         };
         let ki = KeyInfo {
             source: KeySourceMaterial::Imported {
-                seed: SecretString::new(private_keymultibase),
+                seed: SecretString::new(private_keymultibase.into()),
             },
             secret,
             expiry: expiry_td,
@@ -392,7 +393,8 @@ fn extract_primary_key_details(primary_key: &SignedSecretKey) -> Result<(KeyFlag
                 seed: SecretString::new(
                     secret
                         .get_private_keymultibase()
-                        .context("Failed to encode primary key as multibase")?,
+                        .context("Failed to encode primary key as multibase")?
+                        .into(),
                 ),
             },
             secret,

--- a/openvtc-cli/src/setup/pgp_import.rs
+++ b/openvtc-cli/src/setup/pgp_import.rs
@@ -9,7 +9,6 @@ use crate::{
     setup::{KeyInfo, KeyPurpose},
 };
 use affinidi_tdk::secrets_resolver::secrets::Secret;
-use secrecy::SecretString;
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, MappedLocalTime, TimeDelta, TimeZone, Utc};
 use console::{StyledObject, style};
@@ -22,7 +21,7 @@ use pgp::{
     types::{KeyDetails, PlainSecretParams, SecretParams},
 };
 use regex::Regex;
-use std::time::SystemTime;
+use secrecy::SecretString;
 use zeroize::Zeroize;
 
 /// Holds imported PGP Keys

--- a/openvtc-cli/src/setup/pgp_import.rs
+++ b/openvtc-cli/src/setup/pgp_import.rs
@@ -9,6 +9,7 @@ use crate::{
     setup::{KeyInfo, KeyPurpose},
 };
 use affinidi_tdk::secrets_resolver::secrets::Secret;
+use secrecy::SecretString;
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, MappedLocalTime, TimeDelta, TimeZone, Utc};
 use console::{StyledObject, style};
@@ -147,7 +148,7 @@ impl PGPKeys {
         };
         let ki = KeyInfo {
             source: KeySourceMaterial::Imported {
-                seed: private_keymultibase,
+                seed: SecretString::new(private_keymultibase),
             },
             secret,
             expiry: expiry_td,
@@ -389,9 +390,11 @@ fn extract_primary_key_details(primary_key: &SignedSecretKey) -> Result<(KeyFlag
         signature.key_flags(),
         KeyInfo {
             source: KeySourceMaterial::Imported {
-                seed: secret
-                    .get_private_keymultibase()
-                    .context("Failed to encode primary key as multibase")?,
+                seed: SecretString::new(
+                    secret
+                        .get_private_keymultibase()
+                        .context("Failed to encode primary key as multibase")?,
+                ),
             },
             secret,
             expiry: expiry_td,

--- a/openvtc-cli/src/status.rs
+++ b/openvtc-cli/src/status.rs
@@ -157,7 +157,7 @@ pub async fn print_status(term: &Term, tdk: &mut TDK, profile: &str) {
         }
     };
 
-    let (user_pin, unlock_passphrase) = match &public_config.protection {
+    let (_user_pin, unlock_passphrase) = match &public_config.protection {
         ConfigProtectionType::Token { .. } => {
             let user_pin = Password::with_theme(&ColorfulTheme::default())
                 .with_prompt("Please enter Token User PIN <blank = default>")
@@ -227,7 +227,7 @@ pub async fn print_status(term: &Term, tdk: &mut TDK, profile: &str) {
         public_config,
         unlock_passphrase.as_ref(),
         #[cfg(feature = "openpgp-card")]
-        &user_pin,
+        &_user_pin,
         #[cfg(feature = "openpgp-card")]
         &a,
         None,
@@ -302,28 +302,32 @@ pub async fn print_status(term: &Term, tdk: &mut TDK, profile: &str) {
 }
 
 // Rust Feature Flags enabled for this build
+// `_prev_flag` tracks whether a comma separator is needed before each feature
+// label. It is written inside cfg-gated blocks and may not be read in all
+// feature combinations — the allow attributes suppress the resulting lints.
+#[allow(unused_assignments, unused_variables)]
 fn feature_flags() {
     print!("{} ", style("openvtc enabled features:").color256(CLI_BLUE),);
-    let mut prev_flag = false; // set to true if a feature has been enabled
+    let mut _prev_flag = false;
 
     #[cfg(not(feature = "default"))]
     {
         print!("{}", style("no-default").color256(CLI_RED));
-        prev_flag = true;
+        _prev_flag = true;
     }
 
     #[cfg(feature = "default")]
     {
-        if prev_flag {
+        if _prev_flag {
             print!("{}", style(", ").bold().color256(CLI_GREEN))
         }
         print!("{}", style("default").bold().color256(CLI_GREEN));
-        prev_flag = true;
+        _prev_flag = true;
     }
 
     #[cfg(feature = "openpgp-card")]
     {
-        if prev_flag {
+        if _prev_flag {
             print!("{}", style(", ").bold().color256(CLI_GREEN))
         }
         print!("{}", style("openpgp-card").bold().color256(CLI_GREEN));

--- a/openvtc-cli2/src/cli.rs
+++ b/openvtc-cli2/src/cli.rs
@@ -2,7 +2,9 @@
 */
 
 use clap::{Arg, Command};
+#[cfg(feature = "openpgp-card")]
 use dialoguer::{Password, theme::ColorfulTheme};
+#[cfg(feature = "openpgp-card")]
 use secrecy::SecretString;
 
 pub fn cli() -> Command {
@@ -26,6 +28,7 @@ pub fn cli() -> Command {
         .subcommand(Command::new("setup").about("Initial configuration of the openvtc tool"))
 }
 
+#[cfg(feature = "openpgp-card")]
 pub fn get_user_pin() -> SecretString {
     let user_pin = Password::with_theme(&ColorfulTheme::default())
         .with_prompt("Please enter Token User PIN")

--- a/openvtc-cli2/src/main.rs
+++ b/openvtc-cli2/src/main.rs
@@ -3,17 +3,17 @@ use crate::{
     state_handler::{DeferredLoad, StartingMode, StateHandler},
     ui::UiManager,
 };
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use console::style;
 use dialoguer::{Password, theme::ColorfulTheme};
 use openvtc::{
     colors::{CLI_BLUE, CLI_ORANGE, CLI_PURPLE, CLI_RED},
     config::{Config, ConfigProtectionType, UnlockCode},
     errors::OpenVTCError,
+    process_lock::{check_duplicate_instance, remove_lock_file},
 };
 use secrecy::SecretString;
-use std::{env, fs, path::Path, process, str::FromStr};
-use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
+use std::env;
 #[cfg(unix)]
 use tokio::signal::unix::signal;
 use tokio::sync::broadcast;
@@ -21,114 +21,6 @@ use tokio::sync::broadcast;
 mod cli;
 mod state_handler;
 mod ui;
-
-/// Checks if another instance of openvtc is running for the same profile
-/// will return an error if a duplicate instance is found
-/// otherwise, creates a lock file to prvent other instances from running
-/// Returns the path to the lock file created
-fn check_duplicate_instance(profile: &str) -> Result<String> {
-    let lock_file = get_lock_file(profile)?;
-
-    // Check if existing lockfile exists
-    // If so, then check if the PID is still running
-    match fs::exists(&lock_file) {
-        Ok(exists) => {
-            if exists {
-                // Check the PID
-                let pid = fs::read_to_string(&lock_file)
-                    .context("Couldn't read from lockfile")?
-                    .trim_end()
-                    .to_string();
-
-                // We want to only refresh processes.
-                let system = System::new_with_specifics(
-                    RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()),
-                );
-                if system.process(Pid::from_str(&pid)?).is_some() {
-                    eprintln!(
-                        "{}{}{} {}",
-                        style("ERROR: Another instance of openvtc is running for this profile (")
-                            .color256(CLI_RED),
-                        style(profile).color256(CLI_PURPLE),
-                        style(")!").color256(CLI_RED),
-                        style(
-                            "Only a single instance of openvtc can run for a given profile at a time!"
-                        )
-                        .color256(CLI_ORANGE)
-                    );
-                    bail!("Duplicate openvtc instance running");
-                }
-            }
-        }
-        Err(e) => {
-            eprintln!(
-                "{} {}",
-                style("ERROR: Couldn't check for lock file! Reason:").color256(CLI_RED),
-                style(e).color256(CLI_ORANGE)
-            );
-            bail!("Lock File Error");
-        }
-    }
-
-    // Create the lock file
-    create_lock_file(&lock_file).context("create_lock_file() failed")?;
-    Ok(lock_file)
-}
-
-/// Returns the path to the lock file for the given profile
-fn get_lock_file(profile: &str) -> Result<String> {
-    let path = if let Ok(config_path) = env::var("OPENVTC_CONFIG_PATH") {
-        if config_path.ends_with('/') {
-            config_path
-        } else {
-            [&config_path, "/"].concat()
-        }
-    } else if let Some(home) = dirs::home_dir()
-        && let Some(home_str) = home.to_str()
-    {
-        [home_str, "/.config/openvtc/"].concat()
-    } else {
-        bail!("Couldn't determine Home directory");
-    };
-
-    if profile == "default" {
-        Ok([&path, "config.lock"].concat())
-    } else {
-        Ok([&path, "config-", profile, ".lock"].concat())
-    }
-}
-
-/// Creates the lock file containg the running process PID
-fn create_lock_file(lock_file: &str) -> Result<()> {
-    let dir_path = Path::new(&lock_file);
-
-    // Check that directory structure exists
-    if let Some(parent_path) = dir_path.parent()
-        && !parent_path.exists()
-    {
-        // Create parent directories
-        fs::create_dir_all(parent_path)?;
-    }
-
-    match fs::write(lock_file, process::id().to_string()) {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            println!(
-                "{}{}{}{}",
-                style("ERROR: Couldn't create lock file: ").color256(CLI_RED),
-                style(lock_file).color256(CLI_PURPLE),
-                style(" Reason: ").color256(CLI_RED),
-                style(e).color256(CLI_ORANGE)
-            );
-            bail!("Couldn't create lock file");
-        }
-    }
-}
-
-/// Removes the lock file for the given profile
-fn remove_lock_file(lock_file: &str) {
-    let _ = fs::remove_file(lock_file);
-}
 
 // ****************************************************************************
 // MAIN Function

--- a/openvtc-cli2/src/main.rs
+++ b/openvtc-cli2/src/main.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "openpgp-card")]
+use crate::cli::get_user_pin;
 use crate::{
-    cli::{cli, get_user_pin},
+    cli::cli,
     state_handler::{DeferredLoad, StartingMode, StateHandler},
     ui::UiManager,
 };
@@ -12,6 +14,7 @@ use openvtc::{
     errors::OpenVTCError,
     process_lock::{check_duplicate_instance, remove_lock_file},
 };
+#[cfg(feature = "openpgp-card")]
 use secrecy::SecretString;
 use std::env;
 #[cfg(unix)]

--- a/openvtc-cli2/src/state_handler/mod.rs
+++ b/openvtc-cli2/src/state_handler/mod.rs
@@ -129,12 +129,16 @@ impl StateHandler {
                 // Spawn TDK init + config load as a background task with progress reporting
                 let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<String>();
 
-                // Prepare shared state for TokenNotifier so it can push UI updates
-                #[cfg(feature = "openpgp-card")]
-                let notifier_state_tx = self.state_tx.clone();
-                #[cfg(feature = "openpgp-card")]
-                let notifier_shared_state =
-                    std::sync::Arc::new(std::sync::Mutex::new(state.clone()));
+                // Dedicated channel for token-touch events.  The notifier sends a bool
+                // (true = touch required, false = touch completed) and the StateHandler's
+                // select loop below is the sole authority that updates `state` and
+                // broadcasts it to the UI.  This preserves unidirectional data flow and
+                // eliminates the previous race-prone Arc<Mutex<State>> pattern.
+                //
+                // The channel is always created so the select! branch below can be
+                // unconditional; when the openpgp-card feature is disabled the sender is
+                // dropped inside the spawn and recv() immediately returns None.
+                let (token_touch_tx, mut token_touch_rx) = mpsc::unbounded_channel::<bool>();
 
                 let mut load_handle = tokio::spawn(async move {
                     let on_progress = |msg: &str| {
@@ -154,36 +158,33 @@ impl StateHandler {
                     .await
                     .map_err(|e| anyhow::anyhow!("TDK init failed: {e}"))?;
 
-                    // TokenInteractions impl for openpgp-card
+                    // TokenInteractions impl for openpgp-card.
+                    // Sends a plain bool through the dedicated channel instead of
+                    // directly mutating shared state, keeping state transitions
+                    // inside the StateHandler's main select loop.
                     #[cfg(feature = "openpgp-card")]
                     let token_notifier = {
                         use openvtc::config::TokenInteractions;
 
                         struct TokenNotifier {
-                            shared_state: std::sync::Arc<
-                                std::sync::Mutex<crate::state_handler::state::State>,
-                            >,
-                            state_tx: mpsc::UnboundedSender<crate::state_handler::state::State>,
+                            touch_tx: mpsc::UnboundedSender<bool>,
                         }
                         impl TokenInteractions for TokenNotifier {
                             fn touch_notify(&self) {
-                                if let Ok(mut s) = self.shared_state.lock() {
-                                    s.token_touch_pending = true;
-                                    let _ = self.state_tx.send(s.clone());
-                                }
+                                let _ = self.touch_tx.send(true);
                             }
                             fn touch_completed(&self) {
-                                if let Ok(mut s) = self.shared_state.lock() {
-                                    s.token_touch_pending = false;
-                                    let _ = self.state_tx.send(s.clone());
-                                }
+                                let _ = self.touch_tx.send(false);
                             }
                         }
                         TokenNotifier {
-                            shared_state: notifier_shared_state,
-                            state_tx: notifier_state_tx,
+                            touch_tx: token_touch_tx,
                         }
                     };
+                    // When openpgp-card is disabled, drop the sender so the receiver
+                    // in the select loop sees a closed channel immediately.
+                    #[cfg(not(feature = "openpgp-card"))]
+                    drop(token_touch_tx);
 
                     let config = Config::load_step2(
                         &mut tdk,
@@ -208,6 +209,12 @@ impl StateHandler {
                         Some(msg) = progress_rx.recv() => {
                             state.connection.status =
                                 state::MediatorStatus::Initializing(msg);
+                            self.state_tx.send(state.clone())?;
+                        }
+                        // Token-touch notifications arrive through the dedicated channel
+                        // so that state is mutated only here, inside the StateHandler loop.
+                        Some(pending) = token_touch_rx.recv() => {
+                            state.token_touch_pending = pending;
                             self.state_tx.send(state.clone())?;
                         }
                         result = &mut load_handle => {

--- a/openvtc-cli2/src/state_handler/mod.rs
+++ b/openvtc-cli2/src/state_handler/mod.rs
@@ -9,6 +9,7 @@ use crate::{
 use affinidi_tdk::{TDK, common::config::TDKConfig};
 use anyhow::Result;
 use openvtc::config::{Config, UnlockCode, public_config::PublicConfig};
+#[cfg(feature = "openpgp-card")]
 use secrecy::SecretString;
 use tokio::sync::{
     broadcast,

--- a/openvtc-cli2/src/state_handler/setup_sequence/config.rs
+++ b/openvtc-cli2/src/state_handler/setup_sequence/config.rs
@@ -16,7 +16,7 @@ use openvtc::{
     },
     logs::{LogFamily, LogMessage, Logs},
 };
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
 use std::{
     collections::{HashMap, VecDeque},
     fs,
@@ -209,7 +209,7 @@ impl ConfigExtension for Config {
             ConfigProtection::PlainText => ConfigProtectionType::Plaintext,
             ConfigProtection::Token(token) => ConfigProtectionType::Token(token.to_string()),
             ConfigProtection::Passcode(unlock) => {
-                unlock_code = Some(unlock.expose_secret().to_vec());
+                unlock_code = Some(SecretBox::new(Box::new(unlock.expose_secret().to_vec())));
                 ConfigProtectionType::Encrypted
             }
         };

--- a/openvtc-cli2/src/state_handler/setup_sequence/config.rs
+++ b/openvtc-cli2/src/state_handler/setup_sequence/config.rs
@@ -207,6 +207,7 @@ impl ConfigExtension for Config {
         let mut unlock_code = None;
         let protection = match &state.protection {
             ConfigProtection::PlainText => ConfigProtectionType::Plaintext,
+            #[cfg(feature = "openpgp-card")]
             ConfigProtection::Token(token) => ConfigProtectionType::Token(token.to_string()),
             ConfigProtection::Passcode(unlock) => {
                 unlock_code = Some(SecretBox::new(Box::new(unlock.expose_secret().to_vec())));

--- a/openvtc-cli2/src/state_handler/setup_sequence/config.rs
+++ b/openvtc-cli2/src/state_handler/setup_sequence/config.rs
@@ -127,7 +127,7 @@ impl ConfigExtension for Config {
             .expect("Imported config missing BIP32 seed");
         let bip32_root = ExtendedSigningKey::from_seed(
             BASE64_URL_SAFE_NO_PAD
-                .decode(bip32_seed)
+                .decode(bip32_seed.expose_secret())
                 .expect("Couldn't base64 decode BIP32 seed")
                 .as_slice(),
         )?;

--- a/openvtc-cli2/src/state_handler/setup_sequence/mod.rs
+++ b/openvtc-cli2/src/state_handler/setup_sequence/mod.rs
@@ -138,6 +138,7 @@ pub struct VtaSetupState {
 pub enum ConfigProtection {
     #[default]
     PlainText,
+    #[cfg(feature = "openpgp-card")]
     Token(String),
     /// Is a SHA256 digest of the input passcode
     Passcode(Arc<SecretBox<Vec<u8>>>),
@@ -147,6 +148,7 @@ impl std::fmt::Debug for ConfigProtection {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConfigProtection::PlainText => write!(f, "ConfigProtection::PlainText"),
+            #[cfg(feature = "openpgp-card")]
             ConfigProtection::Token(token_id) => {
                 write!(f, "ConfigProtection::Token({})", token_id)
             }

--- a/openvtc-cli2/src/state_handler/setup_wizard.rs
+++ b/openvtc-cli2/src/state_handler/setup_wizard.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "openpgp-card")]
+use crate::state_handler::setup_token_actions;
 use crate::{
     Interrupted,
     state_handler::{
@@ -5,7 +7,7 @@ use crate::{
         actions::Action,
         setup_did_actions,
         setup_sequence::{Completion, MessageType, SetupPage, config::ConfigExtension},
-        setup_token_actions, setup_vta_actions,
+        setup_vta_actions,
         state::{ActivePage, State},
     },
 };

--- a/openvtc-cli2/src/state_handler/state.rs
+++ b/openvtc-cli2/src/state_handler/state.rs
@@ -15,8 +15,9 @@ pub struct State {
     #[cfg(feature = "openpgp-card")]
     pub token_admin_pin: Option<SecretString>,
 
-    /// True when the user needs to physically touch their hardware token
-    #[cfg(feature = "openpgp-card")]
+    /// True when the user needs to physically touch their hardware token.
+    /// Not gated behind the openpgp-card feature so the StateHandler's
+    /// select loop can update it unconditionally regardless of build config.
     pub token_touch_pending: bool,
 }
 

--- a/openvtc-cli2/src/ui/pages/setup_flow/unlock_code_set.rs
+++ b/openvtc-cli2/src/ui/pages/setup_flow/unlock_code_set.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crossterm::event::{Event, KeyCode, KeyEvent};
 use openvtc::colors::{COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SOFT_PURPLE, COLOR_TEXT_DEFAULT};
+use openvtc::config::derive_passphrase_key;
 use ratatui::{
     Frame,
     layout::{
@@ -13,7 +14,6 @@ use ratatui::{
     widgets::{Block, Padding, Paragraph},
 };
 use secrecy::SecretBox;
-use sha2::{Digest, Sha256};
 use tui_input::{Input, backend::crossterm::EventHandler};
 
 use crate::{
@@ -41,9 +41,15 @@ impl UnlockCodeSet {
                 let _ = state.action_tx.send(Action::Exit);
             }
             KeyCode::Enter => {
-                let passphrase_hash = Arc::new(SecretBox::new(Box::new(
-                    Sha256::digest(state.unlock_code_set.passphrase.value()).to_vec(),
-                )));
+                let passphrase_value = state.unlock_code_set.passphrase.value().to_string();
+                let key = match derive_passphrase_key(
+                    passphrase_value.as_bytes(),
+                    b"openvtc-unlock-code-v1",
+                ) {
+                    Ok(k) => k,
+                    Err(_) => return,
+                };
+                let passphrase_hash = Arc::new(SecretBox::new(Box::new(key.to_vec())));
                 let result = navigate(
                     SetupEvent::UnlockCodeSet { passphrase_hash },
                     &state.props.state,

--- a/openvtc-lib/Cargo.toml
+++ b/openvtc-lib/Cargo.toml
@@ -44,6 +44,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_json_canonicalizer.workspace = true
 sha2.workspace = true
+sysinfo.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/openvtc-lib/src/config/keys.rs
+++ b/openvtc-lib/src/config/keys.rs
@@ -1,5 +1,7 @@
 //! Key resolution and regeneration logic for persona and relationship DIDs.
 
+use secrecy::ExposeSecret;
+
 use crate::{
     KeyPurpose,
     bip32::Bip32Extension,
@@ -134,12 +136,13 @@ impl Config {
                     };
                     root.get_secret_from_path(path, k_purpose)?
                 }
-                KeySourceMaterial::Imported { seed } => Secret::from_multibase(seed, None)
-                    .map_err(|e| {
+                KeySourceMaterial::Imported { seed } => {
+                    Secret::from_multibase(seed.expose_secret(), None).map_err(|e| {
                         OpenVTCError::Secret(format!(
                             "Couldn't create secret from multibase for key id. Reason: {e}"
                         ))
-                    })?,
+                    })?
+                },
                 KeySourceMaterial::VtaManaged { key_id } => {
                     // Use pre-authenticated VTA client
                     let client = vta_client.ok_or_else(|| {

--- a/openvtc-lib/src/config/keys.rs
+++ b/openvtc-lib/src/config/keys.rs
@@ -142,7 +142,7 @@ impl Config {
                             "Couldn't create secret from multibase for key id. Reason: {e}"
                         ))
                     })?
-                },
+                }
                 KeySourceMaterial::VtaManaged { key_id } => {
                     // Use pre-authenticated VTA client
                     let client = vta_client.ok_or_else(|| {

--- a/openvtc-lib/src/config/loading.rs
+++ b/openvtc-lib/src/config/loading.rs
@@ -271,7 +271,8 @@ impl Config {
             #[cfg(feature = "openpgp-card")]
             token_user_pin: token_user_pin.clone(),
             protection_method: sc.protection_method.clone(),
-            unlock_code: unlock_passphrase.map(|uc| uc.0.expose_secret().to_owned()),
+            unlock_code: unlock_passphrase
+                .map(|uc| SecretBox::new(Box::new(uc.0.expose_secret().to_owned()))),
             atm_profiles,
             vrcs,
         })

--- a/openvtc-lib/src/config/loading.rs
+++ b/openvtc-lib/src/config/loading.rs
@@ -83,9 +83,11 @@ impl Config {
 
         // Determine key backend from secured config
         let key_backend = if let Some(ref bip32_seed) = sc.bip32_seed {
-            // Legacy BIP32 config
+            // Legacy BIP32 config — call .expose_secret() to get the inner &str.
             let bip32_root = ExtendedSigningKey::from_seed(
-                BASE64_URL_SAFE_NO_PAD.decode(bip32_seed)?.as_slice(),
+                BASE64_URL_SAFE_NO_PAD
+                    .decode(bip32_seed.expose_secret())?
+                    .as_slice(),
             )
             .map_err(|e| {
                 OpenVTCError::BIP32(format!(
@@ -95,17 +97,18 @@ impl Config {
             })?;
             KeyBackend::Bip32 {
                 root: bip32_root,
-                seed: SecretString::new(bip32_seed.clone().into()),
+                seed: bip32_seed.clone(),
             }
         } else if let Some(ref credential_bundle) = sc.credential_bundle {
-            // VTA-managed config
-            let bundle = CredentialBundle::decode(credential_bundle).map_err(|e| {
-                OpenVTCError::Config(format!("Couldn't decode VTA credential bundle: {:?}", e))
-            })?;
+            // VTA-managed config — expose only at the point of decoding.
+            let bundle =
+                CredentialBundle::decode(credential_bundle.expose_secret()).map_err(|e| {
+                    OpenVTCError::Config(format!("Couldn't decode VTA credential bundle: {:?}", e))
+                })?;
             let encryption_seed =
                 ProtectedConfig::get_seed_from_credential(&bundle.private_key_multibase)?;
             KeyBackend::Vta {
-                credential_bundle: SecretString::new(credential_bundle.clone().into()),
+                credential_bundle: credential_bundle.clone(),
                 credential_did: bundle.did.clone(),
                 credential_private_key: SecretString::new(
                     bundle.private_key_multibase.clone().into(),

--- a/openvtc-lib/src/config/mod.rs
+++ b/openvtc-lib/src/config/mod.rs
@@ -234,8 +234,12 @@ pub struct Config {
     #[cfg(feature = "openpgp-card")]
     pub token_user_pin: SecretString,
 
-    /// Unlock code if required
-    pub unlock_code: Option<Vec<u8>>,
+    /// Argon2id-derived 32-byte symmetric key used to encrypt/decrypt `SecuredConfig`.
+    ///
+    /// Wrapped in `SecretBox` to ensure the key material is zeroed on drop and
+    /// never accidentally logged or compared in constant time.  Set when the
+    /// user provides an unlock passphrase; `None` for plaintext or token flows.
+    pub unlock_code: Option<SecretBox<Vec<u8>>>,
 
     /// Holds ATM profiles for relationships
     /// Key: Our local DID for the relationship

--- a/openvtc-lib/src/config/saving.rs
+++ b/openvtc-lib/src/config/saving.rs
@@ -42,7 +42,7 @@ impl Config {
             } else {
                 None
             },
-            self.unlock_code.as_ref(),
+            self.unlock_code.as_ref().map(|s| s.expose_secret()),
             #[cfg(feature = "openpgp-card")]
             touch_prompt,
         )?;

--- a/openvtc-lib/src/config/secured_config.rs
+++ b/openvtc-lib/src/config/secured_config.rs
@@ -44,7 +44,8 @@ mod serde_secret_str {
         s.serialize_str(v.expose_secret())
     }
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<SecretString, D::Error> {
-        Ok(SecretString::new(String::deserialize(d)?))
+        // secrecy 0.10: SecretString::new() takes Box<str>, not String
+        Ok(SecretString::new(String::deserialize(d)?.into()))
     }
 }
 mod serde_opt_secret_str {
@@ -57,7 +58,8 @@ mod serde_opt_secret_str {
         }
     }
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<SecretString>, D::Error> {
-        Ok(Option::<String>::deserialize(d)?.map(SecretString::new))
+        // secrecy 0.10: SecretString::new() takes Box<str>, not String
+        Ok(Option::<String>::deserialize(d)?.map(|s| SecretString::new(s.into())))
     }
 }
 
@@ -564,13 +566,49 @@ mod tests {
         // SecretString zeroes itself via ZeroizeOnDrop when dropped.
         // We just verify the variant is constructed and accessible correctly.
         let source = KeySourceMaterial::Imported {
-            seed: SecretString::new("z6MkTestSeed123456789".to_string()),
+            seed: SecretString::new("z6MkTestSeed123456789".into()),
         };
         match &source {
             KeySourceMaterial::Imported { seed } => {
                 assert!(!seed.expose_secret().is_empty())
             }
             _ => panic!("expected Imported variant"),
+        }
+    }
+
+    #[test]
+    fn test_bip32_seed_is_secret_string() {
+        // Verify that SecretString cannot be printed via Debug or Display,
+        // proving the seed value never leaks through formatting.
+        let config = SecuredConfig {
+            bip32_seed: Some(SecretString::new("super-secret-seed-value".into())),
+            credential_bundle: None,
+            vta_url: None,
+            vta_did: None,
+            key_info: std::collections::HashMap::new(),
+            protection_method: ProtectionMethod::default(),
+        };
+        let debug = format!("{:?}", config);
+        assert!(
+            !debug.contains("super-secret-seed-value"),
+            "SecretString must not leak through Debug formatting"
+        );
+    }
+
+    #[test]
+    fn test_imported_seed_requires_expose() {
+        // Prove that the seed field can only be accessed through expose_secret(),
+        // preventing accidental plaintext access.
+        let material = KeySourceMaterial::Imported {
+            seed: SecretString::new("z6MkSensitiveKeyData".into()),
+        };
+        let json = serde_json::to_string(&material).unwrap();
+        // The serde module deliberately exposes the value for serialization only.
+        assert!(json.contains("z6MkSensitiveKeyData"));
+        // But the Rust type system prevents direct field access — must go through
+        // expose_secret(). This test documents the security invariant.
+        if let KeySourceMaterial::Imported { seed } = &material {
+            assert_eq!(seed.expose_secret(), "z6MkSensitiveKeyData");
         }
     }
 }

--- a/openvtc-lib/src/config/secured_config.rs
+++ b/openvtc-lib/src/config/secured_config.rs
@@ -20,9 +20,7 @@ use chrono::{DateTime, Utc};
 use hkdf::Hkdf;
 use keyring::Entry;
 use rand::rngs::OsRng;
-use secrecy::ExposeSecret;
-#[cfg(feature = "openpgp-card")]
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::collections::HashMap;
@@ -31,6 +29,39 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Constants for storing secure info in the OS Secure Store
 const SERVICE: &str = "openvtc";
+
+// ---------------------------------------------------------------------------
+// Serde helpers for SecretString
+//
+// `Secret<String>` does not implement `SerializableSecret`, so the standard
+// `#[serde(with = "secrecy")]` attribute won't compile.  These narrow modules
+// expose the inner value only at the serde boundary and nowhere else.
+// ---------------------------------------------------------------------------
+mod serde_secret_str {
+    use secrecy::{ExposeSecret, SecretString};
+    use serde::{Deserialize, Deserializer, Serializer};
+    pub fn serialize<S: Serializer>(v: &SecretString, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(v.expose_secret())
+    }
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<SecretString, D::Error> {
+        Ok(SecretString::new(String::deserialize(d)?))
+    }
+}
+mod serde_opt_secret_str {
+    use secrecy::{ExposeSecret, SecretString};
+    use serde::{Deserialize, Deserializer, Serializer};
+    pub fn serialize<S: Serializer>(v: &Option<SecretString>, s: S) -> Result<S::Ok, S::Error> {
+        match v {
+            Some(secret) => s.serialize_some(secret.expose_secret()),
+            None => s.serialize_none(),
+        }
+    }
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<SecretString>, D::Error> {
+        Ok(Option::<String>::deserialize(d)?.map(SecretString::new))
+    }
+}
 
 /// Methods of protecting [SecuredConfig]
 #[derive(Clone, Debug, Default)]
@@ -160,13 +191,31 @@ impl SecuredConfigFormat {
 /// Try to keep this as small as possible for ease of secure storage
 #[derive(Serialize, Deserialize, Debug, Zeroize, ZeroizeOnDrop)]
 pub struct SecuredConfig {
-    /// base64 encoded BIP32 private seed (legacy - present only for BIP32-based configs)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub bip32_seed: Option<String>,
+    /// base64 encoded BIP32 private seed (legacy - present only for BIP32-based configs).
+    ///
+    /// `SecretString` ensures the value is zeroed on drop via `Secret<T>`'s `ZeroizeOnDrop`
+    /// implementation.  We set `#[zeroize(skip)]` so the outer `Zeroize` derive does not
+    /// try to call `.zeroize()` on `Secret<String>` directly (it doesn't implement `Zeroize`).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serde_opt_secret_str::serialize",
+        deserialize_with = "serde_opt_secret_str::deserialize"
+    )]
+    #[zeroize(skip)]
+    pub bip32_seed: Option<SecretString>,
 
-    /// base64-encoded CredentialBundle for VTA auth
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub credential_bundle: Option<String>,
+    /// base64-encoded CredentialBundle for VTA auth.
+    ///
+    /// Same `#[zeroize(skip)]` rationale as `bip32_seed` above.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serde_opt_secret_str::serialize",
+        deserialize_with = "serde_opt_secret_str::deserialize"
+    )]
+    #[zeroize(skip)]
+    pub credential_bundle: Option<SecretString>,
 
     /// VTA service URL
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -191,7 +240,7 @@ impl From<&Config> for SecuredConfig {
     fn from(cfg: &Config) -> Self {
         match &cfg.key_backend {
             KeyBackend::Bip32 { seed, .. } => SecuredConfig {
-                bip32_seed: Some(seed.expose_secret().to_owned()),
+                bip32_seed: Some(seed.clone()),
                 credential_bundle: None,
                 vta_url: None,
                 vta_did: None,
@@ -205,7 +254,7 @@ impl From<&Config> for SecuredConfig {
                 ..
             } => SecuredConfig {
                 bip32_seed: None,
-                credential_bundle: Some(credential_bundle.expose_secret().to_owned()),
+                credential_bundle: Some(credential_bundle.clone()),
                 vta_url: Some(vta_url.clone()),
                 vta_did: Some(vta_did.clone()),
                 key_info: cfg.key_info.clone(),
@@ -348,8 +397,15 @@ pub enum KeySourceMaterial {
 
     /// Sourced from an external Key Import
     /// multiencoded private key
-    /// Key Material will be stored in the OS Secure Store
-    Imported { seed: String },
+    /// Key Material will be stored in the OS Secure Store.
+    ///
+    /// `#[zeroize(skip)]`: `Secret<String>` zeroes itself on drop; the outer
+    /// `Zeroize` derive cannot call `.zeroize()` on it directly.
+    Imported {
+        #[serde(with = "serde_secret_str")]
+        #[zeroize(skip)]
+        seed: SecretString,
+    },
 
     /// Managed by VTA service - key_id is VTA's opaque identifier
     /// No derivation paths are stored in openvtc for VTA-managed keys
@@ -507,12 +563,15 @@ mod tests {
 
     #[test]
     fn test_key_source_material_zeroize() {
-        let mut source = KeySourceMaterial::Imported {
-            seed: "z6MkTestSeed123456789".to_string(),
+        // SecretString zeroes itself via ZeroizeOnDrop when dropped.
+        // We just verify the variant is constructed and accessible correctly.
+        let source = KeySourceMaterial::Imported {
+            seed: SecretString::new("z6MkTestSeed123456789".to_string()),
         };
-        source.zeroize();
         match &source {
-            KeySourceMaterial::Imported { seed } => assert!(seed.is_empty()),
+            KeySourceMaterial::Imported { seed } => {
+                assert!(!seed.expose_secret().is_empty())
+            }
             _ => panic!("expected Imported variant"),
         }
     }

--- a/openvtc-lib/src/config/secured_config.rs
+++ b/openvtc-lib/src/config/secured_config.rs
@@ -123,9 +123,12 @@ impl SecuredConfigFormat {
         #[cfg(feature = "openpgp-card")] touch_prompt: &impl TokenInteractions,
     ) -> Result<SecuredConfig, OpenVTCError> {
         let raw_bytes = match self {
-            SecuredConfigFormat::TokenEncrypted { esk, data } => {
+            SecuredConfigFormat::TokenEncrypted {
+                esk: _esk,
+                data: _data,
+            } => {
                 // Token Encrypted format
-                if let Some(token) = token {
+                if let Some(_token) = token {
                     #[cfg(feature = "openpgp-card")]
                     {
                         use crate::openpgp_card::crypt::token_decrypt;
@@ -133,9 +136,9 @@ impl SecuredConfigFormat {
                         token_decrypt(
                             #[cfg(feature = "openpgp-card")]
                             user_pin,
-                            token,
-                            &BASE64_URL_SAFE_NO_PAD.decode(esk)?,
-                            &BASE64_URL_SAFE_NO_PAD.decode(data)?,
+                            _token,
+                            &BASE64_URL_SAFE_NO_PAD.decode(_esk)?,
+                            &BASE64_URL_SAFE_NO_PAD.decode(_data)?,
                             touch_prompt,
                         )?
                     }
@@ -284,12 +287,12 @@ impl SecuredConfig {
         // Serialize SecuredConfig to byte array
         let input = serde_json::to_vec(&self)?;
 
-        let formatted = if let Some(token) = token {
+        let formatted = if let Some(_token) = token {
             #[cfg(feature = "openpgp-card")]
             {
                 use crate::openpgp_card::crypt::token_encrypt;
 
-                let (esk, data) = token_encrypt(token, &input, touch_prompt)?;
+                let (esk, data) = token_encrypt(_token, &input, touch_prompt)?;
                 SecuredConfigFormat::TokenEncrypted {
                     esk: BASE64_URL_SAFE_NO_PAD.encode(&esk),
                     data: BASE64_URL_SAFE_NO_PAD.encode(&data),

--- a/openvtc-lib/src/config/secured_config.rs
+++ b/openvtc-lib/src/config/secured_config.rs
@@ -56,9 +56,7 @@ mod serde_opt_secret_str {
             None => s.serialize_none(),
         }
     }
-    pub fn deserialize<'de, D: Deserializer<'de>>(
-        d: D,
-    ) -> Result<Option<SecretString>, D::Error> {
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<SecretString>, D::Error> {
         Ok(Option::<String>::deserialize(d)?.map(SecretString::new))
     }
 }

--- a/openvtc-lib/src/errors.rs
+++ b/openvtc-lib/src/errors.rs
@@ -92,6 +92,14 @@ pub enum OpenVTCError {
     /// A `Mutex` was found in a poisoned state.
     #[error("Mutex poisoned: {0}")]
     MutexPoisoned(String),
+
+    /// Another instance of openvtc is already running for this profile.
+    #[error("Duplicate instance running for profile '{0}'")]
+    DuplicateInstance(String),
+
+    /// A process lock-file operation (create, read, or remove) failed.
+    #[error("Lock file error: {0}")]
+    LockFile(String),
 }
 
 #[cfg(test)]

--- a/openvtc-lib/src/lib.rs
+++ b/openvtc-lib/src/lib.rs
@@ -21,6 +21,7 @@ pub mod logs;
 pub mod maintainers;
 #[cfg(feature = "openpgp-card")]
 pub mod openpgp_card;
+pub mod process_lock;
 pub mod relationships;
 pub mod tasks;
 pub mod vrc;

--- a/openvtc-lib/src/process_lock.rs
+++ b/openvtc-lib/src/process_lock.rs
@@ -1,0 +1,123 @@
+//! Single-instance enforcement via lock files.
+//!
+//! Both `openvtc-cli` and `openvtc-cli2` need identical logic to detect and
+//! prevent duplicate instances of the application running against the same
+//! profile.  Keeping the implementation here eliminates the maintenance burden
+//! of two copies diverging over time.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use openvtc::process_lock::{check_duplicate_instance, remove_lock_file};
+//!
+//! let lock_path = check_duplicate_instance("default").expect("already running");
+//! // … run application …
+//! remove_lock_file(&lock_path);
+//! ```
+
+use crate::errors::OpenVTCError;
+use std::{fs, path::Path, process, str::FromStr};
+use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System};
+
+/// Checks whether another instance of openvtc is already running for `profile`.
+///
+/// If no duplicate is found a lock file containing the current PID is created
+/// and its path is returned so the caller can [`remove_lock_file`] it on exit.
+///
+/// # Errors
+///
+/// - [`OpenVTCError::DuplicateInstance`] — another live process holds the lock.
+/// - [`OpenVTCError::LockFile`] — the lock file could not be read or created.
+pub fn check_duplicate_instance(profile: &str) -> Result<String, OpenVTCError> {
+    let lock_file = get_lock_file(profile)?;
+
+    match fs::exists(&lock_file) {
+        Ok(true) => {
+            let pid_str = fs::read_to_string(&lock_file)
+                .map_err(|e| OpenVTCError::LockFile(format!("couldn't read lock file: {e}")))?;
+            let pid_str = pid_str.trim_end();
+
+            let system = System::new_with_specifics(
+                RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing()),
+            );
+            let pid = Pid::from_str(pid_str)
+                .map_err(|e| OpenVTCError::LockFile(format!("invalid PID in lock file: {e}")))?;
+
+            if system.process(pid).is_some() {
+                return Err(OpenVTCError::DuplicateInstance(profile.to_string()));
+            }
+            // Stale lock file — fall through to overwrite it.
+        }
+        Ok(false) => {}
+        Err(e) => {
+            return Err(OpenVTCError::LockFile(format!(
+                "couldn't check for lock file: {e}"
+            )));
+        }
+    }
+
+    create_lock_file(&lock_file)?;
+    Ok(lock_file)
+}
+
+/// Returns the canonical path to the lock file for `profile`.
+///
+/// Respects the `OPENVTC_CONFIG_PATH` environment variable if set, otherwise
+/// defaults to `~/.config/openvtc/`.
+///
+/// # Errors
+///
+/// Returns [`OpenVTCError::LockFile`] if the home directory cannot be determined.
+pub fn get_lock_file(profile: &str) -> Result<String, OpenVTCError> {
+    let path = if let Ok(config_path) = std::env::var("OPENVTC_CONFIG_PATH") {
+        if config_path.ends_with('/') {
+            config_path
+        } else {
+            format!("{config_path}/")
+        }
+    } else if let Some(home) = dirs::home_dir()
+        && let Some(home_str) = home.to_str()
+    {
+        format!("{home_str}/.config/openvtc/")
+    } else {
+        return Err(OpenVTCError::LockFile(
+            "couldn't determine home directory".to_string(),
+        ));
+    };
+
+    if profile == "default" {
+        Ok(format!("{path}config.lock"))
+    } else {
+        Ok(format!("{path}config-{profile}.lock"))
+    }
+}
+
+/// Writes a lock file at `lock_file` containing the current process PID.
+///
+/// Parent directories are created if they do not already exist.
+///
+/// # Errors
+///
+/// Returns [`OpenVTCError::LockFile`] on any I/O failure.
+pub fn create_lock_file(lock_file: &str) -> Result<(), OpenVTCError> {
+    let dir_path = Path::new(lock_file);
+    if let Some(parent) = dir_path.parent()
+        && !parent.exists()
+    {
+        fs::create_dir_all(parent)
+            .map_err(|e| OpenVTCError::LockFile(format!("couldn't create lock directory: {e}")))?;
+    }
+
+    fs::write(lock_file, process::id().to_string()).map_err(|e| {
+        OpenVTCError::LockFile(format!("couldn't write lock file '{lock_file}': {e}"))
+    })?;
+    Ok(())
+}
+
+/// Removes the lock file at `lock_file`, ignoring any errors.
+///
+/// Errors are silently discarded because this is always called during
+/// application shutdown, where there is no meaningful recovery path.
+pub fn remove_lock_file(lock_file: &str) {
+    let _ = fs::remove_file(lock_file);
+}

--- a/openvtc-lib/src/relationships.rs
+++ b/openvtc-lib/src/relationships.rs
@@ -262,16 +262,18 @@ impl Relationships {
                                 })
                                 .ok()
                         }
-                        KeySourceMaterial::Imported { seed } => Secret::from_multibase(seed, None)
-                            .map(|mut s| {
-                                s.id = k.clone();
-                                s
-                            })
-                            .map_err(|e| {
-                                warn!("secret import failed for key {}: {e}", k);
-                                e
-                            })
-                            .ok(),
+                        KeySourceMaterial::Imported { seed } => {
+                            Secret::from_multibase(seed.expose_secret(), None)
+                                .map(|mut s| {
+                                    s.id = k.clone();
+                                    s
+                                })
+                                .map_err(|e| {
+                                    warn!("secret import failed for key {}: {e}", k);
+                                    e
+                                })
+                                .ok()
+                        }
                         KeySourceMaterial::VtaManaged { key_id } => {
                             if let Some(client) = vta_client {
                                 match client.get_key_secret(key_id).await {


### PR DESCRIPTION
### Summary
This PR hardens secret handling across the entire codebase and fixes several architectural issues flagged by truff-review + code review.

### Changes

**Security**
- `bip32_seed`, `credential_bundle`, and `KeySourceMaterial::Imported::seed` now use `SecretString`
- `Config::unlock_code` upgraded from `Option<Vec<u8>>` → `Option<SecretBox<Vec<u8>>>` (zeroized on drop)
- Setup wizard KDF changed from weak single-round `Sha256::digest` → proper `derive_passphrase_key` (Argon2id)
- Empty passphrase is now rejected at prompt level (`allow_empty_password(false)`)

**Architecture & DX**
- Centralized `process_lock.rs` in `openvtc-lib` (removed identical duplicate code from both CLIs)
- `TokenNotifier` refactored to use clean `UnboundedSender/Receiver<bool>` channel instead of bypassing `StateHandler`

**Testing**
- Added 2 new security tests for `SecretString` guarantees
- Full CI green (fmt, clippy, tests, docs, MSRV, benchmarks)

Rebased cleanly on latest `main` (secrecy 0.10 + openpgp-card 0.6).

This is PR #2 (separate from the serde tagging fix in PR #34).

cc @stormer78 @AlexanderShenshin