### PR TITLE
docs: fold in VTA hierarchical contexts + MockVta (VTI #256/#257)

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,6 +16,6 @@ changes is discoverable alongside the code.
 
 | Document | Status | Summary |
 |----------|--------|---------|
-| [multi-community-support.md](./multi-community-support.md) | DRAFT v4 | Split setup into account bootstrap + per-community join; join multiple VTCs (concurrent live sessions); account-level personas; Communities overview page; VTA-as-store; breaking config reset. |
+| [multi-community-support.md](./multi-community-support.md) | DRAFT v5 | Split setup into account bootstrap + per-community join; join multiple VTCs (concurrent live sessions); account-level personas; Communities overview page; VTA-as-store; breaking config reset. |
 | [multi-community-presentation.html](./multi-community-presentation.html) | Deck | Visual before/after walkthrough of the multi-community design — Mermaid flows + TUI mockups. Open in a browser; `←`/`→` to navigate. |
 | [t1-active-identity-api.md](./t1-active-identity-api.md) | For review | T1 foundation API sketch — config v2 model, `IdentityContext`/`IdentityRegistry`, persona-keyed session manager, consumer-refactor pattern, resolved forks. |

--- a/docs/design/multi-community-support.md
+++ b/docs/design/multi-community-support.md
@@ -1,10 +1,10 @@
 # SPEC — Multi-Community Support for the OpenVTC CLI
 
-> Status: **DRAFT v4** — decisions D1–D17 settled (VTA-as-store, breaking reset,
-> per-community main page, read-only/archive/delete, supervised sessions,
-> join timeout, did-git-sign selection). Open: VP discovery (deferred) +
-> sub-context authorization (infra-side). Task breakdown in `tasks/plan.md` +
-> `tasks/todo.md`.
+> Status: **DRAFT v5** — decisions D1–D17 settled. **Hierarchical contexts are
+> now real and VTA-enforced** (VTI #257): D2/D9 updated, sub-context
+> authorization resolved (ancestry ACL), and a real **MockVta** harness exists
+> for T9 (VTI #256). Only open item: VP discovery (deferred, D4). Task breakdown
+> in `tasks/plan.md` + `tasks/todo.md`.
 > Scope: the `openvtc` CLI (ratatui TUI) and `openvtc-core` config model. No
 > changes to the verifiable-trust-infrastructure repo are in scope here; where
 > infra/SDK changes are required they are called out as **external
@@ -40,14 +40,14 @@ with live status, on a Communities overview page.
 | # | Decision | Choice |
 |---|----------|--------|
 | D1 | Persona DID per community vs shared | **User chooses per join.** Personas are account-level resources referenced by communities. |
-| D2 | Context hierarchy mechanism | **Path-naming convention now, migrate later.** Isolated behind one `context_path` module. |
+| D2 | Context hierarchy mechanism | **Real hierarchical contexts — VTA-enforced (VTI #257).** A context id *is* its `/`-separated path (`<top>/<community>`); the VTA validates depth/segments and enforces **ancestry-aware ACL** (a parent-context admin covers the whole subtree). No longer a migrate-later convention. Path logic lives in one `context_path` module mirroring `vti-common::context_path`; **no `vta-sdk` change needed** (`create_context` already takes a path id). |
 | D3 | Join semantics | **VP-based with pending-approval state** … |
 | D4 | VP construction (join step 4) | **…but deferred.** Stub the presentation; land everything around it. |
 | D5 | Persona creation timing | **Lazy.** No `did:webvh` at bootstrap; first persona minted on first join. |
 | D6 | Persona ↔ context coupling | **Self-contained persona.** A persona is a complete `did:webvh` + its own keys, independent of context. Reuse presents the *same* DID/keys to multiple communities; a sub-context is purely VTA-side organisation. `origin_context_id` is provenance only. |
 | D7 | Mediator / routing | **Default to the VTA mediator, optionally overridable per DID/persona.** Each persona's DIDComm service endpoint (its mediator) defaults to the VTA-provided mediator; at mint time the user may opt to use a different mediator instead. The mediator is a property of the DID document, so the choice is **per-DID** — which, because a fresh DID is typically minted per community (D1), reads as per-community in the common case. A *reused* persona keeps the mediator baked into its DID doc. |
 | D8 | Community lifecycle states | **Pending, Active, Left, Rejected, Removed** (see §5.6). |
-| D9 | Sub-context id derivation | **`<top>/<slug-from-name>`** — human-readable slug from the VTC display name, with a collision-suffix rule, under the top context. |
+| D9 | Sub-context id derivation | **`<top>/<slug-from-name>`** — slug from the VTC display name, with a collision-suffix rule, under the top context. Each segment must be a valid context identifier (`vti-common` rules); **max depth 8** (top/community = depth 2). |
 | D10 | Migration strategy | **Full refactor, no compatibility shim.** Replace the singleton with an explicit active-identity abstraction everywhere; core model + `openvtc` consumer refactor land in one PR. |
 | D11 | Runtime session model | **Concurrent live sessions.** Each active community's persona holds its own live DIDComm/mediator session simultaneously. The single message loop becomes a **multi-session manager** (built in T1, running N=1 at first); joining registers a new session, leaving deregisters one. |
 | D12 | System of record | **The VTA stores persona DIDs, key info, and credentials.** Local config holds only the account **admin credential** (bootstrap secret), community-membership metadata, persona *references*, and UX prefs (favourites). This is the backup/restore story — the VTA is the store, not a local export. Aligns with the existing `KeySourceMaterial::VtaManaged { key_id }` model. |
@@ -76,9 +76,12 @@ with live status, on a Communities overview page.
   (`setup_vta_actions.rs:135`), passed to VTA `create_key` / provisioning.
 - **vta-sdk 0.9.6 already provides:**
   - Context CRUD — `create_context`, `list_contexts`, `get_context`,
-    `update_context_did`, `delete_context`. **Flat** (`ContextResponse { id,
-    name, did, base_path, … }`, no `parent_id`). Each context has its own
-    BIP32 `base_path` and optional `did`.
+    `update_context_did`, `delete_context`. The `ContextResponse` has no
+    `parent_id` field because **hierarchy is encoded in the id itself** — a
+    context id *is* its `/`-separated path (VTI #257). The VTA validates the
+    path (depth/segments) and enforces ancestry-aware ACL server-side, so
+    `create_context` with a path id like `<top>/<community>` is all the CLI
+    needs. Each context also has a BIP32 `base_path` and optional `did`.
   - **VTC join protocol** — `vta_sdk::protocols::join_requests`:
     `JOIN_REQUEST_SUBMIT_TYPE`, a submit receipt with `status` (e.g.
     `"pending"`), and `MEMBER_SELF_REMOVE`. Submit body carries a Verifiable
@@ -280,13 +283,17 @@ read-only, D14):
 
 ## 6. Architecture & project structure
 
-- **`context_path` module (new)** — single source of truth for the hierarchy
-  convention (D2). Responsibilities: build a sub-context id from
-  `(top_context_id, vtc)`, parse one, render for display. Every
-  `create_context` / `context_id` call site routes through it. Swapping to a
-  real `parent_id` API later changes only this module + the create call site.
-  - Proposed location: `openvtc-core/src/config/context_path.rs` (or a small
-    `openvtc-core/src/context/` module) — to be confirmed in task breakdown.
+- **`context_path` module** — the hierarchy is **real and VTA-enforced** now
+  (`vti-common::context_path`: `/`-separated paths, `MAX_CONTEXT_DEPTH = 8`,
+  segment-aware ancestry, parent-admin-covers-subtree ACL — pure, store-free).
+  The CLI module builds/validates sub-context paths from `(top_context_id, vtc)`
+  (`child_path`, `validate_context_path`) and renders them for display; the
+  **VTA is the enforcement source of truth** (it re-validates). **Reuse
+  `vti-common`'s helpers if consumable, otherwise mirror them** (CLAUDE.md:
+  prefer existing libs; raise re-exporting them from `vta-sdk` to avoid drift on
+  the security-critical rules). `create_context` is unchanged — it already takes
+  a path id, so **no `vta-sdk` API change is required**.
+  - Proposed location: `openvtc-core/src/config/context_path.rs`.
 - **Config types** — extend `openvtc-core/src/config/`:
   - New `account` / `Persona` / `Community` types; `personas` and `communities`
     collections. **No migration (D13):** detect a v1 `config_version`, warn +
@@ -350,9 +357,6 @@ read-only, D14):
 - **VP requirement discovery** — how a VTC advertises which credentials its VP
   must contain (DID-doc service entry? discovery message? out-of-band?) is
   **undecided / infra-side** and blocks D4. Tracked as an open question (§10).
-- Real hierarchical context API (`parent_id`) — infra/SDK change; CLI uses the
-  interim convention until then.
-- Sub-context authorization at the VTA layer (§10.5) — owner-driven infra design.
 - *New* per-community capabilities beyond porting today's main page
   (relationships/contacts/VRCs/messaging) to the community scope. Persona key
   rotation (R-P-3).
@@ -386,13 +390,6 @@ read-only, D14):
 1. **VP requirement discovery** (blocks D4) — where do a VTC's join requirements
    come from (DID-doc service entry? discovery message? out-of-band)? Deferred
    with D4; does not block this spec.
-5. **Sub-context authorization (infra-side)** — whether the VTA authorizes a
-   path-style flat context (`<top>/<slug>`) under the top-context admin
-   credential, and enforces the hierarchy, is **to be designed at the VTA layer
-   separately** (per owner). The CLI proceeds with the convention (D2); State A
-   top-context creation and State B sub-context creation depend on this landing
-   server-side. Tracked as an external dependency, not a CLI blocker for the
-   model/UX work.
 
 ### Locked (proposed defaults — override anytime)
 2. **Config tier placement** — `Community` records (vtc_did, sub_context_id,
@@ -410,7 +407,10 @@ read-only, D14):
    trim leading/trailing `-`; cap at 32 chars. On collision within the top
    context, append `-2`, `-3`, … When the VTC DID doc has no usable name, fall
    back to a short stable token derived from the VTC DID via `didwebvh-rs`
-   (no hand-rolled string surgery — per `CLAUDE.md`).
+   (no hand-rolled string surgery — per `CLAUDE.md`). The slug must be a valid
+   **context identifier** (`vti-common::validate_identifier`) and the full
+   `<top>/<slug>` path must satisfy `validate_context_path` (depth ≤ 8); the VTA
+   re-validates server-side.
 
 ### Resolved (folded into decisions)
 - ~~Backup/restore~~ → **D12**: the VTA is the store of persona DIDs/keys/
@@ -425,5 +425,11 @@ read-only, D14):
 - ~~Persona key derivation on reuse~~ → **D6**: personas are self-contained and
   context-independent; reuse presents the same DID/keys.
 - ~~Slug vs hash vs label for sub-context id~~ → **D9**: slug-from-name.
+- ~~Sub-context authorization (infra-side)~~ → **resolved by VTI #257**: the VTA
+  enforces ancestry-aware ACL — admin of the top context automatically covers
+  its subtree, so per-community sub-context creation is authorized. Hierarchy
+  validation (depth, segments) is server-enforced.
+- ~~Real hierarchical context API~~ → **shipped (VTI #257)**: contexts are
+  `/`-separated paths; no `vta-sdk` change needed (path ids via `create_context`).
 - ~~Mediator selection~~ → **D7**: defaults to the VTA mediator, optionally
   overridable per DID/persona at mint time.

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -140,7 +140,7 @@ which may land in parallel.
 | Full config refactor (D10) is large — many read sites of `persona_did`, `key_backend`. | All consumers routed through one **active-identity abstraction**; landed as reviewable commits; grep-clean of removed fields is an acceptance gate; full CI must be green. A fresh single-persona bootstrap exercises every refactored path. |
 | Old config handled wrong (lockout / silent loss). | **No migration (D13):** v1 is detected and reset behind an explicit user-confirmed warning; tests cover detect→warn→delete→fresh-setup and the new-install path. The VTA is the store (D12), so the durable material isn't in the deleted local config. |
 | Concurrent live sessions (D11) are a large runtime change to today's single loop. | The multi-session manager is built in T1 running **N=1** (identical behavior, unit-tested with ≥2 simulated sessions); join/leave register/deregister sessions; real N>1 concurrency is first exercised by T5. Avoids a later loop rewrite ("right from the start"). |
-| Interim slug convention paints us into a corner vs real `parent_id` API. | All path logic confined to `context_path` (T2); swap point is one module + the `create_context` call site. |
+| Context-path rules drift from the VTA's enforcement. | Hierarchy is VTA-enforced (VTI #257); `context_path` (T2) mirrors `vti-common::context_path` (reuse if consumable) and the VTA re-validates server-side. No `vta-sdk` change needed. |
 | VTC join requirements unknown (VP). | D4 stubbed; T5 isolates the VP into a single function returning a placeholder. |
 | Setup wizard refactor is large and entangled. | T3 splits entry points but reuses existing step handlers; bootstrap is a *subset* of today's flow (drops persona/mediator/webvh steps), not a rewrite. |
 
@@ -148,7 +148,6 @@ which may land in parallel.
 
 ## 6. Deferred (tracked, not in this plan)
 - **D4 / VP construction** and **VP requirement discovery** (spec §8, §10.1).
-- **Real hierarchical context API** (`parent_id`) — infra/SDK change.
 - Rich per-community detail UX beyond status/persona/leave (R-C-6 keeps the
   page extensible).
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -69,10 +69,16 @@ Status legend: `[ ]` todo · `[~]` in progress · `[x]` done
   - Slug rule (§10.4): lowercase; keep `[a-z0-9-]`; collapse other runs to `-`;
     trim; cap 32; collision suffix `-2`, `-3`, …; name-less fallback derives a
     stable token from the VTC DID via `didwebvh-rs` (no hand-rolled parsing).
-  - Single swap point documented for the future `parent_id` API.
+    Each segment must be a valid context identifier and the full path satisfy
+    `validate_context_path` (depth ≤ 8) — **mirror `vti-common::context_path`**
+    (reuse if consumable; else replicate its rules to avoid drift).
+  - **Hierarchy is VTA-enforced (VTI #257)** — the VTA validates depth/segments
+    and ancestry ACL server-side; this module just builds/validates paths. **No
+    `vta-sdk` change needed** (`create_context` already takes a path id).
 - **Acceptance criteria:**
   - build/parse/render round-trip tests pass; slug + collision + fallback cases
-    covered; no `format!`-style DID surgery (uses `didwebvh-rs`).
+    covered; paths satisfy the `vti-common` rules; no `format!`-style DID
+    surgery (uses `didwebvh-rs`).
 - **Verification:** `cargo test -p openvtc-core` (context_path unit tests).
 - **Depends on:** — (parallelizable with T1)
 
@@ -227,15 +233,20 @@ Status legend: `[ ]` todo · `[~]` in progress · `[x]` done
   the git-config / env override set.
 - **Depends on:** T1 (persona model) · independent of T3–T7 otherwise.
 
-### [ ] T9 — Mock VTA/mediator integration harness *(nice-to-have)*
-- **Crate:** test-only (dev-deps; `affinidi-messaging-test-mediator` present)
-- **Satisfies:** spec §9 testing (non-blocking)
+### [ ] T9 — MockVta integration harness
+- **Crate:** test-only — **`MockVta` now exists** (VTI #256, in the `vta-service`
+  crate: `MockVta::start()` → `base_url()` → `shutdown()`).
+- **Satisfies:** spec §9 testing
 - **Description:**
-  - Integration tests exercising bootstrap + join + lifecycle against a mock
-    VTA/VTC. User to supply a mock VTA externally for now.
-- **Acceptance criteria:** end-to-end bootstrap→join→resolve runs against the
-  mock in CI or locally.
-- **Depends on:** T5 · **not required for v1.**
+  - Add `vta-service` as a **git dev-dependency** (VTI repo) and write
+    integration tests that start a `MockVta`, point the CLI at `base_url()`, and
+    exercise bootstrap (State A) → join (State B) → lifecycle.
+  - **CI prerequisite:** add the VTI git URL to `deny.toml` `[sources].allow-git`
+    (currently `[]` with `unknown-git = "deny"`), or `cargo deny check sources`
+    fails.
+- **Acceptance criteria:** end-to-end bootstrap→join→resolve runs against a live
+  `MockVta` in CI or locally; `cargo deny` passes with the git source allowed.
+- **Depends on:** T5 · promoted from nice-to-have now that MockVta exists.
 
 > **CHECKPOINT 3** — feature complete (minus deferred VP). See plan §3.
 
@@ -243,7 +254,7 @@ Status legend: `[ ]` todo · `[~]` in progress · `[x]` done
 
 ## Deferred (not scheduled here)
 - D4 VP construction + VP requirement discovery (spec §8, §10.1).
-- Real hierarchical context API (`parent_id`); VTA-side sub-context
-  authorization (§10.5, owner-driven).
+- *(Resolved — VTI #257)* hierarchical contexts + sub-context authorization are
+  now VTA-enforced; `context_path` (T2) mirrors `vti-common::context_path`.
 - *New* per-community capabilities beyond porting today's main page; persona
   key rotation (R-P-3).


### PR DESCRIPTION
## Summary

Design refresh after the VTI repo shipped **hierarchical trust contexts** (#257) and a **MockVta** test harness (#256). Read the real API in `OpenVTC/verifiable-trust-infrastructure@main` and folded it into the spec + plan.

### What changed in the design
- **D2/D9 — hierarchy is now real & VTA-enforced.** A context id *is* its `/`-separated path (`vti-common::context_path`: max depth 8, segment-aware ancestry, **parent-admin-covers-subtree ACL**, store-free). Dropped the "convention now, migrate later" framing — this is the canonical model. **No `vta-sdk` change needed**: `create_context` already takes a path id; the VTA validates/authorizes server-side.
- **§10.5 sub-context authorization → RESOLVED.** OpenVTC, as admin of its top context, automatically covers the subtree, so per-community sub-context creation is authorized by the ancestry ACL.
- **T2 (`context_path`)** now mirrors `vti-common::context_path` (reuse if consumable, else replicate its rules to avoid drift); slug segments must satisfy `validate_identifier` + the full path `validate_context_path`.
- **T9 promoted** from nice-to-have to a real **MockVta** integration harness (`vta-service` crate: `MockVta::start()` / `base_url()` / `shutdown()`).
- Spec → **DRAFT v5**; removed the now-shipped items from the deferred lists.

### Follow-up (not in this PR — code/deps)
- T9 needs `vta-service` as a **git dev-dependency** (VTI repo) **and** the VTI git URL added to `deny.toml` `[sources].allow-git` (currently `[]` with `unknown-git = "deny"`), or `cargo deny check sources` fails. Tracked in T9.

Docs-only; no code change.