### PR TITLE
feat(ui): list context identities (DIDs) in the VTA panel

### DIFF
--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -105,6 +105,23 @@ pub struct VtaState {
     pub is_vta_managed: bool,
     /// DIDs in use (persona + relationship R-DIDs)
     pub active_dids: Vec<ActiveDid>,
+    /// Every persona DID minted in this context, with how many communities
+    /// present it — the manageable set for the DID manager. A persona bound to
+    /// zero communities is an orphan (e.g. left by a failed join).
+    pub context_dids: Vec<ManagedDid>,
+}
+
+/// A persona DID in the account's context, for the DID manager view.
+#[derive(Clone, Debug, Default)]
+pub struct ManagedDid {
+    /// The persona `did:webvh`.
+    pub did: String,
+    /// Optional human label.
+    pub label: String,
+    /// How many communities present this persona (0 ⇒ orphan).
+    pub bound_communities: usize,
+    /// Whether this is the account's current active persona.
+    pub is_active: bool,
 }
 
 /// A DID in active use within this context.

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -333,6 +333,29 @@ impl MainPageState {
         }
         self.content_panel.vta.active_dids = active_dids;
 
+        // Context identities: every persona in the account, with how many
+        // communities present it. A persona bound to zero communities is an
+        // orphan (e.g. left by a failed join before the rollback fix) —
+        // surfaced so the operator can spot and manage it.
+        let mut context_dids: Vec<content::ManagedDid> = config
+            .account
+            .personas
+            .values()
+            .map(|p| content::ManagedDid {
+                did: p.did.clone(),
+                label: p.label.clone().unwrap_or_default(),
+                bound_communities: config
+                    .account
+                    .communities
+                    .values()
+                    .filter(|c| c.persona_ref == p.persona_id)
+                    .count(),
+                is_active: p.did.as_str() == persona_did,
+            })
+            .collect();
+        context_dids.sort_by(|a, b| a.did.cmp(&b.did));
+        self.content_panel.vta.context_dids = context_dids;
+
         self.content_panel.settings.protection_type = match &config.public.protection {
             openvtc_core::config::ConfigProtectionType::Token(id) => {
                 format!(

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -1,5 +1,7 @@
 use super::panel::Panel;
-use crate::colors::{COLOR_DARK_GRAY, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT};
+use crate::colors::{
+    COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+};
 use crate::state_handler::{
     main_page::content::{ContentPanelState, VtaState},
     state::ConnectionState,
@@ -137,6 +139,62 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
                     Style::new().fg(COLOR_TEXT_DEFAULT),
                 ),
                 Span::styled(did_entry.did.clone(), Style::new().fg(COLOR_DARK_GRAY)),
+            ]));
+        }
+    }
+
+    // Context identities — every persona DID in this context, with its binding.
+    // Orphans (no community) are flagged so they can be spotted and removed.
+    if !state.context_dids.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(
+            Line::from(format!(
+                " Context Identities ({})",
+                state.context_dids.len()
+            ))
+            .fg(COLOR_SUCCESS)
+            .bold(),
+        );
+        lines.push(Line::from(""));
+
+        for d in &state.context_dids {
+            let orphan = d.bound_communities == 0;
+            let (marker, marker_style) = if orphan {
+                ("  ○ ", Style::new().fg(COLOR_ORANGE))
+            } else {
+                ("  ● ", Style::new().fg(COLOR_SUCCESS))
+            };
+            lines.push(Line::from(vec![
+                Span::styled(marker, marker_style),
+                Span::styled(d.did.clone(), Style::new().fg(COLOR_TEXT_DEFAULT)),
+            ]));
+
+            let name = if d.label.is_empty() {
+                "persona".to_string()
+            } else {
+                d.label.clone()
+            };
+            let active = if d.is_active { "  ·  active" } else { "" };
+            let binding = if orphan {
+                "orphan — no community".to_string()
+            } else {
+                format!(
+                    "{} communit{}",
+                    d.bound_communities,
+                    if d.bound_communities == 1 { "y" } else { "ies" }
+                )
+            };
+            let binding_style = if orphan {
+                Style::new().fg(COLOR_ORANGE)
+            } else {
+                Style::new().fg(COLOR_DARK_GRAY)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("      {name}{active}  ·  "),
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Span::styled(binding, binding_style),
             ]));
         }
     }


### PR DESCRIPTION
## What

The **view** half of the VTA DID manager. The VTA Service panel gains a **Context Identities** section listing every persona DID minted in the account's context, and for each: its label, whether it's the **active** persona, and how many **communities** present it.

A persona bound to **zero communities is flagged as an orphan** (orange ○) — e.g. one left by a failed join before the #74 rollback fix. This is what lets you spot your existing `…piece-kick` orphan.

## How
- `VtaState` gains `context_dids: Vec<ManagedDid>` (did / label / bound-community count / active flag), built in the main-page sync from `account.personas` + community bindings (local, no network).
- `vta_panel` renders the section; orphans marked distinctly.

Compiles; `cargo fmt` + `clippy` clean. UI-only, read-only. Not visually verified by me — please eyeball it (you should now see both your active persona and the `piece-kick` orphan listed).

## Next (the delete half)
Select + delete with a confirm prompt (mirroring the community-removal flow): `delete_did_webvh` at the VTA + local persona/identity/key_info cleanup. Async + destructive, so it's a focused follow-up — that's what removes the orphan. Wiring will reuse `VtaClient::delete_did_webvh` (and `list_dids_webvh` if we later want the authoritative VTA-side list rather than the local persona set).