### PR TITLE
feat(ui): per-community detail for the selected community

### DIFF
--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -59,6 +59,19 @@ pub struct CommunitySummary {
     pub favourite: bool,
     /// Whether this community raises the actions-required indicator (R-C-3).
     pub needs_attention: bool,
+    /// Full persona `did:webvh` presented to this community (troubleshooting
+    /// detail). Empty if the `persona_ref` dangles.
+    pub persona_did: String,
+    /// The community's VTC `did:webvh` (troubleshooting detail).
+    pub vtc_did: String,
+    /// The per-community sub-context id (troubleshooting detail).
+    pub sub_context_id: String,
+    /// The join request id while `Pending`; empty otherwise.
+    pub request_id: String,
+    /// Whether the membership credential (VMC) has been received + stored.
+    pub has_membership_credential: bool,
+    /// Whether the role endorsement credential (VEC) has been received.
+    pub has_role_credential: bool,
 }
 
 // ****************************************************************************

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -357,6 +357,12 @@ impl MainPageState {
                 .and_then(|p| p.label.clone())
                 .or_else(|| persona.map(|p| shorten_did(&p.did, 24)))
                 .unwrap_or_default();
+            let request_id = match &c.status {
+                openvtc_core::config::account::CommunityStatus::Pending { request_id } => {
+                    request_id.to_string()
+                }
+                _ => String::new(),
+            };
             community_items.push(content::CommunitySummary {
                 display_name: c
                     .display_name
@@ -370,6 +376,12 @@ impl MainPageState {
                     .unwrap_or_default(),
                 favourite: c.favourite,
                 needs_attention: c.needs_attention(),
+                persona_did: persona.map(|p| p.did.clone()).unwrap_or_default(),
+                vtc_did: c.vtc_did.clone(),
+                sub_context_id: c.sub_context_id.clone(),
+                request_id,
+                has_membership_credential: c.membership_credential.is_some(),
+                has_role_credential: c.role_credential.is_some(),
             });
         }
         let community_count = community_items.len();

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -96,6 +96,40 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
             Style::new().fg(COLOR_DARK_GRAY)
         };
         lines.push(Line::from(Span::styled(detail, detail_style)));
+
+        // Expanded troubleshooting detail for the selected community: which
+        // persona this community actually uses (full DID), the VTC, the
+        // sub-context, the in-flight request id, and which credentials are held.
+        if is_selected {
+            let label = Style::new().fg(COLOR_DARK_GRAY);
+            let value = Style::new().fg(COLOR_TEXT_DEFAULT);
+            let kv = |k: &str, v: String| {
+                Line::from(vec![
+                    Span::styled(format!("      {k:<13}"), label),
+                    Span::styled(v, value),
+                ])
+            };
+            lines.push(kv("Persona DID:", c.persona_did.clone()));
+            lines.push(kv("VTC DID:", c.vtc_did.clone()));
+            if !c.sub_context_id.is_empty() {
+                lines.push(kv("Sub-context:", c.sub_context_id.clone()));
+            }
+            if !c.request_id.is_empty() {
+                lines.push(kv("Request ID:", c.request_id.clone()));
+            }
+            lines.push(kv(
+                "Credentials:",
+                format!(
+                    "membership {}   role {}",
+                    if c.has_membership_credential {
+                        "✓"
+                    } else {
+                        "—"
+                    },
+                    if c.has_role_credential { "✓" } else { "—" },
+                ),
+            ));
+        }
     }
 
     lines.push(Line::from(""));


### PR DESCRIPTION
## What

Selecting a community in the Communities panel now expands a **troubleshooting detail block** showing, for that community:
- the **full persona DID it uses** (resolved from its `persona_ref`),
- the **VTC DID**,
- the **sub-context id**,
- the **join request id** (while `Pending`),
- which **credentials are held** (membership / role).

## Why
Directly answers "which persona am I using for *this* community?" — which is **distinct** from the global active-identity shown in the status panel. That global one can be a different persona (e.g. an orphan left by a failed join attempt), which is exactly the confusion behind the DID mismatch reported (the community is bound to the right persona; the status panel was showing a different one).

## How
- `CommunitySummary` gains `persona_did` / `vtc_did` / `sub_context_id` / `request_id` + `has_membership_credential` / `has_role_credential`, populated in the main-page sync from the `CommunityRecord` and its resolved persona.
- `communities_panel` renders the block for the **selected** row only.

Compiles; `cargo fmt` + `clippy` clean. UI-only (no protocol changes). Not visually verified by me — please eyeball the layout in the TUI.

## Follow-ups (already agreed)
- Fix the orphan-persona-on-failed-join (separate PR, next).
- VTA context DID manager (list + view + delete) to clean up orphans.