### PR TITLE
fix(join): load minted persona secrets into the resolver in-session

### DIFF
--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -1,6 +1,6 @@
 /*! Contains specific Config extensions for the CLI Application. */
 
-use affinidi_tdk::{TDK, messaging::profiles::ATMProfile};
+use affinidi_tdk::{TDK, messaging::profiles::ATMProfile, secrets_resolver::SecretsResolver};
 use anyhow::{Result, bail};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use chrono::Utc;
@@ -22,7 +22,6 @@ use secrecy::{ExposeSecret, SecretBox, SecretString};
 use std::{
     collections::{HashMap, VecDeque},
     fs,
-    sync::Arc,
 };
 use tokio::sync::watch;
 
@@ -385,17 +384,36 @@ impl ConfigExtension for Config {
         // or from a load.
         let persona_did_str = state.webvh_address.did.to_string();
         let document = state.webvh_address.document.clone();
-        let persona_profile = Arc::new(
-            ATMProfile::new(
-                tdk.atm
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("TDK ATM not initialized"))?,
-                Some("Persona DID".to_string()),
-                persona_did_str.clone(),
-                Some(mediator_did.clone()),
-            )
-            .await?,
-        );
+        let atm = tdk
+            .atm
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("TDK ATM not initialized"))?;
+        let persona_profile = ATMProfile::new(
+            atm,
+            Some("Persona DID".to_string()),
+            persona_did_str.clone(),
+            Some(mediator_did.clone()),
+        )
+        .await?;
+        // Register the profile with the ATM (no socket) and load the persona's
+        // secrets into the live secrets resolver, mirroring the config-load path
+        // (`regenerate_persona_keys`). Without this a just-minted persona cannot
+        // pack/unpack DIDComm in THIS session — packing authcrypt fails with
+        // "sender has no usable key agreement key" because its X25519
+        // key-agreement secret isn't in the resolver yet.
+        let persona_profile = atm.profile_add(&persona_profile, false).await?;
+        tdk.get_shared_state()
+            .secrets_resolver()
+            .insert(persona_keys.signing.secret.clone())
+            .await;
+        tdk.get_shared_state()
+            .secrets_resolver()
+            .insert(persona_keys.authentication.secret.clone())
+            .await;
+        tdk.get_shared_state()
+            .secrets_resolver()
+            .insert(persona_keys.decryption.secret.clone())
+            .await;
         let persona_id = PersonaId::new();
         let persona_record = PersonaRecord {
             persona_id,


### PR DESCRIPTION
## Bug

Joining a community failed at the submit step:

```
ERROR: Failed to submit join request: ATM Error: DIDComm message error:
pack_encrypted. Reason: sender has no usable key agreement key
```

(Surfaced by #69, which made the join actually send over DIDComm.)

## Root cause

`mint_persona_into` built the persona's ATM profile (`ATMProfile::new`) but **never loaded the persona's key material into the live TDK secrets resolver**, and didn't `profile_add` it. The config-**load** path does both via `regenerate_persona_keys` + `profile_add` — which is why messaging worked after a restart but not in the minting session.

The join flow packs **authcrypt** immediately after minting. authcrypt needs the *sender's* X25519 key-agreement secret to derive the shared key; it wasn't in the resolver yet → "no usable key agreement key."

## Fix

In `mint_persona_into`, after building the profile:
- `atm.profile_add(&persona_profile, false)` (register, no socket), and
- insert the persona's signing / authentication / **decryption (X25519)** secrets — already in hand from the mint — into `tdk.get_shared_state().secrets_resolver()`.

Mirrors the load path, so a just-minted persona is immediately usable for DIDComm. Fixes **join** (in-session authcrypt send) and also makes **setup**'s persona usable in-session without a restart.

## Verification
Compiles; `cargo fmt` + `clippy` clean. Please re-run the join against the live VTC — submit should now pack and send. (Still pending separately: the submit-receipt handler to reconcile the authoritative VTC `requestId`.)

One file. Leaves untouched the pre-existing uncommitted `vta-sdk 0.9→0.10` bump in the working tree.