### PR TITLE
feat(ui): show membership + role credentials in My Credentials

### DIFF
--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -88,7 +88,8 @@ fn handle_switch_tab(state: &mut State) {
     state.main_page.content_panel.credentials.selected_tab =
         match state.main_page.content_panel.credentials.selected_tab {
             CredentialTab::Received => CredentialTab::Issued,
-            CredentialTab::Issued => CredentialTab::Received,
+            CredentialTab::Issued => CredentialTab::Membership,
+            CredentialTab::Membership => CredentialTab::Received,
         };
     state.main_page.content_panel.credentials.selected_index = 0;
 }

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -331,6 +331,9 @@ pub struct CredentialsState {
     pub received: Vec<VrcSummary>,
     /// VRCs we issued
     pub issued: Vec<VrcSummary>,
+    /// Membership (VMC) + role (VEC) credentials issued to us by the VTCs we've
+    /// joined, one or two entries per community (reuses [`VrcSummary`]).
+    pub membership: Vec<VrcSummary>,
     /// Which tab is active
     pub selected_tab: CredentialTab,
     /// Currently selected index in the active tab's list
@@ -342,11 +345,13 @@ pub struct CredentialsState {
 }
 
 /// Which credential tab is active.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum CredentialTab {
     #[default]
     Received,
     Issued,
+    /// Membership (VMC) + role (VEC) credentials issued to us by joined VTCs.
+    Membership,
 }
 
 /// Display modes for the credentials panel.

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -265,6 +265,7 @@ impl MainPageState {
         self.content_panel.credentials.received =
             collect_vrcs(&config.private.vrcs_received, config);
         self.content_panel.credentials.issued = collect_vrcs(&config.private.vrcs_issued, config);
+        self.content_panel.credentials.membership = collect_membership_creds(config);
 
         // Sync settings
         self.content_panel.settings.friendly_name = config.public.friendly_name.clone();
@@ -455,6 +456,66 @@ fn collect_vrcs(vrcs: &openvtc_core::vrc::Vrcs, config: &Config) -> Vec<VrcSumma
                     valid_until: vrc.valid_until().map(|d| d.format("%Y-%m-%d").to_string()),
                 });
             }
+        }
+    }
+    result
+}
+
+/// Build display summaries for the membership (VMC) + role (VEC) credentials a
+/// VTC issued to us, stored on each community record. Reuses [`VrcSummary`]:
+/// `alias` carries "<community> — Membership/Role" and `remote_p_did` the VTC.
+fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
+    let mut result = Vec::new();
+    for c in config.account.communities.values() {
+        let community = c
+            .display_name
+            .clone()
+            .unwrap_or_else(|| sanitize_display(&c.vtc_did, 64));
+        for (kind, vc) in [
+            ("Membership", c.membership_credential.as_ref()),
+            ("Role", c.role_credential.as_ref()),
+        ] {
+            let Some(vc) = vc else { continue };
+            // `issuer` may be a bare string or an object `{ id, ... }`.
+            let issuer = vc
+                .get("issuer")
+                .and_then(|i| {
+                    i.as_str()
+                        .map(str::to_string)
+                        .or_else(|| i.get("id").and_then(|x| x.as_str()).map(str::to_string))
+                })
+                .unwrap_or_default();
+            let subject = vc
+                .pointer("/credentialSubject/id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let valid_from = vc
+                .get("validFrom")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let valid_until = vc
+                .get("validUntil")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let vc_id = vc
+                .get("id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let raw_json = serde_json::to_string_pretty(vc)
+                .unwrap_or_else(|_| "Failed to serialize credential".to_string());
+            result.push(VrcSummary {
+                vrc_id: vc_id,
+                remote_p_did: sanitize_display(&c.vtc_did, 256),
+                raw_json,
+                alias: Some(format!("{community} — {kind}")),
+                issuer: sanitize_display(&issuer, 256),
+                subject: sanitize_display(&subject, 256),
+                valid_from,
+                valid_until,
+            });
         }
     }
     result

--- a/openvtc/src/ui/pages/main/components/credentials_panel.rs
+++ b/openvtc/src/ui/pages/main/components/credentials_panel.rs
@@ -53,24 +53,33 @@ fn render_list(state: &CredentialsState) -> Vec<Line<'static>> {
     let active_list = match state.selected_tab {
         CredentialTab::Received => &state.received,
         CredentialTab::Issued => &state.issued,
+        CredentialTab::Membership => &state.membership,
     };
 
     // Tab bar
-    let (recv_style, issued_style) = match state.selected_tab {
-        CredentialTab::Received => (
-            Style::new().fg(COLOR_SUCCESS).bold(),
-            Style::new().fg(COLOR_DARK_GRAY),
-        ),
-        CredentialTab::Issued => (
-            Style::new().fg(COLOR_DARK_GRAY),
-            Style::new().fg(COLOR_SUCCESS).bold(),
-        ),
+    let tab_style = |tab: CredentialTab| {
+        if state.selected_tab == tab {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_DARK_GRAY)
+        }
     };
-
+    let sep = || Span::styled(" | ", Style::new().fg(COLOR_DARK_GRAY));
     lines.push(Line::from(vec![
-        Span::styled(format!(" Received ({}) ", state.received.len()), recv_style),
-        Span::styled(" | ", Style::new().fg(COLOR_DARK_GRAY)),
-        Span::styled(format!(" Issued ({}) ", state.issued.len()), issued_style),
+        Span::styled(
+            format!(" Received ({}) ", state.received.len()),
+            tab_style(CredentialTab::Received),
+        ),
+        sep(),
+        Span::styled(
+            format!(" Issued ({}) ", state.issued.len()),
+            tab_style(CredentialTab::Issued),
+        ),
+        sep(),
+        Span::styled(
+            format!(" Membership ({}) ", state.membership.len()),
+            tab_style(CredentialTab::Membership),
+        ),
     ]));
     lines.push(Line::from(""));
 
@@ -122,6 +131,7 @@ fn render_detail(state: &CredentialsState, index: usize) -> Vec<Line<'static>> {
     let active_list = match state.selected_tab {
         CredentialTab::Received => &state.received,
         CredentialTab::Issued => &state.issued,
+        CredentialTab::Membership => &state.membership,
     };
 
     let Some(vrc) = active_list.get(index) else {

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -922,8 +922,14 @@ impl MainPage {
                         let active_list = match creds.selected_tab {
                             CredentialTab::Received => &creds.received,
                             CredentialTab::Issued => &creds.issued,
+                            CredentialTab::Membership => &creds.membership,
                         };
-                        if let Some(vrc) = active_list.get(detail_index) {
+                        // Membership/role credentials are community-bound — there
+                        // is no local-only removal, so `d` is a no-op there (the
+                        // Remove action won't find a matching VRC).
+                        if creds.selected_tab != CredentialTab::Membership
+                            && let Some(vrc) = active_list.get(detail_index)
+                        {
                             let _ =
                                 self.action_tx
                                     .send(Action::Credential(CredentialAction::Remove {
@@ -936,9 +942,10 @@ impl MainPage {
                         let active_list = match creds.selected_tab {
                             CredentialTab::Received => &creds.received,
                             CredentialTab::Issued => &creds.issued,
+                            CredentialTab::Membership => &creds.membership,
                         };
                         if let Some(vrc) = active_list.get(detail_index) {
-                            copy_to_clipboard(&vrc.raw_json, "VRC credential", &self.action_tx);
+                            copy_to_clipboard(&vrc.raw_json, "credential", &self.action_tx);
                         }
                         true
                     }
@@ -949,6 +956,7 @@ impl MainPage {
                 let active_list_len = match creds.selected_tab {
                     CredentialTab::Received => creds.received.len(),
                     CredentialTab::Issued => creds.issued.len(),
+                    CredentialTab::Membership => creds.membership.len(),
                 };
                 let selected = creds.selected_index;
 


### PR DESCRIPTION
## What
Answers "how do I see the credentials issued back to me?" — the **VMC (membership)** and **role VEC** a VTC issues on join were stored on the community record but only shown as a held/not-held tick in the community detail. Their contents weren't viewable anywhere (My Credentials listed only relationship VRCs).

Adds a third **Membership** tab to *My Credentials* listing, per joined community, the membership + role credentials. Tab cycles **Received → Issued → Membership**.

## How
- `CredentialsState` gains `membership: Vec<VrcSummary>` (reuses the existing summary type); `CredentialTab` gains `Membership` (now `Copy + PartialEq`).
- `collect_membership_creds` builds the list from each community's `membership_credential`/`role_credential` JSON, extracting issuer/subject/validity (`issuer` handled as string-or-`{id}`); `alias` shows "<community> — Membership/Role".
- Panel render (list + detail + 3-tab bar) and the keymap handle the new tab. **Detail + copy (`c`)** work as for VRCs; **remove (`d`)** is a deliberate no-op there (these are community-bound).

Compiles; `cargo fmt` + `clippy` clean. UI-only, read-only. Not visually verified — please eyeball the tab + detail.