### PR TITLE
fix(setup): bump vta-sdk to 0.10 for retired provision-integration URI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.9.11",
 ]
 
 [[package]]
@@ -2284,7 +2284,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk",
+ "vta-sdk 0.10.0",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -5192,7 +5192,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.10.0",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5240,7 +5240,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.10.0",
  "x25519-dalek",
  "zeroize",
 ]
@@ -8504,6 +8504,36 @@ name = "vta-sdk"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c72e9ca533c5452a06b69fa4fd0e1c15d0d146c8fbe06c78b20211cf0c0ebc05"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "chrono",
+ "curve25519-dalek",
+ "didwebvh-rs",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1e8bd4a1747816874aacfe79f868331875e5f432976990fc6c97511d7b5c45"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-vta-sdk = { version = "0.9", features = [
+vta-sdk = { version = "0.10", features = [
   "session",
   "client",
   "didcomm",


### PR DESCRIPTION
## Problem

New OpenVTC setups fail at the VTA bootstrap step **"Provision integration DID + admin credential"** with:

```
provision-integration call failed: validation error: unsupported message type:
https://firstperson.network/protocols/provision-integration/1.0/provision-integration
```

Auth and the DIDComm session succeed; only the provision round-trip is rejected.

## Root cause

The error is emitted **server-side** by the VTA (`vta-service` DIDComm dispatcher — `ProblemReport::bad_request("unsupported message type: …")`) and relayed back to the CLI.

`vta-sdk` **0.9.x** sends the legacy `firstperson.network/protocols/provision-integration/1.0/provision-integration` DIDComm message type. That URI was **retired in 0.10** in favour of the canonical `trusttasks.org/spec/provision/integration/0.x` form (see `vta-sdk-0.10.0/src/protocols/provision_integration_management.rs`: *"The legacy firstperson.network provision-integration URI was retired"*).

Upgraded VTA deployments no longer accept the legacy type, so released CLIs (on 0.9) are rejected after auth — a CLI/infrastructure protocol-version skew.

## Fix

Bump `vta-sdk` 0.9 → 0.10 so the provision call sends the canonical URI the VTA accepts.

- **No source changes required** — the bump is API-compatible.
- `affinidi-messaging-mediator` legitimately stays on `vta-sdk 0.9.11` (`^0.9`), so the lock carries both versions; `openvtc`/`openvtc-core` resolve to `0.10.0`.

## Verification

- `cargo check --all-targets --workspace` — compiles, zero source changes
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo test --workspace` — 9 unit + 3 doctests pass
- `cargo deny check` — advisories/bans/licenses/sources ok