### PR TITLE
feat(messaging): one DIDComm listener per persona (multi-community)

### DIFF
--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -202,44 +202,60 @@ impl Config {
             KeyBackend::Vta { mediator_did, .. } => mediator_did.clone().unwrap_or_default(),
             KeyBackend::Bip32 { .. } => String::new(),
         };
-        let active_persona = account.personas.values().next().map(|p| {
-            // A persona minted before the mediator fix was stored with an empty
-            // mediator, which leaves its DIDComm listener failing with "No
-            // Mediator is configured" in an endless reconnect loop. Repair it at
-            // load by falling back to the account's VTA mediator — the persona
-            // DID was minted with the VTA's mediator service, so they match — so
-            // an already-broken persona comes good on the next launch with no
-            // re-join. (Runtime-only; the record is rewritten on the next save.)
-            let mediator = {
-                let stored = p.mediator_did.clone().unwrap_or_default();
-                if stored.is_empty() {
-                    if account_mediator.is_empty() {
-                        warn!(
-                            persona = %p.did,
-                            "persona has no mediator and the account has none either — \
-                             the persona listener will not connect"
-                        );
+        // Resolve a runtime identity for EVERY persona in the account, not just
+        // the first: each persona gets its own DIDComm listener at runtime, so
+        // all of them must be hydrated here (keys regenerated + an ATM messaging
+        // profile registered). A State-A account has zero personas, so the loop
+        // below never runs and `identities` stays empty.
+        type PersonaSeed = (
+            crate::config::account::PersonaId,
+            std::sync::Arc<String>,
+            String,
+            Option<affinidi_tdk::did_common::Document>,
+        );
+        let personas: Vec<PersonaSeed> = account
+            .personas
+            .values()
+            .map(|p| {
+                // A persona minted before the mediator fix was stored with an
+                // empty mediator, which leaves its DIDComm listener failing with
+                // "No Mediator is configured" in an endless reconnect loop.
+                // Repair it at load by falling back to the account's VTA mediator
+                // — the persona DID was minted with the VTA's mediator service,
+                // so they match — so an already-broken persona comes good on the
+                // next launch with no re-join. (Runtime-only; the record is
+                // rewritten on the next save.)
+                let mediator = {
+                    let stored = p.mediator_did.clone().unwrap_or_default();
+                    if stored.is_empty() {
+                        if account_mediator.is_empty() {
+                            warn!(
+                                persona = %p.did,
+                                "persona has no mediator and the account has none either — \
+                                 the persona listener will not connect"
+                            );
+                        } else {
+                            warn!(
+                                persona = %p.did,
+                                "persona stored without a mediator — falling back to the \
+                                 account VTA mediator"
+                            );
+                        }
+                        account_mediator.clone()
                     } else {
-                        warn!(
-                            persona = %p.did,
-                            "persona stored without a mediator — falling back to the \
-                             account VTA mediator"
-                        );
+                        stored
                     }
-                    account_mediator.clone()
-                } else {
-                    stored
-                }
-            };
-            (
-                p.persona_id,
-                std::sync::Arc::new(p.did.clone()),
-                mediator,
-                // PERF #3: the cached DID document, used instead of a network
-                // resolve when present.
-                p.did_document.clone(),
-            )
-        });
+                };
+                (
+                    p.persona_id,
+                    std::sync::Arc::new(p.did.clone()),
+                    mediator,
+                    // PERF #3: the cached DID document, used instead of a network
+                    // resolve when present.
+                    p.did_document.clone(),
+                )
+            })
+            .collect();
 
         // Open the admin VTA session ONLY when there's a persona to rehydrate
         // (regenerate its keys + register messaging profiles). A State-A account
@@ -249,54 +265,52 @@ impl Config {
         // mediator (WebSocket churn → a dropped response on the first burst of
         // requests, e.g. the join's key creation). Skipping it leaves a single
         // admin session for the whole runtime.
-        let vta_client =
-            if matches!(&key_backend, KeyBackend::Vta { .. }) && active_persona.is_some() {
-                report_progress(&on_progress, "VTA establishment", "Connecting to VTA");
-                Some(super::build_runtime_vta_client(&key_backend).await?)
-            } else {
-                None
-            };
+        let vta_client = if matches!(&key_backend, KeyBackend::Vta { .. }) && !personas.is_empty() {
+            report_progress(&on_progress, "VTA establishment", "Connecting to VTA");
+            Some(super::build_runtime_vta_client(&key_backend).await?)
+        } else {
+            None
+        };
 
         let mut identities = HashMap::new();
-        if let Some((active_persona_id, active_persona_did, active_mediator_did, cached_document)) =
-            active_persona
-        {
-            // Name the persona's messaging profile after its community so it is
-            // identifiable (not a generic "Persona") — matches the runtime
-            // listener label (`Config::persona_profile_label`).
-            let profile_label = account
-                .communities
-                .values()
-                .find(|c| c.persona_ref == active_persona_id)
-                .map(|c| {
-                    c.display_name.clone().unwrap_or_else(|| {
-                        crate::config::context_path::render_for_display(&c.vtc_did).to_string()
-                    })
-                })
-                .unwrap_or_else(|| "Persona".to_string());
 
-            // Resolve + key/profile setup for the active persona. Wrapped in an
-            // inner future so that, on the `?` error paths below, the admin VTA
-            // session is shut down before the error propagates (a leaked session
-            // would trip the SDK `LeakGuard` and duel other sessions on the
-            // mediator). On SUCCESS the session is returned to the caller alive
-            // (PERF #1) — it is NOT shut down here.
-            let persona_identity: Result<crate::identity::IdentityContext, OpenVTCError> = async {
+        // Hydrate every persona, then register relationship profiles once. The
+        // whole block is wrapped in an inner future so that on ANY `?` error the
+        // admin VTA session is shut down before the error propagates (a leaked
+        // session trips the SDK `LeakGuard` and duels other sessions on the
+        // mediator). On SUCCESS the session is returned to the caller alive
+        // (PERF #1) — it is NOT shut down here.
+        let hydrate: Result<(), OpenVTCError> = async {
+            for (persona_id, persona_did, persona_mediator, cached_document) in &personas {
+                // Name the persona's messaging profile after its community so it
+                // is identifiable (not a generic "Persona") — matches the runtime
+                // listener label (`Config::persona_profile_label`).
+                let profile_label = account
+                    .communities
+                    .values()
+                    .find(|c| c.persona_ref == *persona_id)
+                    .map(|c| {
+                        c.display_name.clone().unwrap_or_else(|| {
+                            crate::config::context_path::render_for_display(&c.vtc_did).to_string()
+                        })
+                    })
+                    .unwrap_or_else(|| "Persona".to_string());
+
                 // PERF #3: prefer the persisted persona DID document over a fresh
                 // network resolve (~1s). did:webvh docs change rarely between
                 // launches; a stale doc only matters if the persona rotated keys
                 // out-of-band — rare, and recoverable on the next mint/resolve.
-                let document = if let Some(doc) = cached_document {
+                let document = if let Some(doc) = cached_document.clone() {
                     report_progress(&on_progress, "Identity", "Loading DID document (cached)");
                     doc
                 } else {
                     report_progress(&on_progress, "Identity", "Resolving DID document");
                     tdk.did_resolver()
-                        .resolve(&active_persona_did)
+                        .resolve(persona_did)
                         .await
                         .map_err(|e| {
                             OpenVTCError::Resolver(format!(
-                                "Couldn't resolve Persona DID ({active_persona_did}): {e}"
+                                "Couldn't resolve Persona DID ({persona_did}): {e}"
                             ))
                         })?
                         .doc
@@ -308,11 +322,11 @@ impl Config {
                 // DIDCommMessaging service whose endpoint IS the mediator, so it
                 // is always authoritative. Without this the persona listener
                 // fails with "No Mediator is configured" and reconnect-loops.
-                let active_mediator_did = if active_mediator_did.is_empty() {
+                let persona_mediator = if persona_mediator.is_empty() {
                     match super::did::mediator_from_document(&document) {
                         Some(m) => {
                             warn!(
-                                persona = %active_persona_did,
+                                persona = %persona_did,
                                 mediator = %m,
                                 "recovered persona mediator from its DID document"
                             );
@@ -320,15 +334,15 @@ impl Config {
                         }
                         None => {
                             warn!(
-                                persona = %active_persona_did,
+                                persona = %persona_did,
                                 "persona has no mediator anywhere (record, account, \
                                  or DID document) — its listener will not connect"
                             );
-                            active_mediator_did
+                            persona_mediator.clone()
                         }
                     }
                 } else {
-                    active_mediator_did
+                    persona_mediator.clone()
                 };
 
                 report_progress(&on_progress, "Identity", "Fetching persona keys");
@@ -347,8 +361,8 @@ impl Config {
                         OpenVTCError::Config("TDK ATM service not initialized".to_string())
                     })?,
                     Some(profile_label.clone()),
-                    active_persona_did.to_string(),
-                    Some(active_mediator_did.clone()),
+                    persona_did.to_string(),
+                    Some(persona_mediator.clone()),
                 )
                 .await?;
 
@@ -359,51 +373,54 @@ impl Config {
                 })?;
                 let persona_profile = atm.profile_add(&persona_profile, false).await?;
 
+                identities.insert(
+                    *persona_id,
+                    crate::identity::IdentityContext {
+                        persona_id: *persona_id,
+                        did: persona_did.to_string(),
+                        document,
+                        profile: persona_profile,
+                        mediator_did: Some(persona_mediator.clone()),
+                    },
+                );
+            }
+
+            // Register relationship (R-DID) profiles ONCE, excluding ALL persona
+            // DIDs (each persona's own listener carries the relationships served
+            // by its DID). Personas share the account VTA mediator, so any
+            // persona's mediator is correct for the R-DID profiles — use the
+            // first. Registers each profile with the ATM service as a side-effect;
+            // the returned map is no longer stored on `Config`.
+            if let Some((_, _, first_mediator, _)) = personas.first() {
                 report_progress(&on_progress, "Identity", "Loading relationships");
-                // Registers each relationship profile with the ATM service as a
-                // side-effect; the returned map is no longer stored on `Config`.
+                let our_p_dids: std::collections::HashSet<String> = personas
+                    .iter()
+                    .map(|(_, did, _, _)| did.to_string())
+                    .collect();
                 private_cfg
                     .relationships
                     .generate_profiles(
                         tdk,
-                        &active_persona_did,
-                        &active_mediator_did,
+                        &our_p_dids,
+                        first_mediator,
                         &key_backend,
                         &sc.key_info,
                         vta_client.as_ref(),
                     )
                     .await?;
-
-                Ok(crate::identity::IdentityContext {
-                    persona_id: active_persona_id,
-                    did: active_persona_did.to_string(),
-                    document,
-                    profile: persona_profile,
-                    mediator_did: Some(active_mediator_did.clone()),
-                })
             }
-            .await;
+            Ok(())
+        }
+        .await;
 
-            // On ERROR, close the admin session before propagating (a leaked
-            // session would duel others on the mediator). On SUCCESS, the
-            // session is returned to the caller alive (PERF #1) and is NOT shut
-            // down here.
-            match persona_identity {
-                Ok(identity) => {
-                    identities.insert(active_persona_id, identity);
-                }
-                Err(e) => {
-                    if let Some(client) = &vta_client {
-                        client.shutdown().await;
-                    }
-                    return Err(e);
-                }
+        // On ERROR, close the admin session before propagating (a leaked session
+        // would duel others on the mediator). On SUCCESS, the session is returned
+        // to the caller alive (PERF #1) and is NOT shut down here.
+        if let Err(e) = hydrate {
+            if let Some(client) = &vta_client {
+                client.shutdown().await;
             }
-        } else if let Some(client) = &vta_client {
-            // No persona to resolve, but a VTA client was somehow built — close
-            // it (this branch is unreachable: the client is only built when a
-            // persona is present, but kept defensively).
-            client.shutdown().await;
+            return Err(e);
         }
 
         Ok((

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -271,8 +271,10 @@ pub struct Config {
     /// Runtime-resolved identities (resolved DID document + ATM profile),
     /// keyed by persona id. Not persisted — rebuilt at load from `account`.
     ///
-    /// For the single-persona case this holds one entry, surfaced by
-    /// [`Config::active_identity`]. Multi-persona population + selection land in
+    /// Holds one entry per persona — load resolves an [`IdentityContext`] for
+    /// every persona in the account, and a DIDComm listener is started for each.
+    /// [`Config::active_identity`] still surfaces the first as the "active" one
+    /// for user-initiated outbound actions; explicit persona *selection* lands in
     /// a later slice.
     pub identities: HashMap<account::PersonaId, crate::identity::IdentityContext>,
 }
@@ -343,13 +345,20 @@ impl Config {
     /// profile is identifiable rather than a generic "Persona". Falls back to
     /// "Persona" when the persona has no community yet.
     pub fn persona_profile_label(&self) -> String {
-        let Some(pid) = self.active_identity().map(|i| i.persona_id) else {
-            return "Persona".to_string();
-        };
+        match self.active_identity().map(|i| i.persona_id) {
+            Some(pid) => self.persona_profile_label_for(pid),
+            None => "Persona".to_string(),
+        }
+    }
+
+    /// Human label for a *specific* persona's messaging profile (see
+    /// [`Config::persona_profile_label`]). Used when building one DIDComm
+    /// listener per persona so each is named after its community.
+    pub fn persona_profile_label_for(&self, persona_id: account::PersonaId) -> String {
         self.account
             .communities
             .values()
-            .find(|c| c.persona_ref == pid)
+            .find(|c| c.persona_ref == persona_id)
             .map(|c| {
                 c.display_name.clone().unwrap_or_else(|| {
                     crate::config::context_path::render_for_display(&c.vtc_did).to_string()
@@ -371,6 +380,13 @@ impl Config {
         if let Some(ctx) = self.identities.get_mut(&id) {
             ctx.mediator_did = Some(did.to_string());
         }
+    }
+
+    /// Whether `did` is one of our resolved persona DIDs (vs. a relationship
+    /// R-DID or a remote party's DID). Used to route inbound replies out of the
+    /// addressed persona and to map a persona DID to its DIDComm listener.
+    pub fn is_persona_did(&self, did: &str) -> bool {
+        self.identities.values().any(|i| i.did == did)
     }
 }
 

--- a/openvtc-core/src/relationships.rs
+++ b/openvtc-core/src/relationships.rs
@@ -25,7 +25,7 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt::Display,
     sync::{Arc, Mutex},
     time::SystemTime,
@@ -166,10 +166,15 @@ impl Relationships {
     ///
     /// Returns an error if the TDK ATM service is not initialized, VTA authentication
     /// fails, a mutex is poisoned, or secret derivation/import fails.
+    /// `our_p_dids` is the set of *our* persona DIDs. Relationships served
+    /// directly by a persona DID (rather than a dedicated R-DID) are skipped
+    /// here — that persona's own listener carries them. With multiple personas
+    /// the set must contain all of them, or another persona's DID would be
+    /// mistaken for an R-DID and get a spurious `rel-` profile.
     pub async fn generate_profiles(
         &self,
         tdk: &TDK,
-        our_p_did: &Arc<String>,
+        our_p_dids: &HashSet<String>,
         mediator: &str,
         key_backend: &KeyBackend,
         key_info: &HashMap<String, KeyInfoConfig>,
@@ -221,7 +226,7 @@ impl Relationships {
                         RelationshipState::Established
                             | RelationshipState::RequestSent
                             | RelationshipState::RequestAccepted
-                    ) && &lock.our_did != our_p_did
+                    ) && !our_p_dids.contains(lock.our_did.as_str())
                     {
                         Some(lock.our_did.clone())
                     } else {

--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -106,6 +106,9 @@ pub enum ReconnectOutcome {
 /// settings action — both did the same dance inline. Returns:
 ///   * `Connected` once the listener reaches the connected state, or
 ///   * `Failed(reason)` on any error during the replace / connect path.
+///
+/// Active-persona only (these manual actions act on the active identity);
+/// per-persona reconnect lands with the persona-selection slice.
 pub async fn reconnect_persona_listener(
     service: &DIDCommService,
     config: &Config,
@@ -287,9 +290,9 @@ fn default_listener_restart_policy() -> RestartPolicy {
 
 /// Build `ListenerConfig`s from the loaded `Config`.
 ///
-/// Always includes a "persona" listener. Adds per-relationship listeners
-/// for established relationships that use a dedicated R-DID (different
-/// from the persona DID).
+/// Includes one persona listener per resolved identity (so every community's
+/// persona receives messages), plus per-relationship listeners for established
+/// relationships that use a dedicated R-DID (different from any persona DID).
 ///
 /// Secrets for each DID are extracted from the TDK's secrets resolver
 /// so that each listener can authenticate with the mediator.
@@ -299,35 +302,45 @@ pub async fn build_listener_configs(
 ) -> Vec<ListenerConfig> {
     let restart = default_listener_restart_policy();
 
-    let persona_secrets = get_secrets_for_did(tdk, config, config.persona_did()).await;
-
-    let persona_label = config.persona_profile_label();
-    let mut configs = vec![ListenerConfig {
-        id: persona_listener_id(config.persona_did()),
-        profile: make_profile(
-            config.persona_did(),
-            config.mediator_did(),
-            &persona_label,
-            persona_secrets,
-        ),
-        restart_policy: restart.clone(),
-        // Keep `auto_delete: true`. It delegates message deletion to the
-        // mediator's live-stream protocol, which uses the mediator-native
-        // storage id. If you ever set this to false and delete from app
-        // code, you MUST delete by `UnpackMetadata.sha256_hash` (the
-        // mediator-native id), NOT by the DIDComm protocol id `msg.id` —
-        // they are different domains and the mediator's delete API only
-        // accepts the former. Mixing them silently leaks messages and
-        // causes duplicate processing on reconnect (see issue #44).
-        auto_delete: true,
-        ..Default::default()
-    }];
+    // One persona listener per resolved identity. A single-persona account
+    // yields exactly one — identical to the previous behaviour. `persona_dids`
+    // is also the exclusion set for the R-DID listeners below.
+    let mut configs = Vec::new();
+    let mut persona_dids = std::collections::HashSet::new();
+    for identity in config.identities.values() {
+        let did = identity.did.as_str();
+        if !persona_dids.insert(did.to_string()) {
+            continue;
+        }
+        let persona_secrets = get_secrets_for_did(tdk, config, did).await;
+        let mediator = identity
+            .mediator_did
+            .as_deref()
+            .unwrap_or(config.mediator_did());
+        let label = config.persona_profile_label_for(identity.persona_id);
+        configs.push(ListenerConfig {
+            id: persona_listener_id(did),
+            profile: make_profile(did, mediator, &label, persona_secrets),
+            restart_policy: restart.clone(),
+            // Keep `auto_delete: true`. It delegates message deletion to the
+            // mediator's live-stream protocol, which uses the mediator-native
+            // storage id. If you ever set this to false and delete from app
+            // code, you MUST delete by `UnpackMetadata.sha256_hash` (the
+            // mediator-native id), NOT by the DIDComm protocol id `msg.id` —
+            // they are different domains and the mediator's delete API only
+            // accepts the former. Mixing them silently leaks messages and
+            // causes duplicate processing on reconnect (see issue #44).
+            auto_delete: true,
+            ..Default::default()
+        });
+    }
 
     // Add listeners for each relationship with a dedicated R-DID.
     // Include pending relationships (RequestSent, RequestAccepted) so that
     // messages arriving during an in-progress handshake are received after restart.
     // Deduplicate by our_did to prevent multiple listeners for the same DID,
     // which would cause a reconnect loop as the mediator detects duplicates.
+    // Exclude ALL persona DIDs (their own listeners carry those relationships).
     // Extract data from the Mutex before any .await to avoid holding the guard.
     let mut seen_dids = std::collections::HashSet::new();
     let r_did_entries: Vec<(String, String)> = config
@@ -342,7 +355,7 @@ pub async fn build_listener_configs(
                 RelationshipState::Established
                     | RelationshipState::RequestSent
                     | RelationshipState::RequestAccepted
-            ) && rel.our_did.as_str() != config.persona_did()
+            ) && !persona_dids.contains(rel.our_did.as_str())
                 && seen_dids.insert(rel.our_did.to_string())
             {
                 Some((rel.our_did.to_string(), remote_p_did.to_string()))
@@ -372,7 +385,7 @@ pub async fn build_listener_configs(
     }
 
     debug!(
-        persona = %config.persona_did(),
+        persona_listeners = persona_dids.len(),
         r_did_listeners = r_did_entries.len(),
         total = configs.len(),
         "built listener configs"
@@ -383,11 +396,11 @@ pub async fn build_listener_configs(
 
 /// Determine the listener ID to use for sending messages from a given DID.
 ///
-/// If `our_did` matches the persona DID, use "persona". Otherwise, use
-/// the relationship-listener naming convention.
-pub fn listener_id_for_did(our_did: &str, persona_did: &str) -> String {
-    if our_did == persona_did {
-        persona_listener_id(persona_did)
+/// If `our_did` is one of our persona DIDs, use that persona's listener.
+/// Otherwise, use the relationship-listener naming convention.
+pub fn listener_id_for_did(our_did: &str, config: &Config) -> String {
+    if config.is_persona_did(our_did) {
+        persona_listener_id(our_did)
     } else {
         format!("rel-{}", short_did_id(our_did))
     }
@@ -402,7 +415,7 @@ pub async fn send_message(
     from_did: &str,
     to_did: &str,
 ) -> Result<(), DIDCommServiceError> {
-    let listener_id = listener_id_for_did(from_did, config.persona_did());
+    let listener_id = listener_id_for_did(from_did, config);
     send_message_via(service, message, &listener_id, to_did).await
 }
 

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -317,7 +317,7 @@ impl MainPageState {
         }
         for (remote_p_did, rel_arc) in &config.private.relationships.relationships {
             if let Ok(rel) = rel_arc.lock()
-                && rel.our_did.as_str() != config.persona_did()
+                && !config.is_persona_did(rel.our_did.as_str())
             {
                 let alias = config
                     .private

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -329,6 +329,19 @@ pub async fn process_inbound_message(
         }
     };
 
+    // The persona this message was addressed to — the DID any auto-reply must be
+    // sent *from*. Resolved from the envelope's `to`, falling back to the active
+    // persona when `to` is absent or not one of ours. For a single-persona
+    // account `to` is always that persona, so this is identical to the previous
+    // `config.persona_did()` behaviour; with multiple personas it routes the
+    // reply out of the right one.
+    let recipient_did: String = message
+        .to
+        .as_ref()
+        .and_then(|tos| tos.iter().find(|t| config.is_persona_did(t)))
+        .cloned()
+        .unwrap_or_else(|| config.persona_did().to_string());
+
     // Validate message body size to prevent DoS via oversized payloads
     let body_size = serde_json::to_string(&message.body)
         .map(|s| s.len())
@@ -407,12 +420,9 @@ pub async fn process_inbound_message(
             let listener_to_remove = if let Some(rel_arc) =
                 config.private.relationships.find_by_task_id(&task_id)
                 && let Ok(lock) = rel_arc.lock()
-                && lock.our_did.as_str() != config.persona_did()
+                && !config.is_persona_did(lock.our_did.as_str())
             {
-                Some(super::didcomm::listener_id_for_did(
-                    &lock.our_did,
-                    config.persona_did(),
-                ))
+                Some(super::didcomm::listener_id_for_did(&lock.our_did, config))
             } else {
                 None
             };
@@ -482,13 +492,13 @@ pub async fn process_inbound_message(
 
             // Send finalize using persona DIDs (same as request and accept).
             // If the send fails, still persist the Established state.
-            let finalize_msg = create_finalize_message(config.persona_did(), &from_did, &task_id)?;
+            let finalize_msg = create_finalize_message(&recipient_did, &from_did, &task_id)?;
 
             if let Err(e) = super::didcomm::send_message(
                 service,
                 config,
                 &finalize_msg,
-                config.persona_did(),
+                &recipient_did,
                 &from_did,
             )
             .await

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -551,9 +551,14 @@ impl StateHandler {
         // moment a `ListenerEvent::Connected` arrives — and back to Connecting on
         // a disconnect. Subscribe to typed lifecycle events for that.
         let mut listener_events = didcomm_service.subscribe();
-        // The persona listener's id (community-scoped, derived from its DID) is
-        // stable for the life of this loop — compute it once for event matching.
-        let persona_lid = didcomm::persona_listener_id(config.persona_did());
+        // The persona listener ids (one per resolved identity, derived from each
+        // DID) are stable for the life of this loop — compute them once for event
+        // matching. A single-persona account yields a one-element set.
+        let persona_lids: std::collections::HashSet<String> = config
+            .identities
+            .values()
+            .map(|i| didcomm::persona_listener_id(&i.did))
+            .collect();
         state.connection.status = state::MediatorStatus::Connecting;
         state.main_page.log("Connecting to the mediator…");
         let _ = self.state_tx.send(state.clone());
@@ -612,32 +617,46 @@ impl StateHandler {
                         state.main_page.content_panel.communities.confirm_delete = None;
                     },
                     Action::DeleteCommunity(i) => {
-                        // Capture the listener id before the delete, while the
-                        // persona/community are still present.
-                        let listener_id = didcomm::persona_listener_id(config.persona_did());
+                        // Identify the deleted community's persona BEFORE the
+                        // delete so we can tear down *its* listener (not the
+                        // active one) if it ends up with no live community.
+                        let target_persona = config
+                            .account
+                            .communities_for_display(false)
+                            .get(i)
+                            .map(|c| c.persona_ref);
                         self.remove_community(&mut state, &mut config, i);
                         // A deleted community must not leave its persona's
-                        // mediator connection running. If the active persona no
-                        // longer has any live community, stop and remove its
-                        // listener so the connection is torn down with the
-                        // community (not left dangling).
-                        let persona_id = config.active_identity().map(|id| id.persona_id);
-                        let still_live = persona_id.is_some_and(|pid| {
-                            config
+                        // mediator connection running. If that persona no longer
+                        // has any live community, stop and remove its listener so
+                        // the connection is torn down with the community (not left
+                        // dangling).
+                        if let Some(pid) = target_persona {
+                            let still_live = config
                                 .account
                                 .communities
                                 .values()
-                                .any(|c| c.persona_ref == pid && c.is_live())
-                        });
-                        if !still_live {
-                            if let Err(e) = didcomm_service.remove_listener(&listener_id).await {
-                                debug!("remove_listener after community delete: {e}");
+                                .any(|c| c.persona_ref == pid && c.is_live());
+                            if !still_live
+                                && let Some(did) =
+                                    config.identities.get(&pid).map(|id| id.did.clone())
+                            {
+                                let listener_id = didcomm::persona_listener_id(&did);
+                                if let Err(e) =
+                                    didcomm_service.remove_listener(&listener_id).await
+                                {
+                                    debug!("remove_listener after community delete: {e}");
+                                }
+                                state
+                                    .main_page
+                                    .log("Community removed — persona listener stopped.");
                             }
+                        }
+                        // Drop the global messaging status only when NO persona
+                        // has a live community left.
+                        if !config.account.communities.values().any(|c| c.is_live()) {
                             state.connection.status = state::MediatorStatus::NoActiveCommunity;
                             state.connection.messaging_active = false;
-                            state
-                                .main_page
-                                .log("Community removed — persona listener stopped.");
                         }
                     },
                     Action::DidSelect(i) => {
@@ -923,14 +942,16 @@ impl StateHandler {
                     use affinidi_messaging_didcomm_service::ListenerEvent;
                     if let Ok(ev) = ev {
                         match ev {
+                            // Any persona listener connecting marks messaging
+                            // live; a per-persona status panel is future work.
                             ListenerEvent::Connected { listener_id }
-                                if listener_id == persona_lid =>
+                                if persona_lids.contains(&listener_id) =>
                             {
                                 state.connection.status = state::MediatorStatus::Connected;
                                 state.connection.messaging_active = true;
                             }
                             ListenerEvent::Disconnected { listener_id, .. }
-                                if listener_id == persona_lid =>
+                                if persona_lids.contains(&listener_id) =>
                             {
                                 state.connection.status = state::MediatorStatus::Connecting;
                                 state.connection.messaging_active = false;

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -184,7 +184,7 @@ pub async fn ping_relationship(
     info!(
         our_did = %our_did,
         remote_did = %remote_did,
-        is_r_did = our_did.as_str() != config.persona_did(),
+        is_r_did = !config.is_persona_did(our_did.as_str()),
         "ping using relationship DIDs"
     );
     let ping_msg = {
@@ -240,12 +240,9 @@ pub async fn remove_relationship(
     // Extract listener ID before any async work to avoid holding MutexGuard across await
     let listener_to_remove = if let Some(rel_arc) = config.private.relationships.get(&key)
         && let Ok(lock) = rel_arc.lock()
-        && lock.our_did.as_str() != config.persona_did()
+        && !config.is_persona_did(lock.our_did.as_str())
     {
-        Some(super::didcomm::listener_id_for_did(
-            &lock.our_did,
-            config.persona_did(),
-        ))
+        Some(super::didcomm::listener_id_for_did(&lock.our_did, config))
     } else {
         None
     };
@@ -648,7 +645,7 @@ async fn handle_submit(
                          Task ID:       {}",
                         r.remote_p_did,
                         r.our_did,
-                        if r.our_did.as_str() != config.persona_did() {
+                        if !config.is_persona_did(r.our_did.as_str()) {
                             "yes"
                         } else {
                             "no"
@@ -703,7 +700,7 @@ async fn handle_ping(
                 state.main_page.log_error("Failed to save config", &e);
             }
             state.main_page.sync_from_config(config);
-            let using_rdid = our_did_str != config.persona_did();
+            let using_rdid = !config.is_persona_did(&our_did_str);
             state.main_page.log_detailed(
                 format!(
                     "Trust-ping sent to {display_name}{}",


### PR DESCRIPTION
## Problem

Load resolved a single runtime identity — `active_identity()` = the first persona — and started exactly one persona DIDComm listener. A user who has joined more than one community (each presenting its own persona) only received messages for that first persona. The other communities' join approvals and issued credentials (VMC/VEC) never arrived without a restart-into-a-different-ordering or manual poking.

## Change

Resolve an `IdentityContext` for **every** persona in the account and start **one listener per persona**.

- **`loading.rs`** — hydrates all personas (regen keys + register an ATM messaging profile each) in a single inner future. The admin VTA session is still shut down on *every* `?` error path and handed back alive on success (PERF #1). Relationship (R-DID) profiles are now registered **once**, excluding the full set of persona DIDs.
- **`relationships.rs::generate_profiles`** — takes `our_p_dids: &HashSet<String>` instead of a single persona DID, so another persona's DID is never mistaken for an R-DID.
- **`didcomm.rs::build_listener_configs`** — emits one persona listener per identity and excludes all persona DIDs from the R-DID listeners. `listener_id_for_did` now takes `&Config` and uses `is_persona_did`.
- **`mod.rs` runtime loop** — tracks the *set* of persona listener ids for connection status; `DeleteCommunity` tears down the **deleted** community's persona listener (looked up before the delete) and only drops global status to `NoActiveCommunity` when no community anywhere is live.
- **`message_dispatch.rs`** — inbound auto-replies (relationship `finalize`) route **from the persona the message was addressed to** (`message.to`), via a new `recipient_did` with a fallback to the active persona.

## Safety: single-persona invariant

The guiding invariant is that **with exactly one persona, every changed site reduces to the prior code path byte-for-byte** — so existing single-persona setups are unaffected and multi-persona is purely additive. This was verified site-by-site in an adversarial review (leaked-session paths, key regen idempotency, `generate_profiles` relocation, `recipient_did` routing, and `DeleteCommunity` teardown all confirmed equivalent for one persona).

**Out of scope (documented):** explicit persona *selection* for user-initiated outbound actions (inbox approve/reject, relationship requests, manual mediator reconnect) — those still use `active_identity()`. That's the next slice.

## Testing

- `cargo build`, `cargo clippy --workspace`, `cargo fmt`, and `cargo test --workspace` all clean (no test failures).
- Multi-persona runtime behaviour is not exercisable with a single-persona account; the single-persona invariant is the safety net until a second community is joined to validate end-to-end.