### PR TITLE
feat: T1 — config v2 multi-community model + active-identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383822b5aa105040ae6debb29d0321cbb5ad8f755d2c050e437c923434aa72c8"
+checksum = "b3b42d67853904ddcbf3e69dc9522b7088f1557b50e6e49b07d5469b30ed6d93"
 dependencies = [
  "aes",
  "affinidi-encoding",
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce7f611e7bcad221aee953b8ef91d23e0f18ef319c711211357f03f14f63450"
+checksum = "40e3bfdabfb46690fe58cea0801d4b43d15949ee34a92290b68d9447bbb616a5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-encoding"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0d6ba1e7fc9bde231c5c7d6e10f29b6822f93e20000dce2a4647d8de8c8d9a"
+checksum = "8b0faa57ab55df6fad876ac64a223532a9bb159b393d88b66887c1ae42c33f52"
 dependencies = [
  "bs58 0.5.1",
  "serde",
@@ -8457,9 +8457,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bebaa6019eb818117fb3f92e33ffc08b1e1078e235c16458a36d8b64ab3377c"
+checksum = "4ca9a9ef918900c67ca3247018cdaeb4382c5647ab6cd3ab365f2b43e9412d23"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "bytes",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -449,6 +449,51 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "affinidi-oid4vc-core"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fc01f6e5abce1c03dd55aa46faa9d153d8f36b761ab6d02263403d118c6926"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "p256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "affinidi-openid4vci"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8f1a50fcfb61088ee724511d8eae99bacf786f6429a705a77769800956b89d"
+dependencies = [
+ "affinidi-oid4vc-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "affinidi-openid4vp"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552f5fa894b4a362f449afbdaaadde1ad06081244d4c2c08dffd79e1db7294bf"
+dependencies = [
+ "affinidi-oid4vc-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1429,7 +1474,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1794,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -2321,7 +2366,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2945,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -8319,7 +8364,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -8412,14 +8457,16 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa977c66105fc3cdc2247e6e95b3652c2c056c05e4f4b5e567755dee0c3d2340"
+checksum = "1bebaa6019eb818117fb3f92e33ffc08b1e1078e235c16458a36d8b64ab3377c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
@@ -9447,9 +9494,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.1.12"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b42d67853904ddcbf3e69dc9522b7088f1557b50e6e49b07d5469b30ed6d93"
+checksum = "2a56253d8878db88e02d70a0472ec7e346412a4dcf14b84a77cca096ecbbf4f0"
 dependencies = [
  "aes",
  "affinidi-encoding",
@@ -90,6 +90,7 @@ dependencies = [
  "multibase",
  "p256",
  "p384",
+ "p521",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -102,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e3bfdabfb46690fe58cea0801d4b43d15949ee34a92290b68d9447bbb616a5"
+checksum = "be2413307935cc2126c9fc4890a0e38ed69329638b93590a936a2d5bd11a50d8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -125,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-authentication"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f6dddb1c766bd2907802b2d9f6c47b511531664e5715828a667c7cf57cef9d"
+checksum = "df6b7f65487eeb0332943dfb1b7140a9e0657b65c90fc6ae89c3291bd793e291"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -148,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-common"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe027b966094b1a10afedc57c3eb947f1ce9aa9e46eaed439afae873676d325"
+checksum = "4caccbd04e9f77b067659c9ac0312c4dfface553fe2375ceb7ed1affec550061"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -165,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3ef1475ae7fb0378b08e530fc3180f96c2a1a778d60aa9f5ce70b068f3979d"
+checksum = "81bf73e3580e63f3877c10e7648f42b0082eaa4ba8f2ea6e2c16ce5921b2e415"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
@@ -259,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a20a4728d64691ee53bb7af10721050fea21bee3eba2f48f6c3556ce66617f5"
+checksum = "116a97f0ee592f0fa7cda8c30b2c757175ea4a28d9bbf3b800be7e13d1740b02"
 dependencies = [
  "affinidi-crypto",
  "base64ct",
@@ -302,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.15.12"
+version = "0.15.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd932bb1a30c629bdbed212e0098fb1e014424cd21b53b8e27ee1440031a9a7"
+checksum = "550c4325d3e325d3062c2135419d99668987b4f6c6f1063d047b11ea2c248404"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -398,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.6"
+version = "0.18.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536aa87c41fcfb795574e5b6d7275dcfd94599cf20442e62f2acefdcb976bef5"
+checksum = "1e03b90fdf586d88f396350f555b5569f66eee86c1d17f69ada41f6d58ee479b"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -498,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-rdf-encoding"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8c58001cb36e92473a758d4ab29882965347a2b9dd661db0a2761bc5cd2ffe8"
+checksum = "327366e7191a875eddcf0131e2b008e97fce1ba971e0442ac1835492316c0b2f"
 dependencies = [
  "serde",
  "serde_json",
@@ -511,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f5b82eb03c6356e54c041739aaad4bd1a8c25cf19e9b0e9690a32014c3e956"
+checksum = "a5df3f588537611ef80a97ddfaa9fef3d8070553fab051a44e974e66781eff64"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -536,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa8f1cc1d16a7e58b3ecae5d2bc8cd31169923ec531fe0559982e0507619451"
+checksum = "a5245bc666e4270a5706472ab283b10c48f44d3b9c7f0e04303e7e28409e8cd0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -561,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325cf3d04813a5ae8ce92bf4363a4e4da561ce71dd1aca06638ebe9ec0830a52"
+checksum = "6f9612ab9d79a96d32cc80707d9a4f97d9bbf07d78adc0876ccaa9ca2b9b8b92"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
@@ -731,6 +732,15 @@ dependencies = [
  "keyring-core",
  "log",
  "security-framework",
+]
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1099,9 +1109,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitmaps"
@@ -1246,6 +1256,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -1429,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1758,6 +1774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,7 +1819,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2324,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854fcce63deb51e3baac8a5fddc5512c9f437e3ff81c78a78bd08f931672f7ce"
+checksum = "46448d8c4137746b88b66ef7bdfd67b13a981208703936879af11bdecf742519"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
@@ -2409,7 +2431,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -2457,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b7131aa259ef04decb22060173d96b669cffbe172f0ad431f5cb36f1ad9569"
+checksum = "8ac7fa3bbea7023541deabdc0301959bc0ac18dcdde3871a460ac7c9f8435862"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -2721,6 +2743,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -3200,6 +3228,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -4320,7 +4353,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4362,7 +4395,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -4426,9 +4459,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loom"
@@ -4445,11 +4478,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4680,7 +4713,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4905,7 +4938,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -4917,7 +4950,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -4928,7 +4961,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -4947,7 +4980,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4968,7 +5001,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5060,7 +5093,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5147,8 +5180,8 @@ dependencies = [
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.11.0",
- "strum 0.28.0",
- "strum_macros 0.28.0",
+ "strum",
+ "strum_macros",
  "sysinfo",
  "thiserror 2.0.18",
  "tokio",
@@ -5295,6 +5328,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5340,7 +5397,7 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd833ecf8967e65934c49d3521a175929839bf6d0e497f3bd0d3a2ca08943da"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "pcsc-sys",
 ]
 
@@ -5656,7 +5713,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5813,7 +5870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6058,9 +6115,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -6068,22 +6125,26 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
+ "critical-section",
+ "hashbrown 0.17.1",
  "indoc",
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum 0.27.2",
+ "palette",
+ "serde",
+ "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -6092,9 +6153,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -6104,9 +6165,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -6114,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -6124,18 +6185,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.12.1",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -6153,7 +6215,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6232,7 +6294,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6467,7 +6529,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6705,7 +6767,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -6838,9 +6900,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58 0.5.1",
@@ -6858,9 +6920,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -7546,29 +7608,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7669,7 +7713,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -7748,7 +7792,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -8134,7 +8178,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http 1.4.1",
@@ -8457,9 +8501,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b83da57520fdbcf3a7ae45532ff020bb3e732abd6be691ffaf198fb514b612"
+checksum = "c72e9ca533c5452a06b69fa4fd0e1c15d0d146c8fbe06c78b20211cf0c0ebc05"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8627,7 +8671,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -8652,7 +8696,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -8664,7 +8708,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -8676,7 +8720,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9374,7 +9418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5813,7 +5813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8457,9 +8457,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vta-sdk"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca9a9ef918900c67ca3247018cdaeb4382c5647ab6cd3ab365f2b43e9412d23"
+checksum = "95b83da57520fdbcf3a7ae45532ff020bb3e732abd6be691ffaf198fb514b612"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dtg-credentials = "0.1"
 aes-gcm = "0.10"
 argon2 = "0.5"
 affinidi-tdk = "0.7"
-affinidi-data-integrity = "0.6"
+affinidi-data-integrity = "0.7"
 affinidi-messaging-didcomm-service = "0.3"
 anyhow = "1.0"
 arboard = { version = "3.6.1", features = ["wayland-data-control"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tui-input = "0.15"
 url = "2.5"
-uuid = { version = "1.23", features = ["v4", "fast-rng"] }
+uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 vta-sdk = { version = "0.9", features = [
   "session",
   "client",

--- a/did-git-sign/src/main.rs
+++ b/did-git-sign/src/main.rs
@@ -886,8 +886,17 @@ mod tests {
     #[test]
     #[serial_test::serial]
     fn delegate_forwards_all_flags_to_ssh_keygen() {
-        let mock_path =
+        // Copy the mock script into a private temp dir and operate on the COPY —
+        // never mutate the shared, checked-in fixture. Previously this test
+        // chmod'd the fixture in-place, which raced under full-workspace parallel
+        // test runs (the shared file's metadata read could fail mid-mutation),
+        // producing a flaky failure. Each run now owns its own executable copy,
+        // and `tmp_dir` is held for the test's lifetime so it isn't reaped early.
+        let src =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mock_ssh_keygen.sh");
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let mock_path = tmp_dir.path().join("mock_ssh_keygen.sh");
+        std::fs::copy(&src, &mock_path).unwrap();
 
         // Ensure the mock script is executable regardless of git checkout settings.
         #[cfg(unix)]

--- a/docs/design/verifiable-trust-communities-presentation.html
+++ b/docs/design/verifiable-trust-communities-presentation.html
@@ -1,0 +1,894 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Verifiable Trust Communities — From Credentials to Communities</title>
+<style>
+  :root{
+    --bg:#0b1020; --bg2:#121a33; --panel:#16203f; --panel2:#1b2750;
+    --ink:#e8edff; --muted:#9aa7d4; --line:#2b3766;
+    --a:#5eead4;     /* teal   */
+    --b:#a78bfa;     /* violet */
+    --c:#fbbf24;     /* amber  */
+    --d:#60a5fa;     /* blue   */
+    --e:#fb7185;     /* rose   */
+    --ok:#34d399; --warn:#fbbf24; --gate:#fb7185; --plan:#9aa7d4;
+    --r:14px; --shadow:0 18px 50px rgba(0,0,0,.45);
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Inter,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%}
+  body{
+    background:radial-gradient(1200px 700px at 80% -10%,#1a244a 0%,var(--bg) 55%) fixed;
+    color:var(--ink); font-family:var(--sans); -webkit-font-smoothing:antialiased;
+  }
+  .deck{height:100vh;width:100vw;overflow:hidden;position:relative}
+  .slide{
+    position:absolute;inset:0;display:none;flex-direction:column;
+    padding:50px 6.5vw 84px; overflow:auto;
+    animation:fade .45s ease both;
+  }
+  .slide.on{display:flex}
+  @keyframes fade{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
+  h1,h2,h3{margin:0;line-height:1.1;font-weight:800;letter-spacing:-.02em}
+  h1{font-size:clamp(32px,4.8vw,64px)}
+  h2{font-size:clamp(24px,3.2vw,42px)}
+  .kicker{font-family:var(--mono);font-size:13px;letter-spacing:.22em;text-transform:uppercase;color:var(--a);margin-bottom:12px}
+  .sub{color:var(--muted);font-size:clamp(15px,1.5vw,20px);max-width:64ch;margin-top:14px;line-height:1.5}
+  p{line-height:1.55}
+  .grid{display:grid;gap:16px}
+  .card{background:linear-gradient(180deg,var(--panel),var(--bg2));border:1px solid var(--line);border-radius:var(--r);padding:18px 20px;box-shadow:var(--shadow)}
+  .card h3{font-size:18px;margin-bottom:8px}
+  .card p,.card li{color:var(--muted);font-size:14px;line-height:1.5}
+  .tag{display:inline-block;font-family:var(--mono);font-size:11.5px;padding:3px 9px;border-radius:999px;border:1px solid var(--line);color:var(--muted);background:#0e1530}
+  .pill{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:12px;padding:5px 11px;border-radius:999px;border:1px solid var(--line)}
+  .dot{width:8px;height:8px;border-radius:50%;flex:none}
+  .accent-a{color:var(--a)} .accent-b{color:var(--b)} .accent-c{color:var(--c)} .accent-d{color:var(--d)} .accent-e{color:var(--e)}
+  .b-a{border-color:rgba(94,234,212,.5)} .b-b{border-color:rgba(167,139,250,.5)} .b-c{border-color:rgba(251,191,36,.5)} .b-d{border-color:rgba(96,165,250,.5)} .b-e{border-color:rgba(251,113,133,.5)}
+  code,.mono{font-family:var(--mono)}
+  .muted{color:var(--muted)}
+  /* nav */
+  .nav{position:fixed;bottom:20px;left:0;right:0;display:flex;justify-content:center;align-items:center;gap:18px;z-index:20}
+  .nav button{background:var(--panel2);color:var(--ink);border:1px solid var(--line);border-radius:10px;padding:8px 14px;font-size:14px;cursor:pointer;font-family:var(--mono)}
+  .nav button:hover{border-color:var(--a)}
+  .count{font-family:var(--mono);font-size:13px;color:var(--muted);min-width:62px;text-align:center}
+  .progress{position:fixed;top:0;left:0;height:3px;background:linear-gradient(90deg,var(--a),var(--b),var(--c));z-index:30;transition:width .35s}
+  .foot{position:fixed;bottom:22px;right:26px;font-family:var(--mono);font-size:11px;color:var(--muted);z-index:20;letter-spacing:.1em}
+  .hint{position:fixed;bottom:22px;left:26px;font-family:var(--mono);font-size:11px;color:var(--muted);z-index:20}
+  /* journey */
+  .journey{display:grid;grid-template-columns:repeat(4,1fr);gap:0;margin-top:26px;align-items:stretch}
+  .step{position:relative;padding:20px 18px;border:1px solid var(--line);background:linear-gradient(180deg,var(--panel),var(--bg2));margin-right:-1px}
+  .step:first-child{border-radius:var(--r) 0 0 var(--r)}
+  .step:last-child{border-radius:0 var(--r) var(--r) 0;margin-right:0}
+  .step .n{font-family:var(--mono);font-size:12px;color:var(--bg);font-weight:800;width:26px;height:26px;border-radius:50%;display:grid;place-items:center}
+  .step h3{font-size:19px;margin:11px 0 6px}
+  .step p{font-size:13px;color:var(--muted)}
+  .step .role{font-family:var(--mono);font-size:11px;margin-top:11px;color:var(--ink)}
+  /* before/after */
+  .ba{display:grid;grid-template-columns:1fr 56px 1fr;gap:0;align-items:stretch;margin-top:22px}
+  .ba .col{border:1px solid var(--line);border-radius:var(--r);padding:22px;background:linear-gradient(180deg,var(--panel),var(--bg2))}
+  .ba .mid{display:grid;place-items:center;font-size:32px;color:var(--a)}
+  .ba h3{font-size:15px;text-transform:uppercase;letter-spacing:.12em;margin-bottom:14px}
+  .ba ul{margin:0;padding-left:18px}
+  .ba li{margin:8px 0;color:var(--muted);font-size:14px;line-height:1.45}
+  .before h3{color:var(--muted)} .after h3{color:var(--a)}
+  /* sequence */
+  .seq{margin-top:22px;border:1px solid var(--line);border-radius:var(--r);padding:22px 18px;background:#0d1430;overflow:auto}
+  .lanes{display:grid;gap:0;font-family:var(--mono);font-size:12.5px}
+  .lanes .actors{display:grid;margin-bottom:6px}
+  .lanes .actors span{text-align:center;font-weight:700;padding:8px;border:1px solid var(--line);border-radius:8px;background:var(--panel2);margin:0 6px}
+  .msg{display:grid;align-items:center;margin:0;padding:7px 0;border-bottom:1px dashed #233063}
+  .msg:last-child{border-bottom:0}
+  .msg .lbl{grid-column:1/-1;color:var(--muted);font-size:11.5px;padding:2px 8px}
+  .msg .arrow{height:2px;background:var(--d);position:relative;align-self:center;margin:0 8px}
+  .msg .arrow.rev{background:var(--a)}
+  .msg .arrow::after{content:"";position:absolute;right:-1px;top:-4px;border:5px solid transparent;border-left-color:var(--d)}
+  .msg .arrow.rev::after{right:auto;left:-1px;border-left-color:transparent;border-right-color:var(--a)}
+  .msg .arrow.gate{background:var(--gate)} .msg .arrow.gate::after{border-left-color:var(--gate)}
+  /* table */
+  table{border-collapse:collapse;width:100%;margin-top:20px;font-size:14px}
+  th,td{text-align:left;padding:11px 13px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+  td .st{font-family:var(--mono);font-size:11px;padding:3px 8px;border-radius:6px;white-space:nowrap}
+  .live{background:rgba(52,211,153,.15);color:var(--ok);border:1px solid rgba(52,211,153,.4)}
+  .gated{background:rgba(251,113,133,.13);color:var(--gate);border:1px solid rgba(251,113,133,.4)}
+  .planned{background:rgba(251,191,36,.12);color:var(--warn);border:1px solid rgba(251,191,36,.4)}
+  /* chips */
+  .chips{display:flex;flex-wrap:wrap;gap:11px;margin-top:22px}
+  .chip{border:1px solid var(--line);border-radius:12px;padding:13px 15px;background:linear-gradient(180deg,var(--panel),var(--bg2));min-width:190px;flex:1 1 210px}
+  .chip .s{font-family:var(--mono);font-size:11px;color:var(--a);letter-spacing:.12em}
+  .chip .t{font-weight:700;margin-top:5px;font-size:15px}
+  .chip .d{color:var(--muted);font-size:12.5px;margin-top:4px}
+  /* roadmap */
+  .road{display:flex;gap:0;margin-top:26px;align-items:stretch}
+  .phase{flex:1;border:1px solid var(--line);padding:16px 14px;background:linear-gradient(180deg,var(--panel),var(--bg2));margin-right:-1px}
+  .phase:first-child{border-radius:var(--r) 0 0 var(--r)}
+  .phase:last-child{border-radius:0 var(--r) var(--r) 0;margin-right:0}
+  .phase .ph{font-family:var(--mono);font-size:11px;color:var(--c);letter-spacing:.12em}
+  .phase h3{font-size:15px;margin:8px 0 8px}
+  .phase ul{margin:0;padding-left:15px} .phase li{color:var(--muted);font-size:12px;margin:5px 0}
+  .barwrap{margin-top:8px}
+  .bar{height:9px;border-radius:6px;background:#0e1530;overflow:hidden;border:1px solid var(--line)}
+  .bar > span{display:block;height:100%;background:linear-gradient(90deg,var(--a),var(--b))}
+  .lead{font-size:clamp(17px,1.8vw,22px);line-height:1.5;max-width:66ch}
+  .two{grid-template-columns:1fr 1fr}
+  .three{grid-template-columns:1fr 1fr 1fr}
+  .four{grid-template-columns:repeat(4,1fr)}
+  .card.center{display:grid;place-content:center;text-align:center}
+  .slide.closing{justify-content:center;align-items:center;text-align:center}
+  .slide.closing h1,.slide.closing .sub{margin-left:auto;margin-right:auto}
+  .big-num{font-size:50px;font-weight:800;font-family:var(--mono)}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;margin-top:16px;font-size:12.5px;color:var(--muted)}
+  .legend span{display:inline-flex;align-items:center;gap:7px}
+  a{color:var(--a)}
+  /* layer model */
+  .layers{display:grid;gap:14px;margin-top:24px}
+  .layer{display:grid;grid-template-columns:200px 1fr;gap:18px;align-items:center;border:1px solid var(--line);border-radius:var(--r);padding:18px 22px;background:linear-gradient(180deg,var(--panel),var(--bg2))}
+  .layer .who{font-weight:800;font-size:19px}
+  .layer .who .role{display:block;font-family:var(--mono);font-size:11px;color:var(--muted);font-weight:500;margin-top:5px;letter-spacing:.04em}
+  .layer .what{color:var(--muted);font-size:14.5px;line-height:1.5}
+  .layer.la{border-left:4px solid var(--a)} .layer.lb{border-left:4px solid var(--b)} .layer.ld{border-left:4px solid var(--d)}
+  /* pipeline strip */
+  .pipe{display:flex;flex-wrap:wrap;gap:0;margin-top:24px;align-items:stretch}
+  .pstage{flex:1;min-width:110px;border:1px solid var(--line);padding:14px 12px;background:linear-gradient(180deg,var(--panel),var(--bg2));margin-right:-1px;text-align:center}
+  .pstage:first-child{border-radius:var(--r) 0 0 var(--r)}
+  .pstage:last-child{border-radius:0 var(--r) var(--r) 0;margin-right:0}
+  .pstage .pn{font-family:var(--mono);font-size:10.5px;color:var(--muted);letter-spacing:.1em}
+  .pstage .pt{font-weight:700;margin-top:6px;font-size:14.5px}
+  .pstage .pd{color:var(--muted);font-size:11.5px;margin-top:5px;line-height:1.4}
+  .verdicts{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px}
+  .verdict{border:1px solid var(--line);border-radius:10px;padding:10px 14px;flex:1 1 150px}
+  .verdict .vt{font-family:var(--mono);font-weight:700;font-size:13px}
+  .verdict .vd{color:var(--muted);font-size:12px;margin-top:3px}
+  /* TUI mockup */
+  .tui{font-family:var(--mono);font-size:13px;line-height:1.5;background:#070b16;border:1px solid var(--line);
+    border-radius:12px;padding:16px 18px;color:#cdd6e4;box-shadow:var(--shadow);white-space:pre;overflow-x:auto;margin-top:18px}
+  .tui .ok{color:var(--ok)} .tui .pend{color:var(--warn)} .tui .off{color:var(--muted)}
+  .tui .warn{color:var(--gate)} .tui .acc{color:var(--a)} .tui .vio{color:var(--b)} .tui .blu{color:var(--d)}
+  .caption{color:var(--muted);font-size:12.5px;margin-top:10px;font-style:italic}
+  .note{background:rgba(94,234,212,.07);border:1px solid rgba(94,234,212,.3);border-radius:12px;padding:13px 17px;color:var(--ink);font-size:14.5px;margin-top:18px}
+  /* act divider */
+  .slide.act{justify-content:center}
+  .actnum{font-family:var(--mono);font-size:15px;letter-spacing:.3em;color:var(--b)}
+  .actline{height:1px;background:linear-gradient(90deg,transparent,var(--line),transparent);margin:26px 0;max-width:560px}
+  @media (max-width:900px){
+    .journey,.road,.pipe{grid-template-columns:1fr;display:grid}
+    .ba{grid-template-columns:1fr}.ba .mid{transform:rotate(90deg)}
+    .two,.three,.four{grid-template-columns:1fr}
+    .layer{grid-template-columns:1fr}
+  }
+  @media print{
+    .slide{display:flex!important;position:relative;height:auto;page-break-after:always;animation:none}
+    .nav,.foot,.hint,.progress{display:none}
+    body,.deck{height:auto;overflow:visible}
+  }
+</style>
+</head>
+<body>
+<div class="progress" id="bar"></div>
+<div class="deck" id="deck">
+
+  <!-- 1 — TITLE -->
+  <section class="slide on">
+    <div class="kicker">OpenVTC · Verifiable Trust Infrastructure · Combined Design Review</div>
+    <h1>From Credentials to Communities</h1>
+    <h2 style="margin-top:10px;color:var(--muted);font-weight:600">One trust fabric — held, presented, governed, and lived across many communities</h2>
+    <p class="sub">Three layers, one story. A member <strong class="accent-a">holds</strong> and <strong class="accent-a">presents</strong> verifiable credentials (VTA); a community <strong class="accent-b">governs</strong> every state transition through one policy pipeline you can <strong class="accent-b">simulate live</strong> (VTC); and a person <strong class="accent-d">joins and operates</strong> in many communities at once (OpenVTC).</p>
+    <div class="legend">
+      <span><i class="dot" style="background:var(--ok)"></i>Shipped &amp; live</span>
+      <span><i class="dot" style="background:var(--gate)"></i>Gated (audit / Phase-0)</span>
+      <span><i class="dot" style="background:var(--warn)"></i>Planned</span>
+    </div>
+    <div style="margin-top:30px;display:flex;gap:10px;flex-wrap:wrap">
+      <span class="pill b-a"><i class="dot" style="background:var(--a)"></i>VTA = credential agent · hold + present</span>
+      <span class="pill b-b"><i class="dot" style="background:var(--b)"></i>VTC = issuer · verifier · governed ceremonies</span>
+      <span class="pill b-d"><i class="dot" style="background:var(--d)"></i>OpenVTC = multi-community member experience</span>
+    </div>
+    <p class="muted mono" style="margin-top:24px;font-size:11.5px">← → · Space · Home/End · mockups are illustrative, not screenshots</p>
+  </section>
+
+  <!-- 1a — A WEEK AGO (BASELINE) -->
+  <section class="slide">
+    <div class="kicker">Where we were · ~one week ago</div>
+    <h2>The baseline — start of the sprint</h2>
+    <p class="sub">As of late May 2026, the three components were solid but conventional: keys, ACLs, roles, and a single identity. None of the credential-centric machinery, governed ceremonies, or multi-community model existed yet.</p>
+    <div class="grid three" style="margin-top:22px">
+      <div class="card" style="border-top:3px solid var(--gate)">
+        <h3 class="accent-a">VTA</h3>
+        <ul style="padding-left:17px">
+          <li>Key manager + signing oracle (BIP-32), ACL keyspace</li>
+          <li>A <em>secrets</em> vault just taking shape (M1/M2: upsert · get · proxy-login / SIOP)</li>
+          <li>did-management 0.1, per-DID hosting domains</li>
+          <li><span class="accent-e">No credential vault · no OID4VCI/VP · no DCQL</span></li>
+        </ul>
+      </div>
+      <div class="card" style="border-top:3px solid var(--gate)">
+        <h3 class="accent-b">VTC</h3>
+        <ul style="padding-left:17px">
+          <li>Community service: ACL, members, join-requests, audit, status lists</li>
+          <li>Policy via <code>regorus</code> — but raw-Rego upload, flat status enum</li>
+          <li>Accept-any default posture</li>
+          <li><span class="accent-e">No decision pipeline · no ceremonies · no simulator</span></li>
+        </ul>
+      </div>
+      <div class="card" style="border-top:3px solid var(--gate)">
+        <h3 class="accent-d">OpenVTC</h3>
+        <ul style="padding-left:17px">
+          <li>Single-identity CLI / TUI · v0.2.1 (nine security fixes)</li>
+          <li>One persona, one VTA, one mediator, one flat context</li>
+          <li>Monolithic ~19-step setup</li>
+          <li><span class="accent-e">No communities · no multi-membership</span></li>
+        </ul>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:14px;font-size:13px">Good foundations — but trust was still “a row in an ACL + a role in a JWT,” and belonging was singular.</p>
+  </section>
+
+  <!-- 1b — THIS WEEK (THE SPRINT) -->
+  <section class="slide">
+    <div class="kicker">What we've been building · 2026-05-29 → 06-04</div>
+    <h2>Seven days, three layers — nothing to largely live</h2>
+    <p class="sub">In one week the trust fabric was rebuilt around credentials, governed ceremonies, and multi-community membership. The rest of this deck is that work, in depth.</p>
+    <div class="grid three" style="margin-top:22px">
+      <div class="card b-a">
+        <h3 class="accent-a">VTA → credential agent</h3>
+        <ul style="padding-left:17px">
+          <li>Format-agnostic vault: receive · match · mint · present · status</li>
+          <li>SD-JWT-VC + W3C Data-Integrity, encrypted at rest</li>
+          <li>OID4VCI issuance + OID4VP/DCQL presentation over DIDComm</li>
+          <li>Consent records (ISO/IEC 27560 + DPV); ZKP Phase-0 gate</li>
+        </ul>
+      </div>
+      <div class="card b-b">
+        <h3 class="accent-b">VTC → governed ceremonies</h3>
+        <ul style="padding-left:17px">
+          <li>One decision pipeline + four ceremonies <strong>live</strong></li>
+          <li>Effect executor; Phase-2 schema authority (DTG catalog)</li>
+          <li>A working, daemon-wired <strong>ceremony simulator</strong></li>
+          <li>Visual Rule-IR authoring → Rego + Presentation Definition</li>
+        </ul>
+      </div>
+      <div class="card b-d">
+        <h3 class="accent-d">OpenVTC → multi-community</h3>
+        <ul style="padding-left:17px">
+          <li>Design spec + 9-task plan locked (D1–D17)</li>
+          <li>Account → personas → communities model</li>
+          <li>T1 (config v2 + identity + session manager) in progress</li>
+          <li>Plus: mobile agent, device wake, delegated step-up</li>
+        </ul>
+      </div>
+    </div>
+    <div class="legend" style="margin-top:16px">
+      <span><i class="dot" style="background:var(--ok)"></i><strong>50+ commits</strong> across the three layers</span>
+      <span><i class="dot" style="background:var(--a)"></i>13 PRs in the credential line alone</span>
+      <span><i class="dot" style="background:var(--b)"></i>join · leave · role-change · directory all live</span>
+    </div>
+  </section>
+
+  <!-- 2 — THE MENTAL MODEL -->
+  <section class="slide">
+    <div class="kicker">The mental model</div>
+    <h2>Three layers, one trust fabric</h2>
+    <p class="sub">Each layer was a separate design effort. Read top-to-bottom they are a single pipeline: a credential is held, presented into a governed decision, and the result becomes a community you live in.</p>
+    <div class="layers">
+      <div class="layer la">
+        <div class="who accent-a">Hold &amp; Present<span class="role">VTA · credential agent</span></div>
+        <div class="what">A format-agnostic vault holds credentials encrypted at rest; the agent receives (OpenID4VCI), matches (DCQL), and presents (OpenID4VP) selectively, under per-disclosure consent. <em>Trust the member carries.</em></div>
+      </div>
+      <div class="layer lb">
+        <div class="who accent-b">Decide<span class="role">VTC · governed ceremonies</span></div>
+        <div class="what">Every community state transition — join, leave, role-change, directory — is one policy pipeline producing a four-valued verdict, authored visually and <strong>dry-run in a live simulator</strong> before it ever touches state. <em>Trust the community governs.</em></div>
+      </div>
+      <div class="layer ld">
+        <div class="who accent-d">Experience<span class="role">OpenVTC · member CLI/TUI</span></div>
+        <div class="what">A person bootstraps an account, mints per-community identities, joins many Verifiable Trust Communities, and runs concurrent live sessions from one Communities hub. <em>Trust you actually live in.</em></div>
+      </div>
+    </div>
+    <p class="note">The join ceremony is the spine that threads all three: OpenVTC submits a presentation → the VTA assembles it from held credentials → the VTC ceremony pipeline verifies and decides → the member is admitted and issued their membership credential.</p>
+  </section>
+
+  <!-- 3 — THE SHIFT (two shifts) -->
+  <section class="slide">
+    <div class="kicker">Executive summary</div>
+    <h2>Two shifts, one direction</h2>
+    <div class="grid two" style="margin-top:22px">
+      <div class="card b-a">
+        <h3 class="accent-a">Infrastructure shift</h3>
+        <p class="lead" style="font-size:17px;color:var(--ink)">Authorization moved from <strong class="accent-e">“a row in an ACL + a role in a JWT”</strong> to <strong class="accent-a">“a verifiable credential the member holds and presents.”</strong></p>
+        <p style="margin-top:10px">Trust becomes portable, standards-native, privacy-preserving, and re-verifiable by anyone — not just by us.</p>
+      </div>
+      <div class="card b-d">
+        <h3 class="accent-d">Experience shift</h3>
+        <p class="lead" style="font-size:17px;color:var(--ink)">Identity moved from <strong class="accent-e">“one persona, one authority, one flat context”</strong> to <strong class="accent-d">“an account with many personas across many communities.”</strong></p>
+        <p style="margin-top:10px">Belonging becomes plural: per-community identities, a Communities hub, and concurrent live sessions.</p>
+      </div>
+    </div>
+    <div class="grid three" style="margin-top:16px">
+      <div class="card b-a"><h3 class="accent-a">Portable</h3><p>Membership and roles become W3C VCs the holder carries — usable beyond a single VTA/VTC, by external verifiers that show up later.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Governable</h3><p>One decision pipeline per community, authored without code and simulated before activation. Policy is versioned, signed, and rollback-able.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Privacy-preserving</h3><p>Selective disclosure (SD-JWT-VC, BBS+), per-disclosure consent records, and a vault with <em>no enumeration</em> primitive.</p></div>
+    </div>
+  </section>
+
+  <!-- 4 — BEFORE / AFTER ARCHITECTURE -->
+  <section class="slide">
+    <div class="kicker">Before &nbsp;→&nbsp; After · architecture</div>
+    <h2>What changed under the hood</h2>
+    <div class="ba">
+      <div class="col before">
+        <h3>Before — ACL &amp; keys</h3>
+        <ul>
+          <li><strong>VTA</strong> = key manager (BIP-32, signing oracle) + an ACL keyspace.</li>
+          <li><strong>Authorization</strong> = an ACL entry + a <code>role</code> claim baked into a JWT.</li>
+          <li><strong>Join</strong> = bespoke: submit a VP, an admin approves, the membership credential is handed back <em>inline in the HTTP response</em>.</li>
+          <li><strong>Governance</strong> = accept-any default; raw-Rego upload; a flat status enum.</li>
+          <li>One persona, one mediator, one flat context — no notion of multi-membership.</li>
+        </ul>
+      </div>
+      <div class="mid">⟶</div>
+      <div class="col after">
+        <h3>After — hold, present &amp; govern</h3>
+        <ul>
+          <li><strong>VTA</strong> = credential agent with a <strong class="accent-a">format-agnostic vault</strong> (hold) + receive / match / present.</li>
+          <li><strong>Authorization</strong> = a <strong class="accent-b">held Role VC</strong> → a verified-assertion cache; the ACL becomes a <em>derived index</em>.</li>
+          <li><strong>Join</strong> = invite → hold → present (DCQL) → a governed ceremony verdict → admit + issue.</li>
+          <li><strong>Governance</strong> = one default-deny pipeline per purpose; visual Rule IR → Rego; signed policy log + rollback.</li>
+          <li><strong>Account → many personas → many communities</strong>, concurrent live sessions.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- 5 — THE CREDENTIAL MACHINERY -->
+  <section class="slide">
+    <div class="kicker">Layer 1 · Hold &amp; Present</div>
+    <h2>The member journey — invite → hold → present → join</h2>
+    <p class="sub">A prospective member is invited, holds the invitation, presents it on demand, and is admitted — each arrow a standards-based protocol message.</p>
+    <div class="journey">
+      <div class="step"><span class="n" style="background:var(--a)">1</span><h3 class="accent-a">Invite</h3><p>The VTC <strong>issues</strong> a membership credential offer to the prospect's DID — an OpenID4VCI pre-authorized offer.</p><div class="role">VTC → holder · <span class="muted">offer</span></div></div>
+      <div class="step"><span class="n" style="background:var(--d)">2</span><h3 class="accent-d">Hold</h3><p>The VTA <strong>redeems</strong> with a key-binding proof, receives the credential, stores it in the vault (format-agnostic, encrypted).</p><div class="role">holder ⇄ VTC · <span class="muted">request → issue</span></div></div>
+      <div class="step"><span class="n" style="background:var(--b)">3</span><h3 class="accent-b">Present</h3><p>At join, the VTC sends a <strong>DCQL query</strong>. The VTA matches over its vault (no enumeration), gates on consent, builds a selectively-disclosed VP.</p><div class="role">VTC → holder → VTC · <span class="muted">query → present</span></div></div>
+      <div class="step"><span class="n" style="background:var(--c)">4</span><h3 class="accent-c">Join</h3><p>The VTC <strong>verifies</strong> the VP → runs the join ceremony → admits → issues VMC + Role VEC. The member now holds those too.</p><div class="role">VTC · <span class="muted">verify → decide → issue</span></div></div>
+    </div>
+    <p class="muted" style="margin-top:16px;font-size:13px">Every step is the <strong>same credential machinery</strong> — issuance is presentation's mirror image. Build it once, reuse it for invites, memberships, roles, endorsements.</p>
+  </section>
+
+  <!-- 6 — ISSUANCE SEQUENCE -->
+  <section class="slide">
+    <div class="kicker">Layer 1 · Flow A · Issuance</div>
+    <h2>OpenID4VCI over DIDComm — <span class="mono accent-a">offer → request → issue</span></h2>
+    <div class="seq">
+      <div class="lanes">
+        <div class="actors" style="grid-template-columns:1fr 1fr 1fr">
+          <span class="accent-b">VTC (issuer)</span><span class="accent-a">VTA (holder)</span><span class="accent-c">Vault</span>
+        </div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">① <code>credential-exchange/offer</code> — pre-authorized code (doubles as the proof nonce)</div><div style="grid-column:1/3" class="arrow"></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">② <code>credential-exchange/request</code> — holder signs an OID4VCI <em>key-binding proof</em> (EdDSA, bound to its did:key)</div><div></div><div style="grid-column:1/3" class="arrow rev"></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">③ Issuer <strong>verifies the proof</strong> → proven holder DID must equal the credential's subject (else <code>Forbidden</code>)</div><div class="arrow gate" style="grid-column:1/2"></div><div></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">④ <code>credential-exchange/issue</code> — the credential (single-use offer consumed on success only)</div><div style="grid-column:1/3" class="arrow"></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">⑤ Holder infers format, stores via the format-agnostic <code>vault::receive</code> (encrypted at rest)</div><div></div><div style="grid-column:2/4" class="arrow"></div></div>
+      </div>
+    </div>
+    <div class="grid three" style="margin-top:18px">
+      <div class="card b-a"><h3 class="accent-a">Holder binding is the gate</h3><p>A credential is released only to a party that proves possession of the subject key — the heart of OID4VCI, and the part every implementation otherwise hand-rolls.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Relayer ≠ holder is safe</h3><p>DIDComm authcrypt authenticates the relayer; the inner key-binding proof authenticates the holder. They may differ (air-gapped onboarding) with no escalation.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Single-use, DoS-resistant</h3><p>The pending offer is consumed <em>only</em> on a successful issue — a forged or wrong-party request can't burn the legitimate holder's offer.</p></div>
+    </div>
+  </section>
+
+  <!-- 7 — PRESENTATION SEQUENCE -->
+  <section class="slide">
+    <div class="kicker">Layer 1 · Flow B · Presentation</div>
+    <h2>OpenID4VP + DCQL — <span class="mono accent-b">query → match → present</span></h2>
+    <div class="seq">
+      <div class="lanes">
+        <div class="actors" style="grid-template-columns:1fr 1fr 1fr">
+          <span class="accent-b">VTC (verifier)</span><span class="accent-a">VTA (holder)</span><span class="accent-c">Vault</span>
+        </div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">① <code>credential-exchange/query</code> — DCQL query + nonce + <strong>mandatory purpose</strong> (shown to the holder)</div><div style="grid-column:1/3" class="arrow"></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">② Holder gathers candidates by the <code>vct</code>/type index — <strong>no wallet enumeration</strong></div><div></div><div style="grid-column:2/4" class="arrow"></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">③ <code>DcqlQuery::match_credentials</code> → which held credentials satisfy it + the claim paths to disclose</div><div></div><div style="grid-column:2/3;justify-self:center" class="tag">match</div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">④ <strong>Consent gate</strong> (ISO/IEC 27560 + DPV) + selectively-disclosed <code>present</code> → <code>vp_token</code></div><div></div><div class="arrow gate" style="grid-column:2/3"></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">⑤ <code>credential-exchange/present</code> — holder-bound VP; verifier checks binding · status · issuer trust · DCQL</div><div></div><div style="grid-column:1/3" class="arrow rev"></div></div>
+      </div>
+    </div>
+    <div class="grid two" style="margin-top:18px">
+      <div class="card b-a"><h3 class="accent-a">No-enumeration is a feature</h3><p>The vault exposes no “list everything.” Discovery is only via an indexed field + value, so a query with no discriminator returns <em>nothing</em> — the holder never blind-scans its wallet to answer a verifier.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Disclose exactly what was consented</h3><p>The reveal set <em>is</em> the consent record's personal-data list. SD-JWT-VC redacts to the consented subset; plain DI refuses to over-disclose.</p></div>
+    </div>
+  </section>
+
+  <!-- 8 — VAULT -->
+  <section class="slide">
+    <div class="kicker">Layer 1 · the keystone</div>
+    <h2>One vault, every credential format</h2>
+    <p class="sub">The vault and the exchange abstract over credential <em>format</em>, driven by the DCQL <code>format</code> selector. Adding a format never touches the storage schema — every wire op depends on this bridge.</p>
+    <table>
+      <thead><tr><th>Format</th><th>Standard</th><th>Selective disclosure</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td><code>SdJwtVc</code></td><td>IETF SD-JWT-VC + kb-jwt</td><td>Per-claim (selective-disclosures)</td><td><span class="st live">first-class · live</span></td></tr>
+        <tr><td><code>EddsaJcs2022</code></td><td>W3C Data Integrity (eddsa-jcs-2022)</td><td>Whole-credential, holder-bound VP</td><td><span class="st live">first-class · live</span></td></tr>
+        <tr><td><code>Bbs2023</code></td><td>W3C DI · BBS+ (BLS12-381)</td><td>Per-claim + <em>unlinkable</em></td><td><span class="st gated">additive · audit-gated</span></td></tr>
+        <tr><td><code>Zkp</code></td><td>Circom · BabyJubJub-EdDSA + Poseidon</td><td>ZK predicates (future circuit)</td><td><span class="st gated">additive · Phase-0 gate</span></td></tr>
+        <tr><td><code>Other(tag)</code></td><td>forward-compat escape hatch</td><td>—</td><td><span class="st planned">round-trips losslessly</span></td></tr>
+      </tbody>
+    </table>
+    <p class="muted" style="margin-top:16px;font-size:13px"><strong>Decision (Option C):</strong> SD-JWT-VC + W3C-DI are first-class now; BBS+ slots in once its audit clears; a Circom ZKP option is gated behind packaging + a trusted setup. The enum is <em>additive</em> — a new variant is a new arm, never a migration.</p>
+  </section>
+
+  <!-- 9 — VTC DECISION PIPELINE -->
+  <section class="slide">
+    <div class="kicker">Layer 2 · Decide</div>
+    <h2>One decision pipeline; every ceremony is an instance</h2>
+    <p class="sub">A community has many governed state transitions. Rather than a bespoke subsystem per ceremony, every transition flows through the same pipeline, parameterized only by purpose.</p>
+    <div class="pipe">
+      <div class="pstage"><div class="pn">1</div><div class="pt">Trigger</div><div class="pd">a Trust Task arrives</div></div>
+      <div class="pstage"><div class="pn">2</div><div class="pt">Gather</div><div class="pd">collect evidence</div></div>
+      <div class="pstage"><div class="pn">3</div><div class="pt accent-e">Verify</div><div class="pd">crypto only here → <code>Verified*</code></div></div>
+      <div class="pstage"><div class="pn">4</div><div class="pt">Facts</div><div class="pd">typed, verified view</div></div>
+      <div class="pstage"><div class="pn">5</div><div class="pt accent-b">Evaluate</div><div class="pd">&lt;purpose&gt;.rego</div></div>
+      <div class="pstage"><div class="pn">6</div><div class="pt">Verdict</div><div class="pd">four-valued</div></div>
+      <div class="pstage"><div class="pn">7</div><div class="pt">Effects</div><div class="pd">&lt;purpose&gt; handler</div></div>
+    </div>
+    <div class="verdicts">
+      <div class="verdict b-a"><div class="vt accent-a">allow</div><div class="vd">the transition proceeds</div></div>
+      <div class="verdict b-e"><div class="vt accent-e">deny</div><div class="vd">refused</div></div>
+      <div class="verdict b-b"><div class="vt accent-b">refer</div><div class="vd">needs a human / quorum</div></div>
+      <div class="verdict b-c"><div class="vt accent-c">request_more</div><div class="vd">needs more evidence (threaded, async)</div></div>
+    </div>
+    <p class="note">The expensive parts — verification, the four-valued verdict, versioning/rollback, governance, the visual policy compiler — are built <strong>once</strong> and inherited by every ceremony. A new ceremony is a policy module + an evidence slot + an effect handler, <em>not</em> a new subsystem.</p>
+  </section>
+
+  <!-- 10 — CEREMONY CATALOG -->
+  <section class="slide">
+    <div class="kicker">Layer 2 · proven, not asserted</div>
+    <h2>Four maximally-different ceremonies, one pipeline</h2>
+    <p class="sub">If the pipeline only fit join, it would be a join feature. These four were chosen to be as different as possible — and all run through the same machinery.</p>
+    <table>
+      <thead><tr><th>Ceremony</th><th>Nature</th><th>actor = subject?</th><th>Effect</th><th>Invariant</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td><strong class="accent-a">Join</strong></td><td>constructive</td><td>yes</td><td>issue VMC + Role VEC</td><td>privilege ceiling</td><td><span class="st live">live</span></td></tr>
+        <tr><td><strong class="accent-e">Leave</strong></td><td>destructive</td><td>no</td><td>revoke (status-list flip)</td><td>no-last-admin</td><td><span class="st live">live</span></td></tr>
+        <tr><td><strong class="accent-b">Role change</strong></td><td>mutating</td><td>no</td><td>re-issue role VEC</td><td>ceiling + step-up</td><td><span class="st live">live</span></td></tr>
+        <tr><td><strong class="accent-d">Directory</strong></td><td>read-only</td><td>no</td><td>return a filtered projection</td><td>PII boundary</td><td><span class="st live">live</span></td></tr>
+      </tbody>
+    </table>
+    <p class="muted" style="margin-top:16px;font-size:13px">Join and Leave invert each other (constructive/self vs destructive/other). <strong>Directory is the stress test</strong> — a synchronous read returning a projection, proving threads and effects are optional, purpose-specific stages. One signed policy compiles to <strong>Rego</strong> (enforce) + a <strong>DIF Presentation Definition</strong> (so clients self-assemble evidence) + <strong>plain English</strong>.</p>
+  </section>
+
+  <!-- 11 — THE WORKING SIMULATOR -->
+  <section class="slide">
+    <div class="kicker">Layer 2 · the working ceremony simulator</div>
+    <h2>Dry-run any ceremony, live, before it touches state</h2>
+    <p class="sub">Built into the VTC admin-UI and wired to the running daemon, the simulator assembles a verified-Facts document and evaluates the <em>active</em> policy via <code>POST /v1/policies/{id}/test</code> — the same <code>decide()</code> the routes run, minus the effect. State is never mutated.</p>
+    <pre class="tui">┌─ Ceremonies · <span class="acc">Join</span> ─────────────────────  policy: <span class="vio">join v7 · active</span> ─┐
+│ Trigger → Gather → <span class="warn">Verify</span> → Facts → <span class="vio">Evaluate</span> → Verdict → Effects │
+│    <span class="ok">●</span>       <span class="ok">●</span>        <span class="ok">●</span>      <span class="ok">●</span>        <span class="ok">●</span>         <span class="pend">◑</span>        <span class="off">○</span>      │
+├──────────────────────────────────────────────────────────────────┤
+│ Facts (verified)                        Verdict                    │
+│   actor   <span class="blu">did:key:zApplicant</span>  <span class="ok">✓</span>        <span class="pend">◑ request_more</span>            │
+│   cred    MembershipInvite     <span class="ok">✓ trusted</span>  needs:                  │
+│   issuer  <span class="blu">did:webvh:notary…</span>   <span class="ok">✓</span>          · <span class="pend">proof:age_over_18</span>    │
+│                                           · <span class="pend">vc:Endorsement</span>       │
+│   [ <span class="acc">satisfy need</span> ]  [ <span class="acc">re-run</span> ]         → routes to: <span class="vio">moderator</span>   │
+├──────────────────────────────────────────────────────────────────┤
+│ <span class="off">POST /v1/policies/join/test — dry-run · never mutates state</span>      │
+└──────────────────────────────────────────────────────────────────┘</pre>
+    <div class="grid three" style="margin-top:16px">
+      <div class="card b-c"><h3 class="accent-c">Models the negotiation</h3><p>A <code>request_more</code> verdict carries the <code>needs</code> it's missing. Satisfy a need and re-run — exactly the way an applicant would supply it and re-present. The threaded async loop, made tangible.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Authored without raw Rego</h3><p>Operators edit a visual Rule IR that compiles to Rego + a Presentation Definition + English. The simulator checks invariants and shows the real four-valued verdict before activation.</p></div>
+      <div class="card b-a"><h3 class="accent-a">Safe by construction</h3><p>The test endpoint evaluates the active policy and returns a verdict — it never runs effects, so it can't issue, revoke, or admit. Inspect before you commit; version &amp; roll back the policy if wrong.</p></div>
+    </div>
+  </section>
+
+  <!-- 12 — MULTI-COMMUNITY: DATA MODEL -->
+  <section class="slide">
+    <div class="kicker">Layer 3 · Experience</div>
+    <h2>From a profile-singleton to an account graph</h2>
+    <div class="ba">
+      <div class="col before">
+        <h3>Today — one identity, one authority</h3>
+        <ul>
+          <li>One persona DID, one VTA, one mediator, one flat context.</li>
+          <li>A single monolithic ~19-step setup that creates <em>everything</em> up front — including a <code>did:webvh</code> you may not need yet.</li>
+          <li>A single DIDComm session / message loop.</li>
+          <li>No notion of communities, joining, or membership.</li>
+        </ul>
+      </div>
+      <div class="mid">⟶</div>
+      <div class="col after">
+        <h3>After — account → personas → communities</h3>
+        <ul>
+          <li><strong>Account</strong> (vta_did, admin credential, top context) → many <strong>personas</strong> (did:webvh, keys at VTA) → many <strong>communities</strong> (vtc_did, sub-context, persona_ref, status).</li>
+          <li>Personas are <strong>account-level &amp; reusable</strong>; identity is minted <em>lazily</em>, per community.</li>
+          <li><strong>VTA is the system of record</strong> for keys/credentials; local config is metadata + references.</li>
+          <li>A <strong>Communities hub</strong>; the main page is community-scoped with a switcher.</li>
+        </ul>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:14px;font-size:13px">No persona DID is created at bootstrap — privacy by default, and you reveal a linkable identity only when (and where) you choose to.</p>
+  </section>
+
+  <!-- 13 — SETUP SPLIT -->
+  <section class="slide">
+    <div class="kicker">Layer 3 · setup</div>
+    <h2>Setup splits: bootstrap an account, then join communities</h2>
+    <div class="grid two">
+      <div class="card b-a">
+        <h3 class="accent-a">State A · bootstrap (no DID)</h3>
+        <ul style="padding-left:18px">
+          <li>Enter VTA DID → ACL / admin rotate</li>
+          <li>Create the top-level context</li>
+          <li>Protect &amp; land in the Communities hub</li>
+        </ul>
+        <p style="margin-top:8px">No identity minted yet — you have an account, nothing linkable.</p>
+      </div>
+      <div class="card b-d">
+        <h3 class="accent-d">State B · join a community</h3>
+        <ul style="padding-left:18px">
+          <li>Enter VTC DID → resolve the community</li>
+          <li>Mint a new persona <em>or</em> reuse one (you choose)</li>
+          <li>Bring up a live session, submit join → receipt</li>
+        </ul>
+        <p style="margin-top:8px">Persona + session come up <em>before</em> submit so the VTC's async reply is receivable.</p>
+      </div>
+    </div>
+    <p class="note">Old config is a breaking reset, not a migration — a clean, full refactor with no shim. Personas are self-contained and context-independent; the mediator defaults to the VTA's with an optional per-DID override.</p>
+  </section>
+
+  <!-- 14 — THE JOIN, END TO END (THE SPINE) -->
+  <section class="slide">
+    <div class="kicker">Where the three layers meet</div>
+    <h2>The join, end-to-end — the stub becomes real</h2>
+    <p class="sub">OpenVTC's join flow ships today with a <strong>stub VP</strong>. The credential machinery (Layer 1) and the ceremony pipeline (Layer 2) are precisely what turn that stub into a real held-and-presented credential, governed by community policy.</p>
+    <div class="seq">
+      <div class="lanes">
+        <div class="actors" style="grid-template-columns:1fr 1fr 1fr">
+          <span class="accent-d">OpenVTC (member)</span><span class="accent-a">VTA (holder)</span><span class="accent-b">VTC (ceremony)</span>
+        </div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">① Member picks/mints a persona, brings up a live session, taps “Join”</div><div style="grid-column:1/2" class="arrow"></div><div></div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">② VTC verifier sends a <strong>DCQL query</strong> (today: trivially satisfied → stub)</div><div></div><div style="grid-column:2/4" class="arrow rev"></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">③ VTA matches the vault, consent-gates, builds a <strong>real selectively-disclosed VP</strong></div><div></div><div style="grid-column:2/3;justify-self:center" class="tag">present</div><div></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">④ VTC runs the <strong>join ceremony</strong> → verdict (allow / refer / request_more / deny)</div><div></div><div></div><div class="arrow gate" style="grid-column:3/4"></div></div>
+        <div class="msg" style="grid-template-columns:1fr 1fr 1fr"><div class="lbl">⑤ On allow: admit + <strong>issue VMC + Role VEC</strong> → member holds them; status flips to <span class="accent-a">Active</span></div><div style="grid-column:1/4" class="arrow rev"></div></div>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:14px;font-size:13px">Same DCQL match the VTA already runs; same four-valued verdict the simulator already shows. The deferred work is wiring OpenVTC's stub to the live present + decide path — the protocol on both ends already exists.</p>
+  </section>
+
+  <!-- 15 — MULTI-SESSION RUNTIME -->
+  <section class="slide">
+    <div class="kicker">Layer 3 · runtime</div>
+    <h2>Single loop → supervised multi-session manager</h2>
+    <div class="grid two">
+      <div class="card before" style="border-top:3px solid var(--gate)">
+        <h3 class="accent-e">Today</h3>
+        <p>One message loop bound to one mediator session. A mediator hiccup stalls the only thing running.</p>
+        <pre class="tui" style="margin-top:12px;font-size:12px">  Single message loop
+        │
+        ▼
+   one mediator session</pre>
+      </div>
+      <div class="card after" style="border-top:3px solid var(--ok)">
+        <h3 class="accent-a">After</h3>
+        <p>One supervised, isolated task per active community: independently recoverable, bounded concurrency, partial-failure-tolerant launch.</p>
+        <pre class="tui" style="margin-top:12px;font-size:12px">   Multi-session manager
+    ├── <span class="ok">task: Acme</span>      ⟲ retry
+    ├── <span class="ok">task: City DAO</span>  ⟲ isolated
+    └── <span class="pend">task: WG</span>        ~ pending</pre>
+      </div>
+    </div>
+    <p class="note">A mediator outage on one community never blocks the others. This is the runtime precondition for the whole multi-community model — concurrency that fails gracefully, per community.</p>
+  </section>
+
+  <!-- 16 — THE MEMBER EXPERIENCE (MOCKUPS) -->
+  <section class="slide">
+    <div class="kicker">Layer 3 · the member experience</div>
+    <h2>The Communities hub &amp; per-community context</h2>
+    <div class="grid two">
+      <div>
+<pre class="tui" style="font-size:12px">┌──────────────────────────────────────────────┐
+│ OpenVTC                  Account: <span class="acc">alice@vta</span>  │
+│ Communities          [+] Join        (2) !   │
+├──────────────────────────────────────────────┤
+│ * Acme Robotics  <span class="ok">o Active</span>   since 2026-03-01 &gt;│
+│   Open Source WG <span class="pend">~ Pending</span>  requested 2d  ! &gt;│
+│ * City DAO       <span class="ok">o Active</span>   since 2025-11-12 &gt;│
+│   Old Guild      <span class="off">- Left</span>     (read-only)     &gt;│
+│   Trial Net      <span class="warn">x Rejected</span> <span class="warn">acknowledge?</span>    &gt;│
+├──────────────────────────────────────────────┤
+│ ↑↓ select  ⏎ open  s star  j join  a/d arch  │
+└──────────────────────────────────────────────┘</pre>
+        <p class="caption">Favourites sort to top · status + member-since per row · an actions-required badge (!) counts communities needing attention.</p>
+      </div>
+      <div>
+<pre class="tui" style="font-size:12px">┌────────────────────────────────────────────┐
+│ <span class="acc">Acme Robotics ▾</span>  persona: <span class="vio">…webvh:acme</span>   │
+│ Messages  Relationships  Contacts  Creds    │
+├────────────────────────────────────────────┤
+│ &gt; bob@acme       last seen 2h ago           │
+│ &gt; carol@acme     <span class="warn">new message !</span>              │
+│ &gt; dave@acme      <span class="ok">online o</span>                   │
+└────────────────────────────────────────────┘
+   ── Join · how do you want to appear? ──
+   <span class="ok">(o)</span> Create a new identity   <span class="off">best for privacy</span>
+   ( ) Reuse a persona  <span class="warn">! links you across</span></pre>
+        <p class="caption">The main page, scoped to the selected community · a per-join identity choice with the linkability warning on reuse.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 17 — STANDARDS STACK -->
+  <section class="slide">
+    <div class="kicker">Adopt, don't invent</div>
+    <h2>The standards the whole fabric stands on</h2>
+    <p class="sub">Every standard here is <strong class="accent-a">open and publicly specified</strong>; every dependency is <strong class="accent-a">open-source</strong>. No proprietary formats, no closed SDKs, no vendor lock-in — anyone can build an interoperable holder, issuer, or verifier from the same public specs.</p>
+    <div class="chips">
+      <div class="chip"><div class="s">W3C</div><div class="t">Verifiable Credentials 2.0</div><div class="d">Data Integrity · eddsa-jcs-2022 · bbs-2023</div></div>
+      <div class="chip"><div class="s">IETF</div><div class="t">SD-JWT-VC</div><div class="d">Selective disclosure + kb-jwt holder binding</div></div>
+      <div class="chip"><div class="s">OpenID</div><div class="t">OpenID4VCI</div><div class="d">Issuance · pre-authorized-code · key-proof</div></div>
+      <div class="chip"><div class="s">OpenID</div><div class="t">OpenID4VP + DCQL</div><div class="d">Presentation + Digital Credentials Query Language</div></div>
+      <div class="chip"><div class="s">DIF</div><div class="t">DIDComm v2</div><div class="d">authcrypt · intrinsic sender authentication</div></div>
+      <div class="chip"><div class="s">DIF</div><div class="t">Presentation Definition</div><div class="d">clients self-assemble evidence from policy</div></div>
+      <div class="chip"><div class="s">W3C</div><div class="t">DIDs</div><div class="d">did:key · did:webvh · did:web</div></div>
+      <div class="chip"><div class="s">OPA</div><div class="t">Rego (regorus)</div><div class="d">the enforcement target of every ceremony policy</div></div>
+      <div class="chip"><div class="s">trusttasks.org</div><div class="t">Trust Tasks</div><div class="d">transport / auth / threading envelope</div></div>
+      <div class="chip"><div class="s">IRTF CFRG</div><div class="t">BBS Signatures</div><div class="d">Unlinkable selective disclosure · BLS12-381</div></div>
+      <div class="chip"><div class="s">ISO/IEC · W3C</div><div class="t">27560 + DPV</div><div class="d">Consent records · per-disclosure authorization</div></div>
+      <div class="chip"><div class="s">HPKE · IETF</div><div class="t">RFC 9180 · 8037</div><div class="d">Sealed transfer · EdDSA JWS</div></div>
+    </div>
+    <p class="note"><strong>No proprietary standards. No proprietary software.</strong> The entire trust fabric is buildable, auditable, and forkable from open specifications and open-source crates — which is exactly what makes regulatory alignment (next slide) possible rather than aspirational.</p>
+  </section>
+
+  <!-- 17a — eIDAS 2.0 / EUDI -->
+  <section class="slide">
+    <div class="kicker">Regulatory alignment</div>
+    <h2>Built to the EU's rulebook — eIDAS 2.0 &amp; the EUDI Wallet</h2>
+    <p class="sub">eIDAS 2.0 (Regulation (EU) 2024/1183) mandates EU Digital Identity Wallets, and the <strong>EUDI Architecture &amp; Reference Framework (ARF)</strong> fixes the technical standards. We didn't choose our stack to match it — we chose open standards, and they <em>are</em> the ARF's stack. Alignment came for free.</p>
+    <table>
+      <thead><tr><th>EUDI ARF requirement</th><th>Our implementation</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td>Credential format — SD-JWT-VC</td><td><code>SdJwtVc</code> + kb-jwt, first-class in the vault</td><td><span class="st live">live</span></td></tr>
+        <tr><td>Credential format — ISO mdoc (18013-5)</td><td>Additive enum arm via the format-agnostic vault</td><td><span class="st planned">addable, not a rewrite</span></td></tr>
+        <tr><td>Issuance — OpenID4VCI</td><td>offer → request → issue, holder-key-bound</td><td><span class="st live">live</span></td></tr>
+        <tr><td>Presentation — OpenID4VP + DCQL</td><td>query → match → present, holder-bound VP</td><td><span class="st live">live</span></td></tr>
+        <tr><td>Selective disclosure &amp; unlinkability</td><td>SD-JWT-VC per-claim · BBS+ unlinkable</td><td><span class="st live">live</span> / <span class="st gated">gated</span></td></tr>
+        <tr><td>Holder binding / proof-of-possession</td><td>OID4VCI key-binding proof, verified before release</td><td><span class="st live">live</span></td></tr>
+        <tr><td>User consent &amp; data minimisation</td><td>ISO/IEC 27560 + W3C DPV consent records</td><td><span class="st live">live</span></td></tr>
+        <tr><td>Trust model — registries &amp; issuer trust</td><td>W3C DIDs + trust-registry sync + cross-community recognition</td><td><span class="st live">live</span> / in progress</td></tr>
+      </tbody>
+    </table>
+    <p class="muted" style="margin-top:14px;font-size:13px"><strong>Honest framing:</strong> this is <em>conformance-track alignment by construction</em>, not a certification claim. Formal EUDI conformance additionally needs ISO mdoc support, qualified signatures (QES / QEAA), and a certified wallet solution — but the format-agnostic design makes mdoc an additive arm, and the consent + holder-binding + selective-disclosure guarantees the ARF demands are already enforced.</p>
+  </section>
+
+  <!-- 18 — SECURITY MODEL -->
+  <section class="slide">
+    <div class="kicker">Security model</div>
+    <h2>Where the guarantees live</h2>
+    <div class="grid two">
+      <div class="card b-d"><h3 class="accent-d">Holder key-binding proof</h3><p>OID4VCI <code>openid4vci-proof+jwt</code>: verify <code>typ</code>/<code>alg</code>, resolve the <code>kid</code> did:key, check EdDSA (<code>verify_strict</code>), <code>aud</code>, freshness, and the <strong>c_nonce replay binding</strong>. Issuance releases only to the proven subject.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Consent-gated disclosure</h3><p>A signed consent record (ISO/IEC 27560 + DPV) authorizes a verifier + claim set. The reveal set <em>is</em> the consent; revoked / temporally-invalid credentials are refused before any disclosure.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Crypto only in Verify</h3><p>Policy reasons over a <code>Verified*</code> view; skipping verification doesn't compile. Default-deny posture; a signed, append-only policy log with fail-forward rollback and optional M-of-N governance.</p></div>
+      <div class="card b-a"><h3 class="accent-a">No-enumeration vault + sealed transfer</h3><p>No “list all” primitive — targeted index lookups only. Every secret-bearing bundle is HPKE-sealed to a <code>client_did</code>, armored, with a producer assertion + out-of-band SHA-256 digest.</p></div>
+    </div>
+    <p class="muted" style="margin-top:16px;font-size:13px">Each was traced against forgery, replay (time + nonce), wrong-key, wrong-audience, alg-confusion, <code>alg=none</code>, and relayer-escalation attacks during review. Audience isolation separates VTA and VTC JWTs; cross-audience tokens are rejected.</p>
+  </section>
+
+  <!-- 18a — AUTHENTICATION PATHWAYS -->
+  <section class="slide">
+    <div class="kicker">Authentication · every pathway</div>
+    <h2>Many ways to prove who you are — one auth surface</h2>
+    <p class="sub">The <code>/auth</code> endpoints <strong>content-negotiate</strong> on the request shape: flat-JSON in → flat-JSON out, Trust-Task in → Trust-Task out. A new pathway is a new request shape, not a new endpoint — and freshness/replay is anchored by a single-use, TTL'd challenge throughout.</p>
+    <div class="grid four" style="margin-top:20px">
+      <div class="card b-a"><h3 class="accent-a">DI-signed Trust Task</h3><p>A plain JSON <code>auth/authenticate/0.1</code> whose holder <code>eddsa-jcs-2022</code> proof <em>is</em> the authentication. No mediator — a REST-only VTA can authenticate. The whole login→refresh loop runs over plain HTTPS.</p></div>
+      <div class="card b-d"><h3 class="accent-d">DIDComm v2 authcrypt</h3><p>A packed message via the mediator; unpacking yields a cryptographically-proven sender DID. Works even when the VTA is private-network and reachable only through a mediator. Sender auth is intrinsic.</p></div>
+      <div class="card b-b"><h3 class="accent-b">WebAuthn passkey</h3><p>A passkey enrolled as an <code>authentication</code> <code>verificationMethod</code> in the published DID document. Any verifier resolves the DID and checks the assertion against the embedded key — <strong>the DID doc is the trust anchor</strong>.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Biometric step-up (AAL1→AAL2)</h3><p>A sensitive operation escalates to AAL2 via a passkey/biometric approval — optionally <em>delegated</em> to a separate approver, who is push-woken on their device to consent.</p></div>
+    </div>
+    <p class="note">Refresh carries <em>no proof</em> — the opaque rotated token is the bearer credential (OAuth2 §10.4). Together with the DI-signed path, mobile and browser clients run their full session lifecycle without ever needing a mediator, while DIDComm remains available for private-network and air-gapped peers.</p>
+  </section>
+
+  <!-- 18b — CLIENTS: BROWSER + MOBILE -->
+  <section class="slide">
+    <div class="kicker">The clients we built</div>
+    <h2>A passkey in the browser, an agent in your pocket</h2>
+    <div class="grid two">
+      <div class="card b-d">
+        <h3 class="accent-d">Browser plugin — passkey ↔ DID bridge</h3>
+        <ul style="padding-left:17px">
+          <li>Ships as a <strong>PWA</strong> and an <strong>MV3 extension</strong> (Vite + React) over a shared <code>@openvtc/pnm-core</code>.</li>
+          <li>Enrolls a WebAuthn passkey as a DID <code>verificationMethod</code> — prove control of a VTA-hosted DID from any site.</li>
+          <li><strong>No DID private key ever leaves the VTA; no long-lived bearer token sits in browser storage.</strong></li>
+          <li>Speaks REST <em>and</em> full DIDComm v2 (coordinate-mediation/2.0) — usable even when the VTA is mediator-only.</li>
+        </ul>
+      </div>
+      <div class="card b-a">
+        <h3 class="accent-a">Mobile authenticator — iOS agent</h3>
+        <ul style="padding-left:17px">
+          <li>A shared Rust engine, <strong><code>vta-mobile-core</code> (UniFFI)</strong>, under a native SwiftUI shell — one auth/credential brain, native skins.</li>
+          <li>Biometric <strong>AAL1→AAL2 step-up approver</strong>: Touch/Face ID approves the escalation.</li>
+          <li>Hardware key custody in the <strong>Secure Enclave (P-256)</strong>; Ed25519/X25519 held in software (Tier 2).</li>
+          <li>Runs the entire <code>build_authenticate</code> → refresh loop over plain REST — no mediator required.</li>
+        </ul>
+      </div>
+    </div>
+    <p class="muted" style="margin-top:14px;font-size:13px">Both are <em>holders</em> in the Layer-1 sense — they hold keys/credentials, present proofs, and approve step-ups — over the very same open standards as the VTA and VTC.</p>
+  </section>
+
+  <!-- 18c — PROGRAMMABLE AUTHN/AUTHZ (GAME CHANGER) -->
+  <section class="slide">
+    <div class="kicker">The game changer</div>
+    <h2>A programmable authentication &amp; authorization layer</h2>
+    <p class="lead" style="margin-top:14px">Authentication strength and authorization rules stopped being hard-coded. They are now <strong class="accent-a">runtime, governable configuration</strong> — proven by credentials, decided by policy you can simulate, escalated by risk.</p>
+    <div class="grid two" style="margin-top:22px">
+      <div class="card b-a">
+        <h3 class="accent-a">Authentication — pluggable</h3>
+        <p>One content-negotiated surface accepts DI-signed REST proofs, DIDComm authcrypt, WebAuthn passkeys, and delegated biometric step-up. Add a method by adding a request shape — clients, mediators, and verifiers are untouched.</p>
+      </div>
+      <div class="card b-b">
+        <h3 class="accent-b">Authorization — programmable</h3>
+        <p>Not a hard-coded role check: a <strong>VC/VP the holder presents</strong>, evaluated by a <strong>Rego ceremony policy</strong> authored visually and dry-run in the simulator, with a <strong>configurable step-up policy</strong> (per-op-class AAL floor + per-entry override).</p>
+      </div>
+    </div>
+    <p class="note"><strong>Why it changes the game:</strong> an operator changes <em>who can do what, proven how, and how strongly</em> by editing and simulating policy — not by shipping a release. Step-up becomes risk-based and per-operation; new auth methods and new authorization rules are additive; and every decision is the same verified-Facts → four-valued-verdict pipeline, auditable end-to-end.</p>
+  </section>
+
+  <!-- 19 — ACT 2 DIVIDER -->
+  <section class="slide act">
+    <div class="actnum">ACT II</div>
+    <h1 style="margin-top:14px;max-width:20ch">Why it matters, and what it unlocks</h1>
+    <div class="actline"></div>
+    <p class="lead muted" style="max-width:60ch">Act I was the architecture — three layers, built and largely live. Act II is the payoff: the benefits this foundation delivers today, and the capabilities it makes <em>cheap to build next</em> precisely because the hard parts are already done once.</p>
+  </section>
+
+  <!-- 20 — BENEFITS -->
+  <section class="slide">
+    <div class="kicker">The benefits</div>
+    <h2>What this buys us — concretely</h2>
+    <div class="grid three">
+      <div class="card b-a"><h3 class="accent-a">Portable trust</h3><p>Membership and roles are credentials the member <em>carries</em>, not rows in our database. They survive beyond a single VTA/VTC and are re-verifiable by external parties that show up later.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Standards-native</h3><p>Issuance and presentation ride OID4VCI / OID4VP + DCQL over DIDComm; policy compiles to Rego + Presentation Definitions. No bespoke signature schemes to defend — we delegate to well-tested libraries.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Privacy by construction</h3><p>No persona at bootstrap, no wallet enumeration, selective disclosure, and per-disclosure consent. You reveal the minimum, where you choose, linkable only when you opt in.</p></div>
+      <div class="card b-d"><h3 class="accent-d">Governance without engineers</h3><p>Operators author ceremonies as visual rules, <strong>simulate the verdict live</strong>, version and roll back — no Rego, no redeploy, no waiting on a release. Policy becomes an operational lever.</p></div>
+      <div class="card b-a"><h3 class="accent-a">Belonging is plural</h3><p>One account, many personas, many communities, concurrent and fault-isolated. A person's trust graph stops being a single closed silo and becomes the thing they actually live in.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Build once, reuse everywhere</h3><p>Issuance mirrors presentation; every ceremony is one pipeline; the vault abstracts every format. New credential types, new ceremonies, and new formats are arms on existing machinery — not new subsystems.</p></div>
+    </div>
+  </section>
+
+  <!-- 21 — FUTURE UNLOCKS -->
+  <section class="slide">
+    <div class="kicker">Future unlocks</div>
+    <h2>What this foundation makes cheap to build next</h2>
+    <p class="sub">Each of these was expensive-or-impossible before; each is now a small increment on machinery that already exists.</p>
+    <div class="grid two">
+      <div class="card b-a"><h3 class="accent-a">Portable, cross-community reputation</h3><p>A Role VEC or endorsement earned in one community becomes evidence presentable to another. Cross-community recognition + trust-registry sync turn “member here” into “trusted there.”</p></div>
+      <div class="card b-b"><h3 class="accent-b">Unlinkable membership &amp; ZK predicates</h3><p>BBS+ gives unlinkable presentations; the gated Circom option gives ZK predicates — prove “is a member” or “age over 18” with <em>nothing else revealed</em>. The vault is already format-agnostic; these slot in.</p></div>
+      <div class="card b-d"><h3 class="accent-d">External verifiers &amp; an open ecosystem</h3><p>Because everything is W3C VC/VP over open standards, a verifier we've never met can check a member's credential. Trust stops ending at our walls.</p></div>
+      <div class="card b-c"><h3 class="accent-c">Self-governing communities</h3><p>The simulator + Rule IR + signed policy log + M-of-N governance let communities evolve their own admission, role, and removal rules safely — delegated invitation, quorum review, threaded <code>request_more</code> negotiation.</p></div>
+      <div class="card b-a"><h3 class="accent-a">Air-gapped &amp; sealed onboarding</h3><p>Sealed issuance to an unknown holder (HPKE) means inviting someone who isn't online yet, or onboarding across an air gap, with no privilege escalation through the relayer.</p></div>
+      <div class="card b-b"><h3 class="accent-b">Mobile, passkeys &amp; step-up</h3><p>A mobile authenticator that holds the persona and approves AAL1→AAL2 step-up (WebAuthn passkey) over the same DIDComm/Trust-Task surface — the hold/present agent in your pocket.</p></div>
+      <div class="card b-d"><h3 class="accent-d">Hierarchical trust contexts</h3><p>Folder-structured contexts with folder-level admin let large organisations model departments, working groups, and sub-communities under one account graph.</p></div>
+      <div class="card b-c"><h3 class="accent-c">New ceremonies, near-free</h3><p>Personhood assertions, relationship publishing, endorsement issuance — each is a policy module + evidence slot + effect handler on the pipeline that already runs join, leave, role-change, and directory.</p></div>
+    </div>
+  </section>
+
+  <!-- 22 — COMBINED ROADMAP -->
+  <section class="slide">
+    <div class="kicker">Delivery · combined</div>
+    <h2>Where each layer stands</h2>
+    <div class="road">
+      <div class="phase"><div class="ph">VTA · L1</div><h3>Credential agent</h3><ul><li>SD-JWT-VC + DCQL</li><li>Vault: receive · match</li><li>Issuance (OID4VCI)</li><li>Present (3.5c) — in flight</li></ul><div class="barwrap"><div class="bar"><span style="width:80%"></span></div></div></div>
+      <div class="phase"><div class="ph">VTC · L2</div><h3>Ceremonies</h3><ul><li>Pipeline + 4-valued verdict</li><li>Join · Leave · Role · Directory <strong>live</strong></li><li>Rule IR → Rego + PD</li><li>Working simulator</li></ul><div class="barwrap"><div class="bar"><span style="width:88%"></span></div></div></div>
+      <div class="phase"><div class="ph">VTC · L2</div><h3>Role-by-VC &amp; join</h3><ul><li>Verified-assertion cache</li><li>VP-based <code>/auth</code></li><li>Join ceremony ↔ exchange</li></ul><div class="barwrap"><div class="bar"><span style="width:20%"></span></div></div></div>
+      <div class="phase"><div class="ph">OpenVTC · L3</div><h3>Multi-community</h3><ul><li>Config v2 + session mgr (T1)</li><li>State A/B + hub + switcher</li><li>Join (stub VP) + lifecycle</li></ul><div class="barwrap"><div class="bar"><span style="width:30%"></span></div></div></div>
+      <div class="phase"><div class="ph">Spine</div><h3>Stub → real VP</h3><ul><li>Wire OpenVTC join to present</li><li>VTC verifier emits DCQL</li><li>Live verdict end-to-end</li></ul><div class="barwrap"><div class="bar"><span style="width:8%"></span></div></div></div>
+    </div>
+    <p class="muted" style="margin-top:16px;font-size:13px">The two existing decks are the per-layer detail: <code>credential-architecture-presentation</code> (L1/L2 protocol) and <code>multi-community-presentation</code> (L3 experience). This deck is the unifying arc + benefits + unlocks.</p>
+  </section>
+
+  <!-- 23 — THE NUMBERS -->
+  <section class="slide">
+    <div class="kicker">What shipped</div>
+    <h2>The work, in numbers</h2>
+    <div class="grid four">
+      <div class="card center"><div class="big-num accent-a">13</div><p>PRs merged in the credential line</p></div>
+      <div class="card center"><div class="big-num accent-b">4</div><p>ceremonies live through one pipeline</p></div>
+      <div class="card center"><div class="big-num accent-c">4</div><p>credential formats the vault abstracts over</p></div>
+      <div class="card center"><div class="big-num accent-d">10+</div><p>open standards adopted, not invented</p></div>
+    </div>
+    <div class="grid three" style="margin-top:16px">
+      <div class="card center"><div class="big-num accent-a">1</div><p>working, daemon-wired ceremony simulator</p></div>
+      <div class="card center"><div class="big-num accent-b">1</div><p>upstream crate hardened (affinidi-tdk-rs)</p></div>
+      <div class="card center"><div class="big-num accent-d">1</div><p>account graph: ∞ personas × ∞ communities</p></div>
+    </div>
+    <p class="muted" style="margin-top:16px;font-size:13px">The security-critical key-binding proof handling was pushed <strong>upstream</strong> into <code>affinidi-tdk-rs</code> (crypto-agnostic, DID-resolution-with-the-caller) — closing a real footgun where a structural-only check returned <code>Ok</code> for a forged proof, and giving every SIOPv2 / OID4VCI / OID4VP consumer the fix.</p>
+  </section>
+
+  <!-- 24 — DEFERRED, OPEN, THE ASK -->
+  <section class="slide">
+    <div class="kicker">Status &amp; what's next</div>
+    <h2>Deferred, open, and the ask</h2>
+    <div class="grid three">
+      <div class="card b-c">
+        <h3 class="accent-c">Deliberately deferred</h3>
+        <ul style="padding-left:17px">
+          <li>OpenVTC join uses a <strong>stub VP</strong> until wired to live present</li>
+          <li>Real hierarchical context API (<code>parent_id</code>)</li>
+          <li>Persona key rotation</li>
+          <li>BBS+ / ZKP formats (additive, gated)</li>
+        </ul>
+      </div>
+      <div class="card b-e">
+        <h3 class="accent-e">Open — to decide</h3>
+        <ul style="padding-left:17px">
+          <li><strong>VP requirement discovery</strong> — how a VTC advertises required credentials</li>
+          <li><strong>Default posture</strong> — deny vs the MVP's accept-any</li>
+          <li><strong>Governance quorum</strong> — single-admin vs opt-in M-of-N</li>
+          <li>Sub-context authorization at the VTA layer</li>
+        </ul>
+      </div>
+      <div class="card b-a">
+        <h3 class="accent-a">The ask</h3>
+        <p>Sign off on the unified three-layer model and the combined roadmap. Then prioritise the <strong>spine</strong>: wire OpenVTC's stub VP to the live present + ceremony path — the protocol exists on both ends; this is integration, not invention.</p>
+        <p class="muted" style="margin-top:8px;font-size:12.5px">Plus: the one-command mock VTA harness, and settling credential type strings now.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 25 — CLOSE -->
+  <section class="slide closing">
+    <div class="kicker" style="color:var(--b)">From credentials to communities</div>
+    <h1 style="max-width:20ch;margin:0 auto">Trust you can hold, present, govern,<br>and live in.</h1>
+    <p class="sub" style="margin:22px auto 0">Membership stopped being a row in our database and became a credential in your wallet — issued, held, queried, selectively disclosed, governed by a policy you can simulate, and carried across every community a person belongs to.</p>
+    <div style="margin-top:28px;display:flex;gap:10px;flex-wrap:wrap;justify-content:center">
+      <span class="pill b-a"><i class="dot" style="background:var(--ok)"></i>Vault · ceremonies · simulator — live</span>
+      <span class="pill b-c"><i class="dot" style="background:var(--gate)"></i>BBS+ · ZKP — gated &amp; additive</span>
+      <span class="pill b-b"><i class="dot" style="background:var(--warn)"></i>stub → real VP · role-by-VC — next</span>
+    </div>
+    <p class="muted mono" style="margin-top:32px;font-size:11px">openvtc/docs/design/verifiable-trust-communities-presentation.html · unifies credential-architecture-presentation + multi-community-presentation</p>
+  </section>
+
+</div>
+
+<div class="nav">
+  <button id="prev">◀ Prev</button>
+  <span class="count" id="count">1 / 31</span>
+  <button id="next">Next ▶</button>
+</div>
+<div class="hint">← → · Space · Home/End</div>
+<div class="foot">VTC · CREDENTIALS → COMMUNITIES</div>
+
+<script>
+  var slides = Array.prototype.slice.call(document.querySelectorAll('.slide'));
+  var i = 0;
+  var bar = document.getElementById('bar');
+  var count = document.getElementById('count');
+  function show(n){
+    i = Math.max(0, Math.min(slides.length-1, n));
+    slides.forEach(function(s,k){ s.classList.toggle('on', k===i); });
+    count.textContent = (i+1)+' / '+slides.length;
+    bar.style.width = ((i+1)/slides.length*100)+'%';
+    var on = slides[i]; if(on) on.scrollTop = 0;
+    location.hash = i+1;
+  }
+  document.getElementById('next').onclick = function(){ show(i+1); };
+  document.getElementById('prev').onclick = function(){ show(i-1); };
+  document.addEventListener('keydown', function(e){
+    if(e.key==='ArrowRight'||e.key===' '||e.key==='PageDown'){ show(i+1); e.preventDefault(); }
+    else if(e.key==='ArrowLeft'||e.key==='PageUp'){ show(i-1); e.preventDefault(); }
+    else if(e.key==='Home'){ show(0); }
+    else if(e.key==='End'){ show(slides.length-1); }
+  });
+  var start=null;
+  document.addEventListener('touchstart',function(e){start=e.touches[0].clientX;},{passive:true});
+  document.addEventListener('touchend',function(e){
+    if(start===null)return; var dx=e.changedTouches[0].clientX-start;
+    if(Math.abs(dx)>50){ show(i + (dx<0?1:-1)); } start=null;
+  },{passive:true});
+  var h = parseInt(location.hash.replace('#',''),10);
+  show(isNaN(h)?0:h-1);
+</script>
+</body>
+</html>

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -6,12 +6,12 @@
  * [`CommunityRecord`]s. See `docs/design/multi-community-support.md` and
  * `docs/design/t1-active-identity-api.md`.
  *
- * Scope note: this module currently defines the **persisted metadata** model
- * (the `ProtectedConfig` tier). The account admin credential (a secret) stays
- * in `SecuredConfig`/keyring; persona key material is VTA-managed (`key_refs`
- * are non-secret ids, D12). Runtime resolution (`IdentityContext` /
- * `IdentityRegistry`) and wiring into `Config` land in a later T1 commit; these
- * types are additive and not yet referenced by the live load/save path.
+ * Scope note: this module defines the **persisted metadata** model, stored
+ * encrypted in the `ProtectedConfig` tier and treated by `Config::load_step2`
+ * as the source of truth for the active persona. The account admin credential
+ * (a secret) stays in `SecuredConfig`/keyring; persona key material is
+ * VTA-managed (`key_refs` are non-secret ids, D12). Runtime resolution lives in
+ * [`crate::identity`] (`IdentityContext` / `IdentityRegistry`).
  */
 
 use crate::config::KeyTypes;
@@ -206,6 +206,10 @@ pub struct Account {
     pub vta_url: String,
     /// The top-level context this account administers.
     pub top_context_id: String,
+    /// Organisation DID this account is affiliated with (the former
+    /// `public.lk_did` singleton). Account-level, not persona-scoped.
+    #[serde(default)]
+    pub org_did: String,
     /// Account personas, keyed by stable id.
     #[serde(default)]
     pub personas: HashMap<PersonaId, PersonaRecord>,

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -1,0 +1,408 @@
+/*!
+ * Multi-community account model (config v2).
+ *
+ * Replaces the single-persona / single-VTA singleton with an `Account` that
+ * owns a collection of [`PersonaRecord`]s and a collection of
+ * [`CommunityRecord`]s. See `docs/design/multi-community-support.md` and
+ * `docs/design/t1-active-identity-api.md`.
+ *
+ * Scope note: this module currently defines the **persisted metadata** model
+ * (the `ProtectedConfig` tier). The account admin credential (a secret) stays
+ * in `SecuredConfig`/keyring; persona key material is VTA-managed (`key_refs`
+ * are non-secret ids, D12). Runtime resolution (`IdentityContext` /
+ * `IdentityRegistry`) and wiring into `Config` land in a later T1 commit; these
+ * types are additive and not yet referenced by the live load/save path.
+ */
+
+use crate::config::KeyTypes;
+use crate::relationships::Relationships;
+use crate::vrc::Vrcs;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// A VTC community is keyed by its DID (`did:webvh:...`).
+pub type VtcDid = String;
+
+/// Stable, rotation-safe identifier for a persona.
+///
+/// Decoupled from the persona's `did:webvh` (which can rotate) so that a
+/// community's `persona_ref` survives DID rotation (fork resolution: stable
+/// UUID).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PersonaId(pub Uuid);
+
+impl PersonaId {
+    /// Mint a fresh persona id.
+    pub fn new() -> Self {
+        PersonaId(Uuid::new_v4())
+    }
+}
+
+impl Default for PersonaId {
+    fn default() -> Self {
+        PersonaId::new()
+    }
+}
+
+impl std::fmt::Display for PersonaId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A non-secret reference to a VTA-managed key (D12).
+///
+/// Key material lives at the VTA and is fetched at runtime; only the opaque
+/// `key_id`, its purpose, and creation time are persisted locally.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KeyRef {
+    /// Opaque VTA key identifier.
+    pub key_id: String,
+    /// What the key is used for.
+    pub purpose: KeyTypes,
+    /// When the key was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// An account-level persona — a self-contained `did:webvh` identity that one or
+/// more communities may present (D6: context-independent; D1: reusable).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PersonaRecord {
+    /// Stable identifier (rotation-safe).
+    pub persona_id: PersonaId,
+    /// The persona's `did:webvh`.
+    pub did: String,
+    /// Non-secret references to this persona's VTA-managed keys.
+    pub key_refs: Vec<KeyRef>,
+    /// Mediator DID; defaults to the VTA mediator, optional override at mint (D7).
+    pub mediator_did: Option<String>,
+    /// The sub-context the persona was minted under — provenance only (D6).
+    pub origin_context_id: String,
+    /// When the persona was created.
+    pub created_at: DateTime<Utc>,
+    /// Optional human-friendly label.
+    pub label: Option<String>,
+}
+
+/// Lifecycle state of a community membership (D8). Only [`Active`] is live; all
+/// other states are read-only (D14).
+///
+/// [`Active`]: CommunityStatus::Active
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum CommunityStatus {
+    /// Join request submitted, awaiting the VTC's decision.
+    Pending {
+        /// The join request id from the submit receipt.
+        request_id: Uuid,
+    },
+    /// Member in good standing (the only live state).
+    Active,
+    /// Member voluntarily left (`MEMBER_SELF_REMOVE`).
+    Left,
+    /// Join request denied by the VTC.
+    Rejected,
+    /// Member removed by the VTC (involuntary).
+    Removed,
+    /// Pending join unanswered past the 7-day client timeout (D16).
+    Expired,
+}
+
+impl CommunityStatus {
+    /// True only for [`Active`](CommunityStatus::Active) — the single live state.
+    pub fn is_active(&self) -> bool {
+        matches!(self, CommunityStatus::Active)
+    }
+
+    /// True for every non-[`Active`](CommunityStatus::Active) state (read-only, D14).
+    pub fn is_read_only(&self) -> bool {
+        !self.is_active()
+    }
+
+    /// True for terminal/inactive states eligible for archive or delete (R-C-8):
+    /// `Left`, `Rejected`, `Removed`, `Expired`. (`Pending` is not — it is still
+    /// in flight.)
+    pub fn is_inactive(&self) -> bool {
+        matches!(
+            self,
+            CommunityStatus::Left
+                | CommunityStatus::Rejected
+                | CommunityStatus::Removed
+                | CommunityStatus::Expired
+        )
+    }
+
+    /// True when the community should raise the actions-required indicator
+    /// (R-C-3 / R-S-2): a `Pending` decision is awaited, or there is an
+    /// unacknowledged `Rejected` / `Removed` / `Expired` outcome. (Acknowledgement
+    /// of the terminal states is tracked separately and layered on top.)
+    pub fn needs_attention(&self) -> bool {
+        matches!(
+            self,
+            CommunityStatus::Pending { .. }
+                | CommunityStatus::Rejected
+                | CommunityStatus::Removed
+                | CommunityStatus::Expired
+        )
+    }
+}
+
+/// A community membership — one per State-B join, referencing an account persona.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CommunityRecord {
+    /// The community's VTC DID.
+    pub vtc_did: VtcDid,
+    /// Display name resolved from the VTC DID document, if available.
+    pub display_name: Option<String>,
+    /// Sub-context id under the account's top context (`<top>/<slug>`, D9).
+    pub sub_context_id: String,
+    /// Which account persona is presented to this VTC (must resolve, R-P-1).
+    pub persona_ref: PersonaId,
+    /// Membership lifecycle state.
+    pub status: CommunityStatus,
+    /// User-starred favourite (sorts to top; R-C-4).
+    #[serde(default)]
+    pub favourite: bool,
+    /// User-archived (hidden from the default list; R-C-8).
+    #[serde(default)]
+    pub archived: bool,
+    /// Set when the membership first becomes `Active` (member-since; R-C-2).
+    pub member_since: Option<DateTime<Utc>>,
+    /// When the join request was submitted — anchors the 7-day timeout (D16).
+    pub requested_at: Option<DateTime<Utc>>,
+    /// DIDComm relationships scoped to this community.
+    #[serde(default)]
+    pub relationships: Relationships,
+    /// VRCs we have issued within this community.
+    #[serde(default)]
+    pub vrcs_issued: Vrcs,
+    /// VRCs we have received within this community.
+    #[serde(default)]
+    pub vrcs_received: Vrcs,
+}
+
+/// The account — the OpenVTC ↔ VTA relationship (State-A bootstrap) plus its
+/// personas and community memberships.
+///
+/// The account **admin credential** is a secret and is NOT stored here — it
+/// lives in `SecuredConfig`/keyring (D12). This struct is the `ProtectedConfig`
+/// (encrypted) metadata tier.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Account {
+    /// DID of the VTA this account is provisioned against.
+    pub vta_did: String,
+    /// Base URL of the VTA (empty for DIDComm-only VTAs).
+    pub vta_url: String,
+    /// The top-level context this account administers.
+    pub top_context_id: String,
+    /// Account personas, keyed by stable id.
+    #[serde(default)]
+    pub personas: HashMap<PersonaId, PersonaRecord>,
+    /// Community memberships, keyed by VTC DID.
+    #[serde(default)]
+    pub communities: HashMap<VtcDid, CommunityRecord>,
+}
+
+impl Account {
+    /// Resolve the persona presented to a given community, following
+    /// `persona_ref`. Returns `None` if the community is unknown or its
+    /// `persona_ref` dangles (a referential-integrity violation; see
+    /// [`Self::dangling_refs`]).
+    pub fn persona_for(&self, vtc: &VtcDid) -> Option<&PersonaRecord> {
+        let community = self.communities.get(vtc)?;
+        self.personas.get(&community.persona_ref)
+    }
+
+    /// True if any community references this persona.
+    pub fn persona_referenced(&self, id: &PersonaId) -> bool {
+        self.communities.values().any(|c| &c.persona_ref == id)
+    }
+
+    /// Whether a persona may be deleted (R-P-1): it must exist and not be
+    /// referenced by any community.
+    pub fn can_delete_persona(&self, id: &PersonaId) -> bool {
+        self.personas.contains_key(id) && !self.persona_referenced(id)
+    }
+
+    /// Any `persona_ref`s that do not resolve to an existing persona — should
+    /// always be empty (referential integrity, R-P-1).
+    pub fn dangling_refs(&self) -> Vec<(&VtcDid, &PersonaId)> {
+        self.communities
+            .iter()
+            .filter(|(_, c)| !self.personas.contains_key(&c.persona_ref))
+            .map(|(vtc, c)| (vtc, &c.persona_ref))
+            .collect()
+    }
+
+    /// Iterator over communities in the `Active` (live) state.
+    pub fn active_communities(&self) -> impl Iterator<Item = &CommunityRecord> {
+        self.communities.values().filter(|c| c.status.is_active())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn persona(label: &str) -> PersonaRecord {
+        PersonaRecord {
+            persona_id: PersonaId::new(),
+            did: format!("did:webvh:example.com:{label}"),
+            key_refs: vec![KeyRef {
+                key_id: format!("key-{label}"),
+                purpose: KeyTypes::PersonaSigning,
+                created_at: Utc::now(),
+            }],
+            mediator_did: None,
+            origin_context_id: format!("openvtc/{label}"),
+            created_at: Utc::now(),
+            label: Some(label.to_string()),
+        }
+    }
+
+    fn community(vtc: &str, persona_ref: PersonaId, status: CommunityStatus) -> CommunityRecord {
+        CommunityRecord {
+            vtc_did: vtc.to_string(),
+            display_name: Some(vtc.to_string()),
+            sub_context_id: format!("openvtc/{vtc}"),
+            persona_ref,
+            status,
+            favourite: false,
+            archived: false,
+            member_since: None,
+            requested_at: None,
+            relationships: Relationships::default(),
+            vrcs_issued: Vrcs::default(),
+            vrcs_received: Vrcs::default(),
+        }
+    }
+
+    #[test]
+    fn status_classification() {
+        assert!(CommunityStatus::Active.is_active());
+        assert!(!CommunityStatus::Active.is_read_only());
+        assert!(!CommunityStatus::Active.needs_attention());
+
+        for s in [
+            CommunityStatus::Left,
+            CommunityStatus::Rejected,
+            CommunityStatus::Removed,
+            CommunityStatus::Expired,
+        ] {
+            assert!(s.is_read_only(), "{s:?} should be read-only");
+            assert!(s.is_inactive(), "{s:?} should be inactive (archive/delete)");
+        }
+
+        let pending = CommunityStatus::Pending {
+            request_id: Uuid::new_v4(),
+        };
+        assert!(pending.is_read_only());
+        assert!(!pending.is_inactive(), "pending is in-flight, not inactive");
+        assert!(pending.needs_attention());
+        assert!(CommunityStatus::Rejected.needs_attention());
+        assert!(!CommunityStatus::Left.needs_attention());
+    }
+
+    #[test]
+    fn persona_for_resolves_ref() {
+        let mut acct = Account::default();
+        let p = persona("alice");
+        let pid = p.persona_id;
+        acct.personas.insert(pid, p);
+        acct.communities.insert(
+            "vtc:a".into(),
+            community("vtc:a", pid, CommunityStatus::Active),
+        );
+
+        let resolved = acct.persona_for(&"vtc:a".to_string()).expect("resolves");
+        assert_eq!(resolved.persona_id, pid);
+        assert!(acct.persona_for(&"vtc:missing".to_string()).is_none());
+        assert!(acct.dangling_refs().is_empty());
+    }
+
+    #[test]
+    fn referential_integrity_blocks_persona_delete() {
+        let mut acct = Account::default();
+        let p = persona("bob");
+        let pid = p.persona_id;
+        acct.personas.insert(pid, p);
+
+        // Unreferenced: deletable.
+        assert!(acct.can_delete_persona(&pid));
+
+        // Now referenced by an active community: not deletable (R-P-1).
+        acct.communities.insert(
+            "vtc:b".into(),
+            community("vtc:b", pid, CommunityStatus::Active),
+        );
+        assert!(acct.persona_referenced(&pid));
+        assert!(!acct.can_delete_persona(&pid));
+
+        // Unknown persona is never deletable.
+        assert!(!acct.can_delete_persona(&PersonaId::new()));
+    }
+
+    #[test]
+    fn active_communities_filters() {
+        let mut acct = Account::default();
+        let p = persona("carol");
+        let pid = p.persona_id;
+        acct.personas.insert(pid, p);
+        acct.communities
+            .insert("a".into(), community("a", pid, CommunityStatus::Active));
+        acct.communities
+            .insert("b".into(), community("b", pid, CommunityStatus::Left));
+        acct.communities.insert(
+            "c".into(),
+            community(
+                "c",
+                pid,
+                CommunityStatus::Pending {
+                    request_id: Uuid::new_v4(),
+                },
+            ),
+        );
+        assert_eq!(acct.active_communities().count(), 1);
+    }
+
+    #[test]
+    fn account_json_round_trip_preserves_shape() {
+        let mut acct = Account {
+            vta_did: "did:webvh:vta.example".into(),
+            vta_url: "https://vta.example".into(),
+            top_context_id: "openvtc".into(),
+            ..Account::default()
+        };
+        let p = persona("dave");
+        let pid = p.persona_id;
+        let req = Uuid::new_v4();
+        acct.personas.insert(pid, p);
+        acct.communities.insert(
+            "vtc:x".into(),
+            community("vtc:x", pid, CommunityStatus::Pending { request_id: req }),
+        );
+
+        let json = serde_json::to_string(&acct).expect("serialize");
+        let back: Account = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(back.vta_did, acct.vta_did);
+        assert_eq!(back.top_context_id, "openvtc");
+        assert_eq!(back.personas.len(), 1);
+        let bp = back.personas.get(&pid).expect("persona survives");
+        assert_eq!(bp.did, "did:webvh:example.com:dave");
+        let bc = back.communities.get("vtc:x").expect("community survives");
+        assert_eq!(bc.persona_ref, pid);
+        assert_eq!(bc.status, CommunityStatus::Pending { request_id: req });
+    }
+
+    #[test]
+    fn community_status_tag_is_stable() {
+        // The serde tag is part of the on-disk format; pin it.
+        let j = serde_json::to_string(&CommunityStatus::Active).unwrap();
+        assert_eq!(j, r#"{"state":"active"}"#);
+        let j = serde_json::to_string(&CommunityStatus::Expired).unwrap();
+        assert_eq!(j, r#"{"state":"expired"}"#);
+    }
+}

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -135,10 +135,11 @@ impl CommunityStatus {
         )
     }
 
-    /// True when the community should raise the actions-required indicator
-    /// (R-C-3 / R-S-2): a `Pending` decision is awaited, or there is an
-    /// unacknowledged `Rejected` / `Removed` / `Expired` outcome. (Acknowledgement
-    /// of the terminal states is tracked separately and layered on top.)
+    /// The set of *statuses* that can raise the actions-required indicator
+    /// (R-C-3 / R-S-2): `Pending` and the terminal `Rejected` / `Removed` /
+    /// `Expired`. This is status-only; the acknowledgement-aware,
+    /// per-membership predicate is [`CommunityRecord::needs_attention`], which
+    /// layers the `acknowledged` flag on top.
     pub fn needs_attention(&self) -> bool {
         matches!(
             self,
@@ -178,6 +179,11 @@ pub struct CommunityRecord {
     /// User-archived (hidden from the default list; R-C-8).
     #[serde(default)]
     pub archived: bool,
+    /// Whether the user has acknowledged a terminal outcome
+    /// (`Rejected`/`Removed`/`Expired`), clearing the actions-required badge
+    /// (R-C-3 / R-S-2). Reset whenever the membership returns to a live state.
+    #[serde(default)]
+    pub acknowledged: bool,
     /// Set when the membership first becomes `Active` (member-since; R-C-2).
     pub member_since: Option<DateTime<Utc>>,
     /// When the join request was submitted — anchors the 7-day timeout (D16).
@@ -207,26 +213,56 @@ impl CommunityRecord {
     /// Transition to `Active` on acceptance (R-B-8). Stamps `member_since` with
     /// `now` the first time the membership becomes active (R-C-2); leaves an
     /// existing timestamp untouched so a re-activation keeps the original date.
+    /// Returning to a live state clears any prior acknowledgement (R-S-2).
     pub fn activate(&mut self, now: DateTime<Utc>) {
         if self.member_since.is_none() {
             self.member_since = Some(now);
         }
         self.status = CommunityStatus::Active;
+        self.acknowledged = false;
     }
 
-    /// Transition to `Rejected` — the VTC denied the join request (R-B-8).
+    /// Transition to `Rejected` — the VTC denied the join request (R-B-8). A
+    /// fresh terminal outcome starts unacknowledged so it raises the
+    /// actions-required badge until the user clears it (R-S-2).
     pub fn reject(&mut self) {
         self.status = CommunityStatus::Rejected;
+        self.acknowledged = false;
     }
 
-    /// Transition to `Removed` — the VTC removed an active member (R-B-8).
+    /// Transition to `Removed` — the VTC removed an active member (R-B-8). Starts
+    /// unacknowledged (R-S-2).
     pub fn remove(&mut self) {
         self.status = CommunityStatus::Removed;
+        self.acknowledged = false;
     }
 
-    /// Transition to `Left` — the member voluntarily left (R-L-1).
+    /// Transition to `Left` — the member voluntarily left (R-L-1). `Left` never
+    /// raises the actions-required badge (the user chose to leave).
     pub fn leave(&mut self) {
         self.status = CommunityStatus::Left;
+        self.acknowledged = false;
+    }
+
+    /// Acknowledge a terminal outcome (`Rejected`/`Removed`/`Expired`), clearing
+    /// the actions-required badge for this community (R-S-2). No effect on the
+    /// `Pending` badge, which only clears when the request resolves.
+    pub fn acknowledge(&mut self) {
+        self.acknowledged = true;
+    }
+
+    /// Whether this community raises the actions-required indicator (R-C-3):
+    /// `Pending` always (a decision is awaited), or an **unacknowledged**
+    /// terminal outcome `Rejected`/`Removed`/`Expired` (R-S-2). `Active` and
+    /// `Left` never do.
+    pub fn needs_attention(&self) -> bool {
+        match self.status {
+            CommunityStatus::Pending { .. } => true,
+            CommunityStatus::Rejected | CommunityStatus::Removed | CommunityStatus::Expired => {
+                !self.acknowledged
+            }
+            CommunityStatus::Active | CommunityStatus::Left => false,
+        }
     }
 
     /// Toggle the favourite/star flag (R-C-4). Returns the new value.
@@ -252,6 +288,7 @@ impl CommunityRecord {
             && now - requested >= TimeDelta::days(PENDING_TIMEOUT_DAYS)
         {
             self.status = CommunityStatus::Expired;
+            self.acknowledged = false;
             return true;
         }
         false
@@ -352,6 +389,17 @@ impl Account {
         expired
     }
 
+    /// Number of communities currently raising the actions-required indicator
+    /// (R-C-3): see [`CommunityRecord::needs_attention`]. Archived communities
+    /// are excluded — archiving hides a membership from the default list, so it
+    /// no longer nags.
+    pub fn actions_required_count(&self) -> usize {
+        self.communities
+            .values()
+            .filter(|c| !c.archived && c.needs_attention())
+            .count()
+    }
+
     /// Communities for the overview page in display order (R-C-4): favourites
     /// first, then by display name (case-insensitive; unnamed last), then VTC
     /// DID as a stable tiebreak. Archived communities are excluded unless
@@ -443,6 +491,7 @@ mod tests {
             status,
             favourite: false,
             archived: false,
+            acknowledged: false,
             member_since: None,
             requested_at: None,
             relationships: Relationships::default(),
@@ -777,5 +826,79 @@ mod tests {
             CommunityStatus::Pending { .. }
         ));
         assert_eq!(acct.communities["active"].status, CommunityStatus::Active);
+    }
+
+    #[test]
+    fn needs_attention_covers_pending_and_unacked_terminals() {
+        let pid = PersonaId::new();
+        assert!(community("v", pid, pending()).needs_attention());
+        assert!(!community("v", pid, CommunityStatus::Active).needs_attention());
+        assert!(
+            !community("v", pid, CommunityStatus::Left).needs_attention(),
+            "Left is voluntary — never an action"
+        );
+        for s in [
+            CommunityStatus::Rejected,
+            CommunityStatus::Removed,
+            CommunityStatus::Expired,
+        ] {
+            let mut c = community("v", pid, s.clone());
+            assert!(c.needs_attention(), "{s:?} should nag until acknowledged");
+            c.acknowledge();
+            assert!(!c.needs_attention(), "{s:?} clears once acknowledged");
+        }
+    }
+
+    #[test]
+    fn fresh_terminal_outcome_resets_acknowledgement() {
+        let pid = PersonaId::new();
+        // Acknowledge a Rejected, re-activate, then get Removed: the new terminal
+        // outcome must nag again — acknowledgement does not carry across
+        // transitions.
+        let mut c = community("v", pid, CommunityStatus::Rejected);
+        c.acknowledge();
+        assert!(!c.needs_attention());
+        c.activate(Utc::now());
+        assert!(!c.acknowledged, "returning to a live state clears the ack");
+        assert!(!c.needs_attention(), "Active never nags");
+        c.remove();
+        assert!(
+            c.needs_attention(),
+            "a fresh Removed must nag despite the earlier ack"
+        );
+    }
+
+    #[test]
+    fn actions_required_count_excludes_acknowledged_and_archived() {
+        let mut acct = Account::default();
+        let pid = PersonaId::new();
+        acct.communities
+            .insert("pending".into(), community("pending", pid, pending()));
+        acct.communities.insert(
+            "active".into(),
+            community("active", pid, CommunityStatus::Active),
+        );
+
+        // Unacknowledged Rejected → counts.
+        let mut rejected = community("rejected", pid, CommunityStatus::Rejected);
+
+        // Acknowledged Removed → does not count.
+        let mut acked = community("acked", pid, CommunityStatus::Removed);
+        acked.acknowledge();
+        acct.communities.insert("acked".into(), acked);
+
+        // Archived (unacknowledged) Expired → hidden, so does not count.
+        let mut archived = community("archived", pid, CommunityStatus::Expired);
+        archived.archived = true;
+        acct.communities.insert("archived".into(), archived);
+
+        acct.communities.insert("rejected".into(), rejected.clone());
+        // pending + rejected.
+        assert_eq!(acct.actions_required_count(), 2);
+
+        // Acknowledging the rejection drops the count to just the pending.
+        rejected.acknowledge();
+        acct.communities.insert("rejected".into(), rejected);
+        assert_eq!(acct.actions_required_count(), 1);
     }
 }

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -204,6 +204,37 @@ pub struct CommunityRecord {
 pub const PENDING_TIMEOUT_DAYS: i64 = 7;
 
 impl CommunityRecord {
+    /// Build a fresh `Pending` join record (State-B join request, R-B-*).
+    ///
+    /// `request_id` correlates the VTC's asynchronous accept/reject decision
+    /// (R-B-8); `requested_at` is stamped with `now` to anchor the 7-day timeout
+    /// (D16). Starts unfavourited, unarchived, unacknowledged, with empty
+    /// community-scoped relationship/VRC stores.
+    pub fn new_pending(
+        vtc_did: VtcDid,
+        display_name: Option<String>,
+        sub_context_id: String,
+        persona_ref: PersonaId,
+        request_id: Uuid,
+        now: DateTime<Utc>,
+    ) -> Self {
+        CommunityRecord {
+            vtc_did,
+            display_name,
+            sub_context_id,
+            persona_ref,
+            status: CommunityStatus::Pending { request_id },
+            favourite: false,
+            archived: false,
+            acknowledged: false,
+            member_since: None,
+            requested_at: Some(now),
+            relationships: Relationships::default(),
+            vrcs_issued: Vrcs::default(),
+            vrcs_received: Vrcs::default(),
+        }
+    }
+
     /// True for a membership that needs a live DIDComm session (Active or
     /// Pending) — so the VTC's asynchronous join reply is receivable (D16).
     pub fn is_live(&self) -> bool {
@@ -498,6 +529,34 @@ mod tests {
             vrcs_issued: Vrcs::default(),
             vrcs_received: Vrcs::default(),
         }
+    }
+
+    #[test]
+    fn new_pending_builds_a_live_pending_record() {
+        let now = Utc::now();
+        let pid = PersonaId::new();
+        let req = Uuid::new_v4();
+        let rec = CommunityRecord::new_pending(
+            "did:webvh:vtc.example".to_string(),
+            Some("Example VTC".to_string()),
+            "openvtc/example".to_string(),
+            pid,
+            req,
+            now,
+        );
+        assert!(matches!(rec.status, CommunityStatus::Pending { request_id } if request_id == req));
+        assert_eq!(rec.persona_ref, pid);
+        assert_eq!(rec.requested_at, Some(now));
+        assert_eq!(rec.member_since, None);
+        assert!(rec.is_live());
+        assert!(rec.needs_attention());
+        assert!(!rec.favourite && !rec.archived && !rec.acknowledged);
+
+        // Idempotency (R-B-9): a pending join is a live membership, so a re-join
+        // attempt finds it via `live_community`.
+        let mut acct = Account::default();
+        acct.communities.insert(rec.vtc_did.clone(), rec.clone());
+        assert!(acct.live_community(&rec.vtc_did).is_some());
     }
 
     #[test]

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::config::KeyTypes;
+use crate::errors::OpenVTCError;
 use crate::relationships::Relationships;
 use crate::vrc::Vrcs;
 use chrono::{DateTime, TimeDelta, Utc};
@@ -228,6 +229,19 @@ impl CommunityRecord {
         self.status = CommunityStatus::Left;
     }
 
+    /// Toggle the favourite/star flag (R-C-4). Returns the new value.
+    pub fn toggle_favourite(&mut self) -> bool {
+        self.favourite = !self.favourite;
+        self.favourite
+    }
+
+    /// Whether this membership may be archived or deleted (R-C-8): only an
+    /// **inactive** one (`Left`/`Rejected`/`Removed`/`Expired`). An active or
+    /// pending membership must be left first.
+    pub fn can_archive_or_delete(&self) -> bool {
+        self.status.is_inactive()
+    }
+
     /// Expire a stale `Pending` join past the [`PENDING_TIMEOUT_DAYS`] client
     /// timeout (R-B-7 / D16). No-op unless the membership is currently `Pending`
     /// with a `requested_at` at least the timeout old. Returns `true` if it
@@ -336,6 +350,67 @@ impl Account {
             }
         }
         expired
+    }
+
+    /// Communities for the overview page in display order (R-C-4): favourites
+    /// first, then by display name (case-insensitive; unnamed last), then VTC
+    /// DID as a stable tiebreak. Archived communities are excluded unless
+    /// `include_archived` (R-C-8).
+    pub fn communities_for_display(&self, include_archived: bool) -> Vec<&CommunityRecord> {
+        let mut list: Vec<&CommunityRecord> = self
+            .communities
+            .values()
+            .filter(|c| include_archived || !c.archived)
+            .collect();
+        list.sort_by(|a, b| {
+            // Favourites first.
+            b.favourite
+                .cmp(&a.favourite)
+                // Then by display name, case-insensitive; the unnamed sort last.
+                .then_with(|| match (&a.display_name, &b.display_name) {
+                    (Some(an), Some(bn)) => an.to_lowercase().cmp(&bn.to_lowercase()),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => std::cmp::Ordering::Equal,
+                })
+                // Finally the VTC DID for a stable, deterministic order.
+                .then_with(|| a.vtc_did.cmp(&b.vtc_did))
+        });
+        list
+    }
+
+    /// Archive an inactive community (R-C-8): retain its data but hide it from
+    /// the default list. Errors if the community is unknown or still
+    /// active/pending (it must be left first).
+    pub fn archive_community(&mut self, vtc: &VtcDid) -> Result<(), OpenVTCError> {
+        let community = self
+            .communities
+            .get_mut(vtc)
+            .ok_or_else(|| OpenVTCError::Config(format!("Unknown community: {vtc}")))?;
+        if !community.can_archive_or_delete() {
+            return Err(OpenVTCError::Config(format!(
+                "Cannot archive an active/pending community ({vtc}); leave it first"
+            )));
+        }
+        community.archived = true;
+        Ok(())
+    }
+
+    /// Delete an inactive community's local record (R-C-8), returning the removed
+    /// record. Errors if the community is unknown or still active/pending. The
+    /// presented persona is retained even if now unreferenced (R-P-2); explicit
+    /// persona deletion is a separate action.
+    pub fn delete_community(&mut self, vtc: &VtcDid) -> Result<CommunityRecord, OpenVTCError> {
+        match self.communities.get(vtc) {
+            None => Err(OpenVTCError::Config(format!("Unknown community: {vtc}"))),
+            Some(c) if !c.can_archive_or_delete() => Err(OpenVTCError::Config(format!(
+                "Cannot delete an active/pending community ({vtc}); leave it first"
+            ))),
+            Some(_) => Ok(self
+                .communities
+                .remove(vtc)
+                .expect("presence checked above")),
+        }
     }
 }
 
@@ -589,6 +664,90 @@ mod tests {
             "Left is not a live membership"
         );
         assert!(acct.live_community(&"missing".to_string()).is_none());
+    }
+
+    #[test]
+    fn favourite_toggle_and_archive_delete_guard() {
+        let pid = PersonaId::new();
+        let mut c = community("v", pid, CommunityStatus::Active);
+        assert!(!c.favourite);
+        assert!(c.toggle_favourite());
+        assert!(c.favourite);
+        assert!(!c.toggle_favourite());
+
+        // Active/pending cannot be archived/deleted; inactive can.
+        assert!(!community("v", pid, CommunityStatus::Active).can_archive_or_delete());
+        assert!(!community("v", pid, pending()).can_archive_or_delete());
+        for s in [
+            CommunityStatus::Left,
+            CommunityStatus::Rejected,
+            CommunityStatus::Removed,
+            CommunityStatus::Expired,
+        ] {
+            assert!(community("v", pid, s).can_archive_or_delete());
+        }
+    }
+
+    #[test]
+    fn communities_for_display_orders_and_filters() {
+        let mut acct = Account::default();
+        let pid = PersonaId::new();
+
+        let mut zebra = community("did:z", pid, CommunityStatus::Active);
+        zebra.display_name = Some("Zebra".into());
+        let mut acme = community("did:a", pid, CommunityStatus::Active);
+        acme.display_name = Some("acme".into()); // lowercase: case-insensitive sort
+        let mut fav = community("did:f", pid, CommunityStatus::Active);
+        fav.display_name = Some("Middle".into());
+        fav.favourite = true;
+        let mut archived = community("did:x", pid, CommunityStatus::Left);
+        archived.display_name = Some("Aardvark".into());
+        archived.archived = true;
+
+        for c in [zebra, acme, fav, archived] {
+            acct.communities.insert(c.vtc_did.clone(), c);
+        }
+
+        // Default: archived excluded; favourite first, then name (ci).
+        let names: Vec<&str> = acct
+            .communities_for_display(false)
+            .iter()
+            .map(|c| c.display_name.as_deref().unwrap())
+            .collect();
+        assert_eq!(names, vec!["Middle", "acme", "Zebra"]);
+
+        // With archived included, "Aardvark" appears (still after the favourite).
+        let with_archived: Vec<&str> = acct
+            .communities_for_display(true)
+            .iter()
+            .map(|c| c.display_name.as_deref().unwrap())
+            .collect();
+        assert_eq!(with_archived, vec!["Middle", "Aardvark", "acme", "Zebra"]);
+    }
+
+    #[test]
+    fn archive_and_delete_respect_guards() {
+        let mut acct = Account::default();
+        let pid = PersonaId::new();
+        acct.communities.insert(
+            "active".into(),
+            community("active", pid, CommunityStatus::Active),
+        );
+        acct.communities
+            .insert("left".into(), community("left", pid, CommunityStatus::Left));
+
+        // Active cannot be archived or deleted.
+        assert!(acct.archive_community(&"active".to_string()).is_err());
+        assert!(acct.delete_community(&"active".to_string()).is_err());
+        // Unknown errors too.
+        assert!(acct.archive_community(&"missing".to_string()).is_err());
+
+        // Inactive archives, then deletes.
+        acct.archive_community(&"left".to_string()).unwrap();
+        assert!(acct.communities["left"].archived);
+        let removed = acct.delete_community(&"left".to_string()).unwrap();
+        assert_eq!(removed.vtc_did, "left");
+        assert!(!acct.communities.contains_key("left"));
     }
 
     #[test]

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -75,6 +75,14 @@ pub struct PersonaRecord {
     pub persona_id: PersonaId,
     /// The persona's `did:webvh`.
     pub did: String,
+    /// Cached resolved DID document (PERF #3: startup uses this instead of a
+    /// fresh network resolve when present — did:webvh documents change rarely
+    /// between launches, so a cached doc only goes stale if the persona rotated
+    /// keys out-of-band). Persisted with the record; populated at mint/setup and
+    /// whenever the persona is resolved. `None` for records minted before this
+    /// field existed, in which case load falls back to a network resolve.
+    #[serde(default)]
+    pub did_document: Option<affinidi_tdk::did_common::Document>,
     /// Non-secret references to this persona's VTA-managed keys.
     pub key_refs: Vec<KeyRef>,
     /// Mediator DID; defaults to the VTA mediator, optional override at mint (D7).
@@ -501,6 +509,7 @@ mod tests {
         PersonaRecord {
             persona_id: PersonaId::new(),
             did: format!("did:webvh:example.com:{label}"),
+            did_document: None,
             key_refs: vec![KeyRef {
                 key_id: format!("key-{label}"),
                 purpose: KeyTypes::PersonaSigning,

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -147,6 +147,15 @@ impl CommunityStatus {
                 | CommunityStatus::Expired
         )
     }
+
+    /// True when the membership needs a live DIDComm session: `Active` (to
+    /// operate) and `Pending` (so the VTC's join reply is receivable, D16).
+    pub fn requires_live_session(&self) -> bool {
+        matches!(
+            self,
+            CommunityStatus::Active | CommunityStatus::Pending { .. }
+        )
+    }
 }
 
 /// A community membership — one per State-B join, referencing an account persona.

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -17,7 +17,7 @@
 use crate::config::KeyTypes;
 use crate::relationships::Relationships;
 use crate::vrc::Vrcs;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -192,6 +192,58 @@ pub struct CommunityRecord {
     pub vrcs_received: Vrcs,
 }
 
+/// Client-side timeout for an unanswered `Pending` join (D16 / R-B-7): a join
+/// request with no decision after this many days transitions to `Expired`.
+pub const PENDING_TIMEOUT_DAYS: i64 = 7;
+
+impl CommunityRecord {
+    /// True for a membership that needs a live DIDComm session (Active or
+    /// Pending) — so the VTC's asynchronous join reply is receivable (D16).
+    pub fn is_live(&self) -> bool {
+        self.status.requires_live_session()
+    }
+
+    /// Transition to `Active` on acceptance (R-B-8). Stamps `member_since` with
+    /// `now` the first time the membership becomes active (R-C-2); leaves an
+    /// existing timestamp untouched so a re-activation keeps the original date.
+    pub fn activate(&mut self, now: DateTime<Utc>) {
+        if self.member_since.is_none() {
+            self.member_since = Some(now);
+        }
+        self.status = CommunityStatus::Active;
+    }
+
+    /// Transition to `Rejected` — the VTC denied the join request (R-B-8).
+    pub fn reject(&mut self) {
+        self.status = CommunityStatus::Rejected;
+    }
+
+    /// Transition to `Removed` — the VTC removed an active member (R-B-8).
+    pub fn remove(&mut self) {
+        self.status = CommunityStatus::Removed;
+    }
+
+    /// Transition to `Left` — the member voluntarily left (R-L-1).
+    pub fn leave(&mut self) {
+        self.status = CommunityStatus::Left;
+    }
+
+    /// Expire a stale `Pending` join past the [`PENDING_TIMEOUT_DAYS`] client
+    /// timeout (R-B-7 / D16). No-op unless the membership is currently `Pending`
+    /// with a `requested_at` at least the timeout old. Returns `true` if it
+    /// transitioned to `Expired`.
+    pub fn expire_if_stale(&mut self, now: DateTime<Utc>) -> bool {
+        if matches!(self.status, CommunityStatus::Pending { .. })
+            && let Some(requested) = self.requested_at
+            && now - requested >= TimeDelta::days(PENDING_TIMEOUT_DAYS)
+        {
+            self.status = CommunityStatus::Expired;
+            return true;
+        }
+        false
+    }
+}
+
 /// The account — the OpenVTC ↔ VTA relationship (State-A bootstrap) plus its
 /// personas and community memberships.
 ///
@@ -252,6 +304,38 @@ impl Account {
     /// Iterator over communities in the `Active` (live) state.
     pub fn active_communities(&self) -> impl Iterator<Item = &CommunityRecord> {
         self.communities.values().filter(|c| c.status.is_active())
+    }
+
+    /// A membership by VTC DID.
+    pub fn community(&self, vtc: &VtcDid) -> Option<&CommunityRecord> {
+        self.communities.get(vtc)
+    }
+
+    /// A mutable membership by VTC DID — for applying a lifecycle transition.
+    pub fn community_mut(&mut self, vtc: &VtcDid) -> Option<&mut CommunityRecord> {
+        self.communities.get_mut(vtc)
+    }
+
+    /// A *live* membership (Active or Pending) for this VTC, if any.
+    ///
+    /// State B uses this for join idempotency (R-B-9): a live membership is
+    /// surfaced to the user instead of submitting a duplicate, while an inactive
+    /// one (`Left`/`Rejected`/`Removed`/`Expired`) may be re-joined.
+    pub fn live_community(&self, vtc: &VtcDid) -> Option<&CommunityRecord> {
+        self.communities.get(vtc).filter(|c| c.is_live())
+    }
+
+    /// Sweep all `Pending` memberships, expiring any past the client timeout
+    /// (R-B-7 / D16). Returns the VTC DIDs that transitioned to `Expired` so the
+    /// caller can persist and raise the actions-required indicator (R-S-2).
+    pub fn expire_stale_pending(&mut self, now: DateTime<Utc>) -> Vec<VtcDid> {
+        let mut expired = Vec::new();
+        for (vtc, community) in self.communities.iter_mut() {
+            if community.expire_if_stale(now) {
+                expired.push(vtc.clone());
+            }
+        }
+        expired
     }
 }
 
@@ -417,5 +501,122 @@ mod tests {
         assert_eq!(j, r#"{"state":"active"}"#);
         let j = serde_json::to_string(&CommunityStatus::Expired).unwrap();
         assert_eq!(j, r#"{"state":"expired"}"#);
+    }
+
+    fn pending() -> CommunityStatus {
+        CommunityStatus::Pending {
+            request_id: Uuid::new_v4(),
+        }
+    }
+
+    #[test]
+    fn activate_stamps_member_since_once() {
+        let pid = PersonaId::new();
+        let mut c = community("v", pid, pending());
+        let t0 = Utc::now();
+        c.activate(t0);
+        assert_eq!(c.status, CommunityStatus::Active);
+        assert_eq!(c.member_since, Some(t0));
+
+        // Re-activating keeps the original member-since date.
+        c.activate(t0 + TimeDelta::days(5));
+        assert_eq!(c.member_since, Some(t0), "member_since must not be reset");
+    }
+
+    #[test]
+    fn terminal_transitions_set_status() {
+        let pid = PersonaId::new();
+
+        let mut r = community("v", pid, pending());
+        r.reject();
+        assert_eq!(r.status, CommunityStatus::Rejected);
+
+        let mut rm = community("v", pid, CommunityStatus::Active);
+        rm.remove();
+        assert_eq!(rm.status, CommunityStatus::Removed);
+
+        let mut l = community("v", pid, CommunityStatus::Active);
+        l.leave();
+        assert_eq!(l.status, CommunityStatus::Left);
+    }
+
+    #[test]
+    fn expire_if_stale_only_fires_for_old_pending() {
+        let pid = PersonaId::new();
+        let now = Utc::now();
+
+        // Fresh pending (just under the timeout): not expired.
+        let mut fresh = community("v", pid, pending());
+        fresh.requested_at = Some(now - TimeDelta::days(PENDING_TIMEOUT_DAYS - 1));
+        assert!(!fresh.expire_if_stale(now));
+        assert!(matches!(fresh.status, CommunityStatus::Pending { .. }));
+
+        // Stale pending (at the timeout): expires.
+        let mut stale = community("v", pid, pending());
+        stale.requested_at = Some(now - TimeDelta::days(PENDING_TIMEOUT_DAYS));
+        assert!(stale.expire_if_stale(now));
+        assert_eq!(stale.status, CommunityStatus::Expired);
+
+        // Active is never expired, however old.
+        let mut active = community("v", pid, CommunityStatus::Active);
+        active.requested_at = Some(now - TimeDelta::days(365));
+        assert!(!active.expire_if_stale(now));
+        assert_eq!(active.status, CommunityStatus::Active);
+
+        // Pending with no requested_at can't be judged stale.
+        let mut no_ts = community("v", pid, pending());
+        no_ts.requested_at = None;
+        assert!(!no_ts.expire_if_stale(now));
+    }
+
+    #[test]
+    fn live_community_filters_inactive() {
+        let mut acct = Account::default();
+        let pid = PersonaId::new();
+        acct.communities.insert(
+            "active".into(),
+            community("active", pid, CommunityStatus::Active),
+        );
+        acct.communities
+            .insert("left".into(), community("left", pid, CommunityStatus::Left));
+        acct.communities
+            .insert("pend".into(), community("pend", pid, pending()));
+
+        assert!(acct.live_community(&"active".to_string()).is_some());
+        assert!(acct.live_community(&"pend".to_string()).is_some());
+        assert!(
+            acct.live_community(&"left".to_string()).is_none(),
+            "Left is not a live membership"
+        );
+        assert!(acct.live_community(&"missing".to_string()).is_none());
+    }
+
+    #[test]
+    fn expire_stale_pending_sweeps_and_reports() {
+        let mut acct = Account::default();
+        let pid = PersonaId::new();
+        let now = Utc::now();
+
+        let mut stale = community("stale", pid, pending());
+        stale.requested_at = Some(now - TimeDelta::days(10));
+        acct.communities.insert("stale".into(), stale);
+
+        let mut fresh = community("fresh", pid, pending());
+        fresh.requested_at = Some(now - TimeDelta::days(1));
+        acct.communities.insert("fresh".into(), fresh);
+
+        acct.communities.insert(
+            "active".into(),
+            community("active", pid, CommunityStatus::Active),
+        );
+
+        let expired = acct.expire_stale_pending(now);
+        assert_eq!(expired, vec!["stale".to_string()]);
+        assert_eq!(acct.communities["stale"].status, CommunityStatus::Expired);
+        assert!(matches!(
+            acct.communities["fresh"].status,
+            CommunityStatus::Pending { .. }
+        ));
+        assert_eq!(acct.communities["active"].status, CommunityStatus::Active);
     }
 }

--- a/openvtc-core/src/config/context_path.rs
+++ b/openvtc-core/src/config/context_path.rs
@@ -1,0 +1,241 @@
+/*!
+ * Context-path hierarchy convention (D2 / D9).
+ *
+ * The single source of truth for the `<top>/<slug>` sub-context naming scheme.
+ * A community's VTA sub-context id is derived from the account's top context and
+ * the community's display name (slugged), with a collision-suffix rule and a
+ * stable DID-derived fallback when no usable name is available.
+ *
+ * Isolating the convention here (D2) means a later move to a real VTA
+ * `parent_id` API changes only this module and the `create_context` call sites,
+ * not every consumer. Per `CLAUDE.md`, the no-name fallback derives its token
+ * from the VTC `did:webvh` via `didwebvh-rs` rather than hand-rolled string
+ * surgery.
+ */
+
+use crate::errors::OpenVTCError;
+use didwebvh_rs::url::WebVHURL;
+
+/// Maximum length of a slug component (D9).
+const MAX_SLUG_LEN: usize = 32;
+/// Number of leading SCID characters kept for the no-name fallback token.
+const FALLBACK_TOKEN_LEN: usize = 12;
+
+/// Slugify a community display name per D9.
+///
+/// Lowercases the name, keeps `[a-z0-9]`, collapses every run of other
+/// characters (including spaces, punctuation, and `-`) to a single `-`, trims
+/// leading/trailing `-`, and caps the result at [`MAX_SLUG_LEN`] characters.
+/// Returns an empty string when nothing usable remains (e.g. a name with no
+/// ASCII alphanumerics) — callers fall back to [`fallback_token`].
+pub fn slugify(name: &str) -> String {
+    let mut out = String::with_capacity(name.len().min(MAX_SLUG_LEN));
+    let mut pending_dash = false;
+    for c in name.chars() {
+        let lc = c.to_ascii_lowercase();
+        if lc.is_ascii_lowercase() || lc.is_ascii_digit() {
+            // A separator was pending and we have real content on both sides —
+            // emit a single joining dash.
+            if pending_dash && !out.is_empty() {
+                out.push('-');
+            }
+            pending_dash = false;
+            out.push(lc);
+            if out.len() >= MAX_SLUG_LEN {
+                break;
+            }
+        } else {
+            // Any non-alphanumeric (including `-`) collapses to one dash, but we
+            // only commit it once we know real content follows (avoids leading
+            // and trailing dashes).
+            pending_dash = true;
+        }
+    }
+    out
+}
+
+/// A short, stable token derived from a VTC `did:webvh` via `didwebvh-rs`.
+///
+/// Used as the slug when a community has no usable display name (D9). The token
+/// is the lowercased, alphanumeric-only prefix of the DID's SCID — stable for a
+/// given DID and safe as a context-path component.
+///
+/// # Errors
+///
+/// Returns an error if `vtc_did` is not a parseable `did:webvh` or its SCID
+/// yields no usable characters.
+pub fn fallback_token(vtc_did: &str) -> Result<String, OpenVTCError> {
+    let parsed = WebVHURL::parse_did_url(vtc_did)
+        .map_err(|e| OpenVTCError::Config(format!("Invalid VTC did:webvh ({vtc_did}): {e}")))?;
+    let token: String = parsed
+        .scid
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .take(FALLBACK_TOKEN_LEN)
+        .collect();
+    if token.is_empty() {
+        return Err(OpenVTCError::Config(format!(
+            "VTC DID has no usable SCID for a context token: {vtc_did}"
+        )));
+    }
+    Ok(token)
+}
+
+/// Build a `<top>/<slug>` sub-context id for a community (D9).
+///
+/// The slug is [`slugify`]'d from `display_name`, or [`fallback_token`]'d from
+/// `vtc_did` when the name is absent/empty/unusable. `is_taken` reports whether
+/// a candidate id already exists under the top context; on collision the slug
+/// gains a `-2`, `-3`, … suffix until it is unique.
+///
+/// # Errors
+///
+/// Returns an error only when the fallback token is needed and `vtc_did` is not
+/// a usable `did:webvh`.
+pub fn build_sub_context_id(
+    top_context_id: &str,
+    display_name: Option<&str>,
+    vtc_did: &str,
+    is_taken: impl Fn(&str) -> bool,
+) -> Result<String, OpenVTCError> {
+    let base = match display_name.map(slugify) {
+        Some(slug) if !slug.is_empty() => slug,
+        _ => fallback_token(vtc_did)?,
+    };
+
+    let mut candidate = format!("{top_context_id}/{base}");
+    let mut n = 2u32;
+    while is_taken(&candidate) {
+        candidate = format!("{top_context_id}/{base}-{n}");
+        n += 1;
+    }
+    Ok(candidate)
+}
+
+/// Split a `<top>/<slug>` id into `(top, slug)`.
+///
+/// The top context may itself contain `/` (nested), so the split is on the last
+/// `/`. Returns `None` for an id with no `/` (not a sub-context id).
+pub fn parse_sub_context_id(id: &str) -> Option<(&str, &str)> {
+    id.rsplit_once('/')
+}
+
+/// The display form of a sub-context id: its slug (the final path segment), or
+/// the whole string when it has no `/`.
+pub fn render_for_display(id: &str) -> &str {
+    id.rsplit_once('/').map_or(id, |(_, slug)| slug)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn slugify_basic_lowercasing_and_separators() {
+        assert_eq!(slugify("Acme Corp"), "acme-corp");
+        assert_eq!(slugify("ACME"), "acme");
+        assert_eq!(slugify("Foo123"), "foo123");
+    }
+
+    #[test]
+    fn slugify_collapses_runs_and_trims() {
+        assert_eq!(slugify("  Hello,   World!!  "), "hello-world");
+        assert_eq!(slugify("a___b---c"), "a-b-c");
+        assert_eq!(slugify("--leading and trailing--"), "leading-and-trailing");
+        assert_eq!(slugify("a - b"), "a-b");
+    }
+
+    #[test]
+    fn slugify_strips_non_ascii_and_handles_empty() {
+        assert_eq!(slugify(""), "");
+        assert_eq!(slugify("!!!"), "");
+        // Non-ASCII letters are treated as separators (collapsed to dashes).
+        assert_eq!(slugify("café münchen"), "caf-m-nchen");
+    }
+
+    #[test]
+    fn slugify_caps_at_max_len() {
+        let long = "a".repeat(100);
+        assert_eq!(slugify(&long).len(), MAX_SLUG_LEN);
+    }
+
+    #[test]
+    fn fallback_token_is_stable_and_clean() {
+        let did = "did:webvh:zQmTestScidValue:example.com";
+        let t1 = fallback_token(did).unwrap();
+        let t2 = fallback_token(did).unwrap();
+        assert_eq!(t1, t2, "fallback token must be stable for a given DID");
+        assert!(!t1.is_empty());
+        assert!(t1.len() <= FALLBACK_TOKEN_LEN);
+        assert!(
+            t1.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()),
+            "token must be a clean slug component, got {t1}"
+        );
+    }
+
+    #[test]
+    fn fallback_token_rejects_non_webvh() {
+        assert!(fallback_token("did:key:z6Mk").is_err());
+        assert!(fallback_token("not-a-did").is_err());
+    }
+
+    #[test]
+    fn build_uses_slug_under_top() {
+        let taken = HashSet::<String>::new();
+        let id = build_sub_context_id(
+            "openvtc",
+            Some("Acme Corp"),
+            "did:webvh:zScid:example.com",
+            |c| taken.contains(c),
+        )
+        .unwrap();
+        assert_eq!(id, "openvtc/acme-corp");
+    }
+
+    #[test]
+    fn build_falls_back_to_did_token_when_no_name() {
+        let taken = HashSet::<String>::new();
+        let did = "did:webvh:zQmTestScidValue:example.com";
+        let expected = format!("openvtc/{}", fallback_token(did).unwrap());
+        for name in [None, Some(""), Some("   "), Some("!!!")] {
+            let id = build_sub_context_id("openvtc", name, did, |c| taken.contains(c)).unwrap();
+            assert_eq!(id, expected, "name {name:?} should fall back to DID token");
+        }
+    }
+
+    #[test]
+    fn build_suffixes_on_collision() {
+        let mut taken = HashSet::new();
+        taken.insert("openvtc/acme".to_string());
+        taken.insert("openvtc/acme-2".to_string());
+        let id = build_sub_context_id(
+            "openvtc",
+            Some("ACME"),
+            "did:webvh:zScid:example.com",
+            |c| taken.contains(c),
+        )
+        .unwrap();
+        assert_eq!(id, "openvtc/acme-3");
+    }
+
+    #[test]
+    fn parse_and_render_round_trip() {
+        assert_eq!(
+            parse_sub_context_id("openvtc/acme"),
+            Some(("openvtc", "acme"))
+        );
+        // Nested top context: split on the last slash.
+        assert_eq!(
+            parse_sub_context_id("org/openvtc/acme"),
+            Some(("org/openvtc", "acme"))
+        );
+        assert_eq!(parse_sub_context_id("openvtc"), None);
+
+        assert_eq!(render_for_display("openvtc/acme"), "acme");
+        assert_eq!(render_for_display("org/openvtc/acme"), "acme");
+        assert_eq!(render_for_display("openvtc"), "openvtc");
+    }
+}

--- a/openvtc-core/src/config/did.rs
+++ b/openvtc-core/src/config/did.rs
@@ -20,6 +20,34 @@ use url::Url;
 
 use crate::{config::PersonaDIDKeys, errors::OpenVTCError};
 
+/// Extract the mediator DID from a persona's DID document.
+///
+/// A persona DID minted via the VTA's webvh server carries a `DIDCommMessaging`
+/// service whose endpoint URI is the mediator DID (see the `#public-didcomm`
+/// service built above, and the VTA's equivalent `#vta-didcomm`). This is the
+/// authoritative source for a persona's mediator — used to repair a persona
+/// that was persisted without one. Returns `None` if the document has no
+/// DIDComm service or it carries no URI.
+pub fn mediator_from_document(doc: &Document) -> Option<String> {
+    doc.service
+        .iter()
+        .find(|s| s.type_.iter().any(|t| t == "DIDCommMessaging"))
+        .and_then(|s| match &s.service_endpoint {
+            Endpoint::Url(url) => Some(url.to_string()),
+            // The endpoint is `[{"uri": "<mediator did>", "accept": [...]}]` (an
+            // array) or a bare `{"uri": ...}` object. Read the string via
+            // `as_str` (not `Value::to_string`, which would keep the quotes).
+            Endpoint::Map(value) => {
+                let obj = match value {
+                    Value::Array(items) => items.first()?,
+                    other => other,
+                };
+                obj.get("uri").and_then(Value::as_str).map(str::to_owned)
+            }
+        })
+        .filter(|m| !m.is_empty())
+}
+
 /// Creates a new `did:webvh` DID with key pre-rotation enabled.
 ///
 /// This builds a full DID Document containing three verification methods:

--- a/openvtc-core/src/config/keys.rs
+++ b/openvtc-core/src/config/keys.rs
@@ -64,7 +64,10 @@ impl Config {
     /// Returns an error if the DID document is missing any required verification
     /// method, or if the corresponding secret or key info cannot be found.
     pub async fn get_persona_keys(&self, tdk: &TDK) -> Result<PersonaDIDKeys, OpenVTCError> {
-        let doc = &self.persona_did.document;
+        let doc = self
+            .active_identity()
+            .ok_or_else(|| OpenVTCError::Config("No active persona identity".to_string()))?
+            .document();
         let signing = resolve_key_from_document(
             &doc.assertion_method,
             "assertion methods",

--- a/openvtc-core/src/config/keys.rs
+++ b/openvtc-core/src/config/keys.rs
@@ -98,6 +98,17 @@ impl Config {
     /// DIDComm service can authenticate with the mediator. On normal startup
     /// this is done by `load_step2`.
     pub async fn load_persona_secrets(&self, tdk: &TDK) -> Result<(), OpenVTCError> {
+        // Open ONE VTA admin session up front and reuse it for every VtaManaged
+        // key below, instead of connecting (and tearing down) a fresh mediator
+        // session per key.
+        let vta_client = if matches!(&self.key_backend, KeyBackend::Vta { .. }) {
+            super::build_runtime_vta_client(&self.key_backend)
+                .await
+                .ok()
+        } else {
+            None
+        };
+
         for (key_id, key_info) in &self.key_info {
             if !key_id.starts_with(self.persona_did()) {
                 continue;
@@ -107,59 +118,54 @@ impl Config {
                 KeyTypes::PersonaEncryption => KeyPurpose::Encryption,
                 _ => continue,
             };
-            let secret =
-                match &key_info.path {
-                    KeySourceMaterial::Derived { path } => {
-                        let KeyBackend::Bip32 { root, .. } = &self.key_backend else {
-                            continue;
-                        };
-                        root.get_secret_from_path(path, kp)
-                            .map(|mut s| {
-                                s.id = key_id.clone();
-                                s
-                            })
+            let secret = match &key_info.path {
+                KeySourceMaterial::Derived { path } => {
+                    let KeyBackend::Bip32 { root, .. } = &self.key_backend else {
+                        continue;
+                    };
+                    root.get_secret_from_path(path, kp)
+                        .map(|mut s| {
+                            s.id = key_id.clone();
+                            s
+                        })
+                        .ok()
+                }
+                KeySourceMaterial::Imported { seed } => {
+                    use secrecy::ExposeSecret;
+                    Secret::from_multibase(seed.expose_secret(), None)
+                        .map(|mut s| {
+                            s.id = key_id.clone();
+                            s
+                        })
+                        .ok()
+                }
+                KeySourceMaterial::VtaManaged { key_id: vta_key_id } => {
+                    if let Some(client) = vta_client.as_ref() {
+                        client
+                            .get_key_secret(vta_key_id)
+                            .await
                             .ok()
-                    }
-                    KeySourceMaterial::Imported { seed } => {
-                        use secrecy::ExposeSecret;
-                        Secret::from_multibase(seed.expose_secret(), None)
-                            .map(|mut s| {
-                                s.id = key_id.clone();
-                                s
+                            .and_then(|resp| {
+                                secret_from_vta_response(&resp, kp)
+                                    .map(|mut s| {
+                                        s.id = key_id.clone();
+                                        s
+                                    })
+                                    .ok()
                             })
-                            .ok()
+                    } else {
+                        None
                     }
-                    KeySourceMaterial::VtaManaged { key_id: vta_key_id } => {
-                        if matches!(&self.key_backend, KeyBackend::Vta { .. }) {
-                            match super::build_runtime_vta_client(&self.key_backend).await {
-                                Ok(client) => {
-                                    let secret =
-                                        client.get_key_secret(vta_key_id).await.ok().and_then(
-                                            |resp| {
-                                                secret_from_vta_response(&resp, kp)
-                                                    .map(|mut s| {
-                                                        s.id = key_id.clone();
-                                                        s
-                                                    })
-                                                    .ok()
-                                            },
-                                        );
-                                    // Close the persistent DIDComm session so it
-                                    // doesn't linger and duel other admin sessions
-                                    // on the mediator (`Drop` can't close it).
-                                    client.shutdown().await;
-                                    secret
-                                }
-                                Err(_) => None,
-                            }
-                        } else {
-                            None
-                        }
-                    }
-                };
+                }
+            };
             if let Some(s) = secret {
                 tdk.get_shared_state().secrets_resolver().insert(s).await;
             }
+        }
+
+        // Close the single shared session now that all keys are loaded.
+        if let Some(client) = vta_client {
+            client.shutdown().await;
         }
         Ok(())
     }

--- a/openvtc-core/src/config/keys.rs
+++ b/openvtc-core/src/config/keys.rs
@@ -109,6 +109,10 @@ impl Config {
             None
         };
 
+        // PERF: VtaManaged `get_key_secret` calls stay sequential — see the note
+        // in `regenerate_persona_keys`: concurrent fetches on a single
+        // DIDComm-backed session race on the shared live-stream cursor and can
+        // drop each other's responses.
         for (key_id, key_info) in &self.key_info {
             if !key_id.starts_with(self.persona_did()) {
                 continue;
@@ -183,7 +187,21 @@ impl Config {
         doc: &Document,
         vta_client: Option<&vta_sdk::client::VtaClient>,
     ) -> Result<(), OpenVTCError> {
-        // Rehydrate DID keys referenced by Verification Methods in the DID Document
+        // Rehydrate DID keys referenced by Verification Methods in the DID
+        // Document.
+        //
+        // PERF: the VtaManaged `get_key_secret` round-trips below are kept
+        // SEQUENTIAL on purpose. When `vta_client` is DIDComm-backed (the
+        // default for a VTA backend), all cloned `VtaClient`s share ONE
+        // `Arc<ATM>`/`Arc<ATMProfile>` and therefore ONE WebSocket live-stream
+        // cursor. `vta_sdk`'s `send_and_wait` reads that cursor with
+        // `live_stream_next` and DROPS (`continue`) any message whose `thid`
+        // doesn't match the request it is waiting on — so two concurrent
+        // fetches on the same session race: one can consume and discard the
+        // other's response, making that fetch time out. Parallelising here
+        // would risk dropped persona keys at startup. (REST-backed sessions
+        // would be safe, but the transport isn't known here.) See
+        // `vta-sdk/src/didcomm_session.rs::send_and_wait`.
         for vm in &doc.verification_method {
             let Some(kp) = sc.key_info.get(vm.id.as_str()) else {
                 warn!(

--- a/openvtc-core/src/config/keys.rs
+++ b/openvtc-core/src/config/keys.rs
@@ -132,18 +132,24 @@ impl Config {
                     KeySourceMaterial::VtaManaged { key_id: vta_key_id } => {
                         if matches!(&self.key_backend, KeyBackend::Vta { .. }) {
                             match super::build_runtime_vta_client(&self.key_backend).await {
-                                Ok(client) => client
-                                    .get_key_secret(vta_key_id)
-                                    .await
-                                    .ok()
-                                    .and_then(|resp| {
-                                        secret_from_vta_response(&resp, kp)
-                                            .map(|mut s| {
-                                                s.id = key_id.clone();
-                                                s
-                                            })
-                                            .ok()
-                                    }),
+                                Ok(client) => {
+                                    let secret =
+                                        client.get_key_secret(vta_key_id).await.ok().and_then(
+                                            |resp| {
+                                                secret_from_vta_response(&resp, kp)
+                                                    .map(|mut s| {
+                                                        s.id = key_id.clone();
+                                                        s
+                                                    })
+                                                    .ok()
+                                            },
+                                        );
+                                    // Close the persistent DIDComm session so it
+                                    // doesn't linger and duel other admin sessions
+                                    // on the mediator (`Drop` can't close it).
+                                    client.shutdown().await;
+                                    secret
+                                }
                                 Err(_) => None,
                             }
                         } else {

--- a/openvtc-core/src/config/keys.rs
+++ b/openvtc-core/src/config/keys.rs
@@ -99,7 +99,7 @@ impl Config {
     /// this is done by `load_step2`.
     pub async fn load_persona_secrets(&self, tdk: &TDK) -> Result<(), OpenVTCError> {
         for (key_id, key_info) in &self.key_info {
-            if !key_id.starts_with(self.public.persona_did.as_str()) {
+            if !key_id.starts_with(self.persona_did()) {
                 continue;
             }
             let kp = match key_info.purpose {

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -288,6 +288,35 @@ impl Config {
                         .doc
                 };
 
+                // Final mediator resolution. If neither the persona record nor
+                // the account carried a mediator, recover it from the DID
+                // document itself — the persona DID was minted with a
+                // DIDCommMessaging service whose endpoint IS the mediator, so it
+                // is always authoritative. Without this the persona listener
+                // fails with "No Mediator is configured" and reconnect-loops.
+                let active_mediator_did = if active_mediator_did.is_empty() {
+                    match super::did::mediator_from_document(&document) {
+                        Some(m) => {
+                            warn!(
+                                persona = %active_persona_did,
+                                mediator = %m,
+                                "recovered persona mediator from its DID document"
+                            );
+                            m
+                        }
+                        None => {
+                            warn!(
+                                persona = %active_persona_did,
+                                "persona has no mediator anywhere (record, account, \
+                                 or DID document) — its listener will not connect"
+                            );
+                            active_mediator_did
+                        }
+                    }
+                } else {
+                    active_mediator_did
+                };
+
                 report_progress(&on_progress, "Identity", "Fetching persona keys");
                 Config::regenerate_persona_keys(
                     tdk,

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -261,6 +261,20 @@ impl Config {
         if let Some((active_persona_id, active_persona_did, active_mediator_did, cached_document)) =
             active_persona
         {
+            // Name the persona's messaging profile after its community so it is
+            // identifiable (not a generic "Persona") — matches the runtime
+            // listener label (`Config::persona_profile_label`).
+            let profile_label = account
+                .communities
+                .values()
+                .find(|c| c.persona_ref == active_persona_id)
+                .map(|c| {
+                    c.display_name.clone().unwrap_or_else(|| {
+                        crate::config::context_path::render_for_display(&c.vtc_did).to_string()
+                    })
+                })
+                .unwrap_or_else(|| "Persona".to_string());
+
             // Resolve + key/profile setup for the active persona. Wrapped in an
             // inner future so that, on the `?` error paths below, the admin VTA
             // session is shut down before the error propagates (a leaked session
@@ -332,7 +346,7 @@ impl Config {
                     tdk.atm.as_ref().ok_or_else(|| {
                         OpenVTCError::Config("TDK ATM service not initialized".to_string())
                     })?,
-                    Some("Persona DID".to_string()),
+                    Some(profile_label.clone()),
                     active_persona_did.to_string(),
                     Some(active_mediator_did.clone()),
                 )

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     config::{
-        Config, ConfigProtectionType, KeyBackend, PersonaDID, UnlockCode,
+        Config, ConfigProtectionType, KeyBackend, UnlockCode,
         account::{Account, KeyRef, PersonaId, PersonaRecord},
         protected_config::ProtectedConfig,
         public_config::PublicConfig,
@@ -290,8 +290,8 @@ impl Config {
             crate::identity::IdentityContext {
                 persona_id,
                 did: public_config.persona_did.to_string(),
-                document: rr.doc.clone(),
-                profile: persona_profile.clone(),
+                document: rr.doc,
+                profile: persona_profile,
                 mediator_did: Some(public_config.mediator_did.clone()),
             },
         );
@@ -300,10 +300,6 @@ impl Config {
             account,
             identities,
             key_backend,
-            persona_did: PersonaDID {
-                document: rr.doc,
-                profile: persona_profile,
-            },
             public: public_config,
             private: private_cfg,
             key_info: sc.key_info.clone(),

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -280,12 +280,25 @@ impl Config {
             },
             ..Account::default()
         };
-        account
-            .personas
-            .insert(persona_record.persona_id, persona_record);
+        let persona_id = persona_record.persona_id;
+        account.personas.insert(persona_id, persona_record);
+
+        // Runtime identity for the single persona (resolved doc + ATM profile).
+        let mut identities = HashMap::new();
+        identities.insert(
+            persona_id,
+            crate::identity::IdentityContext {
+                persona_id,
+                did: public_config.persona_did.to_string(),
+                document: rr.doc.clone(),
+                profile: persona_profile.clone(),
+                mediator_did: Some(public_config.mediator_did.clone()),
+            },
+        );
 
         Ok(Config {
             account,
+            identities,
             key_backend,
             persona_did: PersonaDID {
                 document: rr.doc,

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -236,19 +236,6 @@ impl Config {
             )
             .await?;
 
-        // Add all VRC's to the top level list
-        let mut vrcs = HashMap::new();
-        for relationship in private_cfg.vrcs_issued.values() {
-            for (vrc_id, vrc) in relationship.iter() {
-                vrcs.insert(vrc_id.clone(), vrc.clone());
-            }
-        }
-        for relationship in private_cfg.vrcs_received.values() {
-            for (vrc_id, vrc) in relationship.iter() {
-                vrcs.insert(vrc_id.clone(), vrc.clone());
-            }
-        }
-
         // T1 (transitional): derive the v2 account from the loaded singleton —
         // one persona (the current persona DID + its keys), no communities yet
         // (the singleton has no community concept). Consumers are migrating onto
@@ -312,7 +299,6 @@ impl Config {
             protection_method: sc.protection_method.clone(),
             unlock_code: unlock_passphrase
                 .map(|uc| SecretBox::new(Box::new(uc.0.expose_secret().to_owned()))),
-            vrcs,
         })
     }
 }

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -2,17 +2,14 @@
 
 use crate::{
     config::{
-        Config, ConfigProtectionType, KeyBackend, UnlockCode,
-        account::{Account, KeyRef, PersonaId, PersonaRecord},
-        protected_config::ProtectedConfig,
-        public_config::PublicConfig,
+        Config, ConfigProtectionType, KeyBackend, UnlockCode, account::PersonaId,
+        protected_config::ProtectedConfig, public_config::PublicConfig,
         secured_config::SecuredConfig,
     },
     errors::OpenVTCError,
 };
 use affinidi_tdk::{TDK, messaging::profiles::ATMProfile};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
-use chrono::Utc;
 use ed25519_dalek_bip32::ExtendedSigningKey;
 use secrecy::{ExposeSecret, SecretBox, SecretString};
 use std::collections::HashMap;
@@ -172,30 +169,32 @@ impl Config {
         debug!("Private Config\n{:#?}", private_cfg);
 
         // T1 (final slice): the v2 `account` persisted in the protected tier is
-        // the source of truth for the active persona. A freshly-loaded v1 config
-        // has an empty persisted account — fall back to deriving from the
-        // singleton, which is re-persisted into `account` on the next save.
-        let persisted_account =
-            (!private_cfg.account.personas.is_empty()).then(|| private_cfg.account.clone());
-        let (active_persona_did, active_mediator_did): (std::sync::Arc<String>, String) =
-            match &persisted_account {
-                Some(acct) => {
-                    // Single-persona for now: the one (and only) persona entry.
-                    let persona = acct
-                        .personas
-                        .values()
-                        .next()
-                        .expect("non-empty personas checked above");
-                    (
-                        std::sync::Arc::new(persona.did.clone()),
-                        persona.mediator_did.clone().unwrap_or_default(),
-                    )
-                }
-                None => (
-                    public_config.persona_did.clone(),
-                    public_config.mediator_did.clone(),
-                ),
-            };
+        // the sole source of truth for the active persona. v1 (singleton) configs
+        // are reset before reaching here (D13/R-RST), so a loadable config always
+        // carries an account; an empty one is corruption, not a v1 fallback.
+        if private_cfg.account.personas.is_empty() {
+            return Err(OpenVTCError::Config(
+                "Config account has no personas — empty or corrupt account".to_string(),
+            ));
+        }
+        let account = private_cfg.account.clone();
+        // Single-persona for now: the one (and only) persona entry.
+        let (active_persona_id, active_persona_did, active_mediator_did): (
+            PersonaId,
+            std::sync::Arc<String>,
+            String,
+        ) = {
+            let persona = account
+                .personas
+                .values()
+                .next()
+                .expect("non-empty personas checked above");
+            (
+                persona.persona_id,
+                std::sync::Arc::new(persona.did.clone()),
+                persona.mediator_did.clone().unwrap_or_default(),
+            )
+        };
 
         // Build the VTA client once upfront (if VTA backend), reusing whichever
         // transport setup chose: DIDComm if a mediator was advertised, REST
@@ -261,55 +260,9 @@ impl Config {
             )
             .await?;
 
-        // Use the persisted v2 account as the source of truth. For a freshly
-        // loaded v1 config (no persisted account) derive one from the singleton —
-        // one persona (the current persona DID + its keys), no communities yet —
-        // which is re-persisted into `account` on the next save.
-        let account = match persisted_account {
-            Some(acct) => acct,
-            None => {
-                let persona_record = PersonaRecord {
-                    persona_id: PersonaId::new(),
-                    did: active_persona_did.to_string(),
-                    key_refs: sc
-                        .key_info
-                        .iter()
-                        .map(|(id, info)| KeyRef {
-                            key_id: id.clone(),
-                            purpose: info.purpose.clone(),
-                            created_at: info.create_time,
-                        })
-                        .collect(),
-                    mediator_did: Some(active_mediator_did.clone()),
-                    origin_context_id: String::new(),
-                    created_at: Utc::now(),
-                    label: Some(public_config.friendly_name.clone()),
-                };
-                let mut account = Account {
-                    vta_did: match &key_backend {
-                        KeyBackend::Vta { vta_did, .. } => vta_did.clone(),
-                        KeyBackend::Bip32 { .. } => String::new(),
-                    },
-                    vta_url: match &key_backend {
-                        KeyBackend::Vta { vta_url, .. } => vta_url.clone(),
-                        KeyBackend::Bip32 { .. } => String::new(),
-                    },
-                    ..Account::default()
-                };
-                account
-                    .personas
-                    .insert(persona_record.persona_id, persona_record);
-                account
-            }
-        };
-        // The active persona id: the single (and only) persona entry for now.
-        let persona_id = *account
-            .personas
-            .keys()
-            .next()
-            .expect("account always has at least one persona after the derive above");
-
-        // Runtime identity for the single persona (resolved doc + ATM profile).
+        // Runtime identity for the single active persona (resolved doc + ATM
+        // profile). `account` and `active_persona_id` were resolved above.
+        let persona_id = active_persona_id;
         let mut identities = HashMap::new();
         identities.insert(
             persona_id,

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -266,6 +266,14 @@ impl Config {
             );
         }
 
+        // Close the transient admin-DID VTA session. `connect_didcomm` opens a
+        // persistent, auto-reconnecting WebSocket that `Drop` cannot close
+        // (shutdown is async), so a leaked admin session duels later admin
+        // sessions on the mediator (duplicate-WebSocket loop → DIDComm timeouts).
+        if let Some(client) = &vta_client {
+            client.shutdown().await;
+        }
+
         Ok(Config {
             account,
             identities,

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -2,9 +2,8 @@
 
 use crate::{
     config::{
-        Config, ConfigProtectionType, KeyBackend, UnlockCode, account::PersonaId,
-        protected_config::ProtectedConfig, public_config::PublicConfig,
-        secured_config::SecuredConfig,
+        Config, ConfigProtectionType, KeyBackend, UnlockCode, protected_config::ProtectedConfig,
+        public_config::PublicConfig, secured_config::SecuredConfig,
     },
     errors::OpenVTCError,
 };
@@ -168,37 +167,15 @@ impl Config {
 
         debug!("Private Config\n{:#?}", private_cfg);
 
-        // T1 (final slice): the v2 `account` persisted in the protected tier is
-        // the sole source of truth for the active persona. v1 (singleton) configs
-        // are reset before reaching here (D13/R-RST), so a loadable config always
-        // carries an account; an empty one is corruption, not a v1 fallback.
-        if private_cfg.account.personas.is_empty() {
-            return Err(OpenVTCError::Config(
-                "Config account has no personas — empty or corrupt account".to_string(),
-            ));
-        }
+        // The v2 `account` persisted in the protected tier is the source of
+        // truth. v1 (singleton) configs are reset before reaching here
+        // (D13/R-RST), so a loadable config always carries an account.
         let account = private_cfg.account.clone();
-        // Single-persona for now: the one (and only) persona entry.
-        let (active_persona_id, active_persona_did, active_mediator_did): (
-            PersonaId,
-            std::sync::Arc<String>,
-            String,
-        ) = {
-            let persona = account
-                .personas
-                .values()
-                .next()
-                .expect("non-empty personas checked above");
-            (
-                persona.persona_id,
-                std::sync::Arc::new(persona.did.clone()),
-                persona.mediator_did.clone().unwrap_or_default(),
-            )
-        };
 
         // Build the VTA client once upfront (if VTA backend), reusing whichever
         // transport setup chose: DIDComm if a mediator was advertised, REST
-        // otherwise. The helper handles auth in both directions.
+        // otherwise. Needed for runtime VTA operations whether or not a persona
+        // is present.
         let vta_client = if matches!(&key_backend, KeyBackend::Vta { .. }) {
             report_progress(&on_progress, "Authenticating...");
             Some(super::build_runtime_vta_client(&key_backend).await?)
@@ -206,74 +183,88 @@ impl Config {
             None
         };
 
-        // All config info has been loaded, load DID Document and regenerate keys
-        report_progress(&on_progress, "Resolving DID...");
-        let rr = tdk
-            .did_resolver()
-            .resolve(&active_persona_did)
-            .await
-            .map_err(|e| {
-                OpenVTCError::Resolver(format!(
-                    "Couldn't resolve Persona DID ({active_persona_did}): {e}"
-                ))
-            })?;
+        // Resolve runtime identities from the account's personas.
+        //
+        // A State-A (account-bootstrap, R-A-5) account persists with NO persona:
+        // the app loads to a "no active community" state and a persona is minted
+        // later in a State-B join. Such an account has no DID to resolve and no
+        // persona/relationship messaging profiles to register, so the whole
+        // resolve/keygen/profile block is skipped and `identities` stays empty.
+        // A State-B account currently carries a single persona, resolved here.
+        let active_persona = account.personas.values().next().map(|p| {
+            (
+                p.persona_id,
+                std::sync::Arc::new(p.did.clone()),
+                p.mediator_did.clone().unwrap_or_default(),
+            )
+        });
 
-        // Create keys from DID Document
-        report_progress(&on_progress, "Loading keys...");
-        Config::regenerate_persona_keys(tdk, &sc, &key_backend, &rr.doc, vta_client.as_ref())
-            .await?;
+        let mut identities = HashMap::new();
+        if let Some((active_persona_id, active_persona_did, active_mediator_did)) = active_persona {
+            // All config info has been loaded, load DID Document and regenerate keys
+            report_progress(&on_progress, "Resolving DID...");
+            let rr = tdk
+                .did_resolver()
+                .resolve(&active_persona_did)
+                .await
+                .map_err(|e| {
+                    OpenVTCError::Resolver(format!(
+                        "Couldn't resolve Persona DID ({active_persona_did}): {e}"
+                    ))
+                })?;
 
-        // Create persona profile
-        report_progress(&on_progress, "Creating messaging profiles...");
-        let persona_profile = ATMProfile::new(
-            tdk.atm.as_ref().ok_or_else(|| {
-                OpenVTCError::Config("TDK ATM service not initialized".to_string())
-            })?,
-            Some("Persona DID".to_string()),
-            active_persona_did.to_string(),
-            Some(active_mediator_did.clone()),
-        )
-        .await?;
+            // Create keys from DID Document
+            report_progress(&on_progress, "Loading keys...");
+            Config::regenerate_persona_keys(tdk, &sc, &key_backend, &rr.doc, vta_client.as_ref())
+                .await?;
 
-        // Register the persona profile with the TDK ATM Service but do NOT
-        // open a WebSocket connection. The DIDComm service manages its own
-        // connections — connecting here would create a duplicate WebSocket for
-        // the same DID, triggering the mediator's duplicate detection loop.
-        let atm = tdk
-            .atm
-            .clone()
-            .ok_or_else(|| OpenVTCError::Config("TDK ATM service not initialized".to_string()))?;
-        let persona_profile = atm.profile_add(&persona_profile, false).await?;
-
-        report_progress(&on_progress, "Loading relationships...");
-        // Registers each relationship profile with the ATM service as a
-        // side-effect; the returned map is no longer stored on `Config`.
-        private_cfg
-            .relationships
-            .generate_profiles(
-                tdk,
-                &active_persona_did,
-                &active_mediator_did,
-                &key_backend,
-                &sc.key_info,
-                vta_client.as_ref(),
+            // Create persona profile
+            report_progress(&on_progress, "Creating messaging profiles...");
+            let persona_profile = ATMProfile::new(
+                tdk.atm.as_ref().ok_or_else(|| {
+                    OpenVTCError::Config("TDK ATM service not initialized".to_string())
+                })?,
+                Some("Persona DID".to_string()),
+                active_persona_did.to_string(),
+                Some(active_mediator_did.clone()),
             )
             .await?;
 
-        // Runtime identity for the single active persona (resolved doc + ATM
-        // profile). `account` and `active_persona_id` were resolved above.
-        let persona_id = active_persona_id;
-        let mut identities = HashMap::new();
-        identities.insert(
-            persona_id,
-            crate::identity::IdentityContext {
-                persona_id,
-                did: active_persona_did.to_string(),
-                document: rr.doc,
-                profile: persona_profile,
-                mediator_did: Some(active_mediator_did.clone()),
-            },
-        );
+            // Register the persona profile with the TDK ATM Service but do NOT
+            // open a WebSocket connection. The DIDComm service manages its own
+            // connections — connecting here would create a duplicate WebSocket for
+            // the same DID, triggering the mediator's duplicate detection loop.
+            let atm = tdk.atm.clone().ok_or_else(|| {
+                OpenVTCError::Config("TDK ATM service not initialized".to_string())
+            })?;
+            let persona_profile = atm.profile_add(&persona_profile, false).await?;
+
+            report_progress(&on_progress, "Loading relationships...");
+            // Registers each relationship profile with the ATM service as a
+            // side-effect; the returned map is no longer stored on `Config`.
+            private_cfg
+                .relationships
+                .generate_profiles(
+                    tdk,
+                    &active_persona_did,
+                    &active_mediator_did,
+                    &key_backend,
+                    &sc.key_info,
+                    vta_client.as_ref(),
+                )
+                .await?;
+
+            identities.insert(
+                active_persona_id,
+                crate::identity::IdentityContext {
+                    persona_id: active_persona_id,
+                    did: active_persona_did.to_string(),
+                    document: rr.doc,
+                    profile: persona_profile,
+                    mediator_did: Some(active_mediator_did),
+                },
+            );
+        }
 
         Ok(Config {
             account,

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -3,13 +3,16 @@
 use crate::{
     config::{
         Config, ConfigProtectionType, KeyBackend, PersonaDID, UnlockCode,
-        protected_config::ProtectedConfig, public_config::PublicConfig,
+        account::{Account, KeyRef, PersonaId, PersonaRecord},
+        protected_config::ProtectedConfig,
+        public_config::PublicConfig,
         secured_config::SecuredConfig,
     },
     errors::OpenVTCError,
 };
 use affinidi_tdk::{TDK, messaging::profiles::ATMProfile};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use chrono::Utc;
 use ed25519_dalek_bip32::ExtendedSigningKey;
 use secrecy::{ExposeSecret, SecretBox, SecretString};
 use std::collections::HashMap;
@@ -244,7 +247,45 @@ impl Config {
             }
         }
 
+        // T1 (transitional): derive the v2 account from the loaded singleton —
+        // one persona (the current persona DID + its keys), no communities yet
+        // (the singleton has no community concept). Consumers are migrating onto
+        // `config.account`; the native multi-persona load replaces this derive
+        // in the final T1 slice.
+        let persona_record = PersonaRecord {
+            persona_id: PersonaId::new(),
+            did: public_config.persona_did.to_string(),
+            key_refs: sc
+                .key_info
+                .iter()
+                .map(|(id, info)| KeyRef {
+                    key_id: id.clone(),
+                    purpose: info.purpose.clone(),
+                    created_at: info.create_time,
+                })
+                .collect(),
+            mediator_did: Some(public_config.mediator_did.clone()),
+            origin_context_id: String::new(),
+            created_at: Utc::now(),
+            label: Some(public_config.friendly_name.clone()),
+        };
+        let mut account = Account {
+            vta_did: match &key_backend {
+                KeyBackend::Vta { vta_did, .. } => vta_did.clone(),
+                KeyBackend::Bip32 { .. } => String::new(),
+            },
+            vta_url: match &key_backend {
+                KeyBackend::Vta { vta_url, .. } => vta_url.clone(),
+                KeyBackend::Bip32 { .. } => String::new(),
+            },
+            ..Account::default()
+        };
+        account
+            .personas
+            .insert(persona_record.persona_id, persona_record);
+
         Ok(Config {
+            account,
             key_backend,
             persona_did: PersonaDID {
                 document: rr.doc,

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -196,11 +196,45 @@ impl Config {
         // persona/relationship messaging profiles to register, so the whole
         // resolve/keygen/profile block is skipped and `identities` stays empty.
         // A State-B account currently carries a single persona, resolved here.
+        // The account's VTA mediator (captured at provisioning). Used as the
+        // fallback below for any persona stored without one.
+        let account_mediator = match &key_backend {
+            KeyBackend::Vta { mediator_did, .. } => mediator_did.clone().unwrap_or_default(),
+            KeyBackend::Bip32 { .. } => String::new(),
+        };
         let active_persona = account.personas.values().next().map(|p| {
+            // A persona minted before the mediator fix was stored with an empty
+            // mediator, which leaves its DIDComm listener failing with "No
+            // Mediator is configured" in an endless reconnect loop. Repair it at
+            // load by falling back to the account's VTA mediator — the persona
+            // DID was minted with the VTA's mediator service, so they match — so
+            // an already-broken persona comes good on the next launch with no
+            // re-join. (Runtime-only; the record is rewritten on the next save.)
+            let mediator = {
+                let stored = p.mediator_did.clone().unwrap_or_default();
+                if stored.is_empty() {
+                    if account_mediator.is_empty() {
+                        warn!(
+                            persona = %p.did,
+                            "persona has no mediator and the account has none either — \
+                             the persona listener will not connect"
+                        );
+                    } else {
+                        warn!(
+                            persona = %p.did,
+                            "persona stored without a mediator — falling back to the \
+                             account VTA mediator"
+                        );
+                    }
+                    account_mediator.clone()
+                } else {
+                    stored
+                }
+            };
             (
                 p.persona_id,
                 std::sync::Arc::new(p.did.clone()),
-                p.mediator_did.clone().unwrap_or_default(),
+                mediator,
                 // PERF #3: the cached DID document, used instead of a network
                 // resolve when present.
                 p.did_document.clone(),

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -222,7 +222,9 @@ impl Config {
         let persona_profile = atm.profile_add(&persona_profile, false).await?;
 
         report_progress(&on_progress, "Loading relationships...");
-        let atm_profiles = private_cfg
+        // Registers each relationship profile with the ATM service as a
+        // side-effect; the returned map is no longer stored on `Config`.
+        private_cfg
             .relationships
             .generate_profiles(
                 tdk,
@@ -310,7 +312,6 @@ impl Config {
             protection_method: sc.protection_method.clone(),
             unlock_code: unlock_passphrase
                 .map(|uc| SecretBox::new(Box::new(uc.0.expose_secret().to_owned()))),
-            atm_profiles,
             vrcs,
         })
     }

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -171,6 +171,32 @@ impl Config {
 
         debug!("Private Config\n{:#?}", private_cfg);
 
+        // T1 (final slice): the v2 `account` persisted in the protected tier is
+        // the source of truth for the active persona. A freshly-loaded v1 config
+        // has an empty persisted account — fall back to deriving from the
+        // singleton, which is re-persisted into `account` on the next save.
+        let persisted_account =
+            (!private_cfg.account.personas.is_empty()).then(|| private_cfg.account.clone());
+        let (active_persona_did, active_mediator_did): (std::sync::Arc<String>, String) =
+            match &persisted_account {
+                Some(acct) => {
+                    // Single-persona for now: the one (and only) persona entry.
+                    let persona = acct
+                        .personas
+                        .values()
+                        .next()
+                        .expect("non-empty personas checked above");
+                    (
+                        std::sync::Arc::new(persona.did.clone()),
+                        persona.mediator_did.clone().unwrap_or_default(),
+                    )
+                }
+                None => (
+                    public_config.persona_did.clone(),
+                    public_config.mediator_did.clone(),
+                ),
+            };
+
         // Build the VTA client once upfront (if VTA backend), reusing whichever
         // transport setup chose: DIDComm if a mediator was advertised, REST
         // otherwise. The helper handles auth in both directions.
@@ -185,12 +211,11 @@ impl Config {
         report_progress(&on_progress, "Resolving DID...");
         let rr = tdk
             .did_resolver()
-            .resolve(&public_config.persona_did)
+            .resolve(&active_persona_did)
             .await
             .map_err(|e| {
                 OpenVTCError::Resolver(format!(
-                    "Couldn't resolve Persona DID ({}): {}",
-                    public_config.persona_did, e
+                    "Couldn't resolve Persona DID ({active_persona_did}): {e}"
                 ))
             })?;
 
@@ -206,8 +231,8 @@ impl Config {
                 OpenVTCError::Config("TDK ATM service not initialized".to_string())
             })?,
             Some("Persona DID".to_string()),
-            public_config.persona_did.to_string(),
-            Some(public_config.mediator_did.clone()),
+            active_persona_did.to_string(),
+            Some(active_mediator_did.clone()),
         )
         .await?;
 
@@ -228,49 +253,61 @@ impl Config {
             .relationships
             .generate_profiles(
                 tdk,
-                &public_config.persona_did,
-                &public_config.mediator_did,
+                &active_persona_did,
+                &active_mediator_did,
                 &key_backend,
                 &sc.key_info,
                 vta_client.as_ref(),
             )
             .await?;
 
-        // T1 (transitional): derive the v2 account from the loaded singleton —
-        // one persona (the current persona DID + its keys), no communities yet
-        // (the singleton has no community concept). Consumers are migrating onto
-        // `config.account`; the native multi-persona load replaces this derive
-        // in the final T1 slice.
-        let persona_record = PersonaRecord {
-            persona_id: PersonaId::new(),
-            did: public_config.persona_did.to_string(),
-            key_refs: sc
-                .key_info
-                .iter()
-                .map(|(id, info)| KeyRef {
-                    key_id: id.clone(),
-                    purpose: info.purpose.clone(),
-                    created_at: info.create_time,
-                })
-                .collect(),
-            mediator_did: Some(public_config.mediator_did.clone()),
-            origin_context_id: String::new(),
-            created_at: Utc::now(),
-            label: Some(public_config.friendly_name.clone()),
+        // Use the persisted v2 account as the source of truth. For a freshly
+        // loaded v1 config (no persisted account) derive one from the singleton —
+        // one persona (the current persona DID + its keys), no communities yet —
+        // which is re-persisted into `account` on the next save.
+        let account = match persisted_account {
+            Some(acct) => acct,
+            None => {
+                let persona_record = PersonaRecord {
+                    persona_id: PersonaId::new(),
+                    did: active_persona_did.to_string(),
+                    key_refs: sc
+                        .key_info
+                        .iter()
+                        .map(|(id, info)| KeyRef {
+                            key_id: id.clone(),
+                            purpose: info.purpose.clone(),
+                            created_at: info.create_time,
+                        })
+                        .collect(),
+                    mediator_did: Some(active_mediator_did.clone()),
+                    origin_context_id: String::new(),
+                    created_at: Utc::now(),
+                    label: Some(public_config.friendly_name.clone()),
+                };
+                let mut account = Account {
+                    vta_did: match &key_backend {
+                        KeyBackend::Vta { vta_did, .. } => vta_did.clone(),
+                        KeyBackend::Bip32 { .. } => String::new(),
+                    },
+                    vta_url: match &key_backend {
+                        KeyBackend::Vta { vta_url, .. } => vta_url.clone(),
+                        KeyBackend::Bip32 { .. } => String::new(),
+                    },
+                    ..Account::default()
+                };
+                account
+                    .personas
+                    .insert(persona_record.persona_id, persona_record);
+                account
+            }
         };
-        let mut account = Account {
-            vta_did: match &key_backend {
-                KeyBackend::Vta { vta_did, .. } => vta_did.clone(),
-                KeyBackend::Bip32 { .. } => String::new(),
-            },
-            vta_url: match &key_backend {
-                KeyBackend::Vta { vta_url, .. } => vta_url.clone(),
-                KeyBackend::Bip32 { .. } => String::new(),
-            },
-            ..Account::default()
-        };
-        let persona_id = persona_record.persona_id;
-        account.personas.insert(persona_id, persona_record);
+        // The active persona id: the single (and only) persona entry for now.
+        let persona_id = *account
+            .personas
+            .keys()
+            .next()
+            .expect("account always has at least one persona after the derive above");
 
         // Runtime identity for the single persona (resolved doc + ATM profile).
         let mut identities = HashMap::new();
@@ -278,10 +315,10 @@ impl Config {
             persona_id,
             crate::identity::IdentityContext {
                 persona_id,
-                did: public_config.persona_did.to_string(),
+                did: active_persona_did.to_string(),
                 document: rr.doc,
                 profile: persona_profile,
-                mediator_did: Some(public_config.mediator_did.clone()),
+                mediator_did: Some(active_mediator_did.clone()),
             },
         );
 

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -201,76 +201,85 @@ impl Config {
 
         let mut identities = HashMap::new();
         if let Some((active_persona_id, active_persona_did, active_mediator_did)) = active_persona {
-            // All config info has been loaded, load DID Document and regenerate keys
-            report_progress(&on_progress, "Resolving DID...");
-            let rr = tdk
-                .did_resolver()
-                .resolve(&active_persona_did)
-                .await
-                .map_err(|e| {
-                    OpenVTCError::Resolver(format!(
-                        "Couldn't resolve Persona DID ({active_persona_did}): {e}"
-                    ))
-                })?;
+            // Resolve + key/profile setup for the active persona. Wrapped in an
+            // inner future so the transient admin-DID VTA session is shut down on
+            // EVERY exit (incl. the `?` error paths below) — a leaked session
+            // would otherwise trip the SDK `LeakGuard` and (pre-0.9.8) duel other
+            // sessions on the mediator.
+            let persona_identity: Result<crate::identity::IdentityContext, OpenVTCError> = async {
+                // All config info has been loaded, load DID Document + regen keys
+                report_progress(&on_progress, "Resolving DID...");
+                let rr = tdk
+                    .did_resolver()
+                    .resolve(&active_persona_did)
+                    .await
+                    .map_err(|e| {
+                        OpenVTCError::Resolver(format!(
+                            "Couldn't resolve Persona DID ({active_persona_did}): {e}"
+                        ))
+                    })?;
 
-            // Create keys from DID Document
-            report_progress(&on_progress, "Loading keys...");
-            Config::regenerate_persona_keys(tdk, &sc, &key_backend, &rr.doc, vta_client.as_ref())
-                .await?;
-
-            // Create persona profile
-            report_progress(&on_progress, "Creating messaging profiles...");
-            let persona_profile = ATMProfile::new(
-                tdk.atm.as_ref().ok_or_else(|| {
-                    OpenVTCError::Config("TDK ATM service not initialized".to_string())
-                })?,
-                Some("Persona DID".to_string()),
-                active_persona_did.to_string(),
-                Some(active_mediator_did.clone()),
-            )
-            .await?;
-
-            // Register the persona profile with the TDK ATM Service but do NOT
-            // open a WebSocket connection. The DIDComm service manages its own
-            // connections — connecting here would create a duplicate WebSocket for
-            // the same DID, triggering the mediator's duplicate detection loop.
-            let atm = tdk.atm.clone().ok_or_else(|| {
-                OpenVTCError::Config("TDK ATM service not initialized".to_string())
-            })?;
-            let persona_profile = atm.profile_add(&persona_profile, false).await?;
-
-            report_progress(&on_progress, "Loading relationships...");
-            // Registers each relationship profile with the ATM service as a
-            // side-effect; the returned map is no longer stored on `Config`.
-            private_cfg
-                .relationships
-                .generate_profiles(
+                report_progress(&on_progress, "Loading keys...");
+                Config::regenerate_persona_keys(
                     tdk,
-                    &active_persona_did,
-                    &active_mediator_did,
+                    &sc,
                     &key_backend,
-                    &sc.key_info,
+                    &rr.doc,
                     vta_client.as_ref(),
                 )
                 .await?;
 
-            identities.insert(
-                active_persona_id,
-                crate::identity::IdentityContext {
+                report_progress(&on_progress, "Creating messaging profiles...");
+                let persona_profile = ATMProfile::new(
+                    tdk.atm.as_ref().ok_or_else(|| {
+                        OpenVTCError::Config("TDK ATM service not initialized".to_string())
+                    })?,
+                    Some("Persona DID".to_string()),
+                    active_persona_did.to_string(),
+                    Some(active_mediator_did.clone()),
+                )
+                .await?;
+
+                // Register the persona profile with the TDK ATM Service but do
+                // NOT open a WebSocket — the DIDComm service owns connections.
+                let atm = tdk.atm.clone().ok_or_else(|| {
+                    OpenVTCError::Config("TDK ATM service not initialized".to_string())
+                })?;
+                let persona_profile = atm.profile_add(&persona_profile, false).await?;
+
+                report_progress(&on_progress, "Loading relationships...");
+                // Registers each relationship profile with the ATM service as a
+                // side-effect; the returned map is no longer stored on `Config`.
+                private_cfg
+                    .relationships
+                    .generate_profiles(
+                        tdk,
+                        &active_persona_did,
+                        &active_mediator_did,
+                        &key_backend,
+                        &sc.key_info,
+                        vta_client.as_ref(),
+                    )
+                    .await?;
+
+                Ok(crate::identity::IdentityContext {
                     persona_id: active_persona_id,
                     did: active_persona_did.to_string(),
                     document: rr.doc,
                     profile: persona_profile,
-                    mediator_did: Some(active_mediator_did),
-                },
-            );
-        }
+                    mediator_did: Some(active_mediator_did.clone()),
+                })
+            }
+            .await;
 
-        // Close the transient admin-DID VTA session. `connect_didcomm` opens a
-        // persistent, auto-reconnecting WebSocket that `Drop` cannot close
-        // (shutdown is async), so a leaked admin session duels later admin
-        // sessions on the mediator (duplicate-WebSocket loop → DIDComm timeouts).
-        if let Some(client) = &vta_client {
+            // Always close the transient admin session before propagating any
+            // error from the body above.
+            if let Some(client) = &vta_client {
+                client.shutdown().await;
+            }
+            identities.insert(active_persona_id, persona_identity?);
+        } else if let Some(client) = &vta_client {
+            // No persona to resolve, but a VTA client was built — close it too.
             client.shutdown().await;
         }
 

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -18,6 +18,11 @@ use vta_sdk::credentials::CredentialBundle;
 #[cfg(feature = "openpgp-card")]
 use super::TokenInteractions;
 
+/// Hierarchical startup-progress callback: invoked as `(major, sub)` when a new
+/// sub-step of a major task begins, so the UI can build a two-level loading view
+/// with per-step and per-major timing.
+pub type ProgressFn<'a> = &'a (dyn Fn(&str, &str) + Send + Sync);
+
 impl Config {
     /// Step 1 of loading the configuration: reads the public config from disk.
     ///
@@ -37,6 +42,17 @@ impl Config {
     /// Requires the [`PublicConfig`] from [`Config::load_step1`] plus any unlock
     /// credentials determined by the protection type.
     ///
+    /// On success returns the loaded [`Config`] **and** the still-open admin VTA
+    /// session (PERF #1) so the caller can reuse the single mediator connection
+    /// for the context-name fetch, relationship/community operations, and joins,
+    /// instead of opening a second session. The session is `None` for non-VTA
+    /// backends or a no-persona (State-A) account, where none was opened. The
+    /// caller is then responsible for shutting it down on every exit path.
+    ///
+    /// Progress is reported hierarchically via `on_progress(major, sub)`: each
+    /// call names the major task and the sub-step now starting, letting the UI
+    /// build a two-level loading view with per-step and per-major timing.
+    ///
     /// # Errors
     ///
     /// Returns an error if decryption fails, the BIP32 seed or VTA credential
@@ -49,17 +65,17 @@ impl Config {
         unlock_passphrase: Option<&UnlockCode>,
         #[cfg(feature = "openpgp-card")] token_user_pin: &SecretString,
         #[cfg(feature = "openpgp-card")] touch_prompt: &impl TokenInteractions,
-        on_progress: Option<&(dyn Fn(&str) + Send + Sync)>,
-    ) -> Result<Self, OpenVTCError> {
+        on_progress: Option<ProgressFn<'_>>,
+    ) -> Result<(Self, Option<vta_sdk::client::VtaClient>), OpenVTCError> {
         use tracing::debug;
 
-        fn report_progress(on_progress: &Option<&(dyn Fn(&str) + Send + Sync)>, msg: &str) {
+        fn report_progress(on_progress: &Option<ProgressFn<'_>>, major: &str, sub: &str) {
             if let Some(f) = on_progress {
-                f(msg);
+                f(major, sub);
             }
         }
 
-        report_progress(&on_progress, "Decrypting secrets...");
+        report_progress(&on_progress, "Local configuration", "Decrypting secrets");
 
         let sc = SecuredConfig::load(
             profile,
@@ -185,6 +201,9 @@ impl Config {
                 p.persona_id,
                 std::sync::Arc::new(p.did.clone()),
                 p.mediator_did.clone().unwrap_or_default(),
+                // PERF #3: the cached DID document, used instead of a network
+                // resolve when present.
+                p.did_document.clone(),
             )
         });
 
@@ -198,43 +217,54 @@ impl Config {
         // admin session for the whole runtime.
         let vta_client =
             if matches!(&key_backend, KeyBackend::Vta { .. }) && active_persona.is_some() {
-                report_progress(&on_progress, "Authenticating...");
+                report_progress(&on_progress, "VTA establishment", "Connecting to VTA");
                 Some(super::build_runtime_vta_client(&key_backend).await?)
             } else {
                 None
             };
 
         let mut identities = HashMap::new();
-        if let Some((active_persona_id, active_persona_did, active_mediator_did)) = active_persona {
+        if let Some((active_persona_id, active_persona_did, active_mediator_did, cached_document)) =
+            active_persona
+        {
             // Resolve + key/profile setup for the active persona. Wrapped in an
-            // inner future so the transient admin-DID VTA session is shut down on
-            // EVERY exit (incl. the `?` error paths below) — a leaked session
-            // would otherwise trip the SDK `LeakGuard` and (pre-0.9.8) duel other
-            // sessions on the mediator.
+            // inner future so that, on the `?` error paths below, the admin VTA
+            // session is shut down before the error propagates (a leaked session
+            // would trip the SDK `LeakGuard` and duel other sessions on the
+            // mediator). On SUCCESS the session is returned to the caller alive
+            // (PERF #1) — it is NOT shut down here.
             let persona_identity: Result<crate::identity::IdentityContext, OpenVTCError> = async {
-                // All config info has been loaded, load DID Document + regen keys
-                report_progress(&on_progress, "Resolving DID...");
-                let rr = tdk
-                    .did_resolver()
-                    .resolve(&active_persona_did)
-                    .await
-                    .map_err(|e| {
-                        OpenVTCError::Resolver(format!(
-                            "Couldn't resolve Persona DID ({active_persona_did}): {e}"
-                        ))
-                    })?;
+                // PERF #3: prefer the persisted persona DID document over a fresh
+                // network resolve (~1s). did:webvh docs change rarely between
+                // launches; a stale doc only matters if the persona rotated keys
+                // out-of-band — rare, and recoverable on the next mint/resolve.
+                let document = if let Some(doc) = cached_document {
+                    report_progress(&on_progress, "Identity", "Loading DID document (cached)");
+                    doc
+                } else {
+                    report_progress(&on_progress, "Identity", "Resolving DID document");
+                    tdk.did_resolver()
+                        .resolve(&active_persona_did)
+                        .await
+                        .map_err(|e| {
+                            OpenVTCError::Resolver(format!(
+                                "Couldn't resolve Persona DID ({active_persona_did}): {e}"
+                            ))
+                        })?
+                        .doc
+                };
 
-                report_progress(&on_progress, "Loading keys...");
+                report_progress(&on_progress, "Identity", "Fetching persona keys");
                 Config::regenerate_persona_keys(
                     tdk,
                     &sc,
                     &key_backend,
-                    &rr.doc,
+                    &document,
                     vta_client.as_ref(),
                 )
                 .await?;
 
-                report_progress(&on_progress, "Creating messaging profiles...");
+                report_progress(&on_progress, "Identity", "Building messaging profiles");
                 let persona_profile = ATMProfile::new(
                     tdk.atm.as_ref().ok_or_else(|| {
                         OpenVTCError::Config("TDK ATM service not initialized".to_string())
@@ -252,7 +282,7 @@ impl Config {
                 })?;
                 let persona_profile = atm.profile_add(&persona_profile, false).await?;
 
-                report_progress(&on_progress, "Loading relationships...");
+                report_progress(&on_progress, "Identity", "Loading relationships");
                 // Registers each relationship profile with the ATM service as a
                 // side-effect; the returned map is no longer stored on `Config`.
                 private_cfg
@@ -270,38 +300,55 @@ impl Config {
                 Ok(crate::identity::IdentityContext {
                     persona_id: active_persona_id,
                     did: active_persona_did.to_string(),
-                    document: rr.doc,
+                    document,
                     profile: persona_profile,
                     mediator_did: Some(active_mediator_did.clone()),
                 })
             }
             .await;
 
-            // Always close the transient admin session before propagating any
-            // error from the body above.
-            if let Some(client) = &vta_client {
-                client.shutdown().await;
+            // On ERROR, close the admin session before propagating (a leaked
+            // session would duel others on the mediator). On SUCCESS, the
+            // session is returned to the caller alive (PERF #1) and is NOT shut
+            // down here.
+            match persona_identity {
+                Ok(identity) => {
+                    identities.insert(active_persona_id, identity);
+                }
+                Err(e) => {
+                    if let Some(client) = &vta_client {
+                        client.shutdown().await;
+                    }
+                    return Err(e);
+                }
             }
-            identities.insert(active_persona_id, persona_identity?);
         } else if let Some(client) = &vta_client {
-            // No persona to resolve, but a VTA client was built — close it too.
+            // No persona to resolve, but a VTA client was somehow built — close
+            // it (this branch is unreachable: the client is only built when a
+            // persona is present, but kept defensively).
             client.shutdown().await;
         }
 
-        Ok(Config {
-            account,
-            identities,
-            key_backend,
-            public: public_config,
-            private: private_cfg,
-            key_info: sc.key_info.clone(),
-            #[cfg(feature = "openpgp-card")]
-            token_admin_pin: None,
-            #[cfg(feature = "openpgp-card")]
-            token_user_pin: token_user_pin.clone(),
-            protection_method: sc.protection_method.clone(),
-            unlock_code: unlock_passphrase
-                .map(|uc| SecretBox::new(Box::new(uc.0.expose_secret().to_owned()))),
-        })
+        Ok((
+            Config {
+                account,
+                identities,
+                key_backend,
+                public: public_config,
+                private: private_cfg,
+                key_info: sc.key_info.clone(),
+                #[cfg(feature = "openpgp-card")]
+                token_admin_pin: None,
+                #[cfg(feature = "openpgp-card")]
+                token_user_pin: token_user_pin.clone(),
+                protection_method: sc.protection_method.clone(),
+                unlock_code: unlock_passphrase
+                    .map(|uc| SecretBox::new(Box::new(uc.0.expose_secret().to_owned()))),
+            },
+            // PERF #1: hand the still-open admin session back to the caller for
+            // reuse (context-name fetch, relationships, joins). `vta_client` is
+            // `Some` only for a VTA backend with an active persona.
+            vta_client,
+        ))
     }
 }

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -172,17 +172,6 @@ impl Config {
         // (D13/R-RST), so a loadable config always carries an account.
         let account = private_cfg.account.clone();
 
-        // Build the VTA client once upfront (if VTA backend), reusing whichever
-        // transport setup chose: DIDComm if a mediator was advertised, REST
-        // otherwise. Needed for runtime VTA operations whether or not a persona
-        // is present.
-        let vta_client = if matches!(&key_backend, KeyBackend::Vta { .. }) {
-            report_progress(&on_progress, "Authenticating...");
-            Some(super::build_runtime_vta_client(&key_backend).await?)
-        } else {
-            None
-        };
-
         // Resolve runtime identities from the account's personas.
         //
         // A State-A (account-bootstrap, R-A-5) account persists with NO persona:
@@ -198,6 +187,22 @@ impl Config {
                 p.mediator_did.clone().unwrap_or_default(),
             )
         });
+
+        // Open the admin VTA session ONLY when there's a persona to rehydrate
+        // (regenerate its keys + register messaging profiles). A State-A account
+        // has none, so opening one here is useless — and opening it then shutting
+        // it down right before `main_loop` opens its own admin session leaves the
+        // shut-down session's auto-reconnect briefly dueling the live one on the
+        // mediator (WebSocket churn → a dropped response on the first burst of
+        // requests, e.g. the join's key creation). Skipping it leaves a single
+        // admin session for the whole runtime.
+        let vta_client =
+            if matches!(&key_backend, KeyBackend::Vta { .. }) && active_persona.is_some() {
+                report_progress(&on_progress, "Authenticating...");
+                Some(super::build_runtime_vta_client(&key_backend).await?)
+            } else {
+                None
+            };
 
         let mut identities = HashMap::new();
         if let Some((active_persona_id, active_persona_did, active_mediator_did)) = active_persona {

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -19,12 +19,11 @@ use crate::{
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 use argon2::{Algorithm, Argon2, Params, Version};
 use chrono::{DateTime, TimeDelta, Utc};
-use dtg_credentials::DTGCredential;
 use ed25519_dalek_bip32::ExtendedSigningKey;
 use secrecy::{ExposeSecret, SecretBox, SecretString};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{collections::HashMap, fmt::Display, sync::Arc};
+use std::{collections::HashMap, fmt::Display};
 
 pub mod account;
 pub mod did;
@@ -259,14 +258,10 @@ pub struct Config {
     /// user provides an unlock passphrase; `None` for plaintext or token flows.
     pub unlock_code: Option<SecretBox<Vec<u8>>>,
 
-    /// All VRC's issued and received by VRC ID
-    /// Key: VRC ID
-    pub vrcs: HashMap<Arc<String>, Arc<DTGCredential>>,
-
     /// Config v2 multi-community account model (personas + communities).
     ///
     /// T1 migration (transitional): populated alongside the remaining singleton
-    /// fields (`key_backend`, `key_info`, `vrcs`, and `public.persona_did` /
+    /// fields (`key_backend`, `key_info`, and `public.persona_did` /
     /// `mediator_did` / `lk_did`). Consumers are being moved onto `account`;
     /// the singleton fields are removed field-by-field as their readers migrate.
     pub account: account::Account,

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -578,4 +578,32 @@ mod tests {
         assert!(validate_passphrase("1234567").is_err());
         assert!(validate_passphrase("").is_err());
     }
+
+    /// A State-A (account-bootstrap, R-A-5) config carries an account but no
+    /// persona, so it resolves no runtime identity. The accessors must degrade
+    /// to the documented "no active community" sentinels rather than panic.
+    #[test]
+    fn zero_persona_config_has_no_active_identity() {
+        let config = Config {
+            public: public_config::PublicConfig::default(),
+            private: ProtectedConfig::default(),
+            key_backend: KeyBackend::Bip32 {
+                root: ExtendedSigningKey::from_seed(&[7u8; 32]).unwrap(),
+                seed: SecretString::new("seed".into()),
+            },
+            key_info: HashMap::new(),
+            protection_method: ProtectionMethod::default(),
+            #[cfg(feature = "openpgp-card")]
+            token_admin_pin: None,
+            #[cfg(feature = "openpgp-card")]
+            token_user_pin: SecretString::new("".into()),
+            unlock_code: None,
+            account: account::Account::default(),
+            identities: HashMap::new(),
+        };
+
+        assert!(config.active_identity().is_none());
+        assert_eq!(config.persona_did(), "");
+        assert_eq!(config.mediator_did(), "");
+    }
 }

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -260,19 +260,19 @@ pub struct Config {
 
     /// Config v2 multi-community account model (personas + communities).
     ///
-    /// T1 migration (transitional): populated alongside the remaining singleton
-    /// fields (`key_backend`, `key_info`, and `public.persona_did` /
-    /// `mediator_did` / `lk_did`). Consumers are being moved onto `account`;
-    /// the singleton fields are removed field-by-field as their readers migrate.
+    /// The persisted source of truth for the account's personas and community
+    /// memberships (stored encrypted in [`ProtectedConfig`]). The persona DID,
+    /// mediator DID, and org DID that used to live as `public.*` singletons are
+    /// now read from here via [`Config::persona_did`], [`Config::mediator_did`],
+    /// and `account.org_did`.
     pub account: account::Account,
 
     /// Runtime-resolved identities (resolved DID document + ATM profile),
-    /// keyed by persona id. Not persisted — rebuilt at load.
+    /// keyed by persona id. Not persisted — rebuilt at load from `account`.
     ///
-    /// T1 migration: built alongside `persona_did`. For the single-persona case
-    /// this holds one entry; consumers move off `persona_did` onto
-    /// [`Config::active_identity`]. Multi-persona population + selection land
-    /// in a later slice.
+    /// For the single-persona case this holds one entry, surfaced by
+    /// [`Config::active_identity`]. Multi-persona population + selection land in
+    /// a later slice.
     pub identities: HashMap<account::PersonaId, crate::identity::IdentityContext>,
 }
 
@@ -308,6 +308,48 @@ impl Config {
     /// `.next()` heuristic when multi-community lands.
     pub fn active_identity(&self) -> Option<&crate::identity::IdentityContext> {
         self.identities.values().next()
+    }
+
+    /// The active persona's `did:webvh` as a string slice.
+    ///
+    /// Replaces the removed `public.persona_did` singleton. Returns `""` when no
+    /// identity is resolved — which should not occur after a successful load or
+    /// setup, where exactly one persona is always active.
+    pub fn persona_did(&self) -> &str {
+        self.active_identity().map(|i| i.did.as_str()).unwrap_or("")
+    }
+
+    /// The active persona's `did:webvh` as an owned `Arc<String>`.
+    ///
+    /// For the call sites that previously cloned the `Arc<String>` singleton
+    /// (e.g. to stash the DID on a message or relationship). The returned `Arc`
+    /// is freshly allocated; equality is by value, so sharing is not required.
+    pub fn persona_did_arc(&self) -> std::sync::Arc<String> {
+        std::sync::Arc::new(self.persona_did().to_string())
+    }
+
+    /// The active persona's mediator DID as a string slice (`""` if unset).
+    ///
+    /// Replaces the removed `public.mediator_did` singleton.
+    pub fn mediator_did(&self) -> &str {
+        self.active_identity()
+            .and_then(|i| i.mediator_did.as_deref())
+            .unwrap_or("")
+    }
+
+    /// Set the active persona's mediator DID, updating both the persisted
+    /// `account` record and the runtime `IdentityContext` so subsequent reads
+    /// (and the next save) see the new value. No-op if no identity is active.
+    pub fn set_active_mediator_did(&mut self, did: &str) {
+        let Some(id) = self.active_identity().map(|i| i.persona_id) else {
+            return;
+        };
+        if let Some(persona) = self.account.personas.get_mut(&id) {
+            persona.mediator_did = Some(did.to_string());
+        }
+        if let Some(ctx) = self.identities.get_mut(&id) {
+            ctx.mediator_did = Some(did.to_string());
+        }
     }
 }
 

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -272,6 +272,14 @@ pub struct Config {
     /// All VRC's issued and received by VRC ID
     /// Key: VRC ID
     pub vrcs: HashMap<Arc<String>, Arc<DTGCredential>>,
+
+    /// Config v2 multi-community account model (personas + communities).
+    ///
+    /// T1 migration (transitional): currently populated alongside the singleton
+    /// fields above (`persona_did`, `key_backend`, `key_info`, `atm_profiles`,
+    /// `vrcs`). Consumers are being moved onto `account`; the singleton fields
+    /// are removed in the final T1 slice once nothing reads them.
+    pub account: account::Account,
 }
 
 /// Serializable bundle of public and secured config, used for import/export.

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     errors::OpenVTCError,
 };
-use affinidi_tdk::{messaging::profiles::ATMProfile, secrets_resolver::secrets::Secret};
+use affinidi_tdk::secrets_resolver::secrets::Secret;
 use argon2::{Algorithm, Argon2, Params, Version};
 use chrono::{DateTime, TimeDelta, Utc};
 use dtg_credentials::DTGCredential;
@@ -259,21 +259,16 @@ pub struct Config {
     /// user provides an unlock passphrase; `None` for plaintext or token flows.
     pub unlock_code: Option<SecretBox<Vec<u8>>>,
 
-    /// Holds ATM profiles for relationships
-    /// Key: Our local DID for the relationship
-    /// NOTE: Does not hold the persona DID profile!
-    pub atm_profiles: HashMap<Arc<String>, Arc<ATMProfile>>,
-
     /// All VRC's issued and received by VRC ID
     /// Key: VRC ID
     pub vrcs: HashMap<Arc<String>, Arc<DTGCredential>>,
 
     /// Config v2 multi-community account model (personas + communities).
     ///
-    /// T1 migration (transitional): currently populated alongside the singleton
-    /// fields above (`persona_did`, `key_backend`, `key_info`, `atm_profiles`,
-    /// `vrcs`). Consumers are being moved onto `account`; the singleton fields
-    /// are removed in the final T1 slice once nothing reads them.
+    /// T1 migration (transitional): populated alongside the remaining singleton
+    /// fields (`key_backend`, `key_info`, `vrcs`, and `public.persona_did` /
+    /// `mediator_did` / `lk_did`). Consumers are being moved onto `account`;
+    /// the singleton fields are removed field-by-field as their readers migrate.
     pub account: account::Account,
 
     /// Runtime-resolved identities (resolved DID document + ATM profile),

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -338,6 +338,26 @@ impl Config {
             .unwrap_or("")
     }
 
+    /// Human label for the active persona's messaging profile: the community it
+    /// belongs to (its display name, else the VTC DID slug), so each community's
+    /// profile is identifiable rather than a generic "Persona". Falls back to
+    /// "Persona" when the persona has no community yet.
+    pub fn persona_profile_label(&self) -> String {
+        let Some(pid) = self.active_identity().map(|i| i.persona_id) else {
+            return "Persona".to_string();
+        };
+        self.account
+            .communities
+            .values()
+            .find(|c| c.persona_ref == pid)
+            .map(|c| {
+                c.display_name.clone().unwrap_or_else(|| {
+                    crate::config::context_path::render_for_display(&c.vtc_did).to_string()
+                })
+            })
+            .unwrap_or_else(|| "Persona".to_string())
+    }
+
     /// Set the active persona's mediator DID, updating both the persisted
     /// `account` record and the runtime `IdentityContext` so subsequent reads
     /// (and the next save) see the new value. No-op if no identity is active.

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -422,6 +422,30 @@ pub async fn build_runtime_vta_client(
     }
 }
 
+/// Run `f` with a runtime VTA client built from `backend`, guaranteeing the
+/// (DIDComm) session is shut down whether `f` returns `Ok` **or** `Err`.
+///
+/// Mirrors [`vta_sdk::client::VtaClient::with_didcomm`] but threads the caller's
+/// own error type — any `E: From<OpenVTCError>` (e.g. [`OpenVTCError`] or
+/// `anyhow::Error`). `shutdown` is a no-op for the REST transport. Prefer this
+/// over [`build_runtime_vta_client`] + a manual `shutdown()`: an early `?` in the
+/// body can otherwise drop the session without closing it, leaking a live
+/// session (and tripping the SDK's `LeakGuard`).
+pub async fn with_runtime_vta_client<F, Fut, T, E>(backend: &KeyBackend, f: F) -> Result<T, E>
+where
+    F: FnOnce(vta_sdk::client::VtaClient) -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: From<OpenVTCError>,
+{
+    // Hand the body an owned clone (a `VtaClient` shares its session across
+    // clones, and `shutdown` is idempotent) — passing by value sidesteps the
+    // async-closure-borrowed-argument lifetime limitation.
+    let client = build_runtime_vta_client(backend).await?;
+    let result = f(client.clone()).await;
+    client.shutdown().await;
+    result
+}
+
 // ****************************************************************************
 // Key Types
 // ****************************************************************************

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -280,6 +280,15 @@ pub struct Config {
     /// `vrcs`). Consumers are being moved onto `account`; the singleton fields
     /// are removed in the final T1 slice once nothing reads them.
     pub account: account::Account,
+
+    /// Runtime-resolved identities (resolved DID document + ATM profile),
+    /// keyed by persona id. Not persisted — rebuilt at load.
+    ///
+    /// T1 migration: built alongside `persona_did`. For the single-persona case
+    /// this holds one entry; consumers move off `persona_did` onto
+    /// [`Config::active_identity`]. Multi-persona population + selection land
+    /// in a later slice.
+    pub identities: HashMap<account::PersonaId, crate::identity::IdentityContext>,
 }
 
 /// Serializable bundle of public and secured config, used for import/export.
@@ -315,6 +324,15 @@ impl Config {
                 encryption_seed.expose_secret().to_vec(),
             ))),
         }
+    }
+
+    /// The currently-active runtime identity.
+    ///
+    /// T1 migration: for the single-persona case this returns the one resolved
+    /// identity. A proper "selected working community" selection replaces the
+    /// `.next()` heuristic when multi-community lands.
+    pub fn active_identity(&self) -> Option<&crate::identity::IdentityContext> {
+        self.identities.values().next()
     }
 }
 

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -16,9 +16,7 @@ use crate::{
     },
     errors::OpenVTCError,
 };
-use affinidi_tdk::{
-    did_common::Document, messaging::profiles::ATMProfile, secrets_resolver::secrets::Secret,
-};
+use affinidi_tdk::{messaging::profiles::ATMProfile, secrets_resolver::secrets::Secret};
 use argon2::{Algorithm, Argon2, Params, Version};
 use chrono::{DateTime, TimeDelta, Utc};
 use dtg_credentials::DTGCredential;
@@ -241,9 +239,6 @@ pub struct Config {
     /// Where did the key values come from? Derived or Imported?
     pub key_info: HashMap<String, KeyInfoConfig>,
 
-    /// Persona DID and Document
-    pub persona_did: PersonaDID,
-
     // *********************************************
     // Temporary Config values
     /// What protection method is being used for the secured config.
@@ -298,16 +293,6 @@ pub struct ExportedConfig {
     pub pc: public_config::PublicConfig,
     /// The secured (secret key material) portion of the configuration.
     pub sc: secured_config::SecuredConfig,
-}
-
-/// Our public Persona DID used to identify ourselves within the Linux Foundation ecosystem
-#[derive(Clone, Debug)]
-pub struct PersonaDID {
-    /// Resolved DID Document for this DID
-    pub document: Document,
-
-    /// Messaging Profile representing this DID within the TDK
-    pub profile: Arc<ATMProfile>,
 }
 
 impl Config {

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -26,6 +26,7 @@ use sha2::{Digest, Sha256};
 use std::{collections::HashMap, fmt::Display};
 
 pub mod account;
+pub mod context_path;
 pub mod did;
 pub mod keys;
 pub mod loading;

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
+pub mod account;
 pub mod did;
 pub mod keys;
 pub mod loading;

--- a/openvtc-core/src/config/protected_config.rs
+++ b/openvtc-core/src/config/protected_config.rs
@@ -5,6 +5,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
+    config::account::Account,
     config::secured_config::{unlock_code_decrypt, unlock_code_encrypt},
     errors::OpenVTCError,
     logs::{LogFamily, Logs},
@@ -175,6 +176,15 @@ impl From<ContactsShadow> for Contacts {
 /// not key data
 #[derive(Clone, Default, Serialize, Deserialize, Debug)]
 pub struct ProtectedConfig {
+    /// Config v2 multi-community account model (personas + communities).
+    ///
+    /// The encrypted source of truth for the account's personas and community
+    /// memberships. Empty in v1 (singleton) configs; populated on the first v2
+    /// save. `Config::load_step2` reads it back to rebuild the runtime
+    /// [`crate::identity::IdentityContext`]s and drive DID resolution.
+    #[serde(default)]
+    pub account: Account,
+
     /// Known contacts and associated information
     pub contacts: Contacts,
 
@@ -315,6 +325,41 @@ mod tests {
 
         let loaded = ProtectedConfig::load(&seed, &saved).unwrap();
         assert!(loaded.contacts.is_empty());
+    }
+
+    #[test]
+    fn test_protected_config_account_round_trips() {
+        use crate::config::account::{Account, PersonaId, PersonaRecord};
+        use chrono::Utc;
+
+        let mut config = ProtectedConfig::default();
+        let pid = PersonaId::new();
+        config.account = Account {
+            vta_did: "did:webvh:vta.example".into(),
+            vta_url: "https://vta.example".into(),
+            top_context_id: "openvtc".into(),
+            ..Account::default()
+        };
+        config.account.personas.insert(
+            pid,
+            PersonaRecord {
+                persona_id: pid,
+                did: "did:webvh:example:p".into(),
+                key_refs: Vec::new(),
+                mediator_did: Some("did:webvh:mediator".into()),
+                origin_context_id: String::new(),
+                created_at: Utc::now(),
+                label: Some("alice".into()),
+            },
+        );
+
+        let seed = test_seed();
+        let saved = config.save(&seed).unwrap();
+        let loaded = ProtectedConfig::load(&seed, &saved).unwrap();
+
+        assert_eq!(loaded.account.vta_did, "did:webvh:vta.example");
+        assert_eq!(loaded.account.personas.len(), 1);
+        assert_eq!(loaded.account.personas[&pid].did, "did:webvh:example:p");
     }
 
     #[test]

--- a/openvtc-core/src/config/protected_config.rs
+++ b/openvtc-core/src/config/protected_config.rs
@@ -345,6 +345,7 @@ mod tests {
             PersonaRecord {
                 persona_id: pid,
                 did: "did:webvh:example:p".into(),
+                did_document: None,
                 key_refs: Vec::new(),
                 mediator_did: Some("did:webvh:mediator".into()),
                 origin_context_id: String::new(),

--- a/openvtc-core/src/config/public_config.rs
+++ b/openvtc-core/src/config/public_config.rs
@@ -11,7 +11,7 @@ use secrecy::SecretBox;
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::{env, fs, path::PathBuf, sync::Arc};
+use std::{env, fs, path::PathBuf};
 use tracing::warn;
 
 /// Current config format version. Increment when the format changes.
@@ -45,17 +45,8 @@ pub struct PublicConfig {
     /// How is the configuration protected?
     pub protection: ConfigProtectionType,
 
-    /// Persona DID
-    pub persona_did: Arc<String>,
-
-    /// Mediator DID
-    pub mediator_did: String,
-
     /// Human friendly name to use when referring to ourself
     pub friendly_name: String,
-
-    /// Linux Organisation DID
-    pub lk_did: String,
 
     #[serde(default)]
     pub logs: Logs,
@@ -395,9 +386,8 @@ mod tests {
     #[test]
     fn test_public_config_default() {
         let pc = PublicConfig::default();
-        assert!(pc.persona_did.is_empty());
-        assert!(pc.mediator_did.is_empty());
         assert!(pc.friendly_name.is_empty());
         assert!(pc.private.is_none());
+        assert_eq!(pc.config_version, 0);
     }
 }

--- a/openvtc-core/src/config/public_config.rs
+++ b/openvtc-core/src/config/public_config.rs
@@ -15,7 +15,11 @@ use std::{env, fs, path::PathBuf, sync::Arc};
 use tracing::warn;
 
 /// Current config format version. Increment when the format changes.
-pub const CONFIG_VERSION: u32 = 1;
+///
+/// v2 (T1): the multi-community `account` model is the persisted source of
+/// truth. There is no in-place v1→v2 migration — a pre-v2 config triggers a
+/// breaking reset (D13 / R-RST): the CLI warns, deletes it, and re-runs setup.
+pub const CONFIG_VERSION: u32 = 2;
 
 /// Result of [`PublicConfig::delete_profile`]. Mostly informational —
 /// callers render `warnings` when surfacing partial-state issues. None of
@@ -250,7 +254,7 @@ impl PublicConfig {
         let file = fs::File::open(&path)
             .map_err(|e| OpenVTCError::ConfigNotFound(path.to_string_lossy().into_owned(), e))?;
 
-        let mut config: Self = match serde_json::from_reader(file) {
+        let config: Self = match serde_json::from_reader(file) {
             Ok(s) => s,
             Err(e) => {
                 warn!("Couldn't Deserialize PublicConfig. Reason: {e}");
@@ -258,46 +262,24 @@ impl PublicConfig {
             }
         };
 
-        // Run migrations if config is from an older version
+        // Breaking reset (D13 / R-RST-1): a pre-v2 config cannot be migrated in
+        // place. Detect it here — on the plaintext public config, before any
+        // decryption that assumes the v2 shape — and surface a typed error the
+        // CLI maps to a "warn → delete → fresh setup" flow.
         if config.config_version < CONFIG_VERSION {
-            tracing::info!(
+            warn!(
                 from = config.config_version,
                 to = CONFIG_VERSION,
-                "migrating config format"
+                "incompatible config version — breaking reset required"
             );
-            migrate_config(&mut config)?;
+            return Err(OpenVTCError::ConfigVersionUnsupported {
+                found: config.config_version,
+                expected: CONFIG_VERSION,
+            });
         }
 
         Ok(config)
     }
-}
-
-/// Run config migrations from `config.config_version` up to [`CONFIG_VERSION`].
-///
-/// Each migration step handles one version increment. New migrations are added
-/// as new match arms. The version field is updated after all migrations complete.
-fn migrate_config(config: &mut PublicConfig) -> Result<(), OpenVTCError> {
-    let mut version = config.config_version;
-
-    while version < CONFIG_VERSION {
-        match version {
-            // Version 0 → 1: no structural changes, just adding the version field.
-            // Pre-0.2.0 configs lack `config_version` and deserialize as 0.
-            0 => {
-                tracing::debug!("migration 0→1: adding config_version field");
-            }
-            v => {
-                return Err(OpenVTCError::Config(format!(
-                    "Unknown config version {v} — cannot migrate. \
-                     Expected version <= {CONFIG_VERSION}."
-                )));
-            }
-        }
-        version += 1;
-    }
-
-    config.config_version = CONFIG_VERSION;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -374,6 +356,40 @@ mod tests {
             "fallback path should end with openvtc/config.json: {}",
             path.display()
         );
+    }
+
+    #[test]
+    fn test_load_pre_v2_config_triggers_breaking_reset() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join("openvtc-reset-test");
+        let _ = fs::create_dir_all(&dir);
+        unsafe { env::set_var("OPENVTC_CONFIG_PATH", &dir) };
+
+        // Write a v1-shaped config (config_version = 1) to disk.
+        let old = PublicConfig {
+            config_version: 1,
+            ..PublicConfig::default()
+        };
+        fs::write(
+            dir.join("config.json"),
+            serde_json::to_string_pretty(&old).unwrap(),
+        )
+        .unwrap();
+
+        let err = PublicConfig::load("default").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                OpenVTCError::ConfigVersionUnsupported {
+                    found: 1,
+                    expected: CONFIG_VERSION
+                }
+            ),
+            "pre-v2 config must surface ConfigVersionUnsupported, got: {err:?}"
+        );
+
+        let _ = fs::remove_file(dir.join("config.json"));
+        unsafe { env::remove_var("OPENVTC_CONFIG_PATH") };
     }
 
     #[test]

--- a/openvtc-core/src/config/saving.rs
+++ b/openvtc-core/src/config/saving.rs
@@ -31,7 +31,11 @@ impl Config {
         #[cfg(feature = "openpgp-card")] touch_prompt: &(dyn Fn() + Send + Sync),
     ) -> Result<(), OpenVTCError> {
         let encryption_seed = self.get_encryption_seed()?;
-        self.public.save(profile, &self.private, &encryption_seed)?;
+        // The v2 `account` is the encrypted source of truth — mirror the live
+        // in-memory account into the protected tier so it round-trips to disk.
+        let mut private = self.private.clone();
+        private.account = self.account.clone();
+        self.public.save(profile, &private, &encryption_seed)?;
 
         let sc = SecuredConfig::from(self);
         sc.save(

--- a/openvtc-core/src/errors.rs
+++ b/openvtc-core/src/errors.rs
@@ -59,6 +59,17 @@ pub enum OpenVTCError {
     #[error("Config Not Found! path({0}): {1}")]
     ConfigNotFound(String, std::io::Error),
 
+    /// The on-disk config predates the current [`crate::config::public_config::CONFIG_VERSION`]
+    /// and cannot be migrated in place (T1 breaking reset, D13/R-RST). The caller
+    /// must warn the user, delete the old config + keyring entries, and re-run setup.
+    #[error("Config version {found} is incompatible with required version {expected}")]
+    ConfigVersionUnsupported {
+        /// The `config_version` read from disk.
+        found: u32,
+        /// The version this build requires.
+        expected: u32,
+    },
+
     /// An error from a hardware security token (e.g. OpenPGP card / YubiKey).
     #[cfg(feature = "openpgp-card")]
     #[error("Token Error: {0}")]

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -180,6 +180,7 @@ mod tests {
             status,
             favourite: false,
             archived: false,
+            acknowledged: false,
             member_since: None,
             requested_at: None,
             relationships: Default::default(),

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -15,7 +15,9 @@
  */
 
 use crate::config::account::{Account, CommunityRecord, PersonaId, PersonaRecord, VtcDid};
+use affinidi_tdk::{did_common::Document, messaging::profiles::ATMProfile};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 /// A resolved community membership paired with the persona it presents.
 ///
@@ -108,6 +110,45 @@ impl<'a> IdentityRegistry<'a> {
     /// The set of persona ids that should currently have a live session.
     pub fn active_session_keys(&self) -> HashSet<PersonaId> {
         self.sessions().into_keys().collect()
+    }
+}
+
+/// A fully-resolved, runtime-ready identity: a persona plus its resolved DID
+/// document and registered ATM messaging profile.
+///
+/// Built at config load (and at setup) and held on [`crate::config::Config`].
+/// This is what consumers use to *act* as a persona — sign, send, and receive.
+/// It replaces the singleton `Config.persona_did` (`PersonaDID`) as the runtime
+/// identity as consumers migrate onto it.
+#[derive(Clone, Debug)]
+pub struct IdentityContext {
+    /// Stable id of the persona this context resolves.
+    pub persona_id: PersonaId,
+    /// The persona's `did:webvh`.
+    pub did: String,
+    /// Resolved DID document.
+    pub document: Document,
+    /// Registered ATM messaging profile for this persona (not connected here;
+    /// the DIDComm session manager owns connections).
+    pub profile: Arc<ATMProfile>,
+    /// The persona's mediator DID, if any.
+    pub mediator_did: Option<String>,
+}
+
+impl IdentityContext {
+    /// The persona's `did:webvh`.
+    pub fn persona_did(&self) -> &str {
+        &self.did
+    }
+
+    /// The resolved DID document.
+    pub fn document(&self) -> &Document {
+        &self.document
+    }
+
+    /// The persona's ATM messaging profile.
+    pub fn profile(&self) -> &Arc<ATMProfile> {
+        &self.profile
     }
 }
 

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -1,0 +1,227 @@
+/*!
+ * Active-identity resolution over the config v2 [`Account`] model.
+ *
+ * A community presents a persona; many communities may present the **same**
+ * persona (D1 reuse). Because the DIDComm layer keys connections by DID and a
+ * reused persona must share one connection, the **session key is the persona**,
+ * not the community (see `docs/design/t1-active-identity-api.md`).
+ *
+ * This is the metadata-only routing layer: it resolves communities → personas
+ * and groups them by the persona session that serves them. The runtime-heavy
+ * `IdentityContext` (resolved DID Document, ATM messaging profile, key/secret
+ * loading) is layered on during config load in a later T1 commit; this module
+ * gives the session manager the persona-keyed routing it needs without runtime
+ * state.
+ */
+
+use crate::config::account::{Account, CommunityRecord, PersonaId, PersonaRecord, VtcDid};
+use std::collections::{HashMap, HashSet};
+
+/// A resolved community membership paired with the persona it presents.
+///
+/// Borrows from the owning [`Account`]; cheap to construct.
+#[derive(Clone, Copy, Debug)]
+pub struct IdentityRef<'a> {
+    /// The community membership.
+    pub community: &'a CommunityRecord,
+    /// The persona presented to this community.
+    pub persona: &'a PersonaRecord,
+}
+
+impl<'a> IdentityRef<'a> {
+    /// The persona's `did:webvh`.
+    pub fn persona_did(&self) -> &'a str {
+        &self.persona.did
+    }
+
+    /// The DIDComm session key for this membership — the **persona** id.
+    /// Memberships sharing a persona share one session.
+    pub fn session_key(&self) -> PersonaId {
+        self.persona.persona_id
+    }
+
+    /// The persona's mediator DID, if set.
+    pub fn mediator_did(&self) -> Option<&'a str> {
+        self.persona.mediator_did.as_deref()
+    }
+}
+
+/// Read-only index over an [`Account`] that resolves communities to the persona
+/// identity they present and groups them by persona session.
+#[derive(Clone, Copy, Debug)]
+pub struct IdentityRegistry<'a> {
+    account: &'a Account,
+}
+
+impl<'a> IdentityRegistry<'a> {
+    /// Build a registry view over an account. Cheap (borrows).
+    pub fn new(account: &'a Account) -> Self {
+        Self { account }
+    }
+
+    /// Resolve a community to its identity (community + presented persona).
+    /// Returns `None` if the community is unknown or its `persona_ref` dangles.
+    pub fn get(&self, vtc: &VtcDid) -> Option<IdentityRef<'a>> {
+        let community = self.account.communities.get(vtc)?;
+        let persona = self.account.personas.get(&community.persona_ref)?;
+        Some(IdentityRef { community, persona })
+    }
+
+    /// Iterator over all resolvable memberships (skips any with a dangling
+    /// `persona_ref`, which [`Account::dangling_refs`] reports separately).
+    pub fn all(&self) -> impl Iterator<Item = IdentityRef<'a>> {
+        self.account.communities.values().filter_map(move |c| {
+            self.account
+                .personas
+                .get(&c.persona_ref)
+                .map(|persona| IdentityRef {
+                    community: c,
+                    persona,
+                })
+        })
+    }
+
+    /// Memberships in the `Active` (live) state.
+    pub fn active(&self) -> impl Iterator<Item = IdentityRef<'a>> {
+        self.all().filter(|r| r.community.status.is_active())
+    }
+
+    /// Persona sessions that must be live, mapped to the communities they serve.
+    ///
+    /// A persona needs a session if any of its communities is `Active` or
+    /// `Pending` ([`CommunityStatus::requires_live_session`]). A reused persona
+    /// appears once, serving several communities — one shared connection.
+    ///
+    /// [`CommunityStatus::requires_live_session`]: crate::config::account::CommunityStatus::requires_live_session
+    pub fn sessions(&self) -> HashMap<PersonaId, Vec<&'a VtcDid>> {
+        let mut map: HashMap<PersonaId, Vec<&'a VtcDid>> = HashMap::new();
+        for c in self.account.communities.values() {
+            if c.status.requires_live_session()
+                && self.account.personas.contains_key(&c.persona_ref)
+            {
+                map.entry(c.persona_ref).or_default().push(&c.vtc_did);
+            }
+        }
+        map
+    }
+
+    /// The set of persona ids that should currently have a live session.
+    pub fn active_session_keys(&self) -> HashSet<PersonaId> {
+        self.sessions().into_keys().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::account::{CommunityStatus, KeyRef, PersonaRecord};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn persona() -> PersonaRecord {
+        PersonaRecord {
+            persona_id: PersonaId::new(),
+            did: "did:webvh:example:p".into(),
+            key_refs: Vec::<KeyRef>::new(),
+            mediator_did: Some("did:webvh:mediator".into()),
+            origin_context_id: "openvtc/p".into(),
+            created_at: Utc::now(),
+            label: None,
+        }
+    }
+
+    fn community(vtc: &str, persona_ref: PersonaId, status: CommunityStatus) -> CommunityRecord {
+        CommunityRecord {
+            vtc_did: vtc.into(),
+            display_name: None,
+            sub_context_id: format!("openvtc/{vtc}"),
+            persona_ref,
+            status,
+            favourite: false,
+            archived: false,
+            member_since: None,
+            requested_at: None,
+            relationships: Default::default(),
+            vrcs_issued: Default::default(),
+            vrcs_received: Default::default(),
+        }
+    }
+
+    #[test]
+    fn resolves_and_exposes_session_key() {
+        let mut acct = Account::default();
+        let p = persona();
+        let pid = p.persona_id;
+        acct.personas.insert(pid, p);
+        acct.communities
+            .insert("a".into(), community("a", pid, CommunityStatus::Active));
+
+        let reg = IdentityRegistry::new(&acct);
+        let id = reg.get(&"a".to_string()).expect("resolves");
+        assert_eq!(id.session_key(), pid);
+        assert_eq!(id.persona_did(), "did:webvh:example:p");
+        assert_eq!(id.mediator_did(), Some("did:webvh:mediator"));
+    }
+
+    #[test]
+    fn reused_persona_shares_one_session() {
+        let mut acct = Account::default();
+        let p = persona();
+        let pid = p.persona_id;
+        acct.personas.insert(pid, p);
+        // Two Active communities present the SAME persona.
+        acct.communities
+            .insert("a".into(), community("a", pid, CommunityStatus::Active));
+        acct.communities
+            .insert("b".into(), community("b", pid, CommunityStatus::Active));
+
+        let reg = IdentityRegistry::new(&acct);
+        let sessions = reg.sessions();
+        assert_eq!(sessions.len(), 1, "one shared persona session");
+        assert_eq!(sessions[&pid].len(), 2, "serving both communities");
+        assert_eq!(reg.active_session_keys().len(), 1);
+    }
+
+    #[test]
+    fn pending_needs_session_inactive_does_not() {
+        let mut acct = Account::default();
+        let p1 = persona();
+        let p2 = persona();
+        let (id1, id2) = (p1.persona_id, p2.persona_id);
+        acct.personas.insert(id1, p1);
+        acct.personas.insert(id2, p2);
+        // p1 → Pending (needs session); p2 → Left (does not).
+        acct.communities.insert(
+            "pending".into(),
+            community(
+                "pending",
+                id1,
+                CommunityStatus::Pending {
+                    request_id: Uuid::new_v4(),
+                },
+            ),
+        );
+        acct.communities
+            .insert("left".into(), community("left", id2, CommunityStatus::Left));
+
+        let reg = IdentityRegistry::new(&acct);
+        let keys = reg.active_session_keys();
+        assert!(keys.contains(&id1), "pending persona needs a session");
+        assert!(!keys.contains(&id2), "left persona needs no session");
+        assert_eq!(reg.active().count(), 0, "no Active communities here");
+    }
+
+    #[test]
+    fn dangling_ref_is_skipped() {
+        let mut acct = Account::default();
+        // Community references a persona that doesn't exist.
+        acct.communities.insert(
+            "x".into(),
+            community("x", PersonaId::new(), CommunityStatus::Active),
+        );
+        let reg = IdentityRegistry::new(&acct);
+        assert!(reg.get(&"x".to_string()).is_none());
+        assert_eq!(reg.all().count(), 0);
+        assert!(reg.sessions().is_empty());
+    }
+}

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -163,6 +163,7 @@ mod tests {
         PersonaRecord {
             persona_id: PersonaId::new(),
             did: "did:webvh:example:p".into(),
+            did_document: None,
             key_refs: Vec::<KeyRef>::new(),
             mediator_did: Some("did:webvh:mediator".into()),
             origin_context_id: "openvtc/p".into(),

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod bip32;
 pub mod config;
 pub mod display;
 pub mod errors;
+pub mod identity;
 pub mod logs;
 pub mod maintainers;
 #[cfg(feature = "openpgp-card")]

--- a/openvtc-core/src/relationships.rs
+++ b/openvtc-core/src/relationships.rs
@@ -205,129 +205,138 @@ impl Relationships {
             }
         };
 
-        // Collect R-DID relationships that need profiles + secrets.
-        // Extract data from Mutex before any async work.
-        let r_did_entries: Vec<Arc<String>> = self
-            .relationships
-            .values()
-            .filter_map(|rel| {
-                let lock = rel.lock().ok()?;
-                if matches!(
-                    lock.state,
-                    RelationshipState::Established
-                        | RelationshipState::RequestSent
-                        | RelationshipState::RequestAccepted
-                ) && &lock.our_did != our_p_did
-                {
-                    Some(lock.our_did.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        // Collect all VTA key fetch futures upfront so they can run concurrently.
-        // Non-VTA secrets (BIP32 derived, imported) are resolved synchronously.
-        struct PendingVtaFetch {
-            key_id: String,
-            secret_id: String,
-            purpose: KeyPurpose,
-        }
-
-        let mut all_secrets: Vec<Secret> = Vec::new();
-        let mut vta_fetches: Vec<PendingVtaFetch> = Vec::new();
-
-        for our_did in &r_did_entries {
-            // Create ATM profile (no network — just registration)
-            let profile =
-                ATMProfile::new(&atm, None, our_did.to_string(), Some(mediator.to_string()))
-                    .await?;
-            profiles.insert(our_did.clone(), atm.profile_add(&profile, false).await?);
-
-            // Collect secrets for this DID
-            for (k, v) in key_info.iter() {
-                if !k.starts_with(our_did.as_str()) {
-                    continue;
-                }
-                let kp = match v.purpose {
-                    KeyTypes::RelationshipVerification => KeyPurpose::Signing,
-                    KeyTypes::RelationshipEncryption => KeyPurpose::Encryption,
-                    _ => continue,
-                };
-                match &v.path {
-                    KeySourceMaterial::Derived { path } => {
-                        if let KeyBackend::Bip32 { root, .. } = key_backend
-                            && let Ok(mut s) = root.get_secret_from_path(path, kp)
-                        {
-                            s.id = k.clone();
-                            all_secrets.push(s);
-                        }
+        // Build the relationship profiles + gather their secrets, wrapped so our
+        // own admin-DID VTA session (if built above) is shut down on EVERY exit,
+        // including the `?` error paths below.
+        let profiles_result: Result<(), OpenVTCError> = async {
+            // Collect R-DID relationships that need profiles + secrets.
+            // Extract data from Mutex before any async work.
+            let r_did_entries: Vec<Arc<String>> = self
+                .relationships
+                .values()
+                .filter_map(|rel| {
+                    let lock = rel.lock().ok()?;
+                    if matches!(
+                        lock.state,
+                        RelationshipState::Established
+                            | RelationshipState::RequestSent
+                            | RelationshipState::RequestAccepted
+                    ) && &lock.our_did != our_p_did
+                    {
+                        Some(lock.our_did.clone())
+                    } else {
+                        None
                     }
-                    KeySourceMaterial::Imported { seed } => {
-                        if let Ok(mut s) = Secret::from_multibase(seed.expose_secret(), None) {
-                            s.id = k.clone();
-                            all_secrets.push(s);
-                        }
+                })
+                .collect();
+
+            // Collect all VTA key fetch futures upfront so they can run concurrently.
+            // Non-VTA secrets (BIP32 derived, imported) are resolved synchronously.
+            struct PendingVtaFetch {
+                key_id: String,
+                secret_id: String,
+                purpose: KeyPurpose,
+            }
+
+            let mut all_secrets: Vec<Secret> = Vec::new();
+            let mut vta_fetches: Vec<PendingVtaFetch> = Vec::new();
+
+            for our_did in &r_did_entries {
+                // Create ATM profile (no network — just registration)
+                let profile =
+                    ATMProfile::new(&atm, None, our_did.to_string(), Some(mediator.to_string()))
+                        .await?;
+                profiles.insert(our_did.clone(), atm.profile_add(&profile, false).await?);
+
+                // Collect secrets for this DID
+                for (k, v) in key_info.iter() {
+                    if !k.starts_with(our_did.as_str()) {
+                        continue;
                     }
-                    KeySourceMaterial::VtaManaged { key_id } => {
-                        vta_fetches.push(PendingVtaFetch {
-                            key_id: key_id.clone(),
-                            secret_id: k.clone(),
-                            purpose: kp,
-                        });
+                    let kp = match v.purpose {
+                        KeyTypes::RelationshipVerification => KeyPurpose::Signing,
+                        KeyTypes::RelationshipEncryption => KeyPurpose::Encryption,
+                        _ => continue,
+                    };
+                    match &v.path {
+                        KeySourceMaterial::Derived { path } => {
+                            if let KeyBackend::Bip32 { root, .. } = key_backend
+                                && let Ok(mut s) = root.get_secret_from_path(path, kp)
+                            {
+                                s.id = k.clone();
+                                all_secrets.push(s);
+                            }
+                        }
+                        KeySourceMaterial::Imported { seed } => {
+                            if let Ok(mut s) = Secret::from_multibase(seed.expose_secret(), None) {
+                                s.id = k.clone();
+                                all_secrets.push(s);
+                            }
+                        }
+                        KeySourceMaterial::VtaManaged { key_id } => {
+                            vta_fetches.push(PendingVtaFetch {
+                                key_id: key_id.clone(),
+                                secret_id: k.clone(),
+                                purpose: kp,
+                            });
+                        }
                     }
                 }
             }
-        }
 
-        // Fetch all VTA secrets concurrently — VtaClient is Clone so cloned
-        // clients share the HTTP connection pool and auth tokens.
-        if let Some(client) = vta_client
-            && !vta_fetches.is_empty()
-        {
-            debug!("fetching {} VTA secrets concurrently", vta_fetches.len());
-            let mut handles = Vec::with_capacity(vta_fetches.len());
-            for fetch in &vta_fetches {
-                let client = client.clone();
-                let key_id = fetch.key_id.clone();
-                handles.push(tokio::spawn(
-                    async move { client.get_key_secret(&key_id).await },
-                ));
-            }
-            for (fetch, handle) in vta_fetches.iter().zip(handles) {
-                match handle.await {
-                    Ok(Ok(resp)) => {
-                        if let Ok(mut s) =
-                            crate::config::keys::secret_from_vta_response(&resp, fetch.purpose)
-                        {
-                            s.id = fetch.secret_id.clone();
-                            all_secrets.push(s);
+            // Fetch all VTA secrets concurrently — VtaClient is Clone so cloned
+            // clients share the HTTP connection pool and auth tokens.
+            if let Some(client) = vta_client
+                && !vta_fetches.is_empty()
+            {
+                debug!("fetching {} VTA secrets concurrently", vta_fetches.len());
+                let mut handles = Vec::with_capacity(vta_fetches.len());
+                for fetch in &vta_fetches {
+                    let client = client.clone();
+                    let key_id = fetch.key_id.clone();
+                    handles.push(tokio::spawn(
+                        async move { client.get_key_secret(&key_id).await },
+                    ));
+                }
+                for (fetch, handle) in vta_fetches.iter().zip(handles) {
+                    match handle.await {
+                        Ok(Ok(resp)) => {
+                            if let Ok(mut s) =
+                                crate::config::keys::secret_from_vta_response(&resp, fetch.purpose)
+                            {
+                                s.id = fetch.secret_id.clone();
+                                all_secrets.push(s);
+                            }
                         }
-                    }
-                    Ok(Err(e)) => {
-                        warn!(key_id = %fetch.key_id, "VTA get_key_secret failed: {e}");
-                    }
-                    Err(e) => {
-                        warn!(key_id = %fetch.key_id, "VTA fetch task panicked: {e}");
+                        Ok(Err(e)) => {
+                            warn!(key_id = %fetch.key_id, "VTA get_key_secret failed: {e}");
+                        }
+                        Err(e) => {
+                            warn!(key_id = %fetch.key_id, "VTA fetch task panicked: {e}");
+                        }
                     }
                 }
             }
-        }
 
-        // Insert all secrets at once
-        if !all_secrets.is_empty() {
-            tdk.get_shared_state()
-                .secrets_resolver()
-                .insert_vec(&all_secrets)
-                .await;
-        }
+            // Insert all secrets at once
+            if !all_secrets.is_empty() {
+                tdk.get_shared_state()
+                    .secrets_resolver()
+                    .insert_vec(&all_secrets)
+                    .await;
+            }
 
-        // If we opened our own admin-DID VTA session above, close it. A client
-        // passed in by the caller is the caller's to shut down. `connect_didcomm`
-        // opens a persistent reconnecting WebSocket that `Drop` can't close.
+            Ok(())
+        }
+        .await;
+
+        // Close our own admin-DID VTA session (if we built one) on every exit; a
+        // caller-passed client is the caller's to close. `connect_didcomm` opens a
+        // session that `Drop` can't close.
         if let Some(client) = &owned_vta_client {
             client.shutdown().await;
         }
+        profiles_result?;
 
         Ok(profiles)
     }

--- a/openvtc-core/src/relationships.rs
+++ b/openvtc-core/src/relationships.rs
@@ -191,13 +191,14 @@ impl Relationships {
         // The previous fallback hand-rolled `challenge_response` against
         // `vta_url` and silently broke for DIDComm-only VTAs whose
         // `vta_url` is empty.
-        let owned_vta_client;
+        let mut owned_vta_client: Option<vta_sdk::client::VtaClient> = None;
         let vta_client: Option<&vta_sdk::client::VtaClient> = match vta_client {
             Some(client) => Some(client),
             None => {
                 if matches!(key_backend, KeyBackend::Vta { .. }) {
-                    owned_vta_client = super::config::build_runtime_vta_client(key_backend).await?;
-                    Some(&owned_vta_client)
+                    owned_vta_client =
+                        Some(super::config::build_runtime_vta_client(key_backend).await?);
+                    owned_vta_client.as_ref()
                 } else {
                     None
                 }
@@ -319,6 +320,13 @@ impl Relationships {
                 .secrets_resolver()
                 .insert_vec(&all_secrets)
                 .await;
+        }
+
+        // If we opened our own admin-DID VTA session above, close it. A client
+        // passed in by the caller is the caller's to shut down. `connect_didcomm`
+        // opens a persistent reconnecting WebSocket that `Drop` can't close.
+        if let Some(client) = &owned_vta_client {
+            client.shutdown().await;
         }
 
         Ok(profiles)

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -309,7 +309,7 @@ pub fn apply_env_overrides(config: &mut Config) {
     use openvtc_core::config::KeyBackend;
 
     if let Ok(val) = std::env::var("OPENVTC_MEDIATOR_DID") {
-        config.public.mediator_did = val;
+        config.set_active_mediator_did(&val);
     }
     if let Ok(val) = std::env::var("OPENVTC_VTA_URL")
         && let KeyBackend::Vta {

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -8,9 +8,9 @@ use crate::{
 };
 use anyhow::{Result, bail};
 use console::style;
-use dialoguer::{Password, theme::ColorfulTheme};
+use dialoguer::{Confirm, Password, theme::ColorfulTheme};
 use openvtc_core::{
-    config::{Config, ConfigProtectionType, UnlockCode},
+    config::{Config, ConfigProtectionType, UnlockCode, public_config::PublicConfig},
     errors::OpenVTCError,
     process_lock::{check_duplicate_instance, remove_lock_file},
 };
@@ -160,6 +160,46 @@ async fn main() -> Result<()> {
             }
             Err(OpenVTCError::ConfigNotFound(_, _)) => {
                 // Configuration not found, start in setup mode
+                starting_mode = StartingMode::SetupWizard;
+            }
+            Err(OpenVTCError::ConfigVersionUnsupported { found, expected }) => {
+                // Breaking reset (D13 / R-RST-2,3): the on-disk config predates
+                // the v2 account model and cannot be migrated. Warn explicitly,
+                // require confirmation, then delete it and run setup from scratch.
+                eprintln!(
+                    "{}",
+                    style(format!(
+                        "Your existing configuration (format v{found}) is incompatible with \
+                         this version of OpenVTC (format v{expected}) and cannot be upgraded \
+                         automatically."
+                    ))
+                    .color256(CLI_ORANGE)
+                );
+                eprintln!(
+                    "{}",
+                    style(
+                        "Continuing will DELETE the existing configuration and its stored \
+                         credentials, then start a fresh setup. This cannot be undone."
+                    )
+                    .color256(CLI_RED)
+                );
+                let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Delete the incompatible configuration and reset?")
+                    .default(false)
+                    .interact()
+                    .unwrap_or(false);
+                if !confirmed {
+                    bail!("Incompatible configuration; reset declined by user");
+                }
+                let summary = PublicConfig::delete_profile(&profile).map_err(|e| {
+                    anyhow::anyhow!("Failed to delete incompatible configuration: {e}")
+                })?;
+                for warning in &summary.warnings {
+                    eprintln!(
+                        "{}",
+                        style(format!("warning during reset: {warning}")).color256(CLI_ORANGE)
+                    );
+                }
                 starting_mode = StartingMode::SetupWizard;
             }
             Err(e) => {

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -220,6 +220,13 @@ pub enum Action {
     /// Cancel the join flow and return to the main page.
     JoinCancel,
 
+    /// Move the Communities-list selection to this index.
+    CommunitySelect(usize),
+
+    /// Remove the community at this index in the Communities list (withdraws a
+    /// live/pending membership, then deletes the record).
+    DeleteCommunity(usize),
+
     // ************************************************************************
     // SETUP Pages
     /// Import existing Config

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -223,8 +223,16 @@ pub enum Action {
     /// Move the Communities-list selection to this index.
     CommunitySelect(usize),
 
+    /// Arm a removal confirmation for the community at this index (the panel
+    /// prompts for y/n before anything is deleted).
+    CommunityConfirmDelete(usize),
+
+    /// Dismiss a pending removal confirmation without deleting.
+    CommunityCancelDelete,
+
     /// Remove the community at this index in the Communities list (withdraws a
-    /// live/pending membership, then deletes the record).
+    /// live/pending membership, then deletes the record). Only sent after the
+    /// user confirms.
     DeleteCommunity(usize),
 
     // ************************************************************************

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -271,8 +271,11 @@ pub enum Action {
     TokenWriteKeys(Option<Arc<Mutex<Card<Open>>>>),
 
     // ************************************************************************
-    /// Create a DID via a WebVH server (server_id, optional custom path)
-    WebvhServerCreateDid(String, Option<String>),
+    /// Create a DID via a WebVH server (server_id, path mode)
+    WebvhServerCreateDid(
+        String,
+        vta_sdk::protocols::did_management::create::WebvhPathMode,
+    ),
 
     /// Using a custom mediator DID
     SetCustomMediator(String),

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -208,6 +208,19 @@ pub enum Action {
     Settings(SettingsAction),
 
     // ************************************************************************
+    // JOIN flow (R-A-5 Stage 4 — State-B "join a community")
+    /// Open the join flow (pressing `j` on the Communities panel). Handled in
+    /// both the degraded loop (State-A first join) and the runtime select loop.
+    StartJoin,
+
+    /// Submit the entered community VTC DID — kicks off the automated
+    /// persona-mint + sub-context + join-submit sequence.
+    JoinSubmitVtc(String),
+
+    /// Cancel the join flow and return to the main page.
+    JoinCancel,
+
+    // ************************************************************************
     // SETUP Pages
     /// Import existing Config
     /// Filename, config_unlock_passphrase, new_unlock_passphrase

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -207,6 +207,11 @@ pub enum Action {
     Contact(ContactAction),
     Settings(SettingsAction),
 
+    /// Dismiss the startup loading screen (Enter, once loading has completed) and
+    /// reveal the main page. Phase-2 connections are already running in the
+    /// background by this point.
+    DismissLoading,
+
     // ************************************************************************
     // JOIN flow (R-A-5 Stage 4 — State-B "join a community")
     /// Open the join flow (pressing `j` on the Communities panel). Handled in

--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -281,13 +281,13 @@ pub async fn build_listener_configs(
 ) -> Vec<ListenerConfig> {
     let restart = default_listener_restart_policy();
 
-    let persona_secrets = get_secrets_for_did(tdk, config, &config.public.persona_did).await;
+    let persona_secrets = get_secrets_for_did(tdk, config, config.persona_did()).await;
 
     let mut configs = vec![ListenerConfig {
         id: PERSONA_LISTENER_ID.to_string(),
         profile: make_profile(
-            &config.public.persona_did,
-            &config.public.mediator_did,
+            config.persona_did(),
+            config.mediator_did(),
             "Persona",
             persona_secrets,
         ),
@@ -323,7 +323,7 @@ pub async fn build_listener_configs(
                 RelationshipState::Established
                     | RelationshipState::RequestSent
                     | RelationshipState::RequestAccepted
-            ) && *rel.our_did != *config.public.persona_did
+            ) && rel.our_did.as_str() != config.persona_did()
                 && seen_dids.insert(rel.our_did.to_string())
             {
                 Some((rel.our_did.to_string(), remote_p_did.to_string()))
@@ -339,7 +339,7 @@ pub async fn build_listener_configs(
             id: format!("rel-{}", short_did_id(our_did)),
             profile: make_profile(
                 our_did,
-                &config.public.mediator_did,
+                config.mediator_did(),
                 &format!(
                     "R-DID for {}",
                     openvtc_core::display::truncate_did(remote_p_did, 32)
@@ -353,7 +353,7 @@ pub async fn build_listener_configs(
     }
 
     debug!(
-        persona = %config.public.persona_did,
+        persona = %config.persona_did(),
         r_did_listeners = r_did_entries.len(),
         total = configs.len(),
         "built listener configs"
@@ -383,7 +383,7 @@ pub async fn send_message(
     from_did: &str,
     to_did: &str,
 ) -> Result<(), DIDCommServiceError> {
-    let listener_id = listener_id_for_did(from_did, &config.public.persona_did);
+    let listener_id = listener_id_for_did(from_did, config.persona_did());
     send_message_via(service, message, &listener_id, to_did).await
 }
 
@@ -475,12 +475,12 @@ pub fn spawn_lifecycle_logger(
 
 /// Build a single `ListenerConfig` for the persona DID.
 pub async fn persona_listener_config(config: &Config, tdk: &affinidi_tdk::TDK) -> ListenerConfig {
-    let secrets = get_secrets_for_did(tdk, config, &config.public.persona_did).await;
+    let secrets = get_secrets_for_did(tdk, config, config.persona_did()).await;
     ListenerConfig {
         id: PERSONA_LISTENER_ID.to_string(),
         profile: make_profile(
-            &config.public.persona_did,
-            &config.public.mediator_did,
+            config.persona_did(),
+            config.mediator_did(),
             "Persona",
             secrets,
         ),

--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -283,12 +283,13 @@ pub async fn build_listener_configs(
 
     let persona_secrets = get_secrets_for_did(tdk, config, config.persona_did()).await;
 
+    let persona_label = config.persona_profile_label();
     let mut configs = vec![ListenerConfig {
         id: PERSONA_LISTENER_ID.to_string(),
         profile: make_profile(
             config.persona_did(),
             config.mediator_did(),
-            "Persona",
+            &persona_label,
             persona_secrets,
         ),
         restart_policy: restart.clone(),
@@ -481,7 +482,7 @@ pub async fn persona_listener_config(config: &Config, tdk: &affinidi_tdk::TDK) -
         profile: make_profile(
             config.persona_did(),
             config.mediator_did(),
-            "Persona",
+            &config.persona_profile_label(),
             secrets,
         ),
         restart_policy: default_listener_restart_policy(),

--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -19,8 +19,23 @@ use tracing::debug;
 /// Standard message expiry: 48 hours.
 pub const MESSAGE_EXPIRY_SECS: u64 = 60 * 60 * 48;
 
-/// Listener ID used for the persona DID listener.
+/// Fallback listener ID for the persona DID listener when no DID is available
+/// (e.g. a State-A account with no persona).
 pub const PERSONA_LISTENER_ID: &str = "persona";
+
+/// The listener ID for a persona, derived from its DID slug so it is stable,
+/// unique per community (one persona per community), and identifiable in the
+/// activity log — e.g. `silent-tongue` rather than a generic `persona`. Derived
+/// from the DID alone (not the full `Config`) so the runtime and message senders
+/// (`listener_id_for_did`) agree on the same id without extra context.
+pub fn persona_listener_id(persona_did: &str) -> String {
+    let slug = openvtc_core::config::context_path::render_for_display(persona_did).to_string();
+    if slug.is_empty() {
+        PERSONA_LISTENER_ID.to_string()
+    } else {
+        slug
+    }
+}
 
 /// Build a timestamped DIDComm message with standard 48-hour expiry.
 pub fn build_didcomm_message(
@@ -96,7 +111,8 @@ pub async fn reconnect_persona_listener(
     config: &Config,
     tdk: &affinidi_tdk::TDK,
 ) -> ReconnectOutcome {
-    if let Err(e) = service.remove_listener(PERSONA_LISTENER_ID).await {
+    let lid = persona_listener_id(config.persona_did());
+    if let Err(e) = service.remove_listener(&lid).await {
         debug!("remove_listener during reconnect: {e}");
     }
     let new_config = persona_listener_config(config, tdk).await;
@@ -104,7 +120,7 @@ pub async fn reconnect_persona_listener(
         return ReconnectOutcome::Failed(format!("{e:#}"));
     }
     match service
-        .wait_connected(PERSONA_LISTENER_ID, std::time::Duration::from_secs(30))
+        .wait_connected(&lid, std::time::Duration::from_secs(30))
         .await
     {
         Ok(()) => ReconnectOutcome::Connected,
@@ -285,7 +301,7 @@ pub async fn build_listener_configs(
 
     let persona_label = config.persona_profile_label();
     let mut configs = vec![ListenerConfig {
-        id: PERSONA_LISTENER_ID.to_string(),
+        id: persona_listener_id(config.persona_did()),
         profile: make_profile(
             config.persona_did(),
             config.mediator_did(),
@@ -369,7 +385,7 @@ pub async fn build_listener_configs(
 /// the relationship-listener naming convention.
 pub fn listener_id_for_did(our_did: &str, persona_did: &str) -> String {
     if our_did == persona_did {
-        PERSONA_LISTENER_ID.to_string()
+        persona_listener_id(persona_did)
     } else {
         format!("rel-{}", short_did_id(our_did))
     }
@@ -478,7 +494,7 @@ pub fn spawn_lifecycle_logger(
 pub async fn persona_listener_config(config: &Config, tdk: &affinidi_tdk::TDK) -> ListenerConfig {
     let secrets = get_secrets_for_did(tdk, config, config.persona_did()).await;
     ListenerConfig {
-        id: PERSONA_LISTENER_ID.to_string(),
+        id: persona_listener_id(config.persona_did()),
         profile: make_profile(
             config.persona_did(),
             config.mediator_did(),

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -33,6 +33,7 @@ pub async fn accept_relationship_request(
     service: &DIDCommService,
     task_id: &str,
     generate_r_did: bool,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) -> Result<()> {
     let task_id = Arc::new(task_id.to_string());
 
@@ -73,7 +74,8 @@ pub async fn accept_relationship_request(
         // Snapshot the mediator before the &mut config borrow below.
         let mediator = config.mediator_did().to_string();
         let r_did = Arc::new(
-            super::relationship_actions::create_relationship_did(tdk, config, &mediator).await?,
+            super::relationship_actions::create_relationship_did(tdk, config, &mediator, admin_vta)
+                .await?,
         );
         // Register listener for post-establishment use (no need to wait for connection)
         let listener_config = super::didcomm::relationship_listener_config(
@@ -555,6 +557,7 @@ async fn handle_accept_relationship(
     profile: &str,
     task_id: &str,
     generate_r_did: bool,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) {
     if generate_r_did {
         state.main_page.content_panel.inbox.status_message =
@@ -569,7 +572,9 @@ async fn handle_accept_relationship(
     }
     let _ = state_tx.send(state.clone());
 
-    match accept_relationship_request(config, tdk, service, task_id, generate_r_did).await {
+    match accept_relationship_request(config, tdk, service, task_id, generate_r_did, admin_vta)
+        .await
+    {
         Ok(()) => save_and_sync(
             config,
             state,
@@ -691,6 +696,7 @@ pub(crate) async fn dispatch(
     state: &mut State,
     state_tx: &watch::Sender<State>,
     profile: &str,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) {
     match action {
         InboxAction::SelectTask(index) => handle_inbox_select(state, index),
@@ -711,6 +717,7 @@ pub(crate) async fn dispatch(
                 profile,
                 &task_id,
                 generate_r_did,
+                admin_vta,
             )
             .await
         }

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -70,13 +70,10 @@ pub async fn accept_relationship_request(
     // from/to so the mediator can route them and sender validation is simple.
     // The R-DID listener is registered for post-establishment communication.
     let our_did = if generate_r_did {
+        // Snapshot the mediator before the &mut config borrow below.
+        let mediator = config.mediator_did().to_string();
         let r_did = Arc::new(
-            super::relationship_actions::create_relationship_did(
-                tdk,
-                config,
-                &config.public.mediator_did.clone(),
-            )
-            .await?,
+            super::relationship_actions::create_relationship_did(tdk, config, &mediator).await?,
         );
         // Register listener for post-establishment use (no need to wait for connection)
         let listener_config = super::didcomm::relationship_listener_config(
@@ -84,7 +81,7 @@ pub async fn accept_relationship_request(
             tdk,
             &r_did,
             &from_did,
-            &config.public.mediator_did,
+            config.mediator_did(),
         )
         .await;
         if let Err(e) = service.add_listener(listener_config).await {
@@ -92,7 +89,7 @@ pub async fn accept_relationship_request(
         }
         r_did
     } else {
-        Arc::clone(&config.public.persona_did)
+        config.persona_did_arc()
     };
 
     // Add or update contact with sender's name as alias
@@ -134,12 +131,12 @@ pub async fn accept_relationship_request(
     // The R-DID is carried in the body — the mediator only sees persona DIDs.
     // from/to use persona DIDs so encryption keys match the persona listener.
     let msg = build_accept_message(
-        &config.public.persona_did, // from: our persona
-        &from_did,                  // to: their persona
-        &our_did,                   // body.did: our R-DID (or persona if no R-DID)
+        config.persona_did(), // from: our persona
+        &from_did,            // to: their persona
+        &our_did,             // body.did: our R-DID (or persona if no R-DID)
         &task_id,
     )?;
-    super::didcomm::send_message(service, config, &msg, &config.public.persona_did, &from_did)
+    super::didcomm::send_message(service, config, &msg, config.persona_did(), &from_did)
         .await
         .map_err(|e| anyhow::anyhow!("failed to send acceptance: {e}"))?;
 
@@ -197,8 +194,8 @@ pub async fn reject_relationship_request(
     };
 
     // Build and send rejection message
-    let msg = build_reject_message(&config.public.persona_did, &from_did, reason, &task_id)?;
-    super::didcomm::send_message(service, config, &msg, &config.public.persona_did, &from_did)
+    let msg = build_reject_message(config.persona_did(), &from_did, reason, &task_id)?;
+    super::didcomm::send_message(service, config, &msg, config.persona_did(), &from_did)
         .await
         .map_err(|e| anyhow::anyhow!("failed to send rejection: {e}"))?;
 
@@ -303,7 +300,7 @@ pub async fn accept_vrc_request(
     // Create VRC with current timestamp
     let valid_from = Utc::now();
     let mut vrc = DTGCredential::new_vrc(
-        config.public.persona_did.to_string(),
+        config.persona_did().to_string(),
         their_r_did.to_string(),
         valid_from,
         None, // no valid_until

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -36,6 +36,9 @@ pub struct JoinState {
     pub completed: Completion,
     /// The pending community record created on success (for the success page).
     pub created_community: Option<CommunityRecord>,
+    /// The DID of the persona minted for this community, shown on the success
+    /// page alongside the community DID.
+    pub created_persona_did: Option<String>,
 }
 
 impl JoinState {

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -1,0 +1,58 @@
+//! State-B "join a community" flow state (R-A-5 Stage 4).
+//!
+//! Holds the transient UI/progress state for the two-page join flow:
+//! `VtcEnterDid` (the operator pastes the community VTC DID) and `JoinProgress`
+//! (a live log of the automated persona-mint → sub-context → join-submit
+//! sequence). Persona-mint working fields are reused from
+//! [`SetupState`](crate::state_handler::setup_sequence::SetupState) on
+//! `State.setup`; this struct only tracks the join-specific surface.
+
+use openvtc_core::config::account::CommunityRecord;
+
+use crate::state_handler::setup_sequence::{Completion, MessageType};
+
+/// Which page of the join flow is currently active.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum JoinPage {
+    /// Operator enters the community (VTC) DID.
+    #[default]
+    EnterDid,
+    /// Automated mint + join sequence progress / result.
+    Progress,
+}
+
+/// Transient state for the join flow.
+#[derive(Clone, Debug, Default)]
+pub struct JoinState {
+    /// Active page within the join flow.
+    pub page: JoinPage,
+    /// Display name resolved from the VTC DID document (best-effort).
+    pub display_name: Option<String>,
+    /// True while the background mint+join sequence is running. Locks input.
+    pub processing: bool,
+    /// Progress / error log shown on the `JoinProgress` page.
+    pub messages: Vec<MessageType>,
+    /// Overall outcome of the sequence.
+    pub completed: Completion,
+    /// The pending community record created on success (for the success page).
+    pub created_community: Option<CommunityRecord>,
+}
+
+impl JoinState {
+    /// Reset to a fresh `EnterDid` page (called when the flow opens).
+    pub fn reset(&mut self) {
+        *self = JoinState::default();
+    }
+
+    /// Append an info message to the progress log.
+    pub fn info(&mut self, msg: impl Into<String>) {
+        self.messages.push(MessageType::Info(msg.into()));
+    }
+
+    /// Append an error message and mark the sequence failed.
+    pub fn fail(&mut self, msg: impl Into<String>) {
+        self.messages.push(MessageType::Error(msg.into()));
+        self.completed = Completion::CompletedFail;
+        self.processing = false;
+    }
+}

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -321,12 +321,12 @@ async fn run_join_sequence(
     state.main_page.sync_from_config(config);
     state
         .main_page
-        .log("Join request submitted — restart to activate.");
+        .log("Join request submitted — Pending in your Communities list.");
     state.join.created_community = Some(record);
     state.join.completed = Completion::CompletedOK;
     state
         .join
-        .info("Done. Restart OpenVTC to activate this community.");
+        .info("Join request submitted — it's now Pending in your Communities list.");
 }
 
 /// Persist the config, abstracting over the openpgp-card touch prompt.

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -239,8 +239,15 @@ async fn run_join_sequence(
         }
     }
 
-    // Default mediator; label the persona after the community.
-    state.setup.custom_mediator = None;
+    // The persona's mediator is the account's VTA mediator: the DID minted via
+    // the VTA's webvh server advertises that mediator in its DIDComm service, so
+    // the persona listener must use the same one. Hardcoding `None` (the public
+    // default) left the persona with no usable mediator — the listener then
+    // failed with "No Mediator is configured" and retried forever.
+    state.setup.custom_mediator = match &config.key_backend {
+        openvtc_core::config::KeyBackend::Vta { mediator_did, .. } => mediator_did.clone(),
+        _ => None,
+    };
     state.setup.username = display_name.clone().unwrap_or_else(|| {
         openvtc_core::config::context_path::render_for_display(&vtc_did).to_string()
     });

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -161,10 +161,11 @@ async fn run_join_sequence(
     let top_context_id = config.account.top_context_id.clone();
 
     // 4. Mint a fresh persona into `state.setup` (reusing the setup helpers).
-    state.join.info("Minting a persona for this community…");
-    let _ = handler.state_tx.send(state.clone());
-
     // Persona signing/auth/encryption keys.
+    state
+        .join
+        .info("Creating persona keys (signing, authentication, encryption)…");
+    let _ = handler.state_tx.send(state.clone());
     match vta::create_persona_keys(admin_vta, Some(&top_context_id)).await {
         Ok(keys) => state.setup.did_keys = Some(keys),
         Err(e) => {
@@ -175,6 +176,8 @@ async fn run_join_sequence(
         }
     }
     // WebVH update keys.
+    state.join.info("Creating DID update keys…");
+    let _ = handler.state_tx.send(state.clone());
     match vta::create_update_keys(admin_vta, Some(&top_context_id)).await {
         Ok((update, next_update)) => {
             state.setup.vta.update_secret = Some(update);
@@ -189,6 +192,8 @@ async fn run_join_sequence(
     }
 
     // Pick the first WebVH server. Serverless mint is a deliberate follow-up.
+    state.join.info("Finding a DID hosting server…");
+    let _ = handler.state_tx.send(state.clone());
     let server_id = match vta::list_webvh_servers(admin_vta).await {
         Ok(servers) => match servers.into_iter().next() {
             Some(s) => s.id,

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -330,6 +330,7 @@ async fn run_join_sequence(
         .main_page
         .log("Join request submitted — Pending in your Communities list.");
     state.join.created_community = Some(record);
+    state.join.created_persona_did = Some(persona_did.clone());
     state.join.completed = Completion::CompletedOK;
     state
         .join

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -1,0 +1,346 @@
+//! State-B "join a community" orchestration (R-A-5 Stage 4).
+//!
+//! [`StateHandler::join_flow`] is a nested `tokio::select!` loop modelled on
+//! [`setup_wizard`](crate::state_handler::setup_wizard): it owns the screen
+//! while [`ActivePage::Join`](crate::state_handler::state::ActivePage::Join) is
+//! active, processes the join actions, renders via `state_tx`, and returns to
+//! the main page when the user cancels or the sequence finishes.
+//!
+//! The actual work runs in [`run_join_sequence`]: mint a fresh persona (reusing
+//! the setup VTA helpers), derive + register the per-community sub-context,
+//! submit the join, and persist a `Pending` [`CommunityRecord`]. Every failure
+//! is surfaced into the join log as a [`MessageType::Error`] — the loop never
+//! `?`-bubbles a sequence error in a way that would kill the app.
+
+use affinidi_tdk::TDK;
+use anyhow::Result;
+use chrono::Utc;
+use openvtc_core::config::{Config, account::CommunityRecord, context_path::build_sub_context_id};
+use tokio::sync::{broadcast, mpsc::UnboundedReceiver};
+use tracing::debug;
+use vta_sdk::{client::VtaClient, protocols::did_management::create::WebvhPathMode};
+
+use crate::{
+    Interrupted,
+    state_handler::{
+        StateHandler,
+        actions::Action,
+        join::JoinPage,
+        setup_sequence::{Completion, config::ConfigExtension, vta},
+        state::{ActivePage, State},
+    },
+};
+
+impl StateHandler {
+    /// Run the join flow until the user cancels or the sequence finishes.
+    ///
+    /// Mirrors `setup_wizard`'s loop shape. `admin_vta` is the always-on admin
+    /// VTA session (threaded in from the caller); `config` is mutated in place
+    /// and persisted by the sequence on success.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn join_flow(
+        &self,
+        action_rx: &mut UnboundedReceiver<Action>,
+        interrupt_rx: &mut broadcast::Receiver<Interrupted>,
+        state: &mut State,
+        tdk: &TDK,
+        config: &mut Config,
+        admin_vta: Option<&VtaClient>,
+        profile: &str,
+    ) -> Result<JoinExit> {
+        // Enter the flow on a fresh EnterDid page.
+        state.join.reset();
+        state.active_page = ActivePage::Join;
+        let _ = self.state_tx.send(state.clone());
+
+        loop {
+            tokio::select! {
+                maybe_action = action_rx.recv() => {
+                    let Some(action) = maybe_action else {
+                        // Channel closed — treat as a user-initiated exit.
+                        return Ok(JoinExit::Exit(Interrupted::UserInt));
+                    };
+                    match action {
+                        Action::Exit => return Ok(JoinExit::Exit(Interrupted::UserInt)),
+                        Action::UXError(interrupted) => {
+                            return Ok(JoinExit::Exit(interrupted));
+                        }
+                        Action::JoinCancel => {
+                            // Leave the flow; the caller restores the main page.
+                            state.active_page = ActivePage::Main;
+                            return Ok(JoinExit::Returned);
+                        }
+                        Action::JoinSubmitVtc(vtc_did) => {
+                            let vtc_did = vtc_did.trim().to_string();
+                            if vtc_did.is_empty() {
+                                continue;
+                            }
+                            // Move to the progress page and lock input.
+                            state.join.page = JoinPage::Progress;
+                            state.join.processing = true;
+                            state.join.completed = Completion::NotFinished;
+                            state.join.messages.clear();
+                            state.join.info(format!("Joining {vtc_did}…"));
+                            let _ = self.state_tx.send(state.clone());
+
+                            run_join_sequence(
+                                self,
+                                state,
+                                tdk,
+                                config,
+                                admin_vta,
+                                profile,
+                                vtc_did,
+                            )
+                            .await;
+
+                            state.join.processing = false;
+                            let _ = self.state_tx.send(state.clone());
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(interrupted) = interrupt_rx.recv() => {
+                    return Ok(JoinExit::Exit(interrupted));
+                }
+            }
+            let _ = self.state_tx.send(state.clone());
+        }
+    }
+}
+
+/// Outcome of a `join_flow` invocation.
+pub(crate) enum JoinExit {
+    /// User cancelled / finished — return to the main page and resume the
+    /// caller's loop.
+    Returned,
+    /// Application is exiting (Exit / UXError / interrupt).
+    Exit(Interrupted),
+}
+
+/// Run the automated mint → sub-context → join-submit → persist sequence.
+///
+/// All progress and errors land in `state.join`. On success
+/// `state.join.completed` is `CompletedOK` and `created_community` holds the new
+/// pending record; on any failure it is `CompletedFail` with the error logged.
+async fn run_join_sequence(
+    handler: &StateHandler,
+    state: &mut State,
+    tdk: &TDK,
+    config: &mut Config,
+    admin_vta: Option<&VtaClient>,
+    profile: &str,
+    vtc_did: String,
+) {
+    // 1. Idempotency (R-B-9): refuse a duplicate live/pending membership.
+    if config.account.live_community(&vtc_did).is_some() {
+        state
+            .join
+            .fail("Already a member of (or have a pending request for) this community.");
+        return;
+    }
+
+    // 3. The mint + join sequence needs the admin VTA session.
+    let Some(admin_vta) = admin_vta else {
+        state
+            .join
+            .fail("VTA session unavailable — cannot join right now.");
+        return;
+    };
+
+    // 2. Resolve a display name for the community (best-effort).
+    let display_name = match tdk.did_resolver().resolve(&vtc_did).await {
+        Ok(resolved) => resolved_display_name(&resolved.doc),
+        Err(e) => {
+            debug!("VTC DID resolve failed (continuing without name): {e}");
+            None
+        }
+    };
+    state.join.display_name = display_name.clone();
+
+    let top_context_id = config.account.top_context_id.clone();
+
+    // 4. Mint a fresh persona into `state.setup` (reusing the setup helpers).
+    state.join.info("Minting a persona for this community…");
+    let _ = handler.state_tx.send(state.clone());
+
+    // Persona signing/auth/encryption keys.
+    match vta::create_persona_keys(admin_vta, Some(&top_context_id)).await {
+        Ok(keys) => state.setup.did_keys = Some(keys),
+        Err(e) => {
+            state
+                .join
+                .fail(format!("Failed to create persona keys: {e}"));
+            return;
+        }
+    }
+    // WebVH update keys.
+    match vta::create_update_keys(admin_vta, Some(&top_context_id)).await {
+        Ok((update, next_update)) => {
+            state.setup.vta.update_secret = Some(update);
+            state.setup.vta.next_update_secret = Some(next_update);
+        }
+        Err(e) => {
+            state
+                .join
+                .fail(format!("Failed to create update keys: {e}"));
+            return;
+        }
+    }
+
+    // Pick the first WebVH server. Serverless mint is a deliberate follow-up.
+    let server_id = match vta::list_webvh_servers(admin_vta).await {
+        Ok(servers) => match servers.into_iter().next() {
+            Some(s) => s.id,
+            None => {
+                state.join.fail(
+                    "No WebVH server available from the VTA (serverless mint not yet supported).",
+                );
+                return;
+            }
+        },
+        Err(e) => {
+            state
+                .join
+                .fail(format!("Failed to list WebVH servers: {e}"));
+            return;
+        }
+    };
+
+    // Create the persona did:webvh via the server (auto-assigned path).
+    state
+        .join
+        .info(format!("Creating persona DID via {server_id}…"));
+    let _ = handler.state_tx.send(state.clone());
+    match vta::create_did_via_server(
+        admin_vta,
+        tdk,
+        &top_context_id,
+        &server_id,
+        WebvhPathMode::AutoAssign,
+    )
+    .await
+    {
+        Ok((keys, did, document, _mnemonic)) => {
+            state.setup.did_keys = Some(keys);
+            state.setup.webvh_address.did = did;
+            state.setup.webvh_address.document = document;
+        }
+        Err(e) => {
+            state
+                .join
+                .fail(format!("Failed to create persona DID: {e}"));
+            return;
+        }
+    }
+
+    // Default mediator; label the persona after the community.
+    state.setup.custom_mediator = None;
+    state.setup.username = display_name.clone().unwrap_or_else(|| {
+        openvtc_core::config::context_path::render_for_display(&vtc_did).to_string()
+    });
+
+    // 5. Persist the persona into the account.
+    let persona_id = match Config::mint_persona_into(config, &state.setup, tdk, profile).await {
+        Ok(id) => id,
+        Err(e) => {
+            state.join.fail(format!("Failed to save persona: {e}"));
+            return;
+        }
+    };
+    let persona_did = state.setup.webvh_address.did.clone();
+    state.join.info(format!("Persona created: {persona_did}"));
+    let _ = handler.state_tx.send(state.clone());
+
+    // 6. Derive the per-community sub-context id (D9, collision-safe).
+    let sub_context_id =
+        match build_sub_context_id(&top_context_id, display_name.as_deref(), &vtc_did, |id| {
+            config
+                .account
+                .communities
+                .values()
+                .any(|c| c.sub_context_id == id)
+        }) {
+            Ok(id) => id,
+            Err(e) => {
+                state
+                    .join
+                    .fail(format!("Failed to derive sub-context id: {e}"));
+                return;
+            }
+        };
+
+    // 7. Register the sub-context at the VTA.
+    state
+        .join
+        .info(format!("Creating sub-context {sub_context_id}…"));
+    let _ = handler.state_tx.send(state.clone());
+    if let Err(e) = vta::create_sub_context(admin_vta, &top_context_id, &sub_context_id).await {
+        state
+            .join
+            .fail(format!("Failed to create sub-context: {e}"));
+        return;
+    }
+
+    // 8. Submit the join request.
+    state.join.info("Submitting join request…");
+    let _ = handler.state_tx.send(state.clone());
+    let receipt = match vta::submit_join(admin_vta, &vtc_did, &sub_context_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            state
+                .join
+                .fail(format!("Failed to submit join request: {e}"));
+            return;
+        }
+    };
+
+    // 9. Record the pending membership and persist.
+    let record = CommunityRecord::new_pending(
+        vtc_did.clone(),
+        display_name,
+        sub_context_id,
+        persona_id,
+        receipt.request_id,
+        Utc::now(),
+    );
+    config.account.communities.insert(vtc_did, record.clone());
+    if let Err(e) = save_config(config, profile) {
+        state
+            .join
+            .fail(format!("Failed to save community record: {e}"));
+        return;
+    }
+
+    // 10. Success — refresh the communities panel and surface the relaunch prompt.
+    state.main_page.sync_from_config(config);
+    state
+        .main_page
+        .log("Join request submitted — restart to activate.");
+    state.join.created_community = Some(record);
+    state.join.completed = Completion::CompletedOK;
+    state
+        .join
+        .info("Done. Restart OpenVTC to activate this community.");
+}
+
+/// Persist the config, abstracting over the openpgp-card touch prompt.
+fn save_config(config: &Config, profile: &str) -> Result<(), openvtc_core::errors::OpenVTCError> {
+    config.save(
+        profile,
+        #[cfg(feature = "openpgp-card")]
+        &|| {
+            eprintln!("Touch confirmation needed for decryption");
+        },
+    )
+}
+
+/// Best-effort display name from a resolved VTC DID document. Prefers a
+/// non-empty `name`-like service/alias if present; falls back to `None` so the
+/// sub-context derivation uses the DID-derived token (D9).
+fn resolved_display_name(_doc: &affinidi_tdk::did_common::Document) -> Option<String> {
+    // The DID-core document has no canonical human name field; community naming
+    // (whois/metadata) is a later enrichment. Returning `None` keeps the
+    // derivation deterministic (DID-token slug) until that lands.
+    None
+}

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -39,6 +39,9 @@ pub struct CommunitiesState {
     pub actions_required: usize,
     /// Transient status message.
     pub status_message: Option<String>,
+    /// When `Some(index)`, a removal of that community is awaiting `y`/`n`
+    /// confirmation (the panel shows a prompt and other keys are suppressed).
+    pub confirm_delete: Option<usize>,
 }
 
 /// Lightweight display summary of a community membership (no Arc/Mutex).

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -19,6 +19,43 @@ pub struct ContentPanelState {
     pub vta: VtaState,
     /// Logs panel state
     pub logs: LogsState,
+    /// Communities overview panel state
+    pub communities: CommunitiesState,
+}
+
+// ****************************************************************************
+// Communities State (R-C-*)
+// ****************************************************************************
+
+/// State for the Communities overview panel — the account's community
+/// memberships, in display order (favourites first).
+#[derive(Clone, Debug, Default)]
+pub struct CommunitiesState {
+    /// Display summaries of the (non-archived) communities, in display order.
+    pub items: Vec<CommunitySummary>,
+    /// Currently selected index in the list.
+    pub selected_index: usize,
+    /// Number of communities raising the actions-required indicator (R-C-3).
+    pub actions_required: usize,
+    /// Transient status message.
+    pub status_message: Option<String>,
+}
+
+/// Lightweight display summary of a community membership (no Arc/Mutex).
+#[derive(Clone, Debug)]
+pub struct CommunitySummary {
+    /// Display name (resolved name, or the VTC DID when unnamed).
+    pub display_name: String,
+    /// Human-readable membership status (e.g. "Active", "Pending", "Left").
+    pub status_label: String,
+    /// Label of the persona presented to this community.
+    pub persona_label: String,
+    /// Member-since date (when Active), formatted; empty otherwise.
+    pub member_since: String,
+    /// Whether the user has starred this community (R-C-4).
+    pub favourite: bool,
+    /// Whether this community raises the actions-required indicator (R-C-3).
+    pub needs_attention: bool,
 }
 
 // ****************************************************************************

--- a/openvtc/src/state_handler/main_page/menu.rs
+++ b/openvtc/src/state_handler/main_page/menu.rs
@@ -23,7 +23,9 @@ impl Default for MenuPanelState {
 
 #[derive(Default, Debug, Clone, EnumIter, PartialEq, Eq)]
 pub enum MainMenu {
+    /// Communities overview — the account hub and post-bootstrap landing (R-C).
     #[default]
+    Communities,
     Inbox,
     Relationships,
     Credentials,
@@ -37,6 +39,7 @@ pub enum MainMenu {
 impl Display for MainMenu {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            MainMenu::Communities => write!(f, "Communities"),
             MainMenu::Inbox => write!(f, "Inbox"),
             MainMenu::Relationships => write!(f, "My Relationships"),
             MainMenu::Credentials => write!(f, "My Credentials"),
@@ -53,7 +56,8 @@ impl MainMenu {
     /// Returns the previous MainMenu item
     pub fn prev(&self) -> MainMenu {
         match self {
-            MainMenu::Inbox => MainMenu::Quit,
+            MainMenu::Communities => MainMenu::Quit,
+            MainMenu::Inbox => MainMenu::Communities,
             MainMenu::Relationships => MainMenu::Inbox,
             MainMenu::Credentials => MainMenu::Relationships,
             MainMenu::Settings => MainMenu::Credentials,
@@ -67,6 +71,7 @@ impl MainMenu {
     /// Returns the next MainMenu item
     pub fn next(&self) -> MainMenu {
         match self {
+            MainMenu::Communities => MainMenu::Inbox,
             MainMenu::Inbox => MainMenu::Relationships,
             MainMenu::Relationships => MainMenu::Credentials,
             MainMenu::Credentials => MainMenu::Settings,
@@ -74,7 +79,7 @@ impl MainMenu {
             MainMenu::Vta => MainMenu::Logs,
             MainMenu::Logs => MainMenu::Help,
             MainMenu::Help => MainMenu::Quit,
-            MainMenu::Quit => MainMenu::Inbox,
+            MainMenu::Quit => MainMenu::Communities,
         }
     }
 }

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -268,14 +268,13 @@ impl MainPageState {
 
         // Sync settings
         self.content_panel.settings.friendly_name = config.public.friendly_name.clone();
-        self.content_panel.settings.mediator_did = config.public.mediator_did.clone();
-        self.content_panel.settings.org_did = config.public.lk_did.clone();
-        self.content_panel.settings.persona_did = config.public.persona_did.to_string();
-        self.content_panel.settings.did_git_sign =
-            detect_did_git_sign_info(config.public.persona_did.as_str());
+        self.content_panel.settings.mediator_did = config.mediator_did().to_string();
+        self.content_panel.settings.org_did = config.account.org_did.clone();
+        self.content_panel.settings.persona_did = config.persona_did().to_string();
+        self.content_panel.settings.did_git_sign = detect_did_git_sign_info(config.persona_did());
         // Sync VTA info
-        self.content_panel.vta.persona_did = config.public.persona_did.to_string();
-        self.content_panel.vta.mediator_did = config.public.mediator_did.clone();
+        self.content_panel.vta.persona_did = config.persona_did().to_string();
+        self.content_panel.vta.mediator_did = config.mediator_did().to_string();
         match &config.key_backend {
             KeyBackend::Vta {
                 vta_url,
@@ -297,18 +296,18 @@ impl MainPageState {
         self.content_panel.vta.persona_key_count = config
             .key_info
             .keys()
-            .filter(|k| k.starts_with(config.public.persona_did.as_str()))
+            .filter(|k| k.starts_with(config.persona_did()))
             .count();
         self.content_panel.vta.relationship_key_count =
             self.content_panel.vta.key_count - self.content_panel.vta.persona_key_count;
         // Collect active DIDs
         let mut active_dids = vec![content::ActiveDid {
-            did: config.public.persona_did.to_string(),
+            did: config.persona_did().to_string(),
             label: "Persona".to_string(),
         }];
         for (remote_p_did, rel_arc) in &config.private.relationships.relationships {
             if let Ok(rel) = rel_arc.lock()
-                && *rel.our_did != *config.public.persona_did
+                && rel.our_did.as_str() != config.persona_did()
             {
                 let alias = config
                     .private
@@ -483,7 +482,7 @@ impl From<&Box<Config>> for MainMenuConfigState {
     fn from(config: &Box<Config>) -> Self {
         MainMenuConfigState {
             name: config.public.friendly_name.clone(),
-            did: config.public.persona_did.clone(),
+            did: config.persona_did_arc(),
         }
     }
 }
@@ -492,7 +491,7 @@ impl From<&Config> for MainMenuConfigState {
     fn from(config: &Config) -> Self {
         MainMenuConfigState {
             name: config.public.friendly_name.clone(),
-            did: config.public.persona_did.clone(),
+            did: config.persona_did_arc(),
         }
     }
 }

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -535,18 +535,32 @@ pub struct MainMenuConfigState {
 
 impl From<&Box<Config>> for MainMenuConfigState {
     fn from(config: &Box<Config>) -> Self {
-        MainMenuConfigState {
-            name: config.public.friendly_name.clone(),
-            did: config.persona_did_arc(),
-        }
+        MainMenuConfigState::from(config.as_ref())
     }
 }
 
 impl From<&Config> for MainMenuConfigState {
     fn from(config: &Config) -> Self {
+        // The persona identity is community-scoped: only surface it in the top
+        // bar once the user is actually in a community (an Active membership). A
+        // State-A account or a still-Pending join shows no persona name/DID up
+        // there — the persona belongs to a community context, not the chrome.
+        let in_community = config
+            .account
+            .communities
+            .values()
+            .any(|c| c.status.is_active());
         MainMenuConfigState {
-            name: config.public.friendly_name.clone(),
-            did: config.persona_did_arc(),
+            name: if in_community {
+                config.public.friendly_name.clone()
+            } else {
+                String::new()
+            },
+            did: if in_community {
+                config.persona_did_arc()
+            } else {
+                Arc::new(String::new())
+            },
         }
     }
 }

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -347,7 +347,52 @@ impl MainPageState {
                 "Keyring Only (no additional encryption)".to_string()
             }
         };
+
+        // Sync the Communities overview (R-C-*): display order from the model,
+        // archived excluded, with the actions-required count for the badge.
+        let mut community_items = Vec::new();
+        for c in config.account.communities_for_display(false) {
+            let persona = config.account.personas.get(&c.persona_ref);
+            let persona_label = persona
+                .and_then(|p| p.label.clone())
+                .or_else(|| persona.map(|p| shorten_did(&p.did, 24)))
+                .unwrap_or_default();
+            community_items.push(content::CommunitySummary {
+                display_name: c
+                    .display_name
+                    .clone()
+                    .unwrap_or_else(|| shorten_did(&c.vtc_did, 40)),
+                status_label: community_status_label(&c.status),
+                persona_label,
+                member_since: c
+                    .member_since
+                    .map(|d| d.format("%Y-%m-%d").to_string())
+                    .unwrap_or_default(),
+                favourite: c.favourite,
+                needs_attention: c.needs_attention(),
+            });
+        }
+        let community_count = community_items.len();
+        self.content_panel.communities.actions_required = config.account.actions_required_count();
+        self.content_panel.communities.items = community_items;
+        if self.content_panel.communities.selected_index >= community_count {
+            self.content_panel.communities.selected_index = community_count.saturating_sub(1);
+        }
     }
+}
+
+/// Human-readable label for a community membership status (R-C-2).
+fn community_status_label(status: &openvtc_core::config::account::CommunityStatus) -> String {
+    use openvtc_core::config::account::CommunityStatus;
+    match status {
+        CommunityStatus::Pending { .. } => "Pending",
+        CommunityStatus::Active => "Active",
+        CommunityStatus::Left => "Left",
+        CommunityStatus::Rejected => "Rejected",
+        CommunityStatus::Removed => "Removed",
+        CommunityStatus::Expired => "Expired",
+    }
+    .to_string()
 }
 
 /// Collect VRC summaries from a Vrcs collection.

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -292,19 +292,29 @@ impl MainPageState {
             }
         }
         self.content_panel.vta.key_count = config.key_info.len();
-        // Count persona vs relationship keys
-        self.content_panel.vta.persona_key_count = config
-            .key_info
-            .keys()
-            .filter(|k| k.starts_with(config.persona_did()))
-            .count();
+        // Count persona vs relationship keys. With no active persona (State A)
+        // there are no persona keys — and `starts_with("")` would otherwise match
+        // every key, so guard on a non-empty persona DID.
+        let persona_did = config.persona_did();
+        self.content_panel.vta.persona_key_count = if persona_did.is_empty() {
+            0
+        } else {
+            config
+                .key_info
+                .keys()
+                .filter(|k| k.starts_with(persona_did))
+                .count()
+        };
         self.content_panel.vta.relationship_key_count =
             self.content_panel.vta.key_count - self.content_panel.vta.persona_key_count;
-        // Collect active DIDs
-        let mut active_dids = vec![content::ActiveDid {
-            did: config.persona_did().to_string(),
-            label: "Persona".to_string(),
-        }];
+        // Collect active DIDs — none for a zero-persona (State-A) account.
+        let mut active_dids = Vec::new();
+        if !persona_did.is_empty() {
+            active_dids.push(content::ActiveDid {
+                did: persona_did.to_string(),
+                label: "Persona".to_string(),
+            });
+        }
         for (remote_p_did, rel_arc) in &config.private.relationships.relationships {
             if let Ok(rel) = rel_arc.lock()
                 && rel.our_did.as_str() != config.persona_did()

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -239,11 +239,11 @@ pub async fn process_inbound_message(
             let listener_to_remove = if let Some(rel_arc) =
                 config.private.relationships.find_by_task_id(&task_id)
                 && let Ok(lock) = rel_arc.lock()
-                && *lock.our_did != *config.public.persona_did
+                && lock.our_did.as_str() != config.persona_did()
             {
                 Some(super::didcomm::listener_id_for_did(
                     &lock.our_did,
-                    &config.public.persona_did,
+                    config.persona_did(),
                 ))
             } else {
                 None
@@ -314,14 +314,13 @@ pub async fn process_inbound_message(
 
             // Send finalize using persona DIDs (same as request and accept).
             // If the send fails, still persist the Established state.
-            let finalize_msg =
-                create_finalize_message(&config.public.persona_did, &from_did, &task_id)?;
+            let finalize_msg = create_finalize_message(config.persona_did(), &from_did, &task_id)?;
 
             if let Err(e) = super::didcomm::send_message(
                 service,
                 config,
                 &finalize_msg,
-                &config.public.persona_did,
+                config.persona_did(),
                 &from_did,
             )
             .await

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -552,6 +552,12 @@ impl StateHandler {
                             }
                         }
                     },
+                    Action::CommunitySelect(i) => {
+                        state.main_page.content_panel.communities.selected_index = i;
+                    },
+                    Action::DeleteCommunity(i) => {
+                        self.remove_community(&mut state, &mut config, i);
+                    },
                     Action::StartJoin => {
                         // State-B join from the live runtime: reuse the always-on
                         // admin VTA session. The DIDComm service keeps running in
@@ -829,6 +835,46 @@ impl StateHandler {
         Ok(result)
     }
 
+    /// Remove the community at `index` in the Communities display list: withdraw
+    /// a live (Pending/Active) membership first (R-C-8 — for a pending join this
+    /// is the withdrawal), then delete the record, persist, and refresh the
+    /// panel. Surfaces the outcome as a status message.
+    fn remove_community(&self, state: &mut State, config: &mut Config, index: usize) {
+        let Some(vtc) = config
+            .account
+            .communities_for_display(false)
+            .get(index)
+            .map(|c| c.vtc_did.clone())
+        else {
+            return;
+        };
+        if config.account.community(&vtc).is_some_and(|c| c.is_live())
+            && let Some(c) = config.account.community_mut(&vtc)
+        {
+            c.leave();
+        }
+        match config.account.delete_community(&vtc) {
+            Ok(_) => {
+                if let Err(e) = config.save(
+                    &self.profile,
+                    #[cfg(feature = "openpgp-card")]
+                    &|| eprintln!("Touch confirmation needed for decryption"),
+                ) {
+                    state
+                        .main_page
+                        .log_error("Failed to save after removing community", &e);
+                }
+                state.main_page.sync_from_config(config);
+                state.main_page.content_panel.communities.status_message =
+                    Some("Community removed.".to_string());
+            }
+            Err(e) => {
+                state.main_page.content_panel.communities.status_message =
+                    Some(format!("Could not remove community: {e}"));
+            }
+        }
+    }
+
     /// Minimal event loop for when there is no active community / messaging
     /// (State-A) or after an init failure — keeps the UI alive so the user can
     /// navigate, exit, and (when `join_ctx` is supplied) start a join.
@@ -873,6 +919,14 @@ impl StateHandler {
                                 state.main_page.menu_panel.selected = true;
                                 state.main_page.content_panel.selected = false;
                             }
+                        }
+                    }
+                    Action::CommunitySelect(i) => {
+                        state.main_page.content_panel.communities.selected_index = i;
+                    }
+                    Action::DeleteCommunity(i) => {
+                        if let Some(ctx) = join_ctx.as_mut() {
+                            self.remove_community(state, &mut ctx.config, i);
                         }
                     }
                     Action::StartJoin => {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -533,6 +533,9 @@ impl StateHandler {
         // moment a `ListenerEvent::Connected` arrives — and back to Connecting on
         // a disconnect. Subscribe to typed lifecycle events for that.
         let mut listener_events = didcomm_service.subscribe();
+        // The persona listener's id (community-scoped, derived from its DID) is
+        // stable for the life of this loop — compute it once for event matching.
+        let persona_lid = didcomm::persona_listener_id(config.persona_did());
         state.connection.status = state::MediatorStatus::Connecting;
         state.main_page.log("Connecting to the mediator…");
         let _ = self.state_tx.send(state.clone());
@@ -591,6 +594,9 @@ impl StateHandler {
                         state.main_page.content_panel.communities.confirm_delete = None;
                     },
                     Action::DeleteCommunity(i) => {
+                        // Capture the listener id before the delete, while the
+                        // persona/community are still present.
+                        let listener_id = didcomm::persona_listener_id(config.persona_did());
                         self.remove_community(&mut state, &mut config, i);
                         // A deleted community must not leave its persona's
                         // mediator connection running. If the active persona no
@@ -606,10 +612,7 @@ impl StateHandler {
                                 .any(|c| c.persona_ref == pid && c.is_live())
                         });
                         if !still_live {
-                            if let Err(e) = didcomm_service
-                                .remove_listener(didcomm::PERSONA_LISTENER_ID)
-                                .await
-                            {
+                            if let Err(e) = didcomm_service.remove_listener(&listener_id).await {
                                 debug!("remove_listener after community delete: {e}");
                             }
                             state.connection.status = state::MediatorStatus::NoActiveCommunity;
@@ -884,13 +887,13 @@ impl StateHandler {
                     if let Ok(ev) = ev {
                         match ev {
                             ListenerEvent::Connected { listener_id }
-                                if listener_id == didcomm::PERSONA_LISTENER_ID =>
+                                if listener_id == persona_lid =>
                             {
                                 state.connection.status = state::MediatorStatus::Connected;
                                 state.connection.messaging_active = true;
                             }
                             ListenerEvent::Disconnected { listener_id, .. }
-                                if listener_id == didcomm::PERSONA_LISTENER_ID =>
+                                if listener_id == persona_lid =>
                             {
                                 state.connection.status = state::MediatorStatus::Connecting;
                                 state.connection.messaging_active = false;

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -372,7 +372,7 @@ impl StateHandler {
         // / context creation), so the admin DID holds ONE mediator connection
         // instead of reconnecting per operation. It is shut down at every exit
         // path below (degraded returns + end of the main loop).
-        let mut admin_vta: Option<vta_sdk::client::VtaClient> = if matches!(
+        let admin_vta: Option<vta_sdk::client::VtaClient> = if matches!(
             &config.key_backend,
             openvtc_core::config::KeyBackend::Vta { .. }
         ) {
@@ -558,19 +558,6 @@ impl StateHandler {
                         // the background; the join flow owns the screen until the
                         // user returns. Restart is required to activate the new
                         // community (hot-start is a deliberate follow-up).
-                        //
-                        // The always-on admin session may have gone stale while
-                        // idle (the mediator closes idle WebSockets), so its first
-                        // round-trip would time out. Reconnect a fresh one right
-                        // before the join — the old one is closed first, so the
-                        // admin DID never has two competing sockets.
-                        if let Some(old) = admin_vta.take() {
-                            old.shutdown().await;
-                        }
-                        admin_vta =
-                            openvtc_core::config::build_runtime_vta_client(&config.key_backend)
-                                .await
-                                .ok();
                         match self
                             .join_flow(
                                 &mut action_rx,
@@ -890,18 +877,6 @@ impl StateHandler {
                     }
                     Action::StartJoin => {
                         if let Some(ctx) = join_ctx.as_mut() {
-                            // Reconnect a fresh admin session before the join: the
-                            // always-on one may have gone stale during idle (the
-                            // mediator closes idle WebSockets). Close the old first
-                            // so the admin DID never has two competing sockets.
-                            if let Some(old) = ctx.admin_vta.take() {
-                                old.shutdown().await;
-                            }
-                            ctx.admin_vta = openvtc_core::config::build_runtime_vta_client(
-                                &ctx.config.key_backend,
-                            )
-                            .await
-                            .ok();
                             match self
                                 .join_flow(
                                     action_rx,

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -144,12 +144,11 @@ impl StateHandler {
                     Ok(SetupWizardExit::Config(mut config)) => {
                         crate::apply_env_overrides(&mut config);
 
-                        // Push the main menu skeleton *before* the slow
-                        // post-setup work (keyring read, VTA round-trip,
-                        // mediator handshake) so the operator isn't stuck
-                        // on FinalPage for several seconds. The remaining
-                        // tasks update connection status as they progress.
-                        state.active_page = ActivePage::Main;
+                        // Show the loading screen during the slow post-setup work
+                        // (keyring read, VTA round-trip, mediator handshake)
+                        // instead of a not-yet-interactive main page; it switches
+                        // to Main once the connection is ready.
+                        state.active_page = ActivePage::Loading;
                         state.main_page.menu_panel.selected = true;
                         state.main_page.sync_from_config(&config);
                         state.connection.status =
@@ -188,8 +187,10 @@ impl StateHandler {
                 }
             }
             StartingMode::MainPageDeferred(deferred) => {
-                // Set minimal state from PublicConfig so UI can render immediately
-                state.active_page = ActivePage::Main;
+                // Show the loading screen while the config decrypts and the
+                // mediator connection is established; it switches to Main once
+                // ready (or stays up to show a startup error).
+                state.active_page = ActivePage::Loading;
                 state.main_page.menu_panel.selected = true;
                 state.main_page.config = main_page::MainMenuConfigState {
                     name: deferred.public_config.friendly_name.clone(),
@@ -279,9 +280,29 @@ impl StateHandler {
                 });
 
                 // Listen for progress updates + handle user actions while loading
+                // Wall-clock start of the step currently in progress, used to
+                // stamp its duration on the loading screen when the next step
+                // begins (or when the load finishes).
+                let mut step_start: Option<std::time::Instant> = None;
                 let (tdk, config) = loop {
                     tokio::select! {
                         Some(msg) = progress_rx.recv() => {
+                            let now = std::time::Instant::now();
+                            // Finalize the previous step's duration.
+                            if let (Some(start), Some(last)) =
+                                (step_start, state.loading_steps.last_mut())
+                            {
+                                last.duration_ms =
+                                    Some(now.duration_since(start).as_millis() as u64);
+                            }
+                            // Begin this step.
+                            state.loading_steps.push(state::LoadingStep {
+                                label: msg.clone(),
+                                started: chrono::Local::now().format("%H:%M:%S").to_string(),
+                                duration_ms: None,
+                            });
+                            step_start = Some(now);
+                            state.tip_index = state.tip_index.wrapping_add(1);
                             state.connection.status =
                                 state::MediatorStatus::Initializing(msg);
                             let _ = self.state_tx.send(state.clone());
@@ -294,7 +315,16 @@ impl StateHandler {
                         }
                         result = &mut load_handle => {
                             match result {
-                                Ok(Ok((tdk, config))) => break (tdk, config),
+                                Ok(Ok((tdk, config))) => {
+                                    // Stamp the final load step's duration.
+                                    if let (Some(start), Some(last)) =
+                                        (step_start, state.loading_steps.last_mut())
+                                    {
+                                        last.duration_ms =
+                                            Some(start.elapsed().as_millis() as u64);
+                                    }
+                                    break (tdk, config);
+                                }
                                 Ok(Err(e)) => {
                                     state.connection.status =
                                         state::MediatorStatus::Failed(format!("{e}"));
@@ -399,12 +429,16 @@ impl StateHandler {
             }
         }
 
+        // Phase 1 (config load + VTA) is complete — leave the loading screen and
+        // show the main page now. The per-community DIDComm connection (phase 2)
+        // runs asynchronously below and reports its status without blocking the
+        // UI (it no longer waits up-front for the listener to connect).
+        state.active_page = ActivePage::Main;
+
         // A State-A account has no persona/community yet (R-A-5): there is no
         // DID to open a DIDComm session for. Skip the persona listener entirely
         // and run the responsive degraded loop so the user can still navigate,
-        // open the Communities page, and start a join. Attempting to connect
-        // would register a listener for an empty DID and stall on
-        // `wait_connected` for 30s before failing.
+        // open the Communities page, and start a join.
         if config.active_identity().is_none() {
             state.connection.status = state::MediatorStatus::NoActiveCommunity;
             let _ = self.state_tx.send(state.clone());
@@ -492,25 +526,15 @@ impl StateHandler {
         }
         info!(count = listeners.len(), "DIDComm listeners registered");
 
-        // Wait for persona listener to connect.
-        // Latency starts at 0 and updates from the first keepalive ping round-trip.
-        match didcomm_service
-            .wait_connected(
-                didcomm::PERSONA_LISTENER_ID,
-                std::time::Duration::from_secs(30),
-            )
-            .await
-        {
-            Ok(()) => {
-                state.connection.status = state::MediatorStatus::Connected;
-                state.connection.messaging_active = true;
-                state.main_page.log("Connected to mediator");
-            }
-            Err(e) => {
-                state.connection.status = state::MediatorStatus::Failed(format!("{e:#}"));
-                state.main_page.log_error("Mediator connection failed", &e);
-            }
-        }
+        // Phase 2 (community/persona DIDComm connection) runs ASYNCHRONOUSLY: we
+        // do NOT block the UI waiting for the listener. The main page is already
+        // showing (Connecting); the persona connection proceeds in the
+        // background and the runtime loop below flips the status to Connected the
+        // moment a `ListenerEvent::Connected` arrives — and back to Connecting on
+        // a disconnect. Subscribe to typed lifecycle events for that.
+        let mut listener_events = didcomm_service.subscribe();
+        state.connection.status = state::MediatorStatus::Connecting;
+        state.main_page.log("Connecting to the mediator…");
         let _ = self.state_tx.send(state.clone());
 
         // Track when a manual trust-ping was sent (for activity log latency display).
@@ -819,6 +843,30 @@ impl StateHandler {
                 // Lifecycle log messages from the DIDCommService
                 Some(log_msg) = lifecycle_log_rx.recv() => {
                     state.main_page.log(log_msg);
+                },
+                // Typed listener lifecycle events → drive the connection status
+                // asynchronously (phase 2). The persona listener connecting flips
+                // the status to Connected; a disconnect drops back to Connecting
+                // while the service auto-reconnects.
+                ev = listener_events.recv() => {
+                    use affinidi_messaging_didcomm_service::ListenerEvent;
+                    if let Ok(ev) = ev {
+                        match ev {
+                            ListenerEvent::Connected { listener_id }
+                                if listener_id == didcomm::PERSONA_LISTENER_ID =>
+                            {
+                                state.connection.status = state::MediatorStatus::Connected;
+                                state.connection.messaging_active = true;
+                            }
+                            ListenerEvent::Disconnected { listener_id, .. }
+                                if listener_id == didcomm::PERSONA_LISTENER_ID =>
+                            {
+                                state.connection.status = state::MediatorStatus::Connecting;
+                                state.connection.messaging_active = false;
+                            }
+                            _ => {}
+                        }
+                    }
                 },
                 // (keepalive removed — WebSocket-level pings handle connectivity)
                 // Catch and handle interrupt signal to gracefully shutdown

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -187,7 +187,10 @@ impl StateHandler {
                 state.main_page.menu_panel.selected = true;
                 state.main_page.config = main_page::MainMenuConfigState {
                     name: deferred.public_config.friendly_name.clone(),
-                    did: deferred.public_config.persona_did.clone(),
+                    // The persona DID now lives in the encrypted account, which
+                    // isn't decrypted yet at this pre-load render. It populates
+                    // from the full Config once load_step2 completes.
+                    did: std::sync::Arc::new(String::new()),
                 };
                 state.connection.status = state::MediatorStatus::Initializing("Starting...".into());
                 let _ = self.state_tx.send(state.clone());
@@ -366,7 +369,7 @@ impl StateHandler {
             if let Some(ctx) = resp
                 .contexts
                 .iter()
-                .find(|c| c.did.as_deref() == Some(config.public.persona_did.as_str()))
+                .find(|c| c.did.as_deref() == Some(config.persona_did()))
             {
                 state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
             } else if let Some(ctx) = resp.contexts.first() {
@@ -611,7 +614,7 @@ impl StateHandler {
                             let sender_arc = std::sync::Arc::new(sender.to_string());
 
                             // Only respond to pings from the mediator or established relationships
-                            let is_mediator = sender == config.public.mediator_did;
+                            let is_mediator = sender == config.mediator_did();
                             let has_relationship = config
                                 .private
                                 .relationships
@@ -629,7 +632,7 @@ impl StateHandler {
                                 let our_listener_did = didcomm_service
                                     .listener_did(&listener_id)
                                     .await
-                                    .unwrap_or_else(|| config.public.persona_did.to_string());
+                                    .unwrap_or_else(|| config.persona_did().to_string());
                                 if let Some(ref from_did) = from
                                     && let Ok(pong_msg) =
                                         build_trust_pong(&our_listener_did, from_did, &message_id)

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -358,24 +358,28 @@ impl StateHandler {
         state.main_page.content_panel.vta.profile = self.profile.clone();
 
         // Fetch VTA context name if using VTA backend. The helper handles
-        // both DIDComm and REST transports automatically.
+        // both DIDComm and REST transports automatically. The DIDComm client
+        // opens a persistent session, so it MUST be shut down after use or it
+        // lingers and duels other admin sessions on the mediator.
         if matches!(
             &config.key_backend,
             openvtc_core::config::KeyBackend::Vta { .. }
         ) && let Ok(client) =
             openvtc_core::config::build_runtime_vta_client(&config.key_backend).await
-            && let Ok(resp) = client.list_contexts().await
         {
-            if let Some(ctx) = resp
-                .contexts
-                .iter()
-                .find(|c| c.did.as_deref() == Some(config.persona_did()))
-            {
-                state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
-            } else if let Some(ctx) = resp.contexts.first() {
-                // Fallback to first context
-                state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
+            if let Ok(resp) = client.list_contexts().await {
+                if let Some(ctx) = resp
+                    .contexts
+                    .iter()
+                    .find(|c| c.did.as_deref() == Some(config.persona_did()))
+                {
+                    state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
+                } else if let Some(ctx) = resp.contexts.first() {
+                    // Fallback to first context
+                    state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
+                }
             }
+            client.shutdown().await;
         }
 
         // A State-A account has no persona/community yet (R-A-5): there is no

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -378,6 +378,25 @@ impl StateHandler {
             }
         }
 
+        // A State-A account has no persona/community yet (R-A-5): there is no
+        // DID to open a DIDComm session for. Skip the persona listener entirely
+        // and run the responsive degraded loop so the user can still navigate,
+        // open the Communities page, and start a join. Attempting to connect
+        // would register a listener for an empty DID and stall on
+        // `wait_connected` for 30s before failing.
+        if config.active_identity().is_none() {
+            state.connection.status = state::MediatorStatus::NoActiveCommunity;
+            let _ = self.state_tx.send(state.clone());
+            return self
+                .run_degraded_loop(
+                    &mut action_rx,
+                    &mut interrupt_rx,
+                    &mut terminator,
+                    &mut state,
+                )
+                .await;
+        }
+
         // Send initial state immediately so the UI renders without blocking
         state.connection.status = state::MediatorStatus::Connecting;
         let _ = self.state_tx.send(state.clone());

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -157,7 +157,11 @@ impl StateHandler {
                         // The setup wizard saved the config but the TDK secrets
                         // resolver is empty. Load persona key secrets so the
                         // DIDComm service can authenticate with the mediator.
-                        if let Err(e) = config.load_persona_secrets(&tdk).await {
+                        // R-A-5: a State-A account has no persona, so there are no
+                        // secrets to load — skip it (and the VTA round-trip).
+                        if config.active_identity().is_some()
+                            && let Err(e) = config.load_persona_secrets(&tdk).await
+                        {
                             state
                                 .main_page
                                 .log_error("Warning: failed to load persona keys", &e);

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -555,6 +555,12 @@ impl StateHandler {
                     Action::CommunitySelect(i) => {
                         state.main_page.content_panel.communities.selected_index = i;
                     },
+                    Action::CommunityConfirmDelete(i) => {
+                        state.main_page.content_panel.communities.confirm_delete = Some(i);
+                    },
+                    Action::CommunityCancelDelete => {
+                        state.main_page.content_panel.communities.confirm_delete = None;
+                    },
                     Action::DeleteCommunity(i) => {
                         self.remove_community(&mut state, &mut config, i);
                     },
@@ -848,6 +854,8 @@ impl StateHandler {
         else {
             return;
         };
+        // The confirmation is now resolved.
+        state.main_page.content_panel.communities.confirm_delete = None;
         if config.account.community(&vtc).is_some_and(|c| c.is_live())
             && let Some(c) = config.account.community_mut(&vtc)
         {
@@ -923,6 +931,12 @@ impl StateHandler {
                     }
                     Action::CommunitySelect(i) => {
                         state.main_page.content_panel.communities.selected_index = i;
+                    }
+                    Action::CommunityConfirmDelete(i) => {
+                        state.main_page.content_panel.communities.confirm_delete = Some(i);
+                    }
+                    Action::CommunityCancelDelete => {
+                        state.main_page.content_panel.communities.confirm_delete = None;
                     }
                     Action::DeleteCommunity(i) => {
                         if let Some(ctx) = join_ctx.as_mut() {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -592,6 +592,32 @@ impl StateHandler {
                     },
                     Action::DeleteCommunity(i) => {
                         self.remove_community(&mut state, &mut config, i);
+                        // A deleted community must not leave its persona's
+                        // mediator connection running. If the active persona no
+                        // longer has any live community, stop and remove its
+                        // listener so the connection is torn down with the
+                        // community (not left dangling).
+                        let persona_id = config.active_identity().map(|id| id.persona_id);
+                        let still_live = persona_id.is_some_and(|pid| {
+                            config
+                                .account
+                                .communities
+                                .values()
+                                .any(|c| c.persona_ref == pid && c.is_live())
+                        });
+                        if !still_live {
+                            if let Err(e) = didcomm_service
+                                .remove_listener(didcomm::PERSONA_LISTENER_ID)
+                                .await
+                            {
+                                debug!("remove_listener after community delete: {e}");
+                            }
+                            state.connection.status = state::MediatorStatus::NoActiveCommunity;
+                            state.connection.messaging_active = false;
+                            state
+                                .main_page
+                                .log("Community removed — persona listener stopped.");
+                        }
                     },
                     Action::StartJoin => {
                         // State-B join from the live runtime: reuse the always-on

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -120,14 +120,17 @@ impl StateHandler {
         let mut state = State::default();
 
         let starting_mode = std::mem::replace(&mut self.starting_mode, StartingMode::NotSet);
-        let (tdk, mut config) = match starting_mode {
+        // The third element is the live admin VTA session handed back by
+        // `load_step2` (PERF #1) for reuse below; `None` for the modes that
+        // don't open one (they fall back to building one as before).
+        let (tdk, mut config, loaded_admin_vta) = match starting_mode {
             StartingMode::MainPage(config, tdk) => {
                 state.active_page = ActivePage::Main;
                 state.main_page.menu_panel.selected = true;
                 state.main_page.config = (&config).into();
                 state.main_page.log("Configuration loaded");
 
-                (tdk.to_owned(), config)
+                (tdk.to_owned(), config, None)
             }
             StartingMode::SetupWizard => {
                 // Instantiate TDK
@@ -169,7 +172,7 @@ impl StateHandler {
                         }
                         state.main_page.log("Setup complete — configuration loaded");
 
-                        (tdk, config)
+                        (tdk, config, None)
                     }
                     Ok(SetupWizardExit::Interrupted(interrupted)) => {
                         if let Err(e) = terminator.terminate(interrupted.clone()) {
@@ -202,8 +205,9 @@ impl StateHandler {
                 state.connection.status = state::MediatorStatus::Initializing("Starting...".into());
                 let _ = self.state_tx.send(state.clone());
 
-                // Spawn TDK init + config load as a background task with progress reporting
-                let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<String>();
+                // Spawn TDK init + config load as a background task with
+                // hierarchical progress reporting: each event is (major, sub).
+                let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<(String, String)>();
 
                 // Dedicated channel for token-touch events.  The notifier sends a bool
                 // (true = touch required, false = touch completed) and the StateHandler's
@@ -217,13 +221,13 @@ impl StateHandler {
                 let (token_touch_tx, mut token_touch_rx) = mpsc::unbounded_channel::<bool>();
 
                 let mut load_handle = tokio::spawn(async move {
-                    let on_progress = |msg: &str| {
-                        if let Err(e) = progress_tx.send(msg.to_string()) {
+                    let on_progress = |major: &str, sub: &str| {
+                        if let Err(e) = progress_tx.send((major.to_string(), sub.to_string())) {
                             debug!("Failed to send progress event: {e}");
                         }
                     };
 
-                    on_progress("Starting TDK...");
+                    on_progress("Local configuration", "Starting TDK");
                     let mut tdk = TDK::new(
                         TDKConfig::builder()
                             .with_load_environment(false)
@@ -262,7 +266,9 @@ impl StateHandler {
                     #[cfg(not(feature = "openpgp-card"))]
                     drop(token_touch_tx);
 
-                    let config = Config::load_step2(
+                    // PERF #1: load_step2 returns its live admin VTA session for
+                    // reuse downstream instead of opening a second one here.
+                    let (config, admin_session) = Config::load_step2(
                         &mut tdk,
                         &deferred.profile,
                         deferred.public_config,
@@ -276,34 +282,23 @@ impl StateHandler {
                     .await
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
-                    Ok::<_, anyhow::Error>((tdk, config))
+                    Ok::<_, anyhow::Error>((tdk, config, admin_session))
                 });
 
-                // Listen for progress updates + handle user actions while loading
-                // Wall-clock start of the step currently in progress, used to
-                // stamp its duration on the loading screen when the next step
-                // begins (or when the load finishes).
-                let mut step_start: Option<std::time::Instant> = None;
-                let (tdk, config) = loop {
+                // Listen for progress updates + handle user actions while
+                // loading. `progress` drives the hierarchical loading model,
+                // stamping each sub-step/major with its duration as the next
+                // begins (and the whole thing when the load finishes).
+                let mut progress = state::LoadingProgress::default();
+                let (tdk, config, loaded_admin_vta) = loop {
                     tokio::select! {
-                        Some(msg) = progress_rx.recv() => {
-                            let now = std::time::Instant::now();
-                            // Finalize the previous step's duration.
-                            if let (Some(start), Some(last)) =
-                                (step_start, state.loading_steps.last_mut())
-                            {
-                                last.duration = Some(now.duration_since(start));
-                            }
-                            // Begin this step.
-                            state.loading_steps.push(state::LoadingStep {
-                                label: msg.clone(),
-                                started: chrono::Local::now().format("%H:%M:%S").to_string(),
-                                duration: None,
-                            });
-                            step_start = Some(now);
+                        Some((major, sub)) = progress_rx.recv() => {
+                            progress.begin(&mut state.loading, &major, &sub);
                             state.tip_index = state.tip_index.wrapping_add(1);
                             state.connection.status =
-                                state::MediatorStatus::Initializing(msg);
+                                state::MediatorStatus::Initializing(
+                                    format!("{major} — {sub}"),
+                                );
                             let _ = self.state_tx.send(state.clone());
                         }
                         // Token-touch notifications arrive through the dedicated channel
@@ -314,16 +309,13 @@ impl StateHandler {
                         }
                         result = &mut load_handle => {
                             match result {
-                                Ok(Ok((tdk, config))) => {
-                                    // Stamp the final load step's duration.
-                                    if let (Some(start), Some(last)) =
-                                        (step_start, state.loading_steps.last_mut())
-                                    {
-                                        last.duration = Some(start.elapsed());
-                                    }
-                                    break (tdk, config);
+                                Ok(Ok((tdk, config, admin_session))) => {
+                                    // Stamp the final step + major as Done.
+                                    progress.finish(&mut state.loading);
+                                    break (tdk, config, admin_session);
                                 }
                                 Ok(Err(e)) => {
+                                    progress.fail(&mut state.loading);
                                     state.connection.status =
                                         state::MediatorStatus::Failed(format!("{e}"));
                                     let _ = self.state_tx.send(state.clone());
@@ -339,6 +331,7 @@ impl StateHandler {
                                         .await;
                                 }
                                 Err(join_err) => {
+                                    progress.fail(&mut state.loading);
                                     state.connection.status =
                                         state::MediatorStatus::Failed(
                                             format!("Internal error: {join_err}"),
@@ -380,7 +373,7 @@ impl StateHandler {
                 state.main_page.sync_from_config(&config);
                 state.main_page.log("Configuration loaded");
 
-                (tdk, config)
+                (tdk, config, loaded_admin_vta)
             }
             StartingMode::NotSet => {
                 let err = Interrupted::SystemError("Starting Mode is Not Set!".to_string());
@@ -394,13 +387,21 @@ impl StateHandler {
         // Set the profile name once (doesn't change during runtime)
         state.main_page.content_panel.vta.profile = self.profile.clone();
 
-        // Open the always-on admin VTA session for VTA backends. It stays open
-        // for the whole time openvtc runs and is reused by every runtime VTA op
+        // The always-on admin VTA session for VTA backends. It stays open for
+        // the whole time openvtc runs and is reused by every runtime VTA op
         // (context-name fetch, relationship creation, and future community joins
         // / context creation), so the admin DID holds ONE mediator connection
         // instead of reconnecting per operation. It is shut down at every exit
         // path below (degraded returns + end of the main loop).
-        let admin_vta: Option<vta_sdk::client::VtaClient> = if matches!(
+        //
+        // PERF #1: prefer the session `load_step2` already opened (handed back
+        // as `loaded_admin_vta`) so the whole runtime uses a SINGLE admin
+        // connection. Only fall back to opening one here when there isn't one
+        // (the SetupWizard / pre-loaded-Config modes, or a State-A account that
+        // had no persona to open a session for).
+        let admin_vta: Option<vta_sdk::client::VtaClient> = if loaded_admin_vta.is_some() {
+            loaded_admin_vta
+        } else if matches!(
             &config.key_backend,
             openvtc_core::config::KeyBackend::Vta { .. }
         ) {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -53,6 +53,8 @@ pub mod actions;
 mod credential_actions;
 pub mod didcomm;
 mod inbox_actions;
+pub mod join;
+mod join_flow;
 pub mod main_page;
 mod message_dispatch;
 mod relationship_actions;
@@ -297,12 +299,14 @@ impl StateHandler {
                                     state.connection.status =
                                         state::MediatorStatus::Failed(format!("{e}"));
                                     let _ = self.state_tx.send(state.clone());
+                                    // No config loaded here — join is unavailable.
                                     return self
                                         .run_degraded_loop(
                                             &mut action_rx,
                                             &mut interrupt_rx,
                                             &mut terminator,
                                             &mut state,
+                                            None,
                                         )
                                         .await;
                                 }
@@ -318,6 +322,7 @@ impl StateHandler {
                                             &mut interrupt_rx,
                                             &mut terminator,
                                             &mut state,
+                                            None,
                                         )
                                         .await;
                                 }
@@ -403,18 +408,22 @@ impl StateHandler {
         if config.active_identity().is_none() {
             state.connection.status = state::MediatorStatus::NoActiveCommunity;
             let _ = self.state_tx.send(state.clone());
-            // No persona yet (State A). The join flow (R-A-5 Stage 4) will reuse
-            // the admin session from the Communities/degraded loop; until then
-            // nothing there uses it, so close it rather than let it linger.
-            if let Some(c) = admin_vta {
-                c.shutdown().await;
-            }
+            // No persona yet (State A). Hand the always-on admin session to the
+            // degraded loop so the Communities `j` → join flow (R-A-5 Stage 4)
+            // can reuse it; the loop closes it on exit.
+            let join_ctx = DegradedJoinContext {
+                tdk,
+                config,
+                admin_vta,
+                profile: self.profile.clone(),
+            };
             return self
                 .run_degraded_loop(
                     &mut action_rx,
                     &mut interrupt_rx,
                     &mut terminator,
                     &mut state,
+                    Some(join_ctx),
                 )
                 .await;
         }
@@ -447,15 +456,22 @@ impl StateHandler {
                     .main_page
                     .log_error("DIDComm service failed to start", &e);
                 let _ = self.state_tx.send(state.clone());
-                if let Some(c) = admin_vta {
-                    c.shutdown().await;
-                }
+                // Messaging is down but the admin VTA session may still be live;
+                // hand it to the degraded loop so the user can still join a
+                // community (State-B path). The loop closes the session on exit.
+                let join_ctx = DegradedJoinContext {
+                    tdk,
+                    config,
+                    admin_vta,
+                    profile: self.profile.clone(),
+                };
                 return self
                     .run_degraded_loop(
                         &mut action_rx,
                         &mut interrupt_rx,
                         &mut terminator,
                         &mut state,
+                        Some(join_ctx),
                     )
                     .await;
             }
@@ -533,6 +549,36 @@ impl StateHandler {
                                 // When switching to MainMenu, reset any content-specific state if needed
                                 state.main_page.menu_panel.selected = true;
                                 state.main_page.content_panel.selected = false;
+                            }
+                        }
+                    },
+                    Action::StartJoin => {
+                        // State-B join from the live runtime: reuse the always-on
+                        // admin VTA session. The DIDComm service keeps running in
+                        // the background; the join flow owns the screen until the
+                        // user returns. Restart is required to activate the new
+                        // community (hot-start is a deliberate follow-up).
+                        match self
+                            .join_flow(
+                                &mut action_rx,
+                                &mut interrupt_rx,
+                                &mut state,
+                                &tdk,
+                                &mut config,
+                                admin_vta.as_ref(),
+                                self.profile.as_str(),
+                            )
+                            .await
+                        {
+                            Ok(join_flow::JoinExit::Returned) => {
+                                state.active_page = state::ActivePage::Main;
+                            }
+                            Ok(join_flow::JoinExit::Exit(interrupted)) => {
+                                break interrupted;
+                            }
+                            Err(e) => {
+                                state.main_page.log_error("Join flow failed", &e);
+                                state.active_page = state::ActivePage::Main;
                             }
                         }
                     },
@@ -783,28 +829,36 @@ impl StateHandler {
         Ok(result)
     }
 
-    /// Minimal event loop for when init fails -- keeps UI alive so user sees the error and can exit.
+    /// Minimal event loop for when there is no active community / messaging
+    /// (State-A) or after an init failure — keeps the UI alive so the user can
+    /// navigate, exit, and (when `join_ctx` is supplied) start a join.
+    ///
+    /// `join_ctx` carries the runtime pieces the join flow needs (TDK, the live
+    /// `Config`, the always-on admin VTA session, profile). The early
+    /// load-failure callers have no loaded config, so they pass `None` and
+    /// `StartJoin` is a no-op there.
     async fn run_degraded_loop(
         &self,
         action_rx: &mut UnboundedReceiver<Action>,
         interrupt_rx: &mut broadcast::Receiver<Interrupted>,
         terminator: &mut Terminator,
         state: &mut State,
+        mut join_ctx: Option<DegradedJoinContext>,
     ) -> Result<Interrupted> {
-        loop {
+        let result = loop {
             tokio::select! {
                 Some(action) = action_rx.recv() => match action {
                     Action::Exit => {
                         if let Err(e) = terminator.terminate(Interrupted::UserInt) {
                             debug!("Failed to send terminate signal: {e}");
                         }
-                        return Ok(Interrupted::UserInt);
+                        break Interrupted::UserInt;
                     }
                     Action::UXError(interrupted) => {
                         if let Err(e) = terminator.terminate(interrupted.clone()) {
                             debug!("Failed to send terminate signal: {e}");
                         }
-                        return Ok(interrupted);
+                        break interrupted;
                     }
                     Action::MainMenuSelected(menu_item) => {
                         state.main_page.menu_panel.selected_menu = menu_item;
@@ -821,15 +875,73 @@ impl StateHandler {
                             }
                         }
                     }
+                    Action::StartJoin => {
+                        if let Some(ctx) = join_ctx.as_mut() {
+                            match self
+                                .join_flow(
+                                    action_rx,
+                                    interrupt_rx,
+                                    state,
+                                    &ctx.tdk,
+                                    &mut ctx.config,
+                                    ctx.admin_vta.as_ref(),
+                                    ctx.profile.as_str(),
+                                )
+                                .await
+                            {
+                                Ok(join_flow::JoinExit::Returned) => {
+                                    // Back on the main page; resume the degraded loop.
+                                    state.active_page = state::ActivePage::Main;
+                                }
+                                Ok(join_flow::JoinExit::Exit(interrupted)) => {
+                                    if let Err(e) = terminator.terminate(interrupted.clone()) {
+                                        debug!("Failed to send terminate signal: {e}");
+                                    }
+                                    break interrupted;
+                                }
+                                Err(e) => {
+                                    state
+                                        .main_page
+                                        .log_error("Join flow failed", &e);
+                                    state.active_page = state::ActivePage::Main;
+                                }
+                            }
+                        } else {
+                            state
+                                .main_page
+                                .log("Cannot join: no active VTA session.");
+                        }
+                    }
                     _ => {}
                 },
                 Ok(interrupted) = interrupt_rx.recv() => {
-                    return Ok(interrupted);
+                    break interrupted;
                 }
             }
             let _ = self.state_tx.send(state.clone());
+        };
+
+        // Close the always-on admin VTA session owned by the join context, if any.
+        if let Some(ctx) = join_ctx
+            && let Some(c) = ctx.admin_vta
+        {
+            c.shutdown().await;
         }
+
+        Ok(result)
     }
+}
+
+/// Runtime context the degraded loop hands to [`StateHandler::join_flow`].
+///
+/// Owns the live `Config` (mutated + persisted by a successful join), the TDK,
+/// the always-on admin VTA session, and the profile name. The admin session is
+/// shut down when the degraded loop returns.
+struct DegradedJoinContext {
+    tdk: TDK,
+    config: Box<Config>,
+    admin_vta: Option<vta_sdk::client::VtaClient>,
+    profile: String,
 }
 
 // Per-domain action dispatch lives in the corresponding sub-module:

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -372,7 +372,7 @@ impl StateHandler {
         // / context creation), so the admin DID holds ONE mediator connection
         // instead of reconnecting per operation. It is shut down at every exit
         // path below (degraded returns + end of the main loop).
-        let admin_vta: Option<vta_sdk::client::VtaClient> = if matches!(
+        let mut admin_vta: Option<vta_sdk::client::VtaClient> = if matches!(
             &config.key_backend,
             openvtc_core::config::KeyBackend::Vta { .. }
         ) {
@@ -558,6 +558,19 @@ impl StateHandler {
                         // the background; the join flow owns the screen until the
                         // user returns. Restart is required to activate the new
                         // community (hot-start is a deliberate follow-up).
+                        //
+                        // The always-on admin session may have gone stale while
+                        // idle (the mediator closes idle WebSockets), so its first
+                        // round-trip would time out. Reconnect a fresh one right
+                        // before the join — the old one is closed first, so the
+                        // admin DID never has two competing sockets.
+                        if let Some(old) = admin_vta.take() {
+                            old.shutdown().await;
+                        }
+                        admin_vta =
+                            openvtc_core::config::build_runtime_vta_client(&config.key_backend)
+                                .await
+                                .ok();
                         match self
                             .join_flow(
                                 &mut action_rx,
@@ -877,6 +890,18 @@ impl StateHandler {
                     }
                     Action::StartJoin => {
                         if let Some(ctx) = join_ctx.as_mut() {
+                            // Reconnect a fresh admin session before the join: the
+                            // always-on one may have gone stale during idle (the
+                            // mediator closes idle WebSockets). Close the old first
+                            // so the admin DID never has two competing sockets.
+                            if let Some(old) = ctx.admin_vta.take() {
+                                old.shutdown().await;
+                            }
+                            ctx.admin_vta = openvtc_core::config::build_runtime_vta_client(
+                                &ctx.config.key_backend,
+                            )
+                            .await
+                            .ok();
                             match self
                                 .join_flow(
                                     action_rx,

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -357,29 +357,37 @@ impl StateHandler {
         // Set the profile name once (doesn't change during runtime)
         state.main_page.content_panel.vta.profile = self.profile.clone();
 
-        // Fetch VTA context name if using VTA backend. The helper handles
-        // both DIDComm and REST transports automatically. The DIDComm client
-        // opens a persistent session, so it MUST be shut down after use or it
-        // lingers and duels other admin sessions on the mediator.
-        if matches!(
+        // Open the always-on admin VTA session for VTA backends. It stays open
+        // for the whole time openvtc runs and is reused by every runtime VTA op
+        // (context-name fetch, relationship creation, and future community joins
+        // / context creation), so the admin DID holds ONE mediator connection
+        // instead of reconnecting per operation. It is shut down at every exit
+        // path below (degraded returns + end of the main loop).
+        let admin_vta: Option<vta_sdk::client::VtaClient> = if matches!(
             &config.key_backend,
             openvtc_core::config::KeyBackend::Vta { .. }
-        ) && let Ok(client) =
-            openvtc_core::config::build_runtime_vta_client(&config.key_backend).await
+        ) {
+            openvtc_core::config::build_runtime_vta_client(&config.key_backend)
+                .await
+                .ok()
+        } else {
+            None
+        };
+
+        // Fetch VTA context name, reusing the always-on admin session.
+        if let Some(client) = admin_vta.as_ref()
+            && let Ok(resp) = client.list_contexts().await
         {
-            if let Ok(resp) = client.list_contexts().await {
-                if let Some(ctx) = resp
-                    .contexts
-                    .iter()
-                    .find(|c| c.did.as_deref() == Some(config.persona_did()))
-                {
-                    state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
-                } else if let Some(ctx) = resp.contexts.first() {
-                    // Fallback to first context
-                    state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
-                }
+            if let Some(ctx) = resp
+                .contexts
+                .iter()
+                .find(|c| c.did.as_deref() == Some(config.persona_did()))
+            {
+                state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
+            } else if let Some(ctx) = resp.contexts.first() {
+                // Fallback to first context
+                state.main_page.content_panel.vta.context_name = Some(ctx.name.clone());
             }
-            client.shutdown().await;
         }
 
         // A State-A account has no persona/community yet (R-A-5): there is no
@@ -391,6 +399,12 @@ impl StateHandler {
         if config.active_identity().is_none() {
             state.connection.status = state::MediatorStatus::NoActiveCommunity;
             let _ = self.state_tx.send(state.clone());
+            // No persona yet (State A). The join flow (R-A-5 Stage 4) will reuse
+            // the admin session from the Communities/degraded loop; until then
+            // nothing there uses it, so close it rather than let it linger.
+            if let Some(c) = admin_vta {
+                c.shutdown().await;
+            }
             return self
                 .run_degraded_loop(
                     &mut action_rx,
@@ -429,6 +443,9 @@ impl StateHandler {
                     .main_page
                     .log_error("DIDComm service failed to start", &e);
                 let _ = self.state_tx.send(state.clone());
+                if let Some(c) = admin_vta {
+                    c.shutdown().await;
+                }
                 return self
                     .run_degraded_loop(
                         &mut action_rx,
@@ -524,6 +541,7 @@ impl StateHandler {
                             &mut state,
                             &self.state_tx,
                             &self.profile,
+                            admin_vta.as_ref(),
                         )
                         .await;
                     },
@@ -537,6 +555,7 @@ impl StateHandler {
                             &self.state_tx,
                             &self.profile,
                             &mut ping_sent_at,
+                            admin_vta.as_ref(),
                         )
                         .await;
                     },
@@ -751,6 +770,11 @@ impl StateHandler {
         // Shut down the DIDComm service gracefully
         shutdown_token.cancel();
         didcomm_service.shutdown().await;
+
+        // Close the always-on admin VTA session.
+        if let Some(c) = admin_vta {
+            c.shutdown().await;
+        }
 
         Ok(result)
     }

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -292,14 +292,13 @@ impl StateHandler {
                             if let (Some(start), Some(last)) =
                                 (step_start, state.loading_steps.last_mut())
                             {
-                                last.duration_ms =
-                                    Some(now.duration_since(start).as_millis() as u64);
+                                last.duration = Some(now.duration_since(start));
                             }
                             // Begin this step.
                             state.loading_steps.push(state::LoadingStep {
                                 label: msg.clone(),
                                 started: chrono::Local::now().format("%H:%M:%S").to_string(),
-                                duration_ms: None,
+                                duration: None,
                             });
                             step_start = Some(now);
                             state.tip_index = state.tip_index.wrapping_add(1);
@@ -320,8 +319,7 @@ impl StateHandler {
                                     if let (Some(start), Some(last)) =
                                         (step_start, state.loading_steps.last_mut())
                                     {
-                                        last.duration_ms =
-                                            Some(start.elapsed().as_millis() as u64);
+                                        last.duration = Some(start.elapsed());
                                     }
                                     break (tdk, config);
                                 }
@@ -429,11 +427,12 @@ impl StateHandler {
             }
         }
 
-        // Phase 1 (config load + VTA) is complete — leave the loading screen and
-        // show the main page now. The per-community DIDComm connection (phase 2)
-        // runs asynchronously below and reports its status without blocking the
-        // UI (it no longer waits up-front for the listener to connect).
-        state.active_page = ActivePage::Main;
+        // Phase 1 (config load + VTA) is complete. Stay on the loading screen
+        // and offer "Press Enter to continue" — but kick off phase 2 (the
+        // per-community DIDComm connection) right away below, so the work is
+        // already happening in the background regardless of when the user hits
+        // Enter. Dismissing the loading screen (Enter) reveals the main page.
+        state.loading_complete = true;
 
         // A State-A account has no persona/community yet (R-A-5): there is no
         // DID to open a DIDComm session for. Skip the persona listener entirely
@@ -557,6 +556,11 @@ impl StateHandler {
                         }
 
                         break interrupted;
+                    },
+                    Action::DismissLoading => {
+                        // Phase 1 done + user pressed Enter — reveal the main page
+                        // (phase-2 connection is already running in the background).
+                        state.active_page = state::ActivePage::Main;
                     },
                     Action::MainMenuSelected(menu_item) => {
                         // User has changed main menu selection
@@ -961,6 +965,9 @@ impl StateHandler {
                             debug!("Failed to send terminate signal: {e}");
                         }
                         break interrupted;
+                    }
+                    Action::DismissLoading => {
+                        state.active_page = state::ActivePage::Main;
                     }
                     Action::MainMenuSelected(menu_item) => {
                         state.main_page.menu_panel.selected_menu = menu_item;

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -84,16 +84,16 @@ pub async fn send_relationship_request(
 
     // Optionally generate a random relationship DID for privacy
     let our_did: Arc<String> = if generate_r_did {
-        let r_did = Arc::new(
-            create_relationship_did(tdk, config, &config.public.mediator_did.clone()).await?,
-        );
+        // Snapshot the mediator before the &mut config borrow below.
+        let mediator = config.mediator_did().to_string();
+        let r_did = Arc::new(create_relationship_did(tdk, config, &mediator).await?);
         // Register a listener for the new R-DID
         let listener_config = super::didcomm::relationship_listener_config(
             config,
             tdk,
             &r_did,
             respondent_did,
-            &config.public.mediator_did,
+            config.mediator_did(),
         )
         .await;
         if let Err(e) = service.add_listener(listener_config).await {
@@ -101,7 +101,7 @@ pub async fn send_relationship_request(
         }
         r_did
     } else {
-        Arc::clone(&config.public.persona_did)
+        config.persona_did_arc()
     };
 
     // Build the relationship request message
@@ -111,7 +111,7 @@ pub async fn send_relationship_request(
         Some(config.public.friendly_name.as_str())
     };
     let msg = create_request_message(
-        &config.public.persona_did,
+        config.persona_did(),
         respondent_did,
         reason,
         &our_did,
@@ -119,15 +119,9 @@ pub async fn send_relationship_request(
     )?;
     let msg_id = Arc::new(msg.id.clone());
 
-    super::didcomm::send_message(
-        service,
-        config,
-        &msg,
-        &config.public.persona_did,
-        respondent_did,
-    )
-    .await
-    .map_err(|e| anyhow::anyhow!("failed to send relationship request: {e}"))?;
+    super::didcomm::send_message(service, config, &msg, config.persona_did(), respondent_did)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to send relationship request: {e}"))?;
 
     // Create relationship entry
     config.private.relationships.relationships.insert(
@@ -188,7 +182,7 @@ pub async fn ping_relationship(
     info!(
         our_did = %our_did,
         remote_did = %remote_did,
-        is_r_did = *our_did != *config.public.persona_did,
+        is_r_did = our_did.as_str() != config.persona_did(),
         "ping using relationship DIDs"
     );
     let ping_msg = {
@@ -244,11 +238,11 @@ pub async fn remove_relationship(
     // Extract listener ID before any async work to avoid holding MutexGuard across await
     let listener_to_remove = if let Some(rel_arc) = config.private.relationships.get(&key)
         && let Ok(lock) = rel_arc.lock()
-        && *lock.our_did != *config.public.persona_did
+        && lock.our_did.as_str() != config.persona_did()
     {
         Some(super::didcomm::listener_id_for_did(
             &lock.our_did,
-            &config.public.persona_did,
+            config.persona_did(),
         ))
     } else {
         None
@@ -627,7 +621,7 @@ async fn handle_submit(
                          Task ID:       {}",
                         r.remote_p_did,
                         r.our_did,
-                        if *r.our_did != *config.public.persona_did {
+                        if r.our_did.as_str() != config.persona_did() {
                             "yes"
                         } else {
                             "no"
@@ -682,7 +676,7 @@ async fn handle_ping(
                 state.main_page.log_error("Failed to save config", &e);
             }
             state.main_page.sync_from_config(config);
-            let using_rdid = our_did_str != *config.public.persona_did;
+            let using_rdid = our_did_str != config.persona_did();
             state.main_page.log_detailed(
                 format!(
                     "Trust-ping sent to {display_name}{}",

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 /// When `generate_r_did` is true and the key backend is BIP32, a unique
 /// relationship DID (did:peer) is derived for privacy. Otherwise the
 /// persona DID is used directly.
+#[allow(clippy::too_many_arguments)]
 pub async fn send_relationship_request(
     config: &mut Config,
     tdk: &TDK,
@@ -39,6 +40,7 @@ pub async fn send_relationship_request(
     alias: &str,
     reason: Option<&str>,
     generate_r_did: bool,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) -> Result<()> {
     // Validate DID format
     if !respondent_did.starts_with("did:") {
@@ -86,7 +88,7 @@ pub async fn send_relationship_request(
     let our_did: Arc<String> = if generate_r_did {
         // Snapshot the mediator before the &mut config borrow below.
         let mediator = config.mediator_did().to_string();
-        let r_did = Arc::new(create_relationship_did(tdk, config, &mediator).await?);
+        let r_did = Arc::new(create_relationship_did(tdk, config, &mediator, admin_vta).await?);
         // Register a listener for the new R-DID
         let listener_config = super::didcomm::relationship_listener_config(
             config,
@@ -284,10 +286,13 @@ pub(crate) async fn create_relationship_did(
     tdk: &TDK,
     config: &mut Config,
     mediator: &str,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) -> Result<String> {
     match &config.key_backend {
         KeyBackend::Bip32 { .. } => create_relationship_did_bip32(tdk, config, mediator).await,
-        KeyBackend::Vta { .. } => create_relationship_did_vta(tdk, config, mediator).await,
+        KeyBackend::Vta { .. } => {
+            create_relationship_did_vta(tdk, config, mediator, admin_vta).await
+        }
     }
 }
 
@@ -393,63 +398,21 @@ async fn create_relationship_did_vta(
     tdk: &TDK,
     config: &mut Config,
     mediator: &str,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) -> Result<String> {
-    use vta_sdk::client::CreateKeyRequest;
-    use vta_sdk::keys::KeyType;
-
     // Create the relationship signing (Ed25519) + encryption (X25519) keys via
-    // the VTA. The wrapper guarantees the DIDComm session is shut down on every
-    // exit (incl. the `?` error paths below), so it can't leak and duel other
-    // admin sessions on the mediator.
-    info!("opening VTA client for R-DID creation...");
-    let (mut v_secret, mut e_secret, sign_key_id, enc_key_id) =
-        openvtc_core::config::with_runtime_vta_client::<_, _, _, anyhow::Error>(
-            &config.key_backend,
-            |client| async move {
-                info!("creating Ed25519 signing key via VTA...");
-                let sign_resp = client
-                    .create_key(CreateKeyRequest {
-                        key_type: KeyType::Ed25519,
-                        derivation_path: None,
-                        key_id: None,
-                        mnemonic: None,
-                        label: Some("relationship-signing".to_string()),
-                        context_id: None,
-                    })
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to create signing key: {e}"))?;
-                let sign_secret_resp = client
-                    .get_key_secret(&sign_resp.key_id)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
-                let mut v_secret = vta_sdk::did_key::secret_from_key_response(&sign_secret_resp)
-                    .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-                v_secret.id = v_secret.get_public_keymultibase()?;
-
-                info!("creating X25519 encryption key via VTA...");
-                let enc_resp = client
-                    .create_key(CreateKeyRequest {
-                        key_type: KeyType::X25519,
-                        derivation_path: None,
-                        key_id: None,
-                        mnemonic: None,
-                        label: Some("relationship-encryption".to_string()),
-                        context_id: None,
-                    })
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to create encryption key: {e}"))?;
-                let enc_secret_resp = client
-                    .get_key_secret(&enc_resp.key_id)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to get encryption key secret: {e}"))?;
-                let mut e_secret = vta_sdk::did_key::secret_from_key_response(&enc_secret_resp)
-                    .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-                e_secret.id = e_secret.get_public_keymultibase()?;
-
-                Ok((v_secret, e_secret, sign_resp.key_id, enc_resp.key_id))
-            },
-        )
-        .await?;
+    // the VTA. Reuse the always-on admin session when the runtime provides one;
+    // otherwise open a transient session (guaranteed to shut down on every exit).
+    let (mut v_secret, mut e_secret, sign_key_id, enc_key_id) = match admin_vta {
+        Some(client) => create_relationship_keys(client).await?,
+        None => {
+            openvtc_core::config::with_runtime_vta_client::<_, _, _, anyhow::Error>(
+                &config.key_backend,
+                |client| async move { create_relationship_keys(&client).await },
+            )
+            .await?
+        }
+    };
 
     // Build did:peer from secrets
     let mut keys = vec![
@@ -490,6 +453,58 @@ async fn create_relationship_did_vta(
         .await;
 
     Ok(r_did)
+}
+
+/// Create a relationship's signing (Ed25519) + encryption (X25519) keys via the
+/// VTA and fetch their secrets, on the given (admin) session. Returns
+/// `(v_secret, e_secret, signing_key_id, encryption_key_id)`.
+async fn create_relationship_keys(
+    client: &vta_sdk::client::VtaClient,
+) -> Result<(Secret, Secret, String, String)> {
+    use vta_sdk::client::CreateKeyRequest;
+    use vta_sdk::keys::KeyType;
+
+    info!("creating Ed25519 signing key via VTA...");
+    let sign_resp = client
+        .create_key(CreateKeyRequest {
+            key_type: KeyType::Ed25519,
+            derivation_path: None,
+            key_id: None,
+            mnemonic: None,
+            label: Some("relationship-signing".to_string()),
+            context_id: None,
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create signing key: {e}"))?;
+    let sign_secret_resp = client
+        .get_key_secret(&sign_resp.key_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
+    let mut v_secret = vta_sdk::did_key::secret_from_key_response(&sign_secret_resp)
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    v_secret.id = v_secret.get_public_keymultibase()?;
+
+    info!("creating X25519 encryption key via VTA...");
+    let enc_resp = client
+        .create_key(CreateKeyRequest {
+            key_type: KeyType::X25519,
+            derivation_path: None,
+            key_id: None,
+            mnemonic: None,
+            label: Some("relationship-encryption".to_string()),
+            context_id: None,
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create encryption key: {e}"))?;
+    let enc_secret_resp = client
+        .get_key_secret(&enc_resp.key_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get encryption key secret: {e}"))?;
+    let mut e_secret = vta_sdk::did_key::secret_from_key_response(&enc_secret_resp)
+        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+    e_secret.id = e_secret.get_public_keymultibase()?;
+
+    Ok((v_secret, e_secret, sign_resp.key_id, enc_resp.key_id))
 }
 
 /// Build a DIDComm relationship request message.
@@ -586,6 +601,7 @@ async fn handle_submit(
     alias: &str,
     reason: Option<&str>,
     generate_r_did: bool,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) {
     if generate_r_did {
         state.main_page.content_panel.relationships.status_message =
@@ -599,7 +615,17 @@ async fn handle_submit(
     }
     let _ = state_tx.send(state.clone());
 
-    match send_relationship_request(config, tdk, service, did, alias, reason, generate_r_did).await
+    match send_relationship_request(
+        config,
+        tdk,
+        service,
+        did,
+        alias,
+        reason,
+        generate_r_did,
+        admin_vta,
+    )
+    .await
     {
         Ok(()) => {
             state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
@@ -847,6 +873,7 @@ pub(crate) async fn dispatch(
     state_tx: &watch::Sender<State>,
     profile: &str,
     ping_sent_at: &mut Option<Instant>,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) {
     match action {
         RelationshipAction::Select(index) => {
@@ -887,6 +914,7 @@ pub(crate) async fn dispatch(
                 &alias,
                 reason.as_deref(),
                 generate_r_did,
+                admin_vta,
             )
             .await
         }

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -397,61 +397,59 @@ async fn create_relationship_did_vta(
     use vta_sdk::client::CreateKeyRequest;
     use vta_sdk::keys::KeyType;
 
-    // Reuse whichever transport setup chose (DIDComm or REST). The helper
-    // handles auth for both.
+    // Create the relationship signing (Ed25519) + encryption (X25519) keys via
+    // the VTA. The wrapper guarantees the DIDComm session is shut down on every
+    // exit (incl. the `?` error paths below), so it can't leak and duel other
+    // admin sessions on the mediator.
     info!("opening VTA client for R-DID creation...");
-    let client = openvtc_core::config::build_runtime_vta_client(&config.key_backend).await?;
+    let (mut v_secret, mut e_secret, sign_key_id, enc_key_id) =
+        openvtc_core::config::with_runtime_vta_client::<_, _, _, anyhow::Error>(
+            &config.key_backend,
+            |client| async move {
+                info!("creating Ed25519 signing key via VTA...");
+                let sign_resp = client
+                    .create_key(CreateKeyRequest {
+                        key_type: KeyType::Ed25519,
+                        derivation_path: None,
+                        key_id: None,
+                        mnemonic: None,
+                        label: Some("relationship-signing".to_string()),
+                        context_id: None,
+                    })
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to create signing key: {e}"))?;
+                let sign_secret_resp = client
+                    .get_key_secret(&sign_resp.key_id)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
+                let mut v_secret = vta_sdk::did_key::secret_from_key_response(&sign_secret_resp)
+                    .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                v_secret.id = v_secret.get_public_keymultibase()?;
 
-    // Create signing key (Ed25519) for verification
-    info!("creating Ed25519 signing key via VTA...");
-    let sign_resp = client
-        .create_key(CreateKeyRequest {
-            key_type: KeyType::Ed25519,
-            derivation_path: None,
-            key_id: None,
-            mnemonic: None,
-            label: Some("relationship-signing".to_string()),
-            context_id: None,
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create signing key: {e}"))?;
+                info!("creating X25519 encryption key via VTA...");
+                let enc_resp = client
+                    .create_key(CreateKeyRequest {
+                        key_type: KeyType::X25519,
+                        derivation_path: None,
+                        key_id: None,
+                        mnemonic: None,
+                        label: Some("relationship-encryption".to_string()),
+                        context_id: None,
+                    })
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to create encryption key: {e}"))?;
+                let enc_secret_resp = client
+                    .get_key_secret(&enc_resp.key_id)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Failed to get encryption key secret: {e}"))?;
+                let mut e_secret = vta_sdk::did_key::secret_from_key_response(&enc_secret_resp)
+                    .map_err(|e| anyhow::anyhow!("{e:?}"))?;
+                e_secret.id = e_secret.get_public_keymultibase()?;
 
-    let sign_secret_resp = client
-        .get_key_secret(&sign_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
-
-    let mut v_secret = vta_sdk::did_key::secret_from_key_response(&sign_secret_resp)
-        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-    v_secret.id = v_secret.get_public_keymultibase()?;
-
-    // Create encryption key (X25519)
-    info!("creating X25519 encryption key via VTA...");
-    let enc_resp = client
-        .create_key(CreateKeyRequest {
-            key_type: KeyType::X25519,
-            derivation_path: None,
-            key_id: None,
-            mnemonic: None,
-            label: Some("relationship-encryption".to_string()),
-            context_id: None,
-        })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create encryption key: {e}"))?;
-
-    let enc_secret_resp = client
-        .get_key_secret(&enc_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get encryption key secret: {e}"))?;
-
-    let mut e_secret = vta_sdk::did_key::secret_from_key_response(&enc_secret_resp)
-        .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-    e_secret.id = e_secret.get_public_keymultibase()?;
-
-    // Close the persistent DIDComm session now that the key fetches are done —
-    // `connect_didcomm` opens an auto-reconnecting WebSocket that `Drop` cannot
-    // close, so a leak duels other admin sessions on the mediator.
-    client.shutdown().await;
+                Ok((v_secret, e_secret, sign_resp.key_id, enc_resp.key_id))
+            },
+        )
+        .await?;
 
     // Build did:peer from secrets
     let mut keys = vec![
@@ -466,7 +464,7 @@ async fn create_relationship_did_vta(
         v_secret.id.clone(),
         KeyInfoConfig {
             path: KeySourceMaterial::VtaManaged {
-                key_id: sign_resp.key_id,
+                key_id: sign_key_id,
             },
             create_time: Utc::now(),
             purpose: KeyTypes::RelationshipVerification,
@@ -475,9 +473,7 @@ async fn create_relationship_did_vta(
     config.key_info.insert(
         e_secret.id.clone(),
         KeyInfoConfig {
-            path: KeySourceMaterial::VtaManaged {
-                key_id: enc_resp.key_id,
-            },
+            path: KeySourceMaterial::VtaManaged { key_id: enc_key_id },
             create_time: Utc::now(),
             purpose: KeyTypes::RelationshipEncryption,
         },

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -448,6 +448,11 @@ async fn create_relationship_did_vta(
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
     e_secret.id = e_secret.get_public_keymultibase()?;
 
+    // Close the persistent DIDComm session now that the key fetches are done —
+    // `connect_didcomm` opens an auto-reconnecting WebSocket that `Drop` cannot
+    // close, so a leak duels other admin sessions on the mediator.
+    client.shutdown().await;
+
     // Build did:peer from secrets
     let mut keys = vec![
         (PeerKeyRole::Verification, &mut v_secret),

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -29,7 +29,7 @@ pub fn update_friendly_name(config: &mut Config, profile: &str, name: &str) -> R
 
 /// Update the mediator DID and save.
 pub fn update_mediator_did(config: &mut Config, profile: &str, did: &str) -> Result<()> {
-    config.public.mediator_did = did.to_string();
+    config.set_active_mediator_did(did);
     config.public.logs.insert(
         LogFamily::Config,
         format!("Mediator DID changed to '{}'", did),
@@ -41,7 +41,7 @@ pub fn update_mediator_did(config: &mut Config, profile: &str, did: &str) -> Res
 
 /// Update the organization DID and save.
 pub fn update_org_did(config: &mut Config, profile: &str, did: &str) -> Result<()> {
-    config.public.lk_did = did.to_string();
+    config.account.org_did = did.to_string();
     config
         .public
         .logs

--- a/openvtc/src/state_handler/setup_did_actions.rs
+++ b/openvtc/src/state_handler/setup_did_actions.rs
@@ -128,6 +128,9 @@ pub(crate) async fn handle_webvh_server_create_did(
     let _ = state_tx.send(state.clone());
 
     apply_server_create_result(state, &client, tdk, &context_id, &server_id, path_mode).await;
+    // Close the persistent DIDComm session so it doesn't linger and duel the
+    // next step's session on the mediator (duplicate-WebSocket loop → timeouts).
+    client.shutdown().await;
     Ok(false)
 }
 
@@ -173,6 +176,9 @@ pub(crate) async fn handle_custom_mediator_webvh(
     let _ = state_tx.send(state.clone());
 
     apply_server_create_result(state, &client, tdk, &context_id, &server_id, path_mode).await;
+    // Close the persistent DIDComm session so it doesn't linger and duel the
+    // next step's session on the mediator (duplicate-WebSocket loop → timeouts).
+    client.shutdown().await;
     Ok(false)
 }
 

--- a/openvtc/src/state_handler/setup_did_actions.rs
+++ b/openvtc/src/state_handler/setup_did_actions.rs
@@ -5,6 +5,7 @@ use openvtc_core::{
 };
 use pgp::composed::ArmorOptions;
 use secrecy::SecretString;
+use vta_sdk::protocols::did_management::create::WebvhPathMode;
 
 use crate::{
     state_handler::{
@@ -91,7 +92,7 @@ pub(crate) async fn handle_webvh_server_create_did(
     state_tx: &watch::Sender<State>,
     tdk: &TDK,
     server_id: String,
-    custom_path: Option<String>,
+    path_mode: WebvhPathMode,
 ) -> anyhow::Result<bool> {
     use crate::state_handler::setup_sequence::vta;
 
@@ -126,7 +127,7 @@ pub(crate) async fn handle_webvh_server_create_did(
         .push(MessageType::Info(format!("Server: {}", server_id)));
     let _ = state_tx.send(state.clone());
 
-    apply_server_create_result(state, &client, tdk, &context_id, &server_id, custom_path).await;
+    apply_server_create_result(state, &client, tdk, &context_id, &server_id, path_mode).await;
     Ok(false)
 }
 
@@ -162,7 +163,7 @@ pub(crate) async fn handle_custom_mediator_webvh(
 
     let context_id = state.setup.vta.context_id.clone().unwrap_or_default();
     let server_id = state.setup.webvh_server.selected_server_id.clone();
-    let custom_path = state.setup.webvh_server.custom_path.clone();
+    let path_mode = state.setup.webvh_server.path_mode.clone();
 
     state
         .setup
@@ -171,7 +172,7 @@ pub(crate) async fn handle_custom_mediator_webvh(
         .push(MessageType::Info(format!("Server: {}", server_id)));
     let _ = state_tx.send(state.clone());
 
-    apply_server_create_result(state, &client, tdk, &context_id, &server_id, custom_path).await;
+    apply_server_create_result(state, &client, tdk, &context_id, &server_id, path_mode).await;
     Ok(false)
 }
 
@@ -182,11 +183,11 @@ async fn apply_server_create_result(
     tdk: &TDK,
     context_id: &str,
     server_id: &str,
-    custom_path: Option<String>,
+    path_mode: WebvhPathMode,
 ) {
     use crate::state_handler::setup_sequence::vta;
 
-    match vta::create_did_via_server(client, tdk, context_id, server_id, custom_path).await {
+    match vta::create_did_via_server(client, tdk, context_id, server_id, path_mode).await {
         Ok((persona_keys, did, document, mnemonic)) => {
             state
                 .setup

--- a/openvtc/src/state_handler/setup_did_actions.rs
+++ b/openvtc/src/state_handler/setup_did_actions.rs
@@ -91,11 +91,10 @@ pub(crate) async fn handle_webvh_server_create_did(
     state: &mut State,
     state_tx: &watch::Sender<State>,
     tdk: &TDK,
+    client: Option<&vta_sdk::client::VtaClient>,
     server_id: String,
     path_mode: WebvhPathMode,
 ) -> anyhow::Result<bool> {
-    use crate::state_handler::setup_sequence::vta;
-
     state.setup.vta.use_webvh_server = true;
     state.setup.active_page = SetupPage::WebvhServerProgress;
     state.setup.webvh_server.messages.clear();
@@ -105,17 +104,15 @@ pub(crate) async fn handle_webvh_server_create_did(
     ));
     let _ = state_tx.send(state.clone());
 
-    let client = match vta::build_vta_client(&state.setup.vta).await {
-        Ok(c) => c,
-        Err(e) => {
-            state
-                .setup
-                .webvh_server
-                .messages
-                .push(MessageType::Error(format!("VTA client unavailable: {e}")));
-            state.setup.webvh_server.completed = Completion::CompletedFail;
-            return Ok(true);
-        }
+    // Reuse the wizard's single admin session (opened at provisioning) instead of
+    // opening a fresh VTA WebSocket here — per-op sockets churn the mediator's
+    // one-socket-per-DID policy and drop in-flight responses.
+    let Some(client) = client else {
+        state.setup.webvh_server.messages.push(MessageType::Error(
+            "VTA admin session unavailable — restart provisioning.".to_string(),
+        ));
+        state.setup.webvh_server.completed = Completion::CompletedFail;
+        return Ok(true);
     };
 
     let context_id = state.setup.vta.context_id.clone().unwrap_or_default();
@@ -127,10 +124,7 @@ pub(crate) async fn handle_webvh_server_create_did(
         .push(MessageType::Info(format!("Server: {}", server_id)));
     let _ = state_tx.send(state.clone());
 
-    apply_server_create_result(state, &client, tdk, &context_id, &server_id, path_mode).await;
-    // Close the persistent DIDComm session so it doesn't linger and duel the
-    // next step's session on the mediator (duplicate-WebSocket loop → timeouts).
-    client.shutdown().await;
+    apply_server_create_result(state, client, tdk, &context_id, &server_id, path_mode).await;
     Ok(false)
 }
 
@@ -140,9 +134,8 @@ pub(crate) async fn handle_custom_mediator_webvh(
     state: &mut State,
     state_tx: &watch::Sender<State>,
     tdk: &TDK,
+    client: Option<&vta_sdk::client::VtaClient>,
 ) -> anyhow::Result<bool> {
-    use crate::state_handler::setup_sequence::vta;
-
     state.setup.active_page = SetupPage::WebvhServerProgress;
     state.setup.webvh_server.messages.clear();
     state.setup.webvh_server.completed = Completion::NotFinished;
@@ -151,17 +144,13 @@ pub(crate) async fn handle_custom_mediator_webvh(
     ));
     let _ = state_tx.send(state.clone());
 
-    let client = match vta::build_vta_client(&state.setup.vta).await {
-        Ok(c) => c,
-        Err(e) => {
-            state
-                .setup
-                .webvh_server
-                .messages
-                .push(MessageType::Error(format!("VTA client unavailable: {e}")));
-            state.setup.webvh_server.completed = Completion::CompletedFail;
-            return Ok(true);
-        }
+    // Reuse the wizard's single admin session (see `handle_webvh_server_create_did`).
+    let Some(client) = client else {
+        state.setup.webvh_server.messages.push(MessageType::Error(
+            "VTA admin session unavailable — restart provisioning.".to_string(),
+        ));
+        state.setup.webvh_server.completed = Completion::CompletedFail;
+        return Ok(true);
     };
 
     let context_id = state.setup.vta.context_id.clone().unwrap_or_default();
@@ -175,10 +164,7 @@ pub(crate) async fn handle_custom_mediator_webvh(
         .push(MessageType::Info(format!("Server: {}", server_id)));
     let _ = state_tx.send(state.clone());
 
-    apply_server_create_result(state, &client, tdk, &context_id, &server_id, path_mode).await;
-    // Close the persistent DIDComm session so it doesn't linger and duel the
-    // next step's session on the mediator (duplicate-WebSocket loop → timeouts).
-    client.shutdown().await;
+    apply_server_create_result(state, client, tdk, &context_id, &server_id, path_mode).await;
     Ok(false)
 }
 

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -325,6 +325,7 @@ impl ConfigExtension for Config {
         let mut account = Account {
             vta_did: state.vta.vta_did.clone(),
             vta_url: state.vta.vta_url.clone(),
+            org_did: LF_ORG_DID.to_string(),
             ..Account::default()
         };
         account.personas.insert(persona_id, persona_record);
@@ -347,8 +348,6 @@ impl ConfigExtension for Config {
             public: PublicConfig {
                 config_version: openvtc_core::config::public_config::CONFIG_VERSION,
                 protection,
-                persona_did: Arc::new(state.webvh_address.did.clone()),
-                mediator_did: mediator_did.clone(),
                 private: None,
                 logs: Logs {
                     messages: VecDeque::from([LogMessage {
@@ -359,7 +358,6 @@ impl ConfigExtension for Config {
                     ..Default::default()
                 },
                 friendly_name: setup_flow.username.username.value().to_string(),
-                lk_did: LF_ORG_DID.to_string(),
             },
             private: ProtectedConfig::default(),
             key_info,

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -369,7 +369,6 @@ impl ConfigExtension for Config {
             token_user_pin: SecretString::new(String::new().into()),
             protection_method: ProtectionMethod::default(),
             unlock_code,
-            vrcs: HashMap::new(),
         };
 
         config.save(

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -400,6 +400,8 @@ impl ConfigExtension for Config {
         let persona_record = PersonaRecord {
             persona_id,
             did: persona_did_str.clone(),
+            // Cache the minted document so the next startup skips the resolve.
+            did_document: Some(document.clone()),
             key_refs: key_info
                 .iter()
                 .map(|(id, info)| KeyRef {

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -52,7 +52,12 @@ pub trait ConfigExtension {
     ) -> Result<()>;
 
     /// Creates a new Config instance based on the setup state
-    /// Saves this to disk and returns the created Config
+    /// Saves this to disk and returns the created Config.
+    ///
+    /// R-A-5: the monolithic account+persona path. Superseded by
+    /// `create_account` (State A) + `mint_persona_into` (State B); kept until the
+    /// Stage-5 cleanup removes it.
+    #[allow(dead_code)]
     async fn create(
         state: &SetupState,
         setup_flow: &SetupFlow,
@@ -67,7 +72,8 @@ pub trait ConfigExtension {
 
     /// State B: mint a persona (`did:webvh` + keys + mediator + runtime identity)
     /// into an existing account `config`, persist, and return its id. Used by the
-    /// join flow once a community has been chosen.
+    /// join flow (Stage 4) once a community has been chosen.
+    #[allow(dead_code)]
     async fn mint_persona_into(
         config: &mut Config,
         state: &SetupState,

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -369,7 +369,6 @@ impl ConfigExtension for Config {
             token_user_pin: SecretString::new(String::new().into()),
             protection_method: ProtectionMethod::default(),
             unlock_code,
-            atm_profiles: HashMap::new(),
             vrcs: HashMap::new(),
         };
 

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -8,7 +8,7 @@ use ed25519_dalek_bip32::ExtendedSigningKey;
 use openvtc_core::{
     LF_ORG_DID, LF_PUBLIC_MEDIATOR_DID,
     config::{
-        Config, ConfigProtectionType, ExportedConfig, KeyBackend, KeyTypes, PersonaDID,
+        Config, ConfigProtectionType, ExportedConfig, KeyBackend, KeyTypes,
         account::{Account, KeyRef, PersonaId, PersonaRecord},
         derive_passphrase_key,
         protected_config::ProtectedConfig,
@@ -334,8 +334,8 @@ impl ConfigExtension for Config {
             IdentityContext {
                 persona_id,
                 did: persona_did_str.clone(),
-                document: document.clone(),
-                profile: persona_profile.clone(),
+                document,
+                profile: persona_profile,
                 mediator_did: Some(mediator_did.clone()),
             },
         );
@@ -362,10 +362,6 @@ impl ConfigExtension for Config {
                 lk_did: LF_ORG_DID.to_string(),
             },
             private: ProtectedConfig::default(),
-            persona_did: PersonaDID {
-                document,
-                profile: persona_profile,
-            },
             key_info,
             #[cfg(feature = "openpgp-card")]
             token_admin_pin: None,

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -291,6 +291,9 @@ impl ConfigExtension for Config {
             // T1 (transitional): the wizard still emits the singleton shape; the
             // v2 account is populated natively when State A/B land. Default for now.
             account: openvtc_core::config::account::Account::default(),
+            // Runtime identities are rebuilt on the next load; empty immediately
+            // post-setup while the TUI still reads the singleton persona_did.
+            identities: std::collections::HashMap::new(),
             key_backend,
             public: PublicConfig {
                 config_version: openvtc_core::config::public_config::CONFIG_VERSION,

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -59,6 +59,22 @@ pub trait ConfigExtension {
         tdk: &TDK,
         profile: &str,
     ) -> Result<Config>;
+
+    /// State A (R-A-5): build and persist an **account-only** Config from the VTA
+    /// bootstrap state — no persona, no community, no `did:webvh`, no mediator.
+    /// The runtime loads this to a "no active community" state until a join.
+    async fn create_account(state: &SetupState, profile: &str) -> Result<Config>;
+
+    /// State B: mint a persona (`did:webvh` + keys + mediator + runtime identity)
+    /// into an existing account `config`, persist, and return its id. Used by the
+    /// join flow once a community has been chosen.
+    async fn mint_persona_into(
+        config: &mut Config,
+        state: &SetupState,
+        setup_flow: &SetupFlow,
+        tdk: &TDK,
+        profile: &str,
+    ) -> Result<PersonaId>;
 }
 
 impl ConfigExtension for Config {
@@ -210,8 +226,14 @@ impl ConfigExtension for Config {
         tdk: &TDK,
         profile: &str,
     ) -> Result<Config> {
-        // Initial Configuration state
+        // Account bootstrap (State A) then persona mint (State B) — the legacy
+        // single-flow setup is exactly these two steps back to back.
+        let mut config = Self::create_account(state, profile).await?;
+        Self::mint_persona_into(&mut config, state, setup_flow, tdk, profile).await?;
+        Ok(config)
+    }
 
+    async fn create_account(state: &SetupState, profile: &str) -> Result<Config> {
         let mut unlock_code = None;
         let protection = match &state.protection {
             ConfigProtection::PlainText => ConfigProtectionType::Plaintext,
@@ -222,43 +244,6 @@ impl ConfigExtension for Config {
                 ConfigProtectionType::Encrypted
             }
         };
-
-        let mediator_did = if let Some(mediator) = &state.custom_mediator {
-            mediator.to_string()
-        } else {
-            LF_PUBLIC_MEDIATOR_DID.to_string()
-        };
-
-        // Build key info from persona keys
-        let mut key_info = HashMap::new();
-        let persona_keys = state
-            .did_keys
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("Persona DID keys not set during setup"))?;
-        key_info.insert(
-            persona_keys.signing.secret.id.clone(),
-            KeyInfoConfig {
-                path: persona_keys.signing.source.clone(),
-                create_time: persona_keys.signing.created,
-                purpose: KeyTypes::PersonaSigning,
-            },
-        );
-        key_info.insert(
-            persona_keys.authentication.secret.id.clone(),
-            KeyInfoConfig {
-                path: persona_keys.authentication.source.clone(),
-                create_time: persona_keys.authentication.created,
-                purpose: KeyTypes::PersonaAuthentication,
-            },
-        );
-        key_info.insert(
-            persona_keys.decryption.secret.id.clone(),
-            KeyInfoConfig {
-                path: persona_keys.decryption.source.clone(),
-                create_time: persona_keys.decryption.created,
-                purpose: KeyTypes::PersonaEncryption,
-            },
-        );
 
         // Build VTA key backend from the admin credential issued during
         // online provisioning. The on-disk `credential_bundle` is the JSON
@@ -289,9 +274,102 @@ impl ConfigExtension for Config {
             encryption_seed,
         };
 
-        // T1: build the v2 account + runtime identity for this single persona,
-        // mirroring `load_step2` so `active_identity()` is consistent whether the
-        // Config came from setup or from a load.
+        // The account owns the VTA relationship + top-level context. No persona,
+        // no community, no runtime identity yet (R-A-5).
+        let account = Account {
+            vta_did: state.vta.vta_did.clone(),
+            vta_url: state.vta.vta_url.clone(),
+            top_context_id: state.vta.context_id.clone().unwrap_or_default(),
+            org_did: LF_ORG_DID.to_string(),
+            ..Account::default()
+        };
+
+        let config = Config {
+            account,
+            identities: HashMap::new(),
+            key_backend,
+            public: PublicConfig {
+                config_version: openvtc_core::config::public_config::CONFIG_VERSION,
+                protection,
+                private: None,
+                logs: Logs {
+                    messages: VecDeque::from([LogMessage {
+                        created: Utc::now(),
+                        type_: LogFamily::Config,
+                        message: "Account bootstrap completed".to_string(),
+                    }]),
+                    ..Default::default()
+                },
+                friendly_name: String::new(),
+            },
+            private: ProtectedConfig::default(),
+            key_info: HashMap::new(),
+            #[cfg(feature = "openpgp-card")]
+            token_admin_pin: None,
+            #[cfg(feature = "openpgp-card")]
+            token_user_pin: SecretString::new(String::new().into()),
+            protection_method: ProtectionMethod::default(),
+            unlock_code,
+        };
+
+        config.save(
+            profile,
+            #[cfg(feature = "openpgp-card")]
+            &|| {
+                eprintln!("Touch confirmation needed for decryption");
+            },
+        )?;
+
+        Ok(config)
+    }
+
+    async fn mint_persona_into(
+        config: &mut Config,
+        state: &SetupState,
+        setup_flow: &SetupFlow,
+        tdk: &TDK,
+        profile: &str,
+    ) -> Result<PersonaId> {
+        let mediator_did = if let Some(mediator) = &state.custom_mediator {
+            mediator.to_string()
+        } else {
+            LF_PUBLIC_MEDIATOR_DID.to_string()
+        };
+
+        // Build key info from the persona keys created during this mint.
+        let mut key_info = HashMap::new();
+        let persona_keys = state
+            .did_keys
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Persona DID keys not set during setup"))?;
+        key_info.insert(
+            persona_keys.signing.secret.id.clone(),
+            KeyInfoConfig {
+                path: persona_keys.signing.source.clone(),
+                create_time: persona_keys.signing.created,
+                purpose: KeyTypes::PersonaSigning,
+            },
+        );
+        key_info.insert(
+            persona_keys.authentication.secret.id.clone(),
+            KeyInfoConfig {
+                path: persona_keys.authentication.source.clone(),
+                create_time: persona_keys.authentication.created,
+                purpose: KeyTypes::PersonaAuthentication,
+            },
+        );
+        key_info.insert(
+            persona_keys.decryption.secret.id.clone(),
+            KeyInfoConfig {
+                path: persona_keys.decryption.source.clone(),
+                create_time: persona_keys.decryption.created,
+                purpose: KeyTypes::PersonaEncryption,
+            },
+        );
+
+        // Build the runtime identity, mirroring `load_step2` so
+        // `active_identity()` is consistent whether the Config came from setup
+        // or from a load.
         let persona_did_str = state.webvh_address.did.to_string();
         let document = state.webvh_address.document.clone();
         let persona_profile = Arc::new(
@@ -322,52 +400,20 @@ impl ConfigExtension for Config {
             created_at: Utc::now(),
             label: Some(setup_flow.username.username.value().to_string()),
         };
-        let mut account = Account {
-            vta_did: state.vta.vta_did.clone(),
-            vta_url: state.vta.vta_url.clone(),
-            org_did: LF_ORG_DID.to_string(),
-            ..Account::default()
-        };
-        account.personas.insert(persona_id, persona_record);
-        let mut identities = HashMap::new();
-        identities.insert(
+
+        config.account.personas.insert(persona_id, persona_record);
+        config.identities.insert(
             persona_id,
             IdentityContext {
                 persona_id,
-                did: persona_did_str.clone(),
+                did: persona_did_str,
                 document,
                 profile: persona_profile,
-                mediator_did: Some(mediator_did.clone()),
+                mediator_did: Some(mediator_did),
             },
         );
-
-        let config = Config {
-            account,
-            identities,
-            key_backend,
-            public: PublicConfig {
-                config_version: openvtc_core::config::public_config::CONFIG_VERSION,
-                protection,
-                private: None,
-                logs: Logs {
-                    messages: VecDeque::from([LogMessage {
-                        created: Utc::now(),
-                        type_: LogFamily::Config,
-                        message: "Initial openvtc setup completed".to_string(),
-                    }]),
-                    ..Default::default()
-                },
-                friendly_name: setup_flow.username.username.value().to_string(),
-            },
-            private: ProtectedConfig::default(),
-            key_info,
-            #[cfg(feature = "openpgp-card")]
-            token_admin_pin: None,
-            #[cfg(feature = "openpgp-card")]
-            token_user_pin: SecretString::new(String::new().into()),
-            protection_method: ProtectionMethod::default(),
-            unlock_code,
-        };
+        config.key_info.extend(key_info);
+        config.public.friendly_name = setup_flow.username.username.value().to_string();
 
         config.save(
             profile,
@@ -377,6 +423,6 @@ impl ConfigExtension for Config {
             },
         )?;
 
-        Ok(config)
+        Ok(persona_id)
     }
 }

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -73,11 +73,15 @@ pub trait ConfigExtension {
     /// State B: mint a persona (`did:webvh` + keys + mediator + runtime identity)
     /// into an existing account `config`, persist, and return its id. Used by the
     /// join flow (Stage 4) once a community has been chosen.
-    #[allow(dead_code)]
+    ///
+    /// The persona label/username is read from `state.username` (set by the
+    /// caller — the setup wizard via `Action::SetUsername`, or the join flow from
+    /// the community display name). This replaces the previous
+    /// `setup_flow.username.username` read so the join flow needn't construct a
+    /// full `SetupFlow` UI component just to carry one string.
     async fn mint_persona_into(
         config: &mut Config,
         state: &SetupState,
-        setup_flow: &SetupFlow,
         tdk: &TDK,
         profile: &str,
     ) -> Result<PersonaId>;
@@ -233,9 +237,13 @@ impl ConfigExtension for Config {
         profile: &str,
     ) -> Result<Config> {
         // Account bootstrap (State A) then persona mint (State B) — the legacy
-        // single-flow setup is exactly these two steps back to back.
-        let mut config = Self::create_account(state, profile).await?;
-        Self::mint_persona_into(&mut config, state, setup_flow, tdk, profile).await?;
+        // single-flow setup is exactly these two steps back to back. The username
+        // travels via `state.username`; mirror the legacy `setup_flow` source
+        // into it so behaviour is unchanged.
+        let mut state = state.clone();
+        state.username = setup_flow.username.username.value().to_string();
+        let mut config = Self::create_account(&state, profile).await?;
+        Self::mint_persona_into(&mut config, &state, tdk, profile).await?;
         Ok(config)
     }
 
@@ -332,7 +340,6 @@ impl ConfigExtension for Config {
     async fn mint_persona_into(
         config: &mut Config,
         state: &SetupState,
-        setup_flow: &SetupFlow,
         tdk: &TDK,
         profile: &str,
     ) -> Result<PersonaId> {
@@ -404,7 +411,7 @@ impl ConfigExtension for Config {
             mediator_did: Some(mediator_did.clone()),
             origin_context_id: String::new(),
             created_at: Utc::now(),
-            label: Some(setup_flow.username.username.value().to_string()),
+            label: Some(state.username.clone()),
         };
 
         config.account.personas.insert(persona_id, persona_record);
@@ -419,7 +426,7 @@ impl ConfigExtension for Config {
             },
         );
         config.key_info.extend(key_info);
-        config.public.friendly_name = setup_flow.username.username.value().to_string();
+        config.public.friendly_name = state.username.clone();
 
         config.save(
             profile,

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -288,6 +288,9 @@ impl ConfigExtension for Config {
         };
 
         let config = Config {
+            // T1 (transitional): the wizard still emits the singleton shape; the
+            // v2 account is populated natively when State A/B land. Default for now.
+            account: openvtc_core::config::account::Account::default(),
             key_backend,
             public: PublicConfig {
                 config_version: openvtc_core::config::public_config::CONFIG_VERSION,

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -9,11 +9,13 @@ use openvtc_core::{
     LF_ORG_DID, LF_PUBLIC_MEDIATOR_DID,
     config::{
         Config, ConfigProtectionType, ExportedConfig, KeyBackend, KeyTypes, PersonaDID,
+        account::{Account, KeyRef, PersonaId, PersonaRecord},
         derive_passphrase_key,
         protected_config::ProtectedConfig,
         public_config::PublicConfig,
         secured_config::{KeyInfoConfig, ProtectionMethod, unlock_code_decrypt},
     },
+    identity::IdentityContext,
     logs::{LogFamily, LogMessage, Logs},
 };
 use secrecy::{ExposeSecret, SecretBox, SecretString};
@@ -287,13 +289,60 @@ impl ConfigExtension for Config {
             encryption_seed,
         };
 
+        // T1: build the v2 account + runtime identity for this single persona,
+        // mirroring `load_step2` so `active_identity()` is consistent whether the
+        // Config came from setup or from a load.
+        let persona_did_str = state.webvh_address.did.to_string();
+        let document = state.webvh_address.document.clone();
+        let persona_profile = Arc::new(
+            ATMProfile::new(
+                tdk.atm
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("TDK ATM not initialized"))?,
+                Some("Persona DID".to_string()),
+                persona_did_str.clone(),
+                Some(mediator_did.clone()),
+            )
+            .await?,
+        );
+        let persona_id = PersonaId::new();
+        let persona_record = PersonaRecord {
+            persona_id,
+            did: persona_did_str.clone(),
+            key_refs: key_info
+                .iter()
+                .map(|(id, info)| KeyRef {
+                    key_id: id.clone(),
+                    purpose: info.purpose.clone(),
+                    created_at: info.create_time,
+                })
+                .collect(),
+            mediator_did: Some(mediator_did.clone()),
+            origin_context_id: String::new(),
+            created_at: Utc::now(),
+            label: Some(setup_flow.username.username.value().to_string()),
+        };
+        let mut account = Account {
+            vta_did: state.vta.vta_did.clone(),
+            vta_url: state.vta.vta_url.clone(),
+            ..Account::default()
+        };
+        account.personas.insert(persona_id, persona_record);
+        let mut identities = HashMap::new();
+        identities.insert(
+            persona_id,
+            IdentityContext {
+                persona_id,
+                did: persona_did_str.clone(),
+                document: document.clone(),
+                profile: persona_profile.clone(),
+                mediator_did: Some(mediator_did.clone()),
+            },
+        );
+
         let config = Config {
-            // T1 (transitional): the wizard still emits the singleton shape; the
-            // v2 account is populated natively when State A/B land. Default for now.
-            account: openvtc_core::config::account::Account::default(),
-            // Runtime identities are rebuilt on the next load; empty immediately
-            // post-setup while the TUI still reads the singleton persona_did.
-            identities: std::collections::HashMap::new(),
+            account,
+            identities,
             key_backend,
             public: PublicConfig {
                 config_version: openvtc_core::config::public_config::CONFIG_VERSION,
@@ -314,18 +363,8 @@ impl ConfigExtension for Config {
             },
             private: ProtectedConfig::default(),
             persona_did: PersonaDID {
-                document: state.webvh_address.document.clone(),
-                profile: Arc::new(
-                    ATMProfile::new(
-                        tdk.atm
-                            .as_ref()
-                            .ok_or_else(|| anyhow::anyhow!("TDK ATM not initialized"))?,
-                        Some("Persona DID".to_string()),
-                        state.webvh_address.did.to_string(),
-                        Some(mediator_did.clone()),
-                    )
-                    .await?,
-                ),
+                document,
+                profile: persona_profile,
             },
             key_info,
             #[cfg(feature = "openpgp-card")]

--- a/openvtc/src/state_handler/setup_sequence/mod.rs
+++ b/openvtc/src/state_handler/setup_sequence/mod.rs
@@ -340,7 +340,9 @@ pub struct WebvhServerState {
     pub completed: Completion,
     pub messages: Vec<MessageType>,
     pub selected_server_id: String,
-    pub custom_path: Option<String>,
+    /// Chosen WebVH path mode: `.well-known` root, an explicit label, or
+    /// server auto-assignment.
+    pub path_mode: vta_sdk::protocols::did_management::create::WebvhPathMode,
     pub did: String,
     pub document: Document,
     pub mnemonic: String,

--- a/openvtc/src/state_handler/setup_sequence/mod.rs
+++ b/openvtc/src/state_handler/setup_sequence/mod.rs
@@ -58,8 +58,13 @@ pub enum SetupPage {
     UnlockCodeAsk,
     UnlockCodeSet,
     UnlockCodeWarn,
+    // R-A-5: persona-minting pages. Unreachable from State-A setup (which ends at
+    // protection → account creation); reconstructed by the State-B join flow
+    // (Stage 4). `#[allow(dead_code)]` until then.
+    #[allow(dead_code)]
     MediatorAsk,
     MediatorCustom,
+    #[allow(dead_code)]
     WebvhServerSelect,
     WebvhServerProgress,
     UserName,

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -256,19 +256,13 @@ pub async fn create_did_via_server(
     tdk: &TDK,
     context_id: &str,
     server_id: &str,
-    path: Option<String>,
+    path_mode: WebvhPathMode,
 ) -> Result<(PersonaDIDKeys, String, Document, String)> {
     let created = Utc::now();
 
-    // Map the optional explicit path to the SDK's `path_mode`. A blank path
-    // means the `.well-known` root DID; a provided path is an explicit label.
-    // (Server auto-assignment is `WebvhPathMode::AutoAssign`, selected upstream.)
-    // The legacy `path` field is rejected for the empty case by the server, so
-    // `path_mode` is the authoritative selector and `path` is left `None`.
-    let path_mode = match path {
-        Some(p) => WebvhPathMode::Explicit(p),
-        None => WebvhPathMode::WellKnown,
-    };
+    // `path_mode` is the authoritative path selector (WellKnown / Explicit /
+    // AutoAssign). The legacy `path` field is left `None` — the server rejects a
+    // present-but-empty path with `e.p.did.path-invalid`.
 
     // Use the VTA's built-in mediator service rather than additional_services,
     // because the VTA formats the service ID as a full DID URL (e.g. "did:...#vta-didcomm")

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -311,3 +311,49 @@ pub async fn create_did_via_server(
 
     Ok((persona_keys, did, resolved.doc, mnemonic))
 }
+
+// ── State-B join seams (R-A-5 Stage 4) ──────────────────────────────────────
+//
+// Stubbed async seams: they carry the final signatures (so the real VTA/VTC
+// calls are a body swap with no call-site churn) but do not hit the network yet.
+
+/// Receipt from submitting a community join request.
+// `dead_code` until the join flow (next Stage-4 slice) calls these seams.
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub struct JoinReceipt {
+    /// Correlates the VTC's asynchronous accept/reject decision (R-B-8).
+    pub request_id: uuid::Uuid,
+}
+
+/// Create the per-community sub-context under the account's top context (D9).
+///
+/// The id is already derived client-side via
+/// [`context_path::build_sub_context_id`](openvtc_core::config::context_path::build_sub_context_id);
+/// this seam is where the VTA registration call will go. STUB: echoes the id
+/// back. `parent_id` is the account's `top_context_id`.
+#[allow(dead_code, clippy::unused_async)]
+pub async fn create_sub_context(
+    client: &VtaClient,
+    parent_id: &str,
+    sub_context_id: &str,
+) -> Result<String> {
+    let _ = (client, parent_id);
+    Ok(sub_context_id.to_string())
+}
+
+/// Submit a join request to a community (VTC), presenting the chosen persona.
+///
+/// STUB: synthesizes a local `request_id`. The real VTA/VTC submission (with the
+/// holder's verifiable presentation) is a later body swap.
+#[allow(dead_code, clippy::unused_async)]
+pub async fn submit_join(
+    client: &VtaClient,
+    vtc_did: &str,
+    sub_context_id: &str,
+) -> Result<JoinReceipt> {
+    let _ = (client, vtc_did, sub_context_id);
+    Ok(JoinReceipt {
+        request_id: uuid::Uuid::new_v4(),
+    })
+}

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -9,6 +9,7 @@ use openvtc_core::config::{KeyInfo, PersonaDIDKeys, secured_config::KeySourceMat
 use vta_sdk::{
     client::{CreateDidWebvhRequest, CreateKeyRequest, VtaClient},
     keys::KeyType,
+    protocols::did_management::create::WebvhPathMode,
     provision_client::Protocol,
     session::{TokenResult, challenge_response},
     webvh::WebvhServerRecord,
@@ -259,6 +260,16 @@ pub async fn create_did_via_server(
 ) -> Result<(PersonaDIDKeys, String, Document, String)> {
     let created = Utc::now();
 
+    // Map the optional explicit path to the SDK's `path_mode`. A blank path
+    // means the `.well-known` root DID; a provided path is an explicit label.
+    // (Server auto-assignment is `WebvhPathMode::AutoAssign`, selected upstream.)
+    // The legacy `path` field is rejected for the empty case by the server, so
+    // `path_mode` is the authoritative selector and `path` is left `None`.
+    let path_mode = match path {
+        Some(p) => WebvhPathMode::Explicit(p),
+        None => WebvhPathMode::WellKnown,
+    };
+
     // Use the VTA's built-in mediator service rather than additional_services,
     // because the VTA formats the service ID as a full DID URL (e.g. "did:...#vta-didcomm")
     // which the TDK resolver requires. A relative fragment like "#public-didcomm" is rejected.
@@ -266,7 +277,8 @@ pub async fn create_did_via_server(
         context_id: context_id.to_string(),
         server_id: Some(server_id.to_string()),
         url: None,
-        path,
+        path: None,
+        path_mode: Some(path_mode),
         // No explicit hosting-domain override: the server determines the
         // domain from the selected `server_id`.
         domain: None,

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -318,8 +318,6 @@ pub async fn create_did_via_server(
 // calls are a body swap with no call-site churn) but do not hit the network yet.
 
 /// Receipt from submitting a community join request.
-// `dead_code` until the join flow (next Stage-4 slice) calls these seams.
-#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct JoinReceipt {
     /// Correlates the VTC's asynchronous accept/reject decision (R-B-8).
@@ -332,7 +330,7 @@ pub struct JoinReceipt {
 /// [`context_path::build_sub_context_id`](openvtc_core::config::context_path::build_sub_context_id);
 /// this seam is where the VTA registration call will go. STUB: echoes the id
 /// back. `parent_id` is the account's `top_context_id`.
-#[allow(dead_code, clippy::unused_async)]
+#[allow(clippy::unused_async)]
 pub async fn create_sub_context(
     client: &VtaClient,
     parent_id: &str,
@@ -346,7 +344,7 @@ pub async fn create_sub_context(
 ///
 /// STUB: synthesizes a local `request_id`. The real VTA/VTC submission (with the
 /// holder's verifiable presentation) is a later body swap.
-#[allow(dead_code, clippy::unused_async)]
+#[allow(clippy::unused_async)]
 pub async fn submit_join(
     client: &VtaClient,
     vtc_did: &str,

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -10,12 +10,9 @@ use vta_sdk::{
     client::{CreateDidWebvhRequest, CreateKeyRequest, VtaClient},
     keys::KeyType,
     protocols::did_management::create::WebvhPathMode,
-    provision_client::Protocol,
     session::{TokenResult, challenge_response},
     webvh::WebvhServerRecord,
 };
-
-use crate::state_handler::setup_sequence::VtaSetupState;
 
 /// Authenticate with VTA using REST challenge-response. Only valid for the
 /// REST transport — DIDComm-only VTAs authenticate implicitly when the
@@ -29,55 +26,6 @@ pub async fn authenticate(
     challenge_response(vta_url, credential_did, private_key_multibase, vta_did)
         .await
         .map_err(|e| anyhow::anyhow!("VTA authentication failed: {e}"))
-}
-
-/// Build a [`VtaClient`] using whichever transport bootstrap selected.
-///
-/// REST path: requires `vta_url` + `access_token` already populated.
-/// DIDComm path: opens a fresh DIDComm session as the rotated admin DID
-/// against the advertised mediator. The session itself is the auth, so
-/// no separate token is needed.
-pub async fn build_vta_client(setup: &VtaSetupState) -> Result<VtaClient> {
-    match setup.protocol {
-        Some(Protocol::DidComm) => {
-            let mediator = setup
-                .mediator_did
-                .as_deref()
-                .ok_or_else(|| anyhow::anyhow!("DIDComm transport: mediator_did not captured"))?;
-            let admin = setup
-                .admin_credential
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("DIDComm transport: admin_credential missing"))?;
-            let rest_fallback = if setup.vta_url.is_empty() {
-                None
-            } else {
-                Some(setup.vta_url.clone())
-            };
-            VtaClient::connect_didcomm(
-                &admin.admin_did,
-                &admin.admin_private_key_mb,
-                &setup.vta_did,
-                mediator,
-                rest_fallback,
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("DIDComm session open failed: {e}"))
-        }
-        // REST (or unset — falls through to REST for compatibility with
-        // any pre-protocol-tracked state).
-        _ => {
-            let token = setup
-                .access_token
-                .clone()
-                .ok_or_else(|| anyhow::anyhow!("REST transport: access_token missing"))?;
-            if setup.vta_url.is_empty() {
-                return Err(anyhow::anyhow!("REST transport: vta_url is empty"));
-            }
-            let client = VtaClient::new(&setup.vta_url);
-            client.set_token(token);
-            Ok(client)
-        }
-    }
 }
 
 /// Create persona keys via VTA service

--- a/openvtc/src/state_handler/setup_vta_actions.rs
+++ b/openvtc/src/state_handler/setup_vta_actions.rs
@@ -435,5 +435,10 @@ pub(crate) async fn handle_vta_create_keys(
             state.setup.vta.completed = Completion::CompletedFail;
         }
     }
+    // Close the DIDComm session — `connect_didcomm` opens a persistent,
+    // auto-reconnecting WebSocket that `Drop` cannot close (shutdown is async).
+    // A leaked admin-DID session duels the next step's session on the mediator
+    // (duplicate-WebSocket loop → DIDComm timeouts).
+    client.shutdown().await;
     Ok(false)
 }

--- a/openvtc/src/state_handler/setup_vta_actions.rs
+++ b/openvtc/src/state_handler/setup_vta_actions.rs
@@ -357,6 +357,11 @@ pub(crate) async fn handle_vta_start_provision(
         }
     }
 
+    // Close the post-bootstrap admin DIDComm session. `connect_didcomm` opens a
+    // session whose only graceful close is the async `shutdown()` — `Drop` can't
+    // do it, and vta-sdk 0.9.8's LeakGuard panics (debug) on a leaked drop.
+    client.shutdown().await;
+
     state.setup.vta.completed = Completion::CompletedOK;
     // Stay on VtaProvisioning so the operator can see the admin DID rotation
     // result (ephemeral setup DID → long-term admin DID) before advancing on

--- a/openvtc/src/state_handler/setup_vta_actions.rs
+++ b/openvtc/src/state_handler/setup_vta_actions.rs
@@ -4,6 +4,7 @@ use crate::state_handler::{
 };
 use std::sync::Arc;
 use tokio::sync::{mpsc, watch};
+use vta_sdk::client::VtaClient;
 use vta_sdk::provision_client::{
     DiagStatus, EphemeralSetupKey, Protocol, ProvisionAsk, VtaEvent, VtaIntent, VtaReply,
     apply_update, pending_list, run_connection_test,
@@ -111,13 +112,20 @@ pub(crate) async fn handle_vta_submit_did(
 /// success store the issued admin VC + access token. The provisioning page
 /// itself emits `VtaAuthCompleted` once the operator confirms, which routes
 /// into the keys-fetch / webvh-server pick flow.
+///
+/// On success it returns the live admin [`VtaClient`] (DIDComm session opened as
+/// the rotated admin DID, or a REST client). The caller (the setup wizard) holds
+/// this **single** session and reuses it for the key/DID-creation steps, then
+/// shuts it down once when setup ends — so the admin DID keeps **one** mediator
+/// connection for the whole flow instead of opening a fresh WebSocket per VTA
+/// call (which churns the mediator's one-socket-per-DID policy and drops
+/// in-flight responses). Returns `Ok(None)` if provisioning did not complete.
 pub(crate) async fn handle_vta_start_provision(
     state: &mut State,
     state_tx: &watch::Sender<State>,
     context_id: String,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<VtaClient>> {
     use crate::state_handler::setup_sequence::vta;
-    use vta_sdk::client::VtaClient;
 
     let setup_key = match state.setup.vta.setup_key.clone() {
         Some(k) => k,
@@ -126,7 +134,7 @@ pub(crate) async fn handle_vta_start_provision(
                 "Setup DID not generated yet — restart the setup wizard.".to_string(),
             ));
             state.setup.vta.completed = Completion::CompletedFail;
-            return Ok(());
+            return Ok(None);
         }
     };
     let vta_did = state.setup.vta.vta_did.clone();
@@ -221,7 +229,7 @@ pub(crate) async fn handle_vta_start_provision(
             state.setup.vta.completed = Completion::CompletedFail;
             let _ = state_tx.send(state.clone());
         }
-        return Ok(());
+        return Ok(None);
     };
 
     // Adopt the admin credential as the authenticated identity for the rest
@@ -254,7 +262,7 @@ pub(crate) async fn handle_vta_start_provision(
                     ));
                     state.setup.vta.completed = Completion::CompletedFail;
                     let _ = state_tx.send(state.clone());
-                    return Ok(());
+                    return Ok(None);
                 }
             };
             state.setup.vta.messages.push(MessageType::Info(
@@ -290,7 +298,7 @@ pub(crate) async fn handle_vta_start_provision(
                     )));
                     state.setup.vta.completed = Completion::CompletedFail;
                     let _ = state_tx.send(state.clone());
-                    return Ok(());
+                    return Ok(None);
                 }
             }
         }
@@ -330,7 +338,7 @@ pub(crate) async fn handle_vta_start_provision(
                         .push(MessageType::Error(format!("Authentication failed: {e}")));
                     state.setup.vta.completed = Completion::CompletedFail;
                     let _ = state_tx.send(state.clone());
-                    return Ok(());
+                    return Ok(None);
                 }
             }
         }
@@ -357,18 +365,16 @@ pub(crate) async fn handle_vta_start_provision(
         }
     }
 
-    // Close the post-bootstrap admin DIDComm session. `connect_didcomm` opens a
-    // session whose only graceful close is the async `shutdown()` — `Drop` can't
-    // do it, and vta-sdk 0.9.8's LeakGuard panics (debug) on a leaked drop.
-    client.shutdown().await;
-
     state.setup.vta.completed = Completion::CompletedOK;
     // Stay on VtaProvisioning so the operator can see the admin DID rotation
     // result (ephemeral setup DID → long-term admin DID) before advancing on
     // Enter.
     let _ = state_tx.send(state.clone());
 
-    Ok(())
+    // Hand the live admin session back to the wizard. It is kept open and reused
+    // for the key/DID-creation steps (one mediator connection for the whole
+    // flow), then shut down once when setup ends.
+    Ok(Some(client))
 }
 
 /// Handle the `VtaCreateKeys` action: create persona keys and WebVH update keys via VTA.
@@ -376,6 +382,7 @@ pub(crate) async fn handle_vta_start_provision(
 pub(crate) async fn handle_vta_create_keys(
     state: &mut State,
     state_tx: &watch::Sender<State>,
+    client: Option<&VtaClient>,
 ) -> anyhow::Result<bool> {
     use crate::state_handler::setup_sequence::vta;
 
@@ -387,22 +394,19 @@ pub(crate) async fn handle_vta_create_keys(
     ));
     let _ = state_tx.send(state.clone());
 
-    let client = match vta::build_vta_client(&state.setup.vta).await {
-        Ok(c) => c,
-        Err(e) => {
-            state
-                .setup
-                .vta
-                .messages
-                .push(MessageType::Error(format!("VTA client unavailable: {e}")));
-            state.setup.vta.completed = Completion::CompletedFail;
-            return Ok(true);
-        }
+    // Reuse the single admin session the wizard opened at provisioning — no fresh
+    // VTA WebSocket per step (which churns the mediator and drops responses).
+    let Some(client) = client else {
+        state.setup.vta.messages.push(MessageType::Error(
+            "VTA admin session unavailable — restart provisioning.".to_string(),
+        ));
+        state.setup.vta.completed = Completion::CompletedFail;
+        return Ok(true);
     };
 
     // Create persona keys (signing, authentication, encryption)
     let context_id = state.setup.vta.context_id.as_deref();
-    match vta::create_persona_keys(&client, context_id).await {
+    match vta::create_persona_keys(client, context_id).await {
         Ok(persona_keys) => {
             state.setup.vta.messages.push(MessageType::Info(
                 "Persona keys created successfully.".to_string(),
@@ -415,7 +419,7 @@ pub(crate) async fn handle_vta_create_keys(
             ));
             let _ = state_tx.send(state.clone());
 
-            match vta::create_update_keys(&client, context_id).await {
+            match vta::create_update_keys(client, context_id).await {
                 Ok((update_secret, next_update_secret)) => {
                     state.setup.vta.update_secret = Some(update_secret);
                     state.setup.vta.next_update_secret = Some(next_update_secret);
@@ -440,10 +444,6 @@ pub(crate) async fn handle_vta_create_keys(
             state.setup.vta.completed = Completion::CompletedFail;
         }
     }
-    // Close the DIDComm session — `connect_didcomm` opens a persistent,
-    // auto-reconnecting WebSocket that `Drop` cannot close (shutdown is async).
-    // A leaked admin-DID session duels the next step's session on the mediator
-    // (duplicate-WebSocket loop → DIDComm timeouts).
-    client.shutdown().await;
+    // No shutdown here — the wizard owns the shared admin session.
     Ok(false)
 }

--- a/openvtc/src/state_handler/setup_wizard.rs
+++ b/openvtc/src/state_handler/setup_wizard.rs
@@ -175,25 +175,28 @@ impl StateHandler {
                 Action::ResolveWebVHDID(did) => {
                     setup_did_actions::handle_resolve_webvh_did(state, tdk, did).await;
                 },
-                Action::SetupCompleted(setup_flow) => {
+                Action::SetupCompleted(_setup_flow) => {
                     state.setup.active_page = SetupPage::FinalPage;
                     // The armored private-key block is no longer needed once we
                     // leave the export page; drop it so it stops being cloned
                     // out on every state broadcast.
                     state.setup.did_keys_export.exported = None;
-                    state.setup.final_page.messages.push(MessageType::Info("Generating your profile configuration...".to_string()));
+                    state.setup.final_page.messages.push(MessageType::Info("Creating your account configuration...".to_string()));
                     state.setup.final_page.messages.push(MessageType::Info("Securing sensitive data for storage...".to_string()));
                     state.setup.final_page.messages.push(MessageType::Info("Your device may prompt for authentication to access OS secure storage.".to_string()));
                     let _ = self.state_tx.send(state.clone());
-                    match Config::create(&state.setup, &setup_flow, tdk, &self.profile).await {
+                    // R-A-5: setup now bootstraps a State-A account (VTA admin
+                    // credential + top-level context, no persona/community). A
+                    // persona is minted later by the State-B join flow.
+                    match Config::create_account(&state.setup, &self.profile).await {
                         Ok(cfg) => {
                             state.setup.final_page.completed = Completion::CompletedOK;
-                            state.setup.final_page.messages.push(MessageType::Info("Profile setup completed successfully.".to_string()));
+                            state.setup.final_page.messages.push(MessageType::Info("Account setup completed successfully.".to_string()));
                             config = Some(cfg);
                         },
                         Err(e) => {
                             state.setup.final_page.completed = Completion::CompletedFail;
-                            state.setup.final_page.messages.push(MessageType::Error(format!("Couldn't create OpenVTC configuration. Reason: {e}")));
+                            state.setup.final_page.messages.push(MessageType::Error(format!("Couldn't create OpenVTC account. Reason: {e}")));
                         }
                     }
                 },

--- a/openvtc/src/state_handler/setup_wizard.rs
+++ b/openvtc/src/state_handler/setup_wizard.rs
@@ -29,7 +29,17 @@ impl StateHandler {
 
         // Holder for the created config
         let mut config: Option<Config> = None;
-        let exit = loop {
+        // The single admin VTA session: opened once at provisioning (after the
+        // ephemeral→admin DID swap) and reused by every subsequent VTA step, so
+        // the admin DID holds ONE mediator connection for the whole flow rather
+        // than a fresh WebSocket per call (which churns the mediator's
+        // one-socket-per-DID policy and drops in-flight responses). Shut down
+        // once when the wizard exits (below).
+        let mut admin_client: Option<vta_sdk::client::VtaClient> = None;
+        // Wrapped so the admin session is torn down on EVERY exit — including a
+        // `?` error out of a handler below — and never leaks (the LeakGuard).
+        let exit: Result<SetupWizardExit> = async {
+            Ok(loop {
             let _ = self.state_tx.send(state.clone());
             tokio::select! {
             Some(action) = action_rx.recv() => match action {
@@ -85,10 +95,14 @@ impl StateHandler {
                     setup_vta_actions::handle_vta_submit_did(state, &self.state_tx, vta_did).await?;
                 },
                 Action::VtaStartProvision(context_id) => {
-                    setup_vta_actions::handle_vta_start_provision(state, &self.state_tx, context_id).await?;
+                    // Close any prior admin session before re-provisioning.
+                    if let Some(c) = admin_client.take() {
+                        c.shutdown().await;
+                    }
+                    admin_client = setup_vta_actions::handle_vta_start_provision(state, &self.state_tx, context_id).await?;
                 },
                 Action::VtaCreateKeys
-                    if setup_vta_actions::handle_vta_create_keys(state, &self.state_tx).await? =>
+                    if setup_vta_actions::handle_vta_create_keys(state, &self.state_tx, admin_client.as_ref()).await? =>
                 {
                     continue;
                 },
@@ -126,14 +140,14 @@ impl StateHandler {
                     // Cannot move owned bound vars into a match guard, so the
                     // collapsible_match form clippy suggests doesn't compile.
                     #[allow(clippy::collapsible_match)]
-                    if setup_did_actions::handle_webvh_server_create_did(state, &self.state_tx, tdk, server_id, path_mode).await? {
+                    if setup_did_actions::handle_webvh_server_create_did(state, &self.state_tx, tdk, admin_client.as_ref(), server_id, path_mode).await? {
                         continue;
                     }
                 },
                 Action::SetCustomMediator(mediator_did) => {
                     state.setup.custom_mediator = Some(mediator_did.clone());
                     if state.setup.vta.use_webvh_server {
-                        if setup_did_actions::handle_custom_mediator_webvh(state, &self.state_tx, tdk).await? {
+                        if setup_did_actions::handle_custom_mediator_webvh(state, &self.state_tx, tdk, admin_client.as_ref()).await? {
                             continue;
                         }
                     } else {
@@ -190,8 +204,17 @@ impl StateHandler {
                     break SetupWizardExit::Interrupted(interrupted);
                 }
             }
-        };
+            })
+        }
+        .await;
 
-        Ok(exit)
+        // Tear down the single admin VTA session now that setup is over (no-op
+        // for the REST transport). This is the one place the wizard's session is
+        // closed — every VTA step above reused it without opening its own.
+        if let Some(c) = admin_client {
+            c.shutdown().await;
+        }
+
+        exit
     }
 }

--- a/openvtc/src/state_handler/setup_wizard.rs
+++ b/openvtc/src/state_handler/setup_wizard.rs
@@ -122,11 +122,11 @@ impl StateHandler {
                 Action::SetTokenName(token, name) => {
                     setup_token_actions::handle_set_token_name(state, &self.state_tx, token, &name);
                 },
-                Action::WebvhServerCreateDid(server_id, custom_path) => {
+                Action::WebvhServerCreateDid(server_id, path_mode) => {
                     // Cannot move owned bound vars into a match guard, so the
                     // collapsible_match form clippy suggests doesn't compile.
                     #[allow(clippy::collapsible_match)]
-                    if setup_did_actions::handle_webvh_server_create_did(state, &self.state_tx, tdk, server_id, custom_path).await? {
+                    if setup_did_actions::handle_webvh_server_create_did(state, &self.state_tx, tdk, server_id, path_mode).await? {
                         continue;
                     }
                 },

--- a/openvtc/src/state_handler/state.rs
+++ b/openvtc/src/state_handler/state.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 #[cfg(feature = "openpgp-card")]
 use secrecy::SecretString;
 
-use crate::state_handler::{main_page::MainPageState, setup_sequence::SetupState};
+use crate::state_handler::{join::JoinState, main_page::MainPageState, setup_sequence::SetupState};
 
 /// State holds the state of the application
 #[derive(Default, Debug, Clone)]
@@ -12,6 +12,8 @@ pub struct State {
     pub active_page: ActivePage,
     pub main_page: MainPageState,
     pub setup: SetupState,
+    /// State-B "join a community" flow (R-A-5 Stage 4).
+    pub join: JoinState,
     pub connection: ConnectionState,
 
     /// Hardware Token Admin Pin (Arc-wrapped so clones share one allocation)
@@ -31,6 +33,8 @@ pub enum ActivePage {
     Main,
     /// The setup wizard flow (comprised of multiple sequential screens).
     Setup,
+    /// The State-B "join a community" flow (R-A-5 Stage 4).
+    Join,
 }
 
 /// Tracks the state of the DIDComm mediator connection.

--- a/openvtc/src/state_handler/state.rs
+++ b/openvtc/src/state_handler/state.rs
@@ -55,4 +55,8 @@ pub enum MediatorStatus {
     Connected,
     /// Connection failed with an error description.
     Failed(String),
+    /// The account has no active community/persona yet (State A, R-A-5/R-C-7):
+    /// there is no DID to open a DIDComm session for. The app runs without
+    /// messaging until the user joins a community.
+    NoActiveCommunity,
 }

--- a/openvtc/src/state_handler/state.rs
+++ b/openvtc/src/state_handler/state.rs
@@ -16,6 +16,15 @@ pub struct State {
     pub join: JoinState,
     pub connection: ConnectionState,
 
+    /// Rotating-tip index for the startup loading screen, advanced as startup
+    /// steps stream so the tip changes during the load/connect.
+    pub tip_index: usize,
+
+    /// Timed startup steps shown on the loading screen, in order. Each entry is
+    /// marked done (with its duration) when the next step begins, so the user
+    /// sees exactly which step is slow.
+    pub loading_steps: Vec<LoadingStep>,
+
     /// Hardware Token Admin Pin (Arc-wrapped so clones share one allocation)
     #[cfg(feature = "openpgp-card")]
     pub token_admin_pin: Option<Arc<SecretString>>,
@@ -26,10 +35,25 @@ pub struct State {
     pub token_touch_pending: bool,
 }
 
+/// One timed step of the startup sequence, shown on the loading screen.
+#[derive(Clone, Debug)]
+pub struct LoadingStep {
+    /// What the step is doing (the progress message).
+    pub label: String,
+    /// Wall-clock time the step started, `HH:MM:SS`.
+    pub started: String,
+    /// Duration once the step completed, in milliseconds. `None` while running.
+    pub duration_ms: Option<u64>,
+}
+
 #[derive(Default, Debug, Clone, Copy)]
 pub enum ActivePage {
-    /// The main application page with menu, content panels, and activity log.
+    /// The startup loading screen, shown while config loads and the mediator
+    /// connection is established (default so the first frame isn't a blank,
+    /// not-yet-interactive main page).
     #[default]
+    Loading,
+    /// The main application page with menu, content panels, and activity log.
     Main,
     /// The setup wizard flow (comprised of multiple sequential screens).
     Setup,

--- a/openvtc/src/state_handler/state.rs
+++ b/openvtc/src/state_handler/state.rs
@@ -25,6 +25,12 @@ pub struct State {
     /// sees exactly which step is slow.
     pub loading_steps: Vec<LoadingStep>,
 
+    /// True once phase 1 (config + VTA) has finished successfully. The loading
+    /// screen then offers "Press Enter to continue" while phase-2 community
+    /// connections already run in the background; pressing Enter reveals the
+    /// main page.
+    pub loading_complete: bool,
+
     /// Hardware Token Admin Pin (Arc-wrapped so clones share one allocation)
     #[cfg(feature = "openpgp-card")]
     pub token_admin_pin: Option<Arc<SecretString>>,
@@ -42,8 +48,8 @@ pub struct LoadingStep {
     pub label: String,
     /// Wall-clock time the step started, `HH:MM:SS`.
     pub started: String,
-    /// Duration once the step completed, in milliseconds. `None` while running.
-    pub duration_ms: Option<u64>,
+    /// How long the step took, once completed. `None` while still running.
+    pub duration: Option<std::time::Duration>,
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/openvtc/src/state_handler/state.rs
+++ b/openvtc/src/state_handler/state.rs
@@ -20,10 +20,12 @@ pub struct State {
     /// steps stream so the tip changes during the load/connect.
     pub tip_index: usize,
 
-    /// Timed startup steps shown on the loading screen, in order. Each entry is
-    /// marked done (with its duration) when the next step begins, so the user
-    /// sees exactly which step is slow.
-    pub loading_steps: Vec<LoadingStep>,
+    /// Hierarchical, timed startup tasks shown on the loading screen, in order.
+    /// Each major task carries its own sub-steps; a step is marked Done (with
+    /// its duration) when the next step begins, and a major is stamped with its
+    /// combined wall-clock span when the next major begins, so the user sees
+    /// exactly which task — and which sub-step — is slow.
+    pub loading: Vec<LoadingTask>,
 
     /// True once phase 1 (config + VTA) has finished successfully. The loading
     /// screen then offers "Press Enter to continue" while phase-2 community
@@ -41,15 +43,156 @@ pub struct State {
     pub token_touch_pending: bool,
 }
 
-/// One timed step of the startup sequence, shown on the loading screen.
+/// Lifecycle state of a single loading task or sub-step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum StepStatus {
+    /// Known ahead of time but not started yet.
+    #[default]
+    Queued,
+    /// Currently in progress.
+    Running,
+    /// Finished successfully.
+    Done,
+    /// The startup failed while this step was running.
+    Failed,
+}
+
+/// A major startup task with its own timed sub-steps. The major's `duration` is
+/// the combined wall-clock span (start of first child → end of last), stamped
+/// when the next major begins; each child carries its own time.
+#[derive(Clone, Debug)]
+pub struct LoadingTask {
+    /// The major task name (e.g. "Identity").
+    pub label: String,
+    /// Lifecycle state of the major as a whole.
+    pub status: StepStatus,
+    /// Wall-clock time the major's first sub-step started, `HH:MM:SS`.
+    pub started: Option<String>,
+    /// Combined duration once the major is Done. `None` while running/queued.
+    pub duration: Option<std::time::Duration>,
+    /// Ordered sub-steps under this major.
+    pub children: Vec<LoadingStep>,
+}
+
+/// One timed sub-step of a [`LoadingTask`], shown on the loading screen.
 #[derive(Clone, Debug)]
 pub struct LoadingStep {
     /// What the step is doing (the progress message).
     pub label: String,
-    /// Wall-clock time the step started, `HH:MM:SS`.
-    pub started: String,
-    /// How long the step took, once completed. `None` while still running.
+    /// Lifecycle state of this sub-step.
+    pub status: StepStatus,
+    /// Wall-clock time the step started, `HH:MM:SS`. `None` while queued.
+    pub started: Option<String>,
+    /// How long the step took, once completed. `None` while queued/running.
     pub duration: Option<std::time::Duration>,
+}
+
+/// Drives the hierarchical loading model from streamed `(major, sub)` progress
+/// events. Held by the StateHandler loop alongside `State.loading`; tracks the
+/// `Instant` each running step/major started so durations can be stamped
+/// without storing `Instant`s in the (Clone, serialisable-ish) state.
+#[derive(Default)]
+pub struct LoadingProgress {
+    /// When the currently-running sub-step began.
+    step_start: Option<std::time::Instant>,
+    /// When the currently-running major began (its first sub-step's start).
+    major_start: Option<std::time::Instant>,
+}
+
+impl LoadingProgress {
+    /// Record that sub-step `sub` of major task `major` is now starting.
+    ///
+    /// Finalises the previously-running sub-step (and, when the major changes,
+    /// the previous major) with their durations, then appends/opens the new
+    /// major/sub as `Running`. Returns the index of the tip the loading screen
+    /// should advance to (the caller bumps `tip_index`).
+    pub fn begin(&mut self, loading: &mut Vec<LoadingTask>, major: &str, sub: &str) {
+        let now = std::time::Instant::now();
+        let clock = chrono::Local::now().format("%H:%M:%S").to_string();
+
+        // Finalise the previous running sub-step.
+        if let Some(start) = self.step_start
+            && let Some(prev) = loading
+                .last_mut()
+                .and_then(|m| m.children.last_mut())
+                .filter(|s| s.status == StepStatus::Running)
+        {
+            prev.status = StepStatus::Done;
+            prev.duration = Some(now.duration_since(start));
+        }
+
+        let same_major = loading.last().is_some_and(|m| m.label == major);
+        if !same_major {
+            // Close out the previous major with its combined span.
+            if let Some(mstart) = self.major_start
+                && let Some(prev) = loading.last_mut()
+            {
+                prev.status = StepStatus::Done;
+                prev.duration = Some(now.duration_since(mstart));
+            }
+            loading.push(LoadingTask {
+                label: major.to_string(),
+                status: StepStatus::Running,
+                started: Some(clock.clone()),
+                duration: None,
+                children: Vec::new(),
+            });
+            self.major_start = Some(now);
+        }
+
+        if let Some(m) = loading.last_mut() {
+            m.children.push(LoadingStep {
+                label: sub.to_string(),
+                status: StepStatus::Running,
+                started: Some(clock),
+                duration: None,
+            });
+        }
+        self.step_start = Some(now);
+    }
+
+    /// Mark the whole sequence finished: stamp the final running sub-step and
+    /// its major as Done with their durations.
+    pub fn finish(&mut self, loading: &mut [LoadingTask]) {
+        if let Some(m) = loading.last_mut() {
+            if let Some(start) = self.step_start
+                && let Some(s) = m
+                    .children
+                    .last_mut()
+                    .filter(|s| s.status == StepStatus::Running)
+            {
+                s.status = StepStatus::Done;
+                s.duration = Some(start.elapsed());
+            }
+            if let Some(mstart) = self.major_start
+                && m.status == StepStatus::Running
+            {
+                m.status = StepStatus::Done;
+                m.duration = Some(mstart.elapsed());
+            }
+        }
+        self.step_start = None;
+        self.major_start = None;
+    }
+
+    /// Mark the currently-running sub-step (and its major) as Failed — the
+    /// startup errored mid-step.
+    pub fn fail(&mut self, loading: &mut [LoadingTask]) {
+        if let Some(m) = loading.last_mut() {
+            if m.status == StepStatus::Running {
+                m.status = StepStatus::Failed;
+            }
+            if let Some(s) = m
+                .children
+                .last_mut()
+                .filter(|s| s.status == StepStatus::Running)
+            {
+                s.status = StepStatus::Failed;
+            }
+        }
+        self.step_start = None;
+        self.major_start = None;
+    }
 }
 
 #[derive(Default, Debug, Clone, Copy)]

--- a/openvtc/src/ui/pages/join_flow/join_progress.rs
+++ b/openvtc/src/ui/pages/join_flow/join_progress.rs
@@ -1,0 +1,146 @@
+//! Join flow — step 2: live progress of the automated mint + join sequence.
+//!
+//! Renders the `JoinState.messages` log plus the terminal outcome. On success
+//! it shows the created persona DID and the pending community, and prompts the
+//! operator to restart OpenVTC to activate the new community (hot-start is a
+//! deliberate follow-up). [ENTER] returns to the main page.
+
+use crate::colors::{
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
+    COLOR_TEXT_DEFAULT, COLOR_WARNING_ACCESSIBLE_RED,
+};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Layout,
+    },
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+
+use crate::{
+    state_handler::{
+        actions::Action,
+        join::JoinState,
+        setup_sequence::{Completion, MessageType},
+    },
+    ui::pages::join_flow::JoinFlow,
+};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct JoinProgress;
+
+impl JoinProgress {
+    pub fn handle_key_event(state: &mut JoinFlow, key: KeyEvent) {
+        match key.code {
+            KeyCode::F(10) => {
+                let _ = state.action_tx.send(Action::Exit);
+            }
+            KeyCode::Enter if !state.props.state.processing => {
+                // Return to the main page once the sequence has settled.
+                let _ = state.action_tx.send(Action::JoinCancel);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn render(&self, state: &JoinState, frame: &mut Frame<'_>) {
+        let [middle, bottom] = Layout::vertical([Min(0), Length(3)]).areas(frame.area());
+
+        let block = Block::bordered()
+            .fg(COLOR_BORDER)
+            .padding(Padding::proportional(1))
+            .title(" Joining community ");
+
+        let mut lines = Vec::new();
+
+        for msg in &state.messages {
+            match msg {
+                MessageType::Info(info) => lines.push(Line::styled(
+                    format!("INFO: {info}"),
+                    Style::new().fg(COLOR_SUCCESS),
+                )),
+                MessageType::Error(err) => lines.push(Line::styled(
+                    format!("ERROR: {err}"),
+                    Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
+                )),
+            }
+        }
+
+        match state.completed {
+            Completion::NotFinished => {
+                lines.push(Line::default());
+                lines.push(Line::styled(
+                    "Working… please wait.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ));
+            }
+            Completion::CompletedOK => {
+                lines.push(Line::default());
+                lines.push(Line::styled(
+                    "Join request submitted.",
+                    Style::new().fg(COLOR_SUCCESS).bold(),
+                ));
+                if let Some(rec) = &state.created_community {
+                    lines.push(Line::default());
+                    lines.push(Line::from(vec![
+                        Span::styled("  Community: ", Style::new().fg(COLOR_SUCCESS)),
+                        Span::styled(
+                            rec.display_name
+                                .clone()
+                                .unwrap_or_else(|| rec.vtc_did.clone()),
+                            Style::new().fg(COLOR_SOFT_PURPLE),
+                        ),
+                    ]));
+                    lines.push(Line::from(vec![
+                        Span::styled("  VTC DID:   ", Style::new().fg(COLOR_SUCCESS)),
+                        Span::styled(rec.vtc_did.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+                    ]));
+                    lines.push(Line::from(vec![
+                        Span::styled("  Status:    ", Style::new().fg(COLOR_SUCCESS)),
+                        Span::styled("Pending", Style::new().fg(COLOR_ORANGE)),
+                    ]));
+                }
+                lines.push(Line::default());
+                lines.push(Line::styled(
+                    "Restart OpenVTC to activate this community.",
+                    Style::new().fg(COLOR_ORANGE).bold(),
+                ));
+            }
+            Completion::CompletedFail => {
+                lines.push(Line::default());
+                lines.push(Line::styled(
+                    "Join failed. Nothing was activated.",
+                    Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED).bold(),
+                ));
+            }
+        }
+
+        if !matches!(state.completed, Completion::NotFinished) {
+            lines.push(Line::default());
+            lines.push(Line::from(vec![
+                Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(" to return", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            ]));
+        }
+
+        frame.render_widget(
+            Paragraph::new(lines)
+                .block(block)
+                .wrap(Wrap { trim: false }),
+            middle,
+        );
+
+        let bottom_line = Line::from(vec![
+            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]);
+        frame.render_widget(
+            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
+            bottom,
+        );
+    }
+}

--- a/openvtc/src/ui/pages/join_flow/join_progress.rs
+++ b/openvtc/src/ui/pages/join_flow/join_progress.rs
@@ -106,7 +106,7 @@ impl JoinProgress {
                 }
                 lines.push(Line::default());
                 lines.push(Line::styled(
-                    "Restart OpenVTC to activate this community.",
+                    "Restart OpenVTC to bring your new persona online.",
                     Style::new().fg(COLOR_ORANGE).bold(),
                 ));
             }

--- a/openvtc/src/ui/pages/join_flow/join_progress.rs
+++ b/openvtc/src/ui/pages/join_flow/join_progress.rs
@@ -86,28 +86,34 @@ impl JoinProgress {
                 ));
                 if let Some(rec) = &state.created_community {
                     lines.push(Line::default());
+                    // Only show a friendly name when one actually resolved —
+                    // otherwise it would just duplicate the DID below.
+                    if let Some(name) = &rec.display_name {
+                        lines.push(Line::from(vec![
+                            Span::styled("  Community:     ", Style::new().fg(COLOR_SUCCESS)),
+                            Span::styled(name.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+                        ]));
+                    }
                     lines.push(Line::from(vec![
-                        Span::styled("  Community: ", Style::new().fg(COLOR_SUCCESS)),
-                        Span::styled(
-                            rec.display_name
-                                .clone()
-                                .unwrap_or_else(|| rec.vtc_did.clone()),
-                            Style::new().fg(COLOR_SOFT_PURPLE),
-                        ),
-                    ]));
-                    lines.push(Line::from(vec![
-                        Span::styled("  VTC DID:   ", Style::new().fg(COLOR_SUCCESS)),
+                        Span::styled("  Community DID: ", Style::new().fg(COLOR_SUCCESS)),
                         Span::styled(rec.vtc_did.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
                     ]));
+                    if let Some(persona_did) = &state.created_persona_did {
+                        lines.push(Line::from(vec![
+                            Span::styled("  Your persona:  ", Style::new().fg(COLOR_SUCCESS)),
+                            Span::styled(persona_did.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+                        ]));
+                    }
                     lines.push(Line::from(vec![
-                        Span::styled("  Status:    ", Style::new().fg(COLOR_SUCCESS)),
+                        Span::styled("  Status:        ", Style::new().fg(COLOR_SUCCESS)),
                         Span::styled("Pending", Style::new().fg(COLOR_ORANGE)),
                     ]));
                 }
                 lines.push(Line::default());
                 lines.push(Line::styled(
-                    "Restart OpenVTC to bring your new persona online.",
-                    Style::new().fg(COLOR_ORANGE).bold(),
+                    "It's now in your Communities list, marked Pending — it will update \
+                     there as the community responds.",
+                    Style::new().fg(COLOR_SUCCESS),
                 ));
             }
             Completion::CompletedFail => {

--- a/openvtc/src/ui/pages/join_flow/mod.rs
+++ b/openvtc/src/ui/pages/join_flow/mod.rs
@@ -1,0 +1,113 @@
+//! The State-B "join a community" flow UI (R-A-5 Stage 4).
+//!
+//! A small two-page [`Component`] mirroring [`SetupFlow`](super::setup_flow):
+//! `VtcEnterDid` collects the community DID, then `JoinProgress` shows the
+//! automated mint + join sequence. The page selection is driven by
+//! [`JoinState.page`](crate::state_handler::join::JoinState::page); the VTC DID
+//! `Input` lives on this component (mirroring how `vta_enter_did` holds its
+//! input), and persists across re-renders via `move_with_state`.
+
+use crate::{
+    state_handler::{
+        actions::Action,
+        join::{JoinPage, JoinState},
+        state::State,
+    },
+    ui::{
+        component::{Component, ComponentRender},
+        pages::join_flow::{join_progress::JoinProgress, vtc_enter_did::VtcEnterDid},
+    },
+};
+use crossterm::event::{KeyEvent, KeyEventKind};
+use ratatui::Frame;
+use tokio::sync::mpsc::UnboundedSender;
+use tui_input::Input;
+
+pub mod join_progress;
+pub mod vtc_enter_did;
+
+/// Handles the join flow sequence.
+#[derive(Clone)]
+pub struct JoinFlow {
+    /// Action sender.
+    pub action_tx: UnboundedSender<Action>,
+
+    /// The community (VTC) DID input (page 1). Held on the component so it
+    /// survives re-renders without round-tripping through the watch channel.
+    pub vtc_did: Input,
+
+    // Page handlers (zero-sized — they read from `props.state`).
+    pub vtc_enter_did: VtcEnterDid,
+    pub join_progress: JoinProgress,
+
+    /// State-mapped join props.
+    pub props: Props,
+}
+
+#[derive(Clone)]
+pub struct Props {
+    pub state: JoinState,
+}
+
+impl From<&State> for Props {
+    fn from(state: &State) -> Self {
+        Props {
+            state: state.join.clone(),
+        }
+    }
+}
+
+impl Component for JoinFlow {
+    fn new(state: &State, action_tx: UnboundedSender<Action>) -> Self
+    where
+        Self: Sized,
+    {
+        JoinFlow {
+            action_tx,
+            vtc_did: Input::default(),
+            vtc_enter_did: VtcEnterDid,
+            join_progress: JoinProgress,
+            props: Props::from(state),
+        }
+        .move_with_state(state)
+    }
+
+    fn move_with_state(self, state: &State) -> Self
+    where
+        Self: Sized,
+    {
+        JoinFlow {
+            props: Props::from(state),
+            ..self
+        }
+    }
+
+    fn handle_key_event(&mut self, key: KeyEvent) {
+        if key.kind != KeyEventKind::Press {
+            return;
+        }
+        match self.props.state.page {
+            JoinPage::EnterDid => VtcEnterDid::handle_key_event(self, key),
+            JoinPage::Progress => JoinProgress::handle_key_event(self, key),
+        }
+    }
+
+    fn handle_paste_event(&mut self, text: &str) {
+        // Paste the whole DID at once (instant for long did:webvh strings).
+        if self.props.state.page == JoinPage::EnterDid && !self.props.state.processing {
+            self.vtc_did = Input::new(text.trim().to_string());
+        }
+    }
+}
+
+impl ComponentRender<()> for JoinFlow {
+    fn render(&self, frame: &mut Frame, _props: ()) {
+        match self.props.state.page {
+            JoinPage::EnterDid => {
+                self.vtc_enter_did
+                    .render(&self.props.state, &self.vtc_did, frame)
+            }
+            JoinPage::Progress => self.join_progress.render(&self.props.state, frame),
+        }
+    }
+}

--- a/openvtc/src/ui/pages/join_flow/vtc_enter_did.rs
+++ b/openvtc/src/ui/pages/join_flow/vtc_enter_did.rs
@@ -1,0 +1,150 @@
+//! Join flow — step 1: ask for the community (VTC) DID.
+//!
+//! Mirrors `setup_flow::vta_enter_did`. On submit we send
+//! [`Action::JoinSubmitVtc`], which kicks off the automated persona-mint +
+//! sub-context + join-submit sequence. Esc cancels the whole flow.
+
+use crate::colors::{
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_TEXT_DEFAULT,
+};
+use crossterm::event::{Event, KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Layout, Margin, Rect,
+    },
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+use tui_input::{Input, backend::crossterm::EventHandler};
+
+use crate::{
+    state_handler::{actions::Action, join::JoinState},
+    ui::pages::join_flow::JoinFlow,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct VtcEnterDid;
+
+impl VtcEnterDid {
+    pub fn handle_key_event(state: &mut JoinFlow, key: KeyEvent) {
+        // Input is locked while the background sequence runs.
+        if state.props.state.processing {
+            return;
+        }
+        match key.code {
+            KeyCode::F(10) => {
+                let _ = state.action_tx.send(Action::Exit);
+            }
+            KeyCode::Enter => {
+                let did = state.vtc_did.value().trim().to_string();
+                if !did.is_empty() {
+                    let _ = state.action_tx.send(Action::JoinSubmitVtc(did));
+                }
+            }
+            KeyCode::Esc => {
+                let _ = state.action_tx.send(Action::JoinCancel);
+            }
+            _ => {
+                state.vtc_did.handle_event(&Event::Key(key));
+            }
+        }
+    }
+
+    pub fn render(&self, state: &JoinState, input: &Input, frame: &mut Frame<'_>) {
+        let [middle, bottom] = Layout::vertical([Min(0), Length(3)]).areas(frame.area());
+
+        frame.render_widget(
+            Block::bordered()
+                .fg(COLOR_BORDER)
+                .padding(Padding::proportional(1))
+                .title(" Join a community "),
+            middle,
+        );
+
+        let content: [Rect; 3] =
+            Layout::vertical([Length(5), Length(2), Min(0)]).areas(middle.inner(Margin::new(3, 2)));
+
+        let [prompt_col, input_col] = Layout::horizontal([Length(2), Min(0)]).areas(content[1]);
+
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::styled(
+                    "Enter the Verifiable Trust Community (VTC) DID you want to join.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::styled(
+                    "OpenVTC will mint a fresh persona and submit a join request on your behalf.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::default(),
+                Line::styled(
+                    "Enter the community's DID:",
+                    Style::new().fg(COLOR_BORDER).bold(),
+                ),
+            ]),
+            content[0],
+        );
+
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                "> ",
+                Style::new().fg(COLOR_SOFT_PURPLE).bold(),
+            )),
+            prompt_col,
+        );
+        render_input(input, frame, input_col);
+
+        let mut lines = vec![
+            Line::styled("Example:", Style::new().fg(COLOR_ORANGE).bold()),
+            Line::styled(
+                "  • did:webvh:QmRoot…:community.example.com",
+                Style::new().fg(COLOR_ORANGE).italic(),
+            ),
+            Line::default(),
+        ];
+        // Surface any pre-submit error (e.g. idempotency) inline.
+        for msg in &state.messages {
+            if let crate::state_handler::setup_sequence::MessageType::Error(err) = msg {
+                lines.push(Line::styled(
+                    format!("ERROR: {err}"),
+                    Style::new().fg(crate::colors::COLOR_WARNING_ACCESSIBLE_RED),
+                ));
+            }
+        }
+        lines.push(Line::from(vec![
+            Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" to cancel  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" to join", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]));
+
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), content[2]);
+
+        let bottom_line = Line::from(vec![
+            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]);
+        frame.render_widget(
+            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
+            bottom,
+        );
+    }
+}
+
+fn render_input(input: &Input, frame: &mut Frame, area: Rect) {
+    let width = area.width.max(3) - 3;
+    let scroll = input.visual_scroll(width as usize);
+    frame.render_widget(
+        Paragraph::new(Span::styled(
+            input.value(),
+            Style::new().fg(COLOR_SOFT_PURPLE),
+        ))
+        .scroll((0, scroll as u16)),
+        area,
+    );
+    let x = input.visual_cursor().max(scroll) - scroll;
+    frame.set_cursor_position((area.x + x as u16, area.y))
+}

--- a/openvtc/src/ui/pages/loading/mod.rs
+++ b/openvtc/src/ui/pages/loading/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     state_handler::{
         actions::Action,
-        state::{LoadingStep, MediatorStatus, State},
+        state::{LoadingTask, MediatorStatus, State, StepStatus},
     },
     ui::component::{Component, ComponentRender},
 };
@@ -59,9 +59,10 @@ const BANNER: &[&str] = &[
 pub struct Props {
     /// Current mediator/connection status, driving the phase + error display.
     pub status: MediatorStatus,
-    /// Timed startup steps, in order (the last may still be in progress).
-    pub steps: Vec<LoadingStep>,
-    /// Rotating-tip index (advanced as startup steps stream).
+    /// Hierarchical, timed startup tasks (the last may still be in progress).
+    pub tasks: Vec<LoadingTask>,
+    /// Rotating-tip index (advanced as startup steps stream); also drives the
+    /// running-step spinner frame.
     pub tip_index: usize,
     /// True once phase 1 finished — show the "Press Enter to continue" prompt.
     pub complete: bool,
@@ -71,7 +72,7 @@ impl From<&State> for Props {
     fn from(state: &State) -> Self {
         Props {
             status: state.connection.status.clone(),
-            steps: state.loading_steps.clone(),
+            tasks: state.loading.clone(),
             tip_index: state.tip_index,
             complete: state.loading_complete,
         }
@@ -154,6 +155,84 @@ impl LoadingScreen {
         };
         Line::styled(text, Style::new().fg(color).bold())
     }
+
+    /// Per-status leading icon + colour. A `Running` step gets a simple
+    /// frame-based spinner driven by `tick` (the tip index, bumped each step).
+    fn status_icon(status: StepStatus, tick: usize) -> (String, ratatui::style::Color) {
+        const SPINNER: &[char] = &['▸', '▹', '▸', '▹'];
+        match status {
+            StepStatus::Queued => ("◦".to_string(), COLOR_DARK_GRAY),
+            StepStatus::Running => (SPINNER[tick % SPINNER.len()].to_string(), COLOR_SOFT_PURPLE),
+            StepStatus::Done => ("✓".to_string(), COLOR_SUCCESS),
+            StepStatus::Failed => ("✗".to_string(), COLOR_WARNING_ACCESSIBLE_RED),
+        }
+    }
+
+    /// Column the timing annotation starts at, so times line up neatly.
+    const TIME_COL: usize = 34;
+
+    /// A right-aligned `(time)` annotation, padded so it lands in [`TIME_COL`].
+    /// `prefix_len` is the visible width already consumed on the line.
+    fn time_span(
+        duration: Option<std::time::Duration>,
+        prefix_len: usize,
+    ) -> Option<Span<'static>> {
+        let d = duration?;
+        let text = format!("({})", format_duration(d));
+        let pad = Self::TIME_COL.saturating_sub(prefix_len).max(1);
+        Some(Span::styled(
+            format!("{}{text}", " ".repeat(pad)),
+            Style::new().fg(COLOR_DARK_GRAY),
+        ))
+    }
+
+    /// Render a major task line: bold, leading status icon, combined time once
+    /// the major is Done.
+    fn major_line(task: &LoadingTask, tick: usize) -> Line<'static> {
+        let (icon, icon_color) = Self::status_icon(task.status, tick);
+        let label_color = match task.status {
+            StepStatus::Failed => COLOR_WARNING_ACCESSIBLE_RED,
+            StepStatus::Queued => COLOR_DARK_GRAY,
+            _ => COLOR_TEXT_DEFAULT,
+        };
+        let clock = task.started.as_deref().unwrap_or("--:--:--");
+        let time_prefix = format!("[{clock}] ");
+        let mut spans = vec![
+            Span::styled(format!("  {icon} "), Style::new().fg(icon_color)),
+            Span::styled(time_prefix.clone(), Style::new().fg(COLOR_DARK_GRAY)),
+            Span::styled(task.label.clone(), Style::new().fg(label_color).bold()),
+        ];
+        // prefix = "  " + icon(1) + " " + "[HH:MM:SS] " + label
+        let prefix_len = 4 + time_prefix.chars().count() + task.label.chars().count();
+        if let Some(t) = Self::time_span(task.duration, prefix_len) {
+            spans.push(t);
+        }
+        Line::from(spans)
+    }
+
+    /// Render a sub-step line: indented under its major, dimmer, prefixed with
+    /// its start time and annotated with its own per-step time once Done.
+    fn sub_line(step: &crate::state_handler::state::LoadingStep, tick: usize) -> Line<'static> {
+        let (icon, icon_color) = Self::status_icon(step.status, tick);
+        let label_color = match step.status {
+            StepStatus::Failed => COLOR_WARNING_ACCESSIBLE_RED,
+            StepStatus::Running => COLOR_TEXT_DEFAULT,
+            _ => COLOR_DARK_GRAY,
+        };
+        let clock = step.started.as_deref().unwrap_or("--:--:--");
+        let time_prefix = format!("[{clock}] ");
+        let mut spans = vec![
+            Span::styled(format!("      {icon} "), Style::new().fg(icon_color)),
+            Span::styled(time_prefix.clone(), Style::new().fg(COLOR_DARK_GRAY)),
+            Span::styled(step.label.clone(), Style::new().fg(label_color)),
+        ];
+        // prefix = 6 spaces + icon(1) + " " + "[HH:MM:SS] " + label
+        let prefix_len = 8 + time_prefix.chars().count() + step.label.chars().count();
+        if let Some(t) = Self::time_span(step.duration, prefix_len) {
+            spans.push(t);
+        }
+        Line::from(spans)
+    }
 }
 
 impl ComponentRender<()> for LoadingScreen {
@@ -199,27 +278,19 @@ impl ComponentRender<()> for LoadingScreen {
             lines.push(Line::default());
         }
 
-        // Timed startup steps — each shows its start time and, once finished,
-        // how long it took, so a slow step is obvious at a glance.
-        if !self.props.steps.is_empty() {
+        // Hierarchical startup tasks — majors in bold with their combined time,
+        // sub-steps indented and dimmer with their own time, so a slow task (and
+        // which sub-step caused it) is obvious at a glance.
+        if !self.props.tasks.is_empty() {
             lines.push(Line::styled(
                 "Startup",
                 Style::new().fg(COLOR_BORDER).bold(),
             ));
-            for step in &self.props.steps {
-                let (marker, detail, marker_color) = match step.duration {
-                    Some(d) => ("✓", format!("  ({})", format_duration(d)), COLOR_SUCCESS),
-                    None => ("▸", "  …".to_string(), COLOR_SOFT_PURPLE),
-                };
-                lines.push(Line::from(vec![
-                    Span::styled(format!("  {marker} "), Style::new().fg(marker_color)),
-                    Span::styled(
-                        format!("[{}] ", step.started),
-                        Style::new().fg(COLOR_DARK_GRAY),
-                    ),
-                    Span::styled(step.label.clone(), Style::new().fg(COLOR_TEXT_DEFAULT)),
-                    Span::styled(detail, Style::new().fg(COLOR_DARK_GRAY)),
-                ]));
+            for task in &self.props.tasks {
+                lines.push(Self::major_line(task, self.props.tip_index));
+                for step in &task.children {
+                    lines.push(Self::sub_line(step, self.props.tip_index));
+                }
             }
             lines.push(Line::default());
         }

--- a/openvtc/src/ui/pages/loading/mod.rs
+++ b/openvtc/src/ui/pages/loading/mod.rs
@@ -63,6 +63,8 @@ pub struct Props {
     pub steps: Vec<LoadingStep>,
     /// Rotating-tip index (advanced as startup steps stream).
     pub tip_index: usize,
+    /// True once phase 1 finished — show the "Press Enter to continue" prompt.
+    pub complete: bool,
 }
 
 impl From<&State> for Props {
@@ -71,7 +73,19 @@ impl From<&State> for Props {
             status: state.connection.status.clone(),
             steps: state.loading_steps.clone(),
             tip_index: state.tip_index,
+            complete: state.loading_complete,
         }
+    }
+}
+
+/// Human-friendly duration: milliseconds (2 dp) under a second, seconds (2 dp)
+/// at or above — e.g. `3.42ms`, `842.10ms`, `5.83s`.
+fn format_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs_f64();
+    if secs >= 1.0 {
+        format!("{secs:.2}s")
+    } else {
+        format!("{:.2}ms", d.as_micros() as f64 / 1000.0)
     }
 }
 
@@ -108,9 +122,16 @@ impl Component for LoadingScreen {
         if key.kind != KeyEventKind::Press {
             return;
         }
-        // The loading screen is non-interactive: only quit is honoured.
-        if let KeyCode::F(10) = key.code {
-            let _ = self.action_tx.send(Action::Exit);
+        match key.code {
+            KeyCode::F(10) => {
+                let _ = self.action_tx.send(Action::Exit);
+            }
+            // Once phase 1 has finished, Enter dismisses the loading screen and
+            // reveals the main page (phase-2 connections already run in the bg).
+            KeyCode::Enter if self.props.complete => {
+                let _ = self.action_tx.send(Action::DismissLoading);
+            }
+            _ => {}
         }
     }
 }
@@ -186,8 +207,8 @@ impl ComponentRender<()> for LoadingScreen {
                 Style::new().fg(COLOR_BORDER).bold(),
             ));
             for step in &self.props.steps {
-                let (marker, detail, marker_color) = match step.duration_ms {
-                    Some(ms) => ("✓", format!("  ({ms} ms)"), COLOR_SUCCESS),
+                let (marker, detail, marker_color) = match step.duration {
+                    Some(d) => ("✓", format!("  ({})", format_duration(d)), COLOR_SUCCESS),
                     None => ("▸", "  …".to_string(), COLOR_SOFT_PURPLE),
                 };
                 lines.push(Line::from(vec![
@@ -212,16 +233,35 @@ impl ComponentRender<()> for LoadingScreen {
             ));
         }
 
+        // Once phase 1 is done, prompt to continue (phase-2 connections are
+        // already running in the background).
+        if self.props.complete {
+            lines.push(Line::default());
+            lines.push(Line::styled(
+                "Press [ENTER] to continue — connecting in the background",
+                Style::new().fg(COLOR_SUCCESS).bold(),
+            ));
+        }
+
         let body = Paragraph::new(lines)
             .wrap(Wrap { trim: false })
             .block(Block::new().padding(Padding::new(1, 1, 1, 0)));
         frame.render_widget(body, body_area);
 
         // Footer.
-        let footer = Line::from(vec![
-            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]);
+        let footer = if self.props.complete {
+            Line::from(vec![
+                Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(" continue   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+                Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(" quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            ])
+        } else {
+            Line::from(vec![
+                Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(" quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            ])
+        };
         frame.render_widget(Paragraph::new(footer).centered(), footer_area);
     }
 }

--- a/openvtc/src/ui/pages/loading/mod.rs
+++ b/openvtc/src/ui/pages/loading/mod.rs
@@ -1,0 +1,227 @@
+//! The startup loading screen (`ActivePage::Loading`).
+//!
+//! Shown while the app loads its config and establishes the mediator
+//! connection, replacing the previous behaviour of rendering the full (but not
+//! yet interactive) main page during startup. It surfaces the current startup
+//! phase, a tail of the activity log, a rotating tip, and — on failure — the
+//! full error plus a recovery suggestion.
+//!
+//! A small [`Component`] mirroring the shape of the other pages: a `Props`
+//! struct mapped `From<&State>` carries everything the screen renders, so the
+//! component itself stays free of business logic.
+
+use crate::{
+    colors::{
+        COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+        COLOR_WARNING_ACCESSIBLE_RED,
+    },
+    state_handler::{
+        actions::Action,
+        state::{LoadingStep, MediatorStatus, State},
+    },
+    ui::component::{Component, ComponentRender},
+};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Flex, Layout,
+    },
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Rotating friendly/fun tips about verifiable trust shown during startup.
+/// Indexed by `tip_index % TIPS.len()`.
+const TIPS: &[&str] = &[
+    "Tip: A DID is an identifier you control — no central registrar required.",
+    "Did you know? Verifiable credentials are cryptographically tamper-evident.",
+    "Tip: Your keys never leave your device — trust is proven, not surrendered.",
+    "Did you know? did:webvh anchors your DID to a verifiable history log.",
+    "Tip: DIDComm messages are end-to-end encrypted between peers.",
+    "Tip: A relationship is mutual — both parties prove who they are.",
+];
+
+/// Multi-line banner shown at the top of the loading screen.
+const BANNER: &[&str] = &[
+    "  ___                __     _______ ___ ",
+    " / _ \\ _ __  ___ _ _ \\ \\   / |_   _/ __|",
+    "| (_) | '_ \\/ -_) ' \\ \\ \\ / /  | || (__ ",
+    " \\___/| .__/\\___|_||_| \\_V_/   |_| \\___|",
+    "      |_|                               ",
+];
+
+/// State-mapped props for the loading screen.
+#[derive(Clone, Debug)]
+pub struct Props {
+    /// Current mediator/connection status, driving the phase + error display.
+    pub status: MediatorStatus,
+    /// Timed startup steps, in order (the last may still be in progress).
+    pub steps: Vec<LoadingStep>,
+    /// Rotating-tip index (advanced as startup steps stream).
+    pub tip_index: usize,
+}
+
+impl From<&State> for Props {
+    fn from(state: &State) -> Self {
+        Props {
+            status: state.connection.status.clone(),
+            steps: state.loading_steps.clone(),
+            tip_index: state.tip_index,
+        }
+    }
+}
+
+/// The startup loading screen.
+pub struct LoadingScreen {
+    /// Action sender (used only to request exit on F10).
+    pub action_tx: UnboundedSender<Action>,
+    /// State-mapped props.
+    pub props: Props,
+}
+
+impl Component for LoadingScreen {
+    fn new(state: &State, action_tx: UnboundedSender<Action>) -> Self
+    where
+        Self: Sized,
+    {
+        LoadingScreen {
+            action_tx,
+            props: Props::from(state),
+        }
+    }
+
+    fn move_with_state(self, state: &State) -> Self
+    where
+        Self: Sized,
+    {
+        LoadingScreen {
+            props: Props::from(state),
+            ..self
+        }
+    }
+
+    fn handle_key_event(&mut self, key: KeyEvent) {
+        if key.kind != KeyEventKind::Press {
+            return;
+        }
+        // The loading screen is non-interactive: only quit is honoured.
+        if let KeyCode::F(10) = key.code {
+            let _ = self.action_tx.send(Action::Exit);
+        }
+    }
+}
+
+impl LoadingScreen {
+    /// The human-readable phase line derived from the connection status.
+    /// `Failed` is handled separately (rendered as a prominent error block).
+    fn phase_line(status: &MediatorStatus) -> Line<'static> {
+        let (text, color) = match status {
+            MediatorStatus::Unknown => ("Starting…".to_string(), COLOR_DARK_GRAY),
+            MediatorStatus::Initializing(step) => (step.clone(), COLOR_SOFT_PURPLE),
+            MediatorStatus::Connecting => {
+                ("Connecting to the mediator…".to_string(), COLOR_SOFT_PURPLE)
+            }
+            MediatorStatus::Connected => ("Connected".to_string(), COLOR_SUCCESS),
+            MediatorStatus::NoActiveCommunity => ("Ready".to_string(), COLOR_SUCCESS),
+            MediatorStatus::Failed(_) => {
+                ("Startup failed".to_string(), COLOR_WARNING_ACCESSIBLE_RED)
+            }
+        };
+        Line::styled(text, Style::new().fg(color).bold())
+    }
+}
+
+impl ComponentRender<()> for LoadingScreen {
+    fn render(&self, frame: &mut Frame, _props: ()) {
+        let area = frame.area();
+
+        // Centre a fixed-width content column; cap height to what we render.
+        let content_width = 64u16.min(area.width.saturating_sub(2));
+        let [col] = Layout::horizontal([Length(content_width)])
+            .flex(Flex::Center)
+            .areas(area);
+
+        let [banner_area, body_area, footer_area] =
+            Layout::vertical([Length(BANNER.len() as u16 + 1), Min(0), Length(1)]).areas(col);
+
+        // Banner.
+        let banner: Vec<Line> = BANNER
+            .iter()
+            .map(|l| Line::styled(*l, Style::new().fg(COLOR_SOFT_PURPLE).bold()))
+            .collect();
+        frame.render_widget(Paragraph::new(banner).centered(), banner_area);
+
+        let mut lines: Vec<Line> = Vec::new();
+
+        // Phase line.
+        lines.push(Self::phase_line(&self.props.status));
+        lines.push(Line::default());
+
+        // On failure, show the full error + a recovery suggestion. The error is
+        // intentionally NOT truncated here — this screen is where the full
+        // message lives (the main status bar truncates elsewhere).
+        if let MediatorStatus::Failed(reason) = &self.props.status {
+            lines.push(Line::styled(
+                reason.clone(),
+                Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
+            ));
+            lines.push(Line::default());
+            lines.push(Line::styled(
+                "Check your network and that your VTA/mediator are reachable, \
+                 then restart OpenVTC. Press F10 to quit.",
+                Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED).bold(),
+            ));
+            lines.push(Line::default());
+        }
+
+        // Timed startup steps — each shows its start time and, once finished,
+        // how long it took, so a slow step is obvious at a glance.
+        if !self.props.steps.is_empty() {
+            lines.push(Line::styled(
+                "Startup",
+                Style::new().fg(COLOR_BORDER).bold(),
+            ));
+            for step in &self.props.steps {
+                let (marker, detail, marker_color) = match step.duration_ms {
+                    Some(ms) => ("✓", format!("  ({ms} ms)"), COLOR_SUCCESS),
+                    None => ("▸", "  …".to_string(), COLOR_SOFT_PURPLE),
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(format!("  {marker} "), Style::new().fg(marker_color)),
+                    Span::styled(
+                        format!("[{}] ", step.started),
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    ),
+                    Span::styled(step.label.clone(), Style::new().fg(COLOR_TEXT_DEFAULT)),
+                    Span::styled(detail, Style::new().fg(COLOR_DARK_GRAY)),
+                ]));
+            }
+            lines.push(Line::default());
+        }
+
+        // Rotating tip.
+        if !TIPS.is_empty() {
+            let tip = TIPS[self.props.tip_index % TIPS.len()];
+            lines.push(Line::styled(
+                tip,
+                Style::new().fg(COLOR_SOFT_PURPLE).italic(),
+            ));
+        }
+
+        let body = Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .block(Block::new().padding(Padding::new(1, 1, 1, 0)));
+        frame.render_widget(body, body_area);
+
+        // Footer.
+        let footer = Line::from(vec![
+            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]);
+        frame.render_widget(Paragraph::new(footer).centered(), footer_area);
+    }
+}

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -99,7 +99,9 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
     }
 
     lines.push(Line::from(""));
-    lines.push(Line::from("↑/↓ navigate   j: join a community").fg(COLOR_DARK_GRAY));
+    lines.push(
+        Line::from("↑/↓ navigate   j: join a community   d: remove selected").fg(COLOR_DARK_GRAY),
+    );
 
     lines
 }

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -99,9 +99,23 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
     }
 
     lines.push(Line::from(""));
-    lines.push(
-        Line::from("↑/↓ navigate   j: join a community   d: remove selected").fg(COLOR_DARK_GRAY),
-    );
+    if let Some(idx) = state.confirm_delete {
+        let name = state
+            .items
+            .get(idx)
+            .map(|c| c.display_name.as_str())
+            .unwrap_or("this community");
+        lines.push(
+            Line::from(format!("Remove “{name}”?   y: confirm    n: cancel"))
+                .fg(COLOR_ORANGE)
+                .bold(),
+        );
+    } else {
+        lines.push(
+            Line::from("↑/↓ navigate   j: join a community   d: remove selected")
+                .fg(COLOR_DARK_GRAY),
+        );
+    }
 
     lines
 }

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -1,0 +1,127 @@
+use super::panel::Panel;
+use crate::colors::{
+    COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+};
+use crate::state_handler::{
+    main_page::content::{CommunitiesState, ContentPanelState},
+    state::ConnectionState,
+};
+use ratatui::{
+    style::{Style, Stylize},
+    text::{Line, Span},
+};
+
+/// Communities overview content panel (R-C-1..R-C-8).
+pub struct CommunitiesPanel;
+
+impl Panel for CommunitiesPanel {
+    fn render(
+        &self,
+        state: &ContentPanelState,
+        _connection: &ConnectionState,
+    ) -> Vec<Line<'static>> {
+        render(&state.communities)
+    }
+}
+
+/// Render the communities panel content.
+pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+
+    if let Some(msg) = &state.status_message {
+        super::status::push_status(&mut lines, msg, "");
+        lines.push(Line::from(""));
+    }
+
+    if state.items.is_empty() {
+        return render_empty(lines);
+    }
+
+    // Header with actions-required count (R-C-3).
+    if state.actions_required > 0 {
+        lines.push(
+            Line::from(format!(
+                " ● {} communit{} need your attention",
+                state.actions_required,
+                if state.actions_required == 1 {
+                    "y"
+                } else {
+                    "ies"
+                }
+            ))
+            .fg(COLOR_ORANGE),
+        );
+    } else {
+        lines.push(
+            Line::from(format!(
+                " {} communit{}",
+                state.items.len(),
+                if state.items.len() == 1 { "y" } else { "ies" }
+            ))
+            .fg(COLOR_TEXT_DEFAULT),
+        );
+    }
+    lines.push(Line::from(""));
+
+    for (i, c) in state.items.iter().enumerate() {
+        let is_selected = i == state.selected_index;
+        let prefix = if is_selected { "▸ " } else { "  " };
+        let name_style = if is_selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+
+        let star = if c.favourite { "★ " } else { "  " };
+        let attention = if c.needs_attention { " ●" } else { "" };
+
+        lines.push(Line::from(vec![
+            Span::styled(prefix, name_style),
+            Span::styled(star, Style::new().fg(COLOR_ORANGE)),
+            Span::styled(c.display_name.clone(), name_style),
+            Span::styled(attention, Style::new().fg(COLOR_ORANGE)),
+        ]));
+
+        // Secondary line: status · persona · member-since.
+        let mut detail = format!("    {}", c.status_label);
+        if !c.persona_label.is_empty() {
+            detail.push_str(&format!("  ·  as {}", c.persona_label));
+        }
+        if !c.member_since.is_empty() {
+            detail.push_str(&format!("  ·  since {}", c.member_since));
+        }
+        let detail_style = if is_selected {
+            Style::new().fg(COLOR_SOFT_PURPLE)
+        } else {
+            Style::new().fg(COLOR_DARK_GRAY)
+        };
+        lines.push(Line::from(Span::styled(detail, detail_style)));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from("↑/↓ navigate   j: join a community").fg(COLOR_DARK_GRAY));
+
+    lines
+}
+
+/// Empty state (R-C-5): a welcoming nudge to go find a community, not a dry
+/// "no items" message.
+fn render_empty(mut lines: Vec<Line<'static>>) -> Vec<Line<'static>> {
+    lines.push(
+        Line::from("Your account is ready. 🎉")
+            .fg(COLOR_SUCCESS)
+            .bold(),
+    );
+    lines.push(Line::from(""));
+    lines.push(
+        Line::from("You haven't joined any communities yet — that's where the fun begins.")
+            .fg(COLOR_TEXT_DEFAULT),
+    );
+    lines.push(
+        Line::from("Find a Verifiable Trust Community and present an identity to join it.")
+            .fg(COLOR_TEXT_DEFAULT),
+    );
+    lines.push(Line::from(""));
+    lines.push(Line::from("Press  j  to join your first community.").fg(COLOR_ORANGE));
+    lines
+}

--- a/openvtc/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc/src/ui/pages/main/components/content_panel.rs
@@ -257,6 +257,10 @@ fn render_status_help(
             Span::styled("  Connection:   ", label_style),
             Span::styled("Not connected", Style::new().fg(COLOR_DARK_GRAY)),
         ]),
+        MediatorStatus::NoActiveCommunity => Line::from(vec![
+            Span::styled("  Connection:   ", label_style),
+            Span::styled("No active community", Style::new().fg(COLOR_DARK_GRAY)),
+        ]),
     };
     lines.push(conn_line);
 

--- a/openvtc/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc/src/ui/pages/main/components/content_panel.rs
@@ -22,8 +22,9 @@ use ratatui::{
 };
 
 use super::{
-    credentials_panel::CredentialsPanel, inbox_panel::InboxPanel, panel::Panel,
-    relationships_panel::RelationshipsPanel, settings_panel::SettingsPanel, vta_panel::VtaPanel,
+    communities_panel::CommunitiesPanel, credentials_panel::CredentialsPanel,
+    inbox_panel::InboxPanel, panel::Panel, relationships_panel::RelationshipsPanel,
+    settings_panel::SettingsPanel, vta_panel::VtaPanel,
 };
 
 // ****************************************************************************
@@ -64,6 +65,7 @@ impl ContentPanelState {
         };
 
         let panel: Option<Box<dyn Panel>> = match menu.selected_menu {
+            MainMenu::Communities => Some(Box::new(CommunitiesPanel)),
             MainMenu::Inbox => Some(Box::new(InboxPanel)),
             MainMenu::Relationships => Some(Box::new(RelationshipsPanel)),
             MainMenu::Credentials => Some(Box::new(CredentialsPanel)),

--- a/openvtc/src/ui/pages/main/components/inbox_panel.rs
+++ b/openvtc/src/ui/pages/main/components/inbox_panel.rs
@@ -50,6 +50,7 @@ pub fn render(state: &InboxState, connection: &ConnectionState) -> Vec<Line<'sta
             Line::from(format!("Initializing: {}", step)).fg(COLOR_ORANGE)
         }
         MediatorStatus::Unknown => Line::from("Not connected").fg(COLOR_ORANGE),
+        MediatorStatus::NoActiveCommunity => Line::from("No active community").fg(COLOR_DARK_GRAY),
     };
     lines.push(status_line);
 

--- a/openvtc/src/ui/pages/main/components/mod.rs
+++ b/openvtc/src/ui/pages/main/components/mod.rs
@@ -1,6 +1,7 @@
 /// The main page is made up of two main panels side by side:
 /// LEFT: Menu Panel
 /// RIGHT: Content Panel
+pub mod communities_panel;
 pub mod content_panel;
 pub mod credentials_panel;
 pub mod inbox_panel;

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -47,17 +47,28 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         ]));
     }
 
-    // Persona DID
-    lines.push(Line::from(vec![
-        Span::styled("  Persona DID:   ", label_style),
-        Span::styled(state.persona_did.clone(), value_style),
-    ]));
-
-    // Mediator DID
-    lines.push(Line::from(vec![
-        Span::styled("  Mediator DID:  ", label_style),
-        Span::styled(state.mediator_did.clone(), value_style),
-    ]));
+    // Persona + Mediator DIDs are community-scoped: they only exist once a
+    // community is joined (a persona is minted). Pre-community (State A) show a
+    // readiness line instead of blank fields, so the panel confirms the account
+    // is set up and ready to join.
+    if state.persona_did.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("  Status:        ", label_style),
+            Span::styled(
+                "Ready — join a community to create your persona",
+                Style::new().fg(COLOR_SUCCESS),
+            ),
+        ]));
+    } else {
+        lines.push(Line::from(vec![
+            Span::styled("  Persona DID:   ", label_style),
+            Span::styled(state.persona_did.clone(), value_style),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("  Mediator DID:  ", label_style),
+            Span::styled(state.mediator_did.clone(), value_style),
+        ]));
+    }
 
     if !state.is_vta_managed {
         lines.push(Line::from(""));

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -309,6 +309,25 @@ impl MainPage {
             MainMenu::Settings => self.handle_settings_key(key),
             MainMenu::Logs => self.handle_logs_key(key),
             MainMenu::Help => self.handle_help_key(key),
+            MainMenu::Communities => self.handle_communities_key(key),
+            _ => false,
+        }
+    }
+
+    /// Communities overview keys (R-A-5 Stage 4): `j` starts the join flow,
+    /// including from the empty state. Returns true if consumed.
+    fn handle_communities_key(&mut self, key: KeyEvent) -> bool {
+        match key.code {
+            KeyCode::Char('j') => {
+                let _ = self.action_tx.send(Action::StartJoin);
+                true
+            }
+            KeyCode::Esc => {
+                let _ = self
+                    .action_tx
+                    .send(Action::MainPanelSwitch(MainPanel::MainMenu));
+                true
+            }
             _ => false,
         }
     }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -314,12 +314,32 @@ impl MainPage {
         }
     }
 
-    /// Communities overview keys (R-A-5 Stage 4): `j` starts the join flow,
-    /// including from the empty state. Returns true if consumed.
+    /// Communities overview keys (R-A-5 Stage 4): `j` starts the join flow
+    /// (incl. from the empty state), ↑/↓ move the selection, `d`/Del removes the
+    /// selected community. Returns true if consumed.
     fn handle_communities_key(&mut self, key: KeyEvent) -> bool {
+        let comms = &self.props.main_page.content_panel.communities;
+        let count = comms.items.len();
+        let selected = comms.selected_index;
         match key.code {
             KeyCode::Char('j') => {
                 let _ = self.action_tx.send(Action::StartJoin);
+                true
+            }
+            KeyCode::Up if count > 0 => {
+                let _ = self
+                    .action_tx
+                    .send(Action::CommunitySelect(selected.saturating_sub(1)));
+                true
+            }
+            KeyCode::Down if count > 0 => {
+                let _ = self
+                    .action_tx
+                    .send(Action::CommunitySelect((selected + 1).min(count - 1)));
+                true
+            }
+            KeyCode::Char('d') | KeyCode::Delete if selected < count => {
+                let _ = self.action_tx.send(Action::DeleteCommunity(selected));
                 true
             }
             KeyCode::Esc => {

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -321,6 +321,21 @@ impl MainPage {
         let comms = &self.props.main_page.content_panel.communities;
         let count = comms.items.len();
         let selected = comms.selected_index;
+
+        // A removal confirmation is pending: only confirm (y/Enter) or cancel
+        // (n/Esc) apply; every other key is swallowed so nothing slips through.
+        if let Some(idx) = comms.confirm_delete {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    let _ = self.action_tx.send(Action::DeleteCommunity(idx));
+                }
+                _ => {
+                    let _ = self.action_tx.send(Action::CommunityCancelDelete);
+                }
+            }
+            return true;
+        }
+
         match key.code {
             KeyCode::Char('j') => {
                 let _ = self.action_tx.send(Action::StartJoin);
@@ -339,7 +354,9 @@ impl MainPage {
                 true
             }
             KeyCode::Char('d') | KeyCode::Delete if selected < count => {
-                let _ = self.action_tx.send(Action::DeleteCommunity(selected));
+                let _ = self
+                    .action_tx
+                    .send(Action::CommunityConfirmDelete(selected));
                 true
             }
             KeyCode::Esc => {

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -1563,6 +1563,10 @@ impl ComponentRender<()> for MainPage {
                 "Mediator: --",
                 ratatui::style::Style::default().fg(COLOR_ORANGE),
             )),
+            MediatorStatus::NoActiveCommunity => Line::from(Span::styled(
+                "No active community",
+                ratatui::style::Style::default().fg(COLOR_ORANGE),
+            )),
         };
         frame.render_widget(
             Paragraph::new(connection_line).alignment(Alignment::Center),

--- a/openvtc/src/ui/pages/mod.rs
+++ b/openvtc/src/ui/pages/mod.rs
@@ -5,13 +5,14 @@ use crate::{
     },
     ui::{
         component::{Component, ComponentRender},
-        pages::{main::MainPage, setup_flow::SetupFlow},
+        pages::{join_flow::JoinFlow, main::MainPage, setup_flow::SetupFlow},
     },
 };
 use crossterm::event::KeyEvent;
 use ratatui::Frame;
 use tokio::sync::mpsc::UnboundedSender;
 
+pub mod join_flow;
 pub mod main;
 pub mod setup_flow;
 
@@ -36,6 +37,7 @@ pub struct AppRouter {
     //
     main_page: MainPage,
     setup_flow: SetupFlow,
+    join_flow: JoinFlow,
 }
 
 impl AppRouter {
@@ -43,6 +45,7 @@ impl AppRouter {
         match self.props.active_page {
             ActivePage::Main => &mut self.main_page,
             ActivePage::Setup => &mut self.setup_flow,
+            ActivePage::Join => &mut self.join_flow,
         }
     }
 }
@@ -57,6 +60,7 @@ impl Component for AppRouter {
             //
             main_page: MainPage::new(state, action_tx.clone()),
             setup_flow: SetupFlow::new(state, action_tx.clone()),
+            join_flow: JoinFlow::new(state, action_tx.clone()),
         }
         .move_with_state(state)
     }
@@ -70,6 +74,7 @@ impl Component for AppRouter {
             //
             main_page: self.main_page.move_with_state(state),
             setup_flow: self.setup_flow.move_with_state(state),
+            join_flow: self.join_flow.move_with_state(state),
         }
     }
 
@@ -88,6 +93,7 @@ impl ComponentRender<()> for AppRouter {
         match self.props.active_page {
             ActivePage::Main => self.main_page.render(frame, props),
             ActivePage::Setup => self.setup_flow.render(frame, props),
+            ActivePage::Join => self.join_flow.render(frame, props),
         }
 
         #[cfg(feature = "openpgp-card")]

--- a/openvtc/src/ui/pages/mod.rs
+++ b/openvtc/src/ui/pages/mod.rs
@@ -5,7 +5,9 @@ use crate::{
     },
     ui::{
         component::{Component, ComponentRender},
-        pages::{join_flow::JoinFlow, main::MainPage, setup_flow::SetupFlow},
+        pages::{
+            join_flow::JoinFlow, loading::LoadingScreen, main::MainPage, setup_flow::SetupFlow,
+        },
     },
 };
 use crossterm::event::KeyEvent;
@@ -13,6 +15,7 @@ use ratatui::Frame;
 use tokio::sync::mpsc::UnboundedSender;
 
 pub mod join_flow;
+pub mod loading;
 pub mod main;
 pub mod setup_flow;
 
@@ -38,11 +41,13 @@ pub struct AppRouter {
     main_page: MainPage,
     setup_flow: SetupFlow,
     join_flow: JoinFlow,
+    loading: LoadingScreen,
 }
 
 impl AppRouter {
     fn get_active_page_component_mut(&mut self) -> &mut dyn Component {
         match self.props.active_page {
+            ActivePage::Loading => &mut self.loading,
             ActivePage::Main => &mut self.main_page,
             ActivePage::Setup => &mut self.setup_flow,
             ActivePage::Join => &mut self.join_flow,
@@ -61,6 +66,7 @@ impl Component for AppRouter {
             main_page: MainPage::new(state, action_tx.clone()),
             setup_flow: SetupFlow::new(state, action_tx.clone()),
             join_flow: JoinFlow::new(state, action_tx.clone()),
+            loading: LoadingScreen::new(state, action_tx.clone()),
         }
         .move_with_state(state)
     }
@@ -75,6 +81,7 @@ impl Component for AppRouter {
             main_page: self.main_page.move_with_state(state),
             setup_flow: self.setup_flow.move_with_state(state),
             join_flow: self.join_flow.move_with_state(state),
+            loading: self.loading.move_with_state(state),
         }
     }
 
@@ -91,6 +98,7 @@ impl Component for AppRouter {
 impl ComponentRender<()> for AppRouter {
     fn render(&self, frame: &mut Frame, props: ()) {
         match self.props.active_page {
+            ActivePage::Loading => self.loading.render(frame, props),
             ActivePage::Main => self.main_page.render(frame, props),
             ActivePage::Setup => self.setup_flow.render(frame, props),
             ActivePage::Join => self.join_flow.render(frame, props),

--- a/openvtc/src/ui/pages/setup_flow/final_page.rs
+++ b/openvtc/src/ui/pages/setup_flow/final_page.rs
@@ -108,11 +108,11 @@ impl FinalPage {
 
             lines.push(Line::default());
             lines.push(Line::styled(
-                "You can now access the dashboard to:",
+                "Your account is ready — you can now join a community to:",
                 Style::new().fg(COLOR_BORDER).bold(),
             ));
             lines.push(Line::styled(
-                "  • Send relationship requests and connect with others.",
+                "  • Connect with its members and send relationship requests.",
                 Style::new().fg(COLOR_TEXT_DEFAULT),
             ));
             lines.push(Line::styled(

--- a/openvtc/src/ui/pages/setup_flow/final_page.rs
+++ b/openvtc/src/ui/pages/setup_flow/final_page.rs
@@ -77,7 +77,7 @@ impl FinalPage {
         if matches!(state.final_page.completed, Completion::CompletedOK) {
             lines.push(Line::default());
             lines.push(Line::styled(
-                "Congratulations! Your OpenVTC account is ready.",
+                "Congratulations! OpenVTC is now securely integrated with your Verifiable Trust Agent (VTA)",
                 Style::new().fg(COLOR_SUCCESS).bold(),
             ));
             lines.push(Line::default());
@@ -101,7 +101,7 @@ impl FinalPage {
 
             lines.push(Line::default());
             lines.push(Line::styled(
-                "Your account is ready — you can now join a community to:",
+                "You are now ready - you can join a community to:",
                 Style::new().fg(COLOR_BORDER).bold(),
             ));
             lines.push(Line::styled(

--- a/openvtc/src/ui/pages/setup_flow/final_page.rs
+++ b/openvtc/src/ui/pages/setup_flow/final_page.rs
@@ -3,7 +3,6 @@ use crate::colors::{
     COLOR_WARNING_ACCESSIBLE_RED,
 };
 use crossterm::event::{KeyCode, KeyEvent};
-use openvtc_core::LF_PUBLIC_MEDIATOR_DID;
 use ratatui::{
     Frame,
     layout::{
@@ -78,32 +77,26 @@ impl FinalPage {
         if matches!(state.final_page.completed, Completion::CompletedOK) {
             lines.push(Line::default());
             lines.push(Line::styled(
-                "Congratulations! Your OpenVTC profile is ready.",
+                "Congratulations! Your OpenVTC account is ready.",
                 Style::new().fg(COLOR_SUCCESS).bold(),
             ));
             lines.push(Line::default());
 
-            // Display profile information
+            // Display account information (State A — no persona/community yet).
             lines.push(Line::styled(
-                "Profile Summary:",
+                "Account Summary:",
                 Style::new().fg(COLOR_BORDER).bold(),
             ));
             lines.push(Line::from(vec![
-                Span::styled("  Display Name: ", Style::new().fg(COLOR_SUCCESS)),
-                Span::styled(&state.username, Style::new().fg(COLOR_SOFT_PURPLE)),
+                Span::styled("  VTA DID: ", Style::new().fg(COLOR_SUCCESS)),
+                Span::styled(&state.vta.vta_did, Style::new().fg(COLOR_SOFT_PURPLE)),
             ]));
             lines.push(Line::from(vec![
-                Span::styled("  Persona DID: ", Style::new().fg(COLOR_SUCCESS)),
-                Span::styled(&state.webvh_address.did, Style::new().fg(COLOR_SOFT_PURPLE)),
-            ]));
-
-            let mediator_did = state
-                .custom_mediator
-                .as_deref()
-                .unwrap_or(LF_PUBLIC_MEDIATOR_DID);
-            lines.push(Line::from(vec![
-                Span::styled("  Mediator DID: ", Style::new().fg(COLOR_SUCCESS)),
-                Span::styled(mediator_did, Style::new().fg(COLOR_SOFT_PURPLE)),
+                Span::styled("  Context: ", Style::new().fg(COLOR_SUCCESS)),
+                Span::styled(
+                    state.vta.context_id.as_deref().unwrap_or("(none)"),
+                    Style::new().fg(COLOR_SOFT_PURPLE),
+                ),
             ]));
 
             lines.push(Line::default());

--- a/openvtc/src/ui/pages/setup_flow/navigation.rs
+++ b/openvtc/src/ui/pages/setup_flow/navigation.rs
@@ -26,7 +26,7 @@ pub enum SetupEvent {
     // WebvhServerSelect
     UseWebvhServer {
         server_id: String,
-        custom_path: Option<String>,
+        path_mode: vta_sdk::protocols::did_management::create::WebvhPathMode,
     },
     CreateManually,
 
@@ -127,8 +127,8 @@ pub fn navigate(event: SetupEvent, state: &SetupState) -> NavResult {
         // === WebvhServerSelect ===
         SetupEvent::UseWebvhServer {
             server_id,
-            custom_path,
-        } => NavResult::SendAction(Action::WebvhServerCreateDid(server_id, custom_path)),
+            path_mode,
+        } => NavResult::SendAction(Action::WebvhServerCreateDid(server_id, path_mode)),
         SetupEvent::CreateManually => NavResult::SendAction(Action::VtaCreateKeys),
 
         // === VtaKeysFetch ===
@@ -333,7 +333,7 @@ mod tests {
         let r = navigate(
             SetupEvent::UseWebvhServer {
                 server_id: "id".to_string(),
-                custom_path: None,
+                path_mode: vta_sdk::protocols::did_management::create::WebvhPathMode::WellKnown,
             },
             &empty_state(),
         );

--- a/openvtc/src/ui/pages/setup_flow/navigation.rs
+++ b/openvtc/src/ui/pages/setup_flow/navigation.rs
@@ -116,13 +116,12 @@ pub fn navigate(event: SetupEvent, state: &SetupState) -> NavResult {
         SetupEvent::ImportConfig => NavResult::GoTo(SetupPage::ConfigImport),
 
         // === VtaProvisioning ===
-        SetupEvent::VtaAuthCompleted => {
-            if !state.vta.webvh_servers.is_empty() {
-                NavResult::GoTo(SetupPage::WebvhServerSelect)
-            } else {
-                NavResult::SendAction(Action::VtaCreateKeys)
-            }
-        }
+        // R-A-5: setup is now State A (account bootstrap) only. Once the admin
+        // credential is issued, go straight to protection then create the
+        // account — minting a persona / did:webvh moves to the State-B join flow
+        // (Stage 4). The persona-minting arms below are unreachable from this
+        // flow and will be reused by the join flow.
+        SetupEvent::VtaAuthCompleted => NavResult::GoTo(protection_entry()),
 
         // === WebvhServerSelect ===
         SetupEvent::UseWebvhServer {
@@ -151,10 +150,10 @@ pub fn navigate(event: SetupEvent, state: &SetupState) -> NavResult {
 
         // === DidGitSignAsk ===
         SetupEvent::DidGitSignAccept => NavResult::SendAction(Action::DidGitSignInstall),
-        SetupEvent::DidGitSignSkip => NavResult::GoTo(after_export()),
+        SetupEvent::DidGitSignSkip => NavResult::GoTo(protection_entry()),
 
         // === DidGitSignSetup ===
-        SetupEvent::DidGitSignDone => NavResult::GoTo(after_export()),
+        SetupEvent::DidGitSignDone => NavResult::GoTo(protection_entry()),
 
         // === Token pages ===
         #[cfg(feature = "openpgp-card")]
@@ -171,17 +170,19 @@ pub fn navigate(event: SetupEvent, state: &SetupState) -> NavResult {
         }
 
         // === UnlockCode ===
+        // R-A-5: after protection is decided, create the account (State A) and
+        // land on FinalPage. SetProtection records the passcode + page; the
+        // trailing SetupCompleted runs `Config::create_account`.
         SetupEvent::WantUnlockCode => NavResult::GoTo(SetupPage::UnlockCodeSet),
         SetupEvent::SkipUnlockCode => NavResult::GoTo(SetupPage::UnlockCodeWarn),
         SetupEvent::UnlockCodeSet { passphrase_hash } => {
-            let next = after_unlock(state);
-            NavResult::SendAction(Action::SetProtection(
+            NavResult::SendActionThenCompleteSetup(Action::SetProtection(
                 ConfigProtection::Passcode(passphrase_hash),
-                next,
+                SetupPage::FinalPage,
             ))
         }
         SetupEvent::ReturnToSetCode => NavResult::GoTo(SetupPage::UnlockCodeSet),
-        SetupEvent::AcceptNoCodeRisk => NavResult::GoTo(after_unlock(state)),
+        SetupEvent::AcceptNoCodeRisk => NavResult::CompleteSetup,
 
         // === Mediator ===
         SetupEvent::UseDefaultMediator => NavResult::GoTo(SetupPage::UserName),
@@ -207,8 +208,10 @@ pub fn navigate(event: SetupEvent, state: &SetupState) -> NavResult {
     }
 }
 
-/// After export (skip or complete), go to token setup or unlock code.
-fn after_export() -> SetupPage {
+/// Entry point into the config-protection sub-flow (token setup on openpgp-card
+/// builds, otherwise the unlock-code prompt). Reached straight after VTA
+/// provisioning in State-A setup, and after key export in the persona flow.
+fn protection_entry() -> SetupPage {
     #[cfg(feature = "openpgp-card")]
     {
         SetupPage::TokenStart
@@ -224,15 +227,6 @@ fn after_export() -> SetupPage {
 fn after_tokens(state: &SetupState) -> SetupPage {
     let _ = state; // tokens always lead to UnlockCodeAsk
     SetupPage::UnlockCodeAsk
-}
-
-/// After unlock code (set or skipped), go to UserName (webvh) or MediatorAsk (manual).
-fn after_unlock(state: &SetupState) -> SetupPage {
-    if state.vta.use_webvh_server {
-        SetupPage::UserName
-    } else {
-        SetupPage::MediatorAsk
-    }
 }
 
 /// Executes a `NavResult` against the setup flow.
@@ -307,25 +301,11 @@ mod tests {
     }
 
     #[test]
-    fn vta_auth_completed_routes_to_webvh_when_servers_advertised() {
-        use chrono::Utc;
-        use vta_sdk::webvh::WebvhServerRecord;
-        let mut state = empty_state();
-        state.vta.webvh_servers = vec![WebvhServerRecord {
-            id: "test-id".to_string(),
-            did: "did:webvh:test".to_string(),
-            label: Some("test".to_string()),
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        }];
-        let r = navigate(SetupEvent::VtaAuthCompleted, &state);
-        assert!(matches_goto(&r, SetupPage::WebvhServerSelect));
-    }
-
-    #[test]
-    fn vta_auth_completed_falls_back_to_create_keys_when_no_server() {
+    fn vta_auth_completed_routes_to_protection() {
+        // R-A-5: provisioning now leads straight into the protection sub-flow
+        // (then State-A account creation) — no persona-minting pages.
         let r = navigate(SetupEvent::VtaAuthCompleted, &empty_state());
-        assert!(is_send_action(&r));
+        assert!(matches_goto(&r, protection_entry()));
     }
 
     #[test]
@@ -401,15 +381,22 @@ mod tests {
     }
 
     #[test]
-    fn accept_no_code_risk_in_webvh_state_lands_on_username() {
-        let r = navigate(SetupEvent::AcceptNoCodeRisk, &webvh_state());
-        assert!(matches_goto(&r, SetupPage::UserName));
+    fn accept_no_code_risk_completes_account_setup() {
+        // R-A-5: no passcode → create the State-A account directly.
+        let r = navigate(SetupEvent::AcceptNoCodeRisk, &empty_state());
+        assert!(is_complete(&r));
     }
 
     #[test]
-    fn accept_no_code_risk_in_manual_state_lands_on_mediator() {
-        let r = navigate(SetupEvent::AcceptNoCodeRisk, &empty_state());
-        assert!(matches_goto(&r, SetupPage::MediatorAsk));
+    fn unlock_code_set_sets_protection_then_completes() {
+        use secrecy::SecretBox;
+        let r = navigate(
+            SetupEvent::UnlockCodeSet {
+                passphrase_hash: Arc::new(SecretBox::new(Box::new(vec![0u8; 32]))),
+            },
+            &empty_state(),
+        );
+        assert!(is_send_then_complete(&r));
     }
 
     #[test]

--- a/openvtc/src/ui/pages/setup_flow/webvh_server_select.rs
+++ b/openvtc/src/ui/pages/setup_flow/webvh_server_select.rs
@@ -14,6 +14,7 @@ use ratatui::{
     widgets::{Block, Padding, Paragraph, Wrap},
 };
 use tui_input::{Input, backend::crossterm::EventHandler};
+use vta_sdk::protocols::did_management::create::WebvhPathMode;
 
 use crate::{
     state_handler::{actions::Action, setup_sequence::SetupState},
@@ -34,6 +35,9 @@ pub struct WebvhServerSelect {
     pub method: SelectMethod,
     pub selected_server_index: usize,
     pub path_input: Input,
+    /// When true, the hosting server auto-assigns the path
+    /// ([`WebvhPathMode::AutoAssign`]); the path text field is ignored.
+    pub server_assign: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -149,26 +153,36 @@ fn handle_server_config(state: &mut SetupFlow, key: KeyEvent) {
             // Go back to method selection
             state.webvh_server_select.phase = SelectPhase::ChooseMethod;
             state.webvh_server_select.path_input.reset();
+            state.webvh_server_select.server_assign = false;
+        }
+        KeyCode::Tab => {
+            // Toggle "let the server choose the path" (auto-assign).
+            state.webvh_server_select.server_assign = !state.webvh_server_select.server_assign;
         }
         KeyCode::Enter => {
             let servers = &state.props.state.vta.webvh_servers;
             if let Some(server) = servers.get(state.webvh_server_select.selected_server_index) {
                 let server_id = server.id.clone();
+                // Path mode (R-B path select): server auto-assign wins; otherwise
+                // a blank field means the `.well-known` root, a value an explicit
+                // label.
                 let path_value = state.webvh_server_select.path_input.value().to_string();
-                let custom_path = if path_value.is_empty() {
-                    None
+                let path_mode = if state.webvh_server_select.server_assign {
+                    WebvhPathMode::AutoAssign
+                } else if path_value.is_empty() {
+                    WebvhPathMode::WellKnown
                 } else {
-                    Some(path_value)
+                    WebvhPathMode::Explicit(path_value)
                 };
 
                 // Store server selection in webvh_server state for UI rendering
                 state.props.state.webvh_server.selected_server_id = server_id.clone();
-                state.props.state.webvh_server.custom_path = custom_path.clone();
+                state.props.state.webvh_server.path_mode = path_mode.clone();
 
                 let result = navigate(
                     SetupEvent::UseWebvhServer {
                         server_id,
-                        custom_path,
+                        path_mode,
                     },
                     &state.props.state,
                 );
@@ -291,10 +305,17 @@ fn render_server_config(
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), content[0]);
 
     // Path input
-    let path_header = Line::styled(
-        "Custom path (optional, leave empty for auto-generated):",
-        Style::new().fg(COLOR_BORDER).bold(),
-    );
+    let path_header = if select.server_assign {
+        Line::styled(
+            "Path: the server will choose one  ([TAB] to set your own)",
+            Style::new().fg(COLOR_BORDER).bold(),
+        )
+    } else {
+        Line::styled(
+            "Path (blank = .well-known root, or type a label  —  [TAB]: let the server choose):",
+            Style::new().fg(COLOR_BORDER).bold(),
+        )
+    };
     frame.render_widget(Paragraph::new(path_header), content[1]);
 
     let [input_prompt, input_box] = Layout::horizontal([Length(2), Min(0)]).areas(Rect {
@@ -335,24 +356,44 @@ fn render_server_config(
         })
         .unwrap_or_default();
 
-    if path_value.is_empty() {
+    if select.server_assign {
         info_lines.push(Line::styled(
-            "If left empty, a random mnemonic phrase will be used as the path.",
+            "The hosting server will allocate the path (a random mnemonic).",
             Style::new().fg(COLOR_DARK_GRAY),
         ));
         info_lines.push(Line::default());
         info_lines.push(Line::from(vec![
             Span::styled("DID document URL: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled(
-                format!("https://{}/{{mnemonic}}/did.jsonl", server_domain),
+                format!("https://{}/{{server-assigned}}/did.jsonl", server_domain),
                 Style::new().fg(COLOR_ORANGE).italic(),
             ),
         ]));
         info_lines.push(Line::from(vec![
             Span::styled("Your DID:         ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled(
-                format!("did:webvh:{{scid}}:{}:{{mnemonic}}", server_domain),
+                format!("did:webvh:{{scid}}:{}:{{server-assigned}}", server_domain),
                 Style::new().fg(COLOR_ORANGE).italic(),
+            ),
+        ]));
+    } else if path_value.is_empty() {
+        info_lines.push(Line::styled(
+            "Blank path → a root DID, served at the host's /.well-known/did.jsonl.",
+            Style::new().fg(COLOR_DARK_GRAY),
+        ));
+        info_lines.push(Line::default());
+        info_lines.push(Line::from(vec![
+            Span::styled("DID document URL: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled(
+                format!("https://{}/.well-known/did.jsonl", server_domain),
+                Style::new().fg(COLOR_SOFT_PURPLE).bold(),
+            ),
+        ]));
+        info_lines.push(Line::from(vec![
+            Span::styled("Your DID:         ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled(
+                format!("did:webvh:{{scid}}:{}", server_domain),
+                Style::new().fg(COLOR_SOFT_PURPLE).bold(),
             ),
         ]));
     } else {
@@ -374,10 +415,17 @@ fn render_server_config(
 
     info_lines.push(Line::default());
 
+    let tab_hint = if select.server_assign {
+        " use my own path  |  "
+    } else {
+        " server-assign path  |  "
+    };
     if servers.len() > 1 {
         info_lines.push(Line::from(vec![
             Span::styled("[UP/DOWN]", Style::new().fg(COLOR_BORDER).bold()),
             Span::styled(" select server  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(tab_hint, Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
             Span::styled(" go back  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
@@ -385,6 +433,8 @@ fn render_server_config(
         ]));
     } else {
         info_lines.push(Line::from(vec![
+            Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(tab_hint, Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
             Span::styled(" go back  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),

--- a/openvtc/src/ui/pages/setup_flow/webvh_server_select.rs
+++ b/openvtc/src/ui/pages/setup_flow/webvh_server_select.rs
@@ -35,9 +35,6 @@ pub struct WebvhServerSelect {
     pub method: SelectMethod,
     pub selected_server_index: usize,
     pub path_input: Input,
-    /// When true, the hosting server auto-assigns the path
-    /// ([`WebvhPathMode::AutoAssign`]); the path text field is ignored.
-    pub server_assign: bool,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -153,27 +150,16 @@ fn handle_server_config(state: &mut SetupFlow, key: KeyEvent) {
             // Go back to method selection
             state.webvh_server_select.phase = SelectPhase::ChooseMethod;
             state.webvh_server_select.path_input.reset();
-            state.webvh_server_select.server_assign = false;
-        }
-        KeyCode::Tab => {
-            // Toggle "let the server choose the path" (auto-assign).
-            state.webvh_server_select.server_assign = !state.webvh_server_select.server_assign;
         }
         KeyCode::Enter => {
             let servers = &state.props.state.vta.webvh_servers;
             if let Some(server) = servers.get(state.webvh_server_select.selected_server_index) {
                 let server_id = server.id.clone();
-                // Path mode (R-B path select): server auto-assign wins; otherwise
-                // a blank field means the `.well-known` root, a value an explicit
-                // label.
+                // Map the typed path to the SDK's path mode (its `From<String>`
+                // convention): blank → server auto-assign, `.well-known` → root
+                // DID, anything else → that explicit label.
                 let path_value = state.webvh_server_select.path_input.value().to_string();
-                let path_mode = if state.webvh_server_select.server_assign {
-                    WebvhPathMode::AutoAssign
-                } else if path_value.is_empty() {
-                    WebvhPathMode::WellKnown
-                } else {
-                    WebvhPathMode::Explicit(path_value)
-                };
+                let path_mode = WebvhPathMode::from(path_value);
 
                 // Store server selection in webvh_server state for UI rendering
                 state.props.state.webvh_server.selected_server_id = server_id.clone();
@@ -305,17 +291,10 @@ fn render_server_config(
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), content[0]);
 
     // Path input
-    let path_header = if select.server_assign {
-        Line::styled(
-            "Path: the server will choose one  ([TAB] to set your own)",
-            Style::new().fg(COLOR_BORDER).bold(),
-        )
-    } else {
-        Line::styled(
-            "Path (blank = .well-known root, or type a label  —  [TAB]: let the server choose):",
-            Style::new().fg(COLOR_BORDER).bold(),
-        )
-    };
+    let path_header = Line::styled(
+        "Path — blank: server assigns one  |  \".well-known\": root DID  |  or type a label:",
+        Style::new().fg(COLOR_BORDER).bold(),
+    );
     frame.render_widget(Paragraph::new(path_header), content[1]);
 
     let [input_prompt, input_box] = Layout::horizontal([Length(2), Min(0)]).areas(Rect {
@@ -356,9 +335,10 @@ fn render_server_config(
         })
         .unwrap_or_default();
 
-    if select.server_assign {
+    let trimmed_path = path_value.trim();
+    if trimmed_path.is_empty() {
         info_lines.push(Line::styled(
-            "The hosting server will allocate the path (a random mnemonic).",
+            "Blank → the hosting server assigns a path (a random mnemonic).",
             Style::new().fg(COLOR_DARK_GRAY),
         ));
         info_lines.push(Line::default());
@@ -376,9 +356,9 @@ fn render_server_config(
                 Style::new().fg(COLOR_ORANGE).italic(),
             ),
         ]));
-    } else if path_value.is_empty() {
+    } else if trimmed_path == ".well-known" {
         info_lines.push(Line::styled(
-            "Blank path → a root DID, served at the host's /.well-known/did.jsonl.",
+            "Root DID, served at the host's /.well-known/did.jsonl.",
             Style::new().fg(COLOR_DARK_GRAY),
         ));
         info_lines.push(Line::default());
@@ -400,14 +380,14 @@ fn render_server_config(
         info_lines.push(Line::from(vec![
             Span::styled("DID document URL: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled(
-                format!("https://{}/{}/did.jsonl", server_domain, path_value),
+                format!("https://{}/{}/did.jsonl", server_domain, trimmed_path),
                 Style::new().fg(COLOR_SOFT_PURPLE).bold(),
             ),
         ]));
         info_lines.push(Line::from(vec![
             Span::styled("Your DID:         ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled(
-                format!("did:webvh:{{scid}}:{}:{}", server_domain, path_value),
+                format!("did:webvh:{{scid}}:{}:{}", server_domain, trimmed_path),
                 Style::new().fg(COLOR_SOFT_PURPLE).bold(),
             ),
         ]));
@@ -415,17 +395,10 @@ fn render_server_config(
 
     info_lines.push(Line::default());
 
-    let tab_hint = if select.server_assign {
-        " use my own path  |  "
-    } else {
-        " server-assign path  |  "
-    };
     if servers.len() > 1 {
         info_lines.push(Line::from(vec![
             Span::styled("[UP/DOWN]", Style::new().fg(COLOR_BORDER).bold()),
             Span::styled(" select server  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(tab_hint, Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
             Span::styled(" go back  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
@@ -433,8 +406,6 @@ fn render_server_config(
         ]));
     } else {
         info_lines.push(Line::from(vec![
-            Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(tab_hint, Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
             Span::styled(" go back  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),


### PR DESCRIPTION
## ✅ T1 — config v2 multi-community model + active-identity

Implements **T1** (multi-community foundation) against the API sketch (#66), landed as **green, reviewable slices** via the strangler technique — every commit builds and passes the full gate (`fmt`, `clippy -D warnings`, `cargo test`). The single-persona/single-community singleton has been removed **field-by-field** as its readers migrated; no big red pass, no shipped shim (D10).

### ✅ Done — foundation + first deletions (slices 1–8)
**Foundation (1–4):**
1. v2 model — `Account`/`PersonaRecord`/`CommunityRecord`/`CommunityStatus`/`PersonaId` (`openvtc-core/src/config/account.rs`)
2. persona-keyed `IdentityRegistry` / `IdentityRef` (`openvtc-core/src/identity.rs`)
3. `Config.account` populated at load (strangler bridge)
4. runtime `IdentityContext` + `Config::active_identity()`

**Wizard consistency + early deletions (5–8):**
5. setup wizard emits `account` + `identities` natively → `active_identity()` consistent across load **and** setup
6. **deleted `Config.persona_did`** (the `PersonaDID` struct) — reader migrated to `active_identity()`
7. **deleted `Config.atm_profiles`** (dead/write-only)
8. **deleted `Config.vrcs`** (derived cache)

### ✅ Done — final slice (9–11): v2 is now the persisted source of truth
9. **Persist `account` in the encrypted tier.** `ProtectedConfig` owns the v2 `Account` (it embeds relationship/VRC data + persona/community DIDs). `Config::save` mirrors the live account in; `load_step2` reads it back and drives DID resolution, the ATM profile, and the runtime `IdentityContext` from the active persona. (commit `f080759`)
10. **`CONFIG_VERSION` → 2 + breaking reset (D13 / R-RST).** A pre-v2 config is detected on the *plaintext* public config — before any v2-shape decryption (R-RST-1) — and surfaced as the new typed `OpenVTCError::ConfigVersionUnsupported`. Boot warns that the config + stored credentials **will be deleted**, requires interactive confirmation (R-RST-2), deletes the profile + keyring entry on yes (R-RST-3), then runs setup. A brand-new install still hits `ConfigNotFound → setup` with no prompt (R-RST-4). The dead in-place `migrate_config` is removed. (commit `436ab62`)
11. **Deleted the persisted `public.persona_did` / `mediator_did` / `lk_did` singletons.** `lk_did` → account-level `Account.org_did`. New `Config` accessors (`persona_did() -> &str`, `persona_did_arc() -> Arc<String>`, `mediator_did() -> &str`, `set_active_mediator_did()`); ~40 reader sites across didcomm / relationship / inbox / message-dispatch / main-page / settings / setup migrated onto them. `load_step2` now requires a persisted account (the v1-derive fallback is dead once v1 resets). (commit `2bcb8a8`)

### ▶️ Out of scope (intentionally left on `Config`)
- **`key_backend`** / **`key_info`** — legitimately *account-singular* runtime secret material (one VTA admin credential / BIP32 seed per profile), not single-persona assumptions; the persisted `Account` holds no secrets (D12). They stay on `Config`.

### Follow-on T1 work (separate, after this PR — `docs/design/multi-community-support.md`)
- Persona-keyed `SessionManager` (consumes `IdentityRegistry::sessions()`).
- Community-scoped main page + State-B community join flow.
- Relocate per-community relationships/VRCs into `CommunityRecord` (still top-level in `ProtectedConfig` today).

### Notes
- Branch `feat/t1-config-v2-identity`, 11 green slices. Gate: `cargo build --workspace && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`.
- GPG signing is off in this environment; all commits use DCO `-s`.
- One UX consequence of moving the persona DID into the encrypted tier: the pre-decrypt main-page render shows a blank DID until `load_step2` completes, then populates.


---

## 🔄 Update — R-A-5 setup reshape + runtime/startup UX (landed on this branch since the above)

The branch has grown beyond the T1 model foundation to also carry the **R-A-5 State-A/State-B reshape** and a substantial **runtime + startup-UX** pass. Every commit remains green (`fmt`, `clippy -D warnings`, full test suite).

### R-A-5 — State-A bootstrap + State-B join
- Zero-persona (State-A) accounts are loadable & coherent; `Config::create` split into `create_account` + `mint_persona_into`.
- Setup is now **State-A account bootstrap only**; persona minting moved into the join flow.
- **Communities overview** page + menu hub: navigate (↑/↓), join (`j`), remove (`d`, with a y/n confirm even for Pending).
- **State-B "join a community" flow** — automated persona-mint → sub-context → join-submit, with granular live progress and a Pending `CommunityRecord`.

### Startup & connection UX
- Dedicated **loading screen** (`ActivePage::Loading`): hierarchical major→sub **timed** steps (status icons, per-step + combined timing), rotating tips, and the full error + recovery suggestion on failure.
- **Two-phase, non-blocking startup**: removed the up-front 30s `wait_connected`; phase-2 community connections run async with event-driven status. **Press [ENTER] to continue** once phase 1 finishes (the connection is already running in the background).
- Perf: **connect to the VTA once** (`load_step2` hands its admin session forward), **cached DID document** (skip the network resolve), human-friendly durations (`3.42ms` / `5.83s`).

### Correctness fixes
- Minted persona uses the **account VTA mediator**; an existing persona stored without one is **recovered from its DID document** at load (no re-join).
- Community-scoped **persona profile name** and **listener id** (no more generic "persona" in logs); the persona listener is **torn down when its community is deleted**.
- Join success screen: no restart prompt, no duplicate DID, shows the persona DID. Top bar hides persona identity until in a community.
- Fixed a pre-existing **flaky `did-git-sign` test** (it mutated a shared fixture under parallel runs).

### Dependencies (Trust Tasks 0.2 line)
- affinidi-data-integrity 0.7, affinidi-crypto 0.2, vta-sdk 0.9.11, affinidi-tdk 0.7.4, didwebvh-rs 0.5.4, dtg-credentials 0.1.3 (+ messaging/resolver patches). API-compatible — no openvtc source changes.
- openvtc already consumes **provision/integration 0.2** via `ProvisionAsk::vta_admin_rotated` (admin-template single-transaction rollover); the other trust-tasks it uses (acl/grant, auth, did-management) remain 0.1-only upstream.
