### PR TITLE
chore(deps): bump affinidi-messaging-didcomm-service lock to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b4b95a1c5aad5ad17259954ca3bf647ad109cb92ac5b1d6a0dc951434e0a99"
+checksum = "1c874b71c8442b216f79eefa24191f8eafe5732659561e3f37f09848d5f1255c"
 dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
@@ -5870,7 +5870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",


### PR DESCRIPTION
Bumps the `Cargo.lock` pin for `affinidi-messaging-didcomm-service` 0.3.3 → **0.3.4**, which carries the *drain DIDComm offline backlog on connect* fix (no more ~30s wait before a queued join-approval credential is delivered). Published upstream in [affinidi/affinidi-tdk-rs#384](https://github.com/affinidi/affinidi-tdk-rs/pull/384).

The manifest dependency is already `= "0.3"`, so no `Cargo.toml` change — this only updates the lockfile so fresh checkouts and CI build the fixed version deterministically (rather than staying on 0.3.3 until someone runs `cargo update`). Replaces the temporary local `[patch.crates-io]` we'd been carrying.

`cargo build --workspace` clean.