### PR TITLE
feat(ui): delete orphan context DIDs from the VTA panel

### DIFF
--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -240,6 +240,19 @@ pub enum Action {
     /// user confirms.
     DeleteCommunity(usize),
 
+    /// Move the Context-Identities (VTA DID manager) selection to this index.
+    DidSelect(usize),
+
+    /// Arm a removal confirmation for the context DID at this index.
+    DidConfirmDelete(usize),
+
+    /// Dismiss a pending DID removal confirmation without deleting.
+    DidCancelDelete,
+
+    /// Delete the orphan context DID at this index — removes it at the VTA and
+    /// locally. Only sent after the user confirms; guarded to unbound personas.
+    DeleteDid(usize),
+
     // ************************************************************************
     // SETUP Pages
     /// Import existing Config

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -109,6 +109,11 @@ pub struct VtaState {
     /// present it — the manageable set for the DID manager. A persona bound to
     /// zero communities is an orphan (e.g. left by a failed join).
     pub context_dids: Vec<ManagedDid>,
+    /// Selected index into [`Self::context_dids`] (DID manager navigation).
+    pub did_selected_index: usize,
+    /// When `Some(index)`, a deletion of that context DID is awaiting `y`/`n`
+    /// confirmation.
+    pub confirm_delete_did: Option<usize>,
 }
 
 /// A persona DID in the account's context, for the DID manager view.

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -622,6 +622,25 @@ impl StateHandler {
                                 .log("Community removed — persona listener stopped.");
                         }
                     },
+                    Action::DidSelect(i) => {
+                        state.main_page.content_panel.vta.did_selected_index = i;
+                    },
+                    Action::DidConfirmDelete(i) => {
+                        state.main_page.content_panel.vta.confirm_delete_did = Some(i);
+                    },
+                    Action::DidCancelDelete => {
+                        state.main_page.content_panel.vta.confirm_delete_did = None;
+                    },
+                    Action::DeleteDid(i) => {
+                        self.delete_context_did(
+                            &mut state,
+                            &mut config,
+                            admin_vta.as_ref(),
+                            &didcomm_service,
+                            i,
+                        )
+                        .await;
+                    },
                     Action::StartJoin => {
                         // State-B join from the live runtime: reuse the always-on
                         // admin VTA session. The DIDComm service keeps running in
@@ -963,6 +982,89 @@ impl StateHandler {
                     Some(format!("Could not remove community: {e}"));
             }
         }
+    }
+
+    /// Delete an **orphan** context identity (persona DID) at `index` in the
+    /// VTA DID manager: remove it at the VTA (`delete_did_webvh`), then locally
+    /// (persona record + runtime identity + key info), tear down its listener,
+    /// and re-save. Guarded to personas presenting **no** community — a
+    /// community-bound identity must not be deleted out from under its
+    /// membership. Feedback goes to the activity log.
+    async fn delete_context_did(
+        &self,
+        state: &mut State,
+        config: &mut Config,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+        didcomm_service: &affinidi_messaging_didcomm_service::DIDCommService,
+        index: usize,
+    ) {
+        state.main_page.content_panel.vta.confirm_delete_did = None;
+        let Some(did) = state
+            .main_page
+            .content_panel
+            .vta
+            .context_dids
+            .get(index)
+            .map(|d| d.did.clone())
+        else {
+            return;
+        };
+
+        // Resolve the persona for this DID + its key ids.
+        let Some(persona) = config.account.personas.values().find(|p| p.did == did) else {
+            state.main_page.log("DID not found — nothing removed.");
+            return;
+        };
+        let persona_id = persona.persona_id;
+        let key_ids: Vec<String> = persona.key_refs.iter().map(|k| k.key_id.clone()).collect();
+
+        // Guard: refuse to delete an identity any community still presents.
+        let bound = config
+            .account
+            .communities
+            .values()
+            .filter(|c| c.persona_ref == persona_id)
+            .count();
+        if bound > 0 {
+            state.main_page.log(format!(
+                "Can't delete — {bound} communit{} still use this identity; leave them first.",
+                if bound == 1 { "y" } else { "ies" }
+            ));
+            return;
+        }
+
+        // Delete at the VTA. Best-effort: a missing/already-deleted DID at the
+        // VTA must not block removing the local orphan, so log and continue.
+        if let Some(vta) = admin_vta
+            && let Err(e) = vta.delete_did_webvh(&did).await
+        {
+            debug!("delete_did_webvh({did}) failed (continuing local cleanup): {e}");
+        }
+
+        // Local cleanup.
+        config.account.personas.remove(&persona_id);
+        config.identities.remove(&persona_id);
+        for kid in &key_ids {
+            config.key_info.remove(kid);
+        }
+        if let Err(e) = config.save(
+            &self.profile,
+            #[cfg(feature = "openpgp-card")]
+            &|| eprintln!("Touch confirmation needed for decryption"),
+        ) {
+            state
+                .main_page
+                .log_error("Failed to save after removing DID", &e);
+        }
+
+        // Tear down the orphan's listener if one was running (best-effort).
+        let listener_id = didcomm::persona_listener_id(&did);
+        if let Err(e) = didcomm_service.remove_listener(&listener_id).await {
+            debug!("remove_listener after DID delete: {e}");
+        }
+
+        state.main_page.sync_from_config(config);
+        state.main_page.log(format!("Removed identity {did}"));
     }
 
     /// Minimal event loop for when there is no active community / messaging

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -157,16 +157,25 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         );
         lines.push(Line::from(""));
 
-        for d in &state.context_dids {
+        for (i, d) in state.context_dids.iter().enumerate() {
+            let is_selected = i == state.did_selected_index;
             let orphan = d.bound_communities == 0;
-            let (marker, marker_style) = if orphan {
-                ("  ○ ", Style::new().fg(COLOR_ORANGE))
+            let prefix = if is_selected { "▸ " } else { "  " };
+            let marker = if orphan { "○ " } else { "● " };
+            let marker_style = if orphan {
+                Style::new().fg(COLOR_ORANGE)
             } else {
-                ("  ● ", Style::new().fg(COLOR_SUCCESS))
+                Style::new().fg(COLOR_SUCCESS)
+            };
+            let did_style = if is_selected {
+                Style::new().fg(COLOR_SUCCESS).bold()
+            } else {
+                Style::new().fg(COLOR_TEXT_DEFAULT)
             };
             lines.push(Line::from(vec![
+                Span::styled(prefix, marker_style),
                 Span::styled(marker, marker_style),
-                Span::styled(d.did.clone(), Style::new().fg(COLOR_TEXT_DEFAULT)),
+                Span::styled(d.did.clone(), did_style),
             ]));
 
             let name = if d.label.is_empty() {
@@ -196,6 +205,23 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
                 ),
                 Span::styled(binding, binding_style),
             ]));
+        }
+
+        // Confirmation prompt (a delete is armed) or the navigation/remove hint.
+        lines.push(Line::from(""));
+        if let Some(idx) = state.confirm_delete_did {
+            let target = state
+                .context_dids
+                .get(idx)
+                .map(|d| d.did.as_str())
+                .unwrap_or("this identity");
+            lines.push(
+                Line::from(format!("Remove {target}?   y: confirm    n: cancel"))
+                    .fg(COLOR_ORANGE)
+                    .bold(),
+            );
+        } else {
+            lines.push(Line::from("↑/↓ select   d: remove selected orphan").fg(COLOR_DARK_GRAY));
         }
     }
 

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -310,6 +310,64 @@ impl MainPage {
             MainMenu::Logs => self.handle_logs_key(key),
             MainMenu::Help => self.handle_help_key(key),
             MainMenu::Communities => self.handle_communities_key(key),
+            MainMenu::Vta => self.handle_vta_key(key),
+            _ => false,
+        }
+    }
+
+    /// VTA Service / DID-manager keys: ↑/↓ move the Context-Identities
+    /// selection, `d`/Del removes the selected **orphan** (unbound) DID after a
+    /// y/n confirmation. Returns true if consumed.
+    fn handle_vta_key(&mut self, key: KeyEvent) -> bool {
+        let vta = &self.props.main_page.content_panel.vta;
+        let count = vta.context_dids.len();
+        let selected = vta.did_selected_index;
+
+        // A deletion confirmation is pending: only y/Enter confirms; anything
+        // else cancels.
+        if let Some(idx) = vta.confirm_delete_did {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    let _ = self.action_tx.send(Action::DeleteDid(idx));
+                }
+                _ => {
+                    let _ = self.action_tx.send(Action::DidCancelDelete);
+                }
+            }
+            return true;
+        }
+
+        match key.code {
+            KeyCode::Up if count > 0 => {
+                let _ = self
+                    .action_tx
+                    .send(Action::DidSelect(selected.saturating_sub(1)));
+                true
+            }
+            KeyCode::Down if count > 0 => {
+                let _ = self
+                    .action_tx
+                    .send(Action::DidSelect((selected + 1).min(count - 1)));
+                true
+            }
+            KeyCode::Char('d') | KeyCode::Delete if selected < count => {
+                // Only orphan (unbound) personas are removable — a persona
+                // serving a community must not be deleted out from under it.
+                if vta
+                    .context_dids
+                    .get(selected)
+                    .is_some_and(|d| d.bound_communities == 0)
+                {
+                    let _ = self.action_tx.send(Action::DidConfirmDelete(selected));
+                }
+                true
+            }
+            KeyCode::Esc => {
+                let _ = self
+                    .action_tx
+                    .send(Action::MainPanelSwitch(MainPanel::MainMenu));
+                true
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
## What

The **delete** half of the VTA DID manager (builds on #75's listing). In the VTA Service view: **↑/↓** selects a Context Identity and **d** removes the selected **orphan** (unbound) persona after a **y/n** confirm — mirroring the community-removal UX. This is what lets you delete your `…piece-kick` orphan.

## How
`DeleteDid` runs in the async action loop using the always-on admin VTA session:
1. `delete_did_webvh(did)` at the VTA — **best-effort** (a missing/already-deleted DID doesn't block local cleanup),
2. remove the persona record + runtime `IdentityContext` + its `key_info`,
3. tear down its DIDComm listener (best-effort),
4. re-save. Feedback → activity log.

## Safety
- **Guarded to unbound personas.** A community-bound identity is refused ("leave the community first") so a live membership can't be deleted out from under it. The keymap only arms the confirm for orphans.
- **Deleting the active orphan is safe.** `persona_did()` derives from `active_identity()` = `identities.values().next()`, so removing the orphan promotes the remaining persona automatically — which also **fixes the active-identity-shows-orphan display** you hit.

## Pieces
- `VtaState`: `did_selected_index` + `confirm_delete_did`.
- Actions: `DidSelect` / `DidConfirmDelete` / `DidCancelDelete` / `DeleteDid`.
- `handle_vta_key` keymap; `delete_context_did` handler; panel selection highlight + confirm prompt + hint.

## Caveats
- Compiles; `cargo fmt` + `clippy` clean. **Not** runtime-tested (TUI + live VTA + destructive) — please test on the `piece-kick` orphan: select it (orange ○ / "orphan"), `d`, `y`; it should disappear and the active identity should flip to your real persona. A restart may be needed for the real persona's listener to (re)connect.
- VTA-side **keys** aren't invalidated (only the DID is deleted); minor cruft, possible follow-up via `invalidate_key`.
- Delete is handled in the main action loop (active-community state); the no-community minimal loop doesn't wire it yet (edge case).
- Leaves untouched the pre-existing uncommitted `vta-sdk 0.9→0.10` bump.