### PR TITLE
refactor(state): hoist save/sync/status/log ritual into shared dispatch_util helpers

### DIFF
--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -78,9 +78,8 @@ pub fn remove_vrc(config: &mut Config, vrc_id: &str) -> Result<()> {
 
 use crate::state_handler::{
     actions::CredentialAction,
-    log_did,
+    dispatch_util, log_did,
     main_page::content::{CredentialTab, CredentialsMode},
-    settings_actions,
     state::State,
 };
 
@@ -153,23 +152,26 @@ async fn handle_submit_request(
     match send_vrc_request(config, tdk, service, relationship_p_did, reason).await {
         Ok(()) => {
             state.main_page.content_panel.credentials.mode = CredentialsMode::List;
-            state.main_page.content_panel.credentials.status_message = Some(format!(
-                "VRC request sent to {}",
-                log_did(relationship_p_did)
-            ));
-            if let Err(e) = settings_actions::save_config(config, profile) {
-                state.main_page.log_error("Failed to save config", &e);
-            }
-            state.main_page.sync_from_config(config);
-            state.main_page.log(format!(
-                "VRC request sent to {}",
-                log_did(relationship_p_did)
-            ));
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::SaveAndSync,
+                |mp| &mut mp.content_panel.credentials.status_message,
+                format!("VRC request sent to {}", log_did(relationship_p_did)),
+                dispatch_util::SyncLog::Plain(format!(
+                    "VRC request sent to {}",
+                    log_did(relationship_p_did)
+                )),
+            );
         }
         Err(e) => {
-            state.main_page.content_panel.credentials.status_message =
-                Some(format!("Error: {e:#}"));
-            state.main_page.log_error("Failed to send VRC request", &e);
+            dispatch_util::record_error(
+                &mut state.main_page,
+                |mp| &mut mp.content_panel.credentials.status_message,
+                "Failed to send VRC request",
+                &e,
+            );
         }
     }
 }
@@ -181,12 +183,15 @@ fn handle_remove(config: &mut Box<Config>, state: &mut State, profile: &str, vrc
     }
     state.main_page.content_panel.credentials.mode = CredentialsMode::List;
     state.main_page.content_panel.credentials.selected_index = 0;
-    state.main_page.content_panel.credentials.status_message = Some("VRC removed".to_string());
-    if let Err(e) = settings_actions::save_config(config, profile) {
-        state.main_page.log_error("Failed to save config", &e);
-    }
-    state.main_page.sync_from_config(config);
-    state.main_page.log("VRC removed");
+    dispatch_util::save_and_sync(
+        &mut state.main_page,
+        config,
+        profile,
+        dispatch_util::Persist::SaveAndSync,
+        |mp| &mut mp.content_panel.credentials.status_message,
+        "VRC removed",
+        dispatch_util::SyncLog::Plain("VRC removed".to_string()),
+    );
 }
 
 /// Dispatch a single `CredentialAction` to its handler.

--- a/openvtc/src/state_handler/dispatch_util.rs
+++ b/openvtc/src/state_handler/dispatch_util.rs
@@ -1,0 +1,93 @@
+//! Shared helpers for the post-action "save / sync / status / log" ritual that
+//! every panel's action handlers perform after a state-mutating operation.
+//!
+//! Before this module existed, the same ~8-line success/error block was copied
+//! inline across the inbox, relationship, credential, and settings handlers:
+//!
+//! 1. set the panel's `status_message`,
+//! 2. persist the config (`save_config`, logging on failure),
+//! 3. rebuild UI state from config (`sync_from_config`),
+//! 4. push an activity-log entry (`log` or `log_detailed`).
+//!
+//! The helpers here generalize that block over the panel-specific status slot
+//! (reached via an accessor closure, since each panel stores its
+//! `status_message` in a different sub-struct) without changing any behavior.
+//! Panel/mode transitions stay at the call site because they vary per panel.
+
+use openvtc_core::config::Config;
+
+use crate::state_handler::main_page::MainPageState;
+use crate::state_handler::settings_actions;
+
+/// Activity-log entry to write after an action completes.
+pub(crate) enum SyncLog {
+    /// A plain, single-line summary (`log`).
+    Plain(String),
+    /// A summary plus a detail pane (`log_detailed`).
+    Detailed { summary: String, detail: String },
+}
+
+impl SyncLog {
+    fn write(self, main_page: &mut MainPageState) {
+        match self {
+            SyncLog::Plain(summary) => main_page.log(summary),
+            SyncLog::Detailed { summary, detail } => main_page.log_detailed(summary, detail),
+        }
+    }
+}
+
+/// How to persist + refresh UI after a successful action.
+pub(crate) enum Persist {
+    /// Save the config (logging on failure), then sync UI from config.
+    SaveAndSync,
+    /// The action already saved the config itself; only sync UI from config.
+    SyncOnly,
+    /// The action already saved the config and no UI sync is required.
+    None,
+}
+
+impl Persist {
+    fn apply(self, main_page: &mut MainPageState, config: &Config, profile: &str) {
+        match self {
+            Persist::SaveAndSync => {
+                if let Err(e) = settings_actions::save_config(config, profile) {
+                    main_page.log_error("Failed to save config", &e);
+                }
+                main_page.sync_from_config(config);
+            }
+            Persist::SyncOnly => main_page.sync_from_config(config),
+            Persist::None => {}
+        }
+    }
+}
+
+/// Finish a successful action: persist/refresh per `persist`, set the panel's
+/// `status_message` (reached via `status`), then write the activity log entry.
+///
+/// `status` returns a mutable reference to the panel's status slot, e.g.
+/// `|mp| &mut mp.content_panel.inbox.status_message`.
+pub(crate) fn save_and_sync(
+    main_page: &mut MainPageState,
+    config: &Config,
+    profile: &str,
+    persist: Persist,
+    status: impl FnOnce(&mut MainPageState) -> &mut Option<String>,
+    success_status: impl Into<String>,
+    log: SyncLog,
+) {
+    *status(main_page) = Some(success_status.into());
+    persist.apply(main_page, config, profile);
+    log.write(main_page);
+}
+
+/// Record a failed action: set the panel's `status_message` to `Error: {err:#}`
+/// (reached via `status`) and log the error with `context`.
+pub(crate) fn record_error(
+    main_page: &mut MainPageState,
+    status: impl FnOnce(&mut MainPageState) -> &mut Option<String>,
+    context: impl Into<String>,
+    err: &anyhow::Error,
+) {
+    *status(main_page) = Some(format!("Error: {err:#}"));
+    main_page.log_error(context, err);
+}

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -468,6 +468,7 @@ fn build_reject_message(from: &str, to: &str, reason: Option<&str>, thid: &str) 
 
 use crate::state_handler::{
     actions::InboxAction,
+    dispatch_util,
     main_page::content::{ActiveTaskView, TaskKind},
     settings_actions,
     state::State,
@@ -534,17 +535,24 @@ fn save_and_sync(
     success_log: &str,
 ) {
     state.main_page.content_panel.inbox.active_task = None;
-    state.main_page.content_panel.inbox.status_message = Some(success_status.to_string());
-    if let Err(e) = settings_actions::save_config(config, profile) {
-        state.main_page.log_error("Failed to save config", &e);
-    }
-    state.main_page.sync_from_config(config);
-    state.main_page.log(success_log);
+    dispatch_util::save_and_sync(
+        &mut state.main_page,
+        config,
+        profile,
+        dispatch_util::Persist::SaveAndSync,
+        |mp| &mut mp.content_panel.inbox.status_message,
+        success_status.to_string(),
+        dispatch_util::SyncLog::Plain(success_log.to_string()),
+    );
 }
 
 fn record_error(state: &mut State, context: &str, err: &anyhow::Error) {
-    state.main_page.content_panel.inbox.status_message = Some(format!("Error: {err:#}"));
-    state.main_page.log_error(context, err);
+    dispatch_util::record_error(
+        &mut state.main_page,
+        |mp| &mut mp.content_panel.inbox.status_message,
+        context,
+        err,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -52,6 +52,7 @@ pub(crate) fn resolve_did_to_display(config: &openvtc_core::config::Config, did:
 pub mod actions;
 mod credential_actions;
 pub mod didcomm;
+mod dispatch_util;
 mod inbox_actions;
 pub mod join;
 mod join_flow;

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -530,7 +530,7 @@ fn create_request_message(
 // ============================================================
 
 use crate::state_handler::{
-    actions::RelationshipAction, credential_actions, log_did,
+    actions::RelationshipAction, credential_actions, dispatch_util, log_did,
     main_page::content::RelationshipsMode, resolve_did_to_display, settings_actions, state::State,
 };
 use openvtc_core::config::protected_config::Contact;
@@ -626,11 +626,6 @@ async fn handle_submit(
     {
         Ok(()) => {
             state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
-            state.main_page.content_panel.relationships.status_message =
-                Some(format!("Request sent to {}", log_did(did)));
-            if let Err(e) = settings_actions::save_config(config, profile) {
-                state.main_page.log_error("Failed to save config", &e);
-            }
             let detail = {
                 let rel_key = std::sync::Arc::new(did.to_string());
                 if let Some(rel_arc) = config.private.relationships.get(&rel_key)
@@ -656,18 +651,26 @@ async fn handle_submit(
                     String::new()
                 }
             };
-            state.main_page.sync_from_config(config);
-            state.main_page.log_detailed(
-                format!("Relationship request sent to {}", log_did(did)),
-                detail,
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::SaveAndSync,
+                |mp| &mut mp.content_panel.relationships.status_message,
+                format!("Request sent to {}", log_did(did)),
+                dispatch_util::SyncLog::Detailed {
+                    summary: format!("Relationship request sent to {}", log_did(did)),
+                    detail,
+                },
             );
         }
         Err(e) => {
-            state.main_page.content_panel.relationships.status_message =
-                Some(format!("Error: {e:#}"));
-            state
-                .main_page
-                .log_error("Failed to send relationship request", &e);
+            dispatch_util::record_error(
+                &mut state.main_page,
+                |mp| &mut mp.content_panel.relationships.status_message,
+                "Failed to send relationship request",
+                &e,
+            );
         }
     }
 }
@@ -694,29 +697,31 @@ async fn handle_ping(
     match ping_relationship(config, tdk, service, remote_p_did).await {
         Ok(()) => {
             state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
-            state.main_page.content_panel.relationships.status_message =
-                Some("Ping sent".to_string());
-            if let Err(e) = settings_actions::save_config(config, profile) {
-                state.main_page.log_error("Failed to save config", &e);
-            }
-            state.main_page.sync_from_config(config);
             let using_rdid = !config.is_persona_did(&our_did_str);
-            state.main_page.log_detailed(
-                format!(
-                    "Trust-ping sent to {display_name}{}",
-                    if using_rdid { " (via R-DID)" } else { "" }
-                ),
-                format!(
-                    "Trust-Ping Sent\n\
-                     ───────────────\n\
-                     To:              {display_name}\n\
-                     Sent to DID:     {remote_did_str}\n\
-                     Sent from DID:   {our_did_str}\n\
-                     Remote persona:  {remote_p_did}\n\
-                     Using R-DIDs:    {}\n\
-                     Routed via:      mediator",
-                    if using_rdid { "yes" } else { "no" },
-                ),
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::SaveAndSync,
+                |mp| &mut mp.content_panel.relationships.status_message,
+                "Ping sent",
+                dispatch_util::SyncLog::Detailed {
+                    summary: format!(
+                        "Trust-ping sent to {display_name}{}",
+                        if using_rdid { " (via R-DID)" } else { "" }
+                    ),
+                    detail: format!(
+                        "Trust-Ping Sent\n\
+                         ───────────────\n\
+                         To:              {display_name}\n\
+                         Sent to DID:     {remote_did_str}\n\
+                         Sent from DID:   {our_did_str}\n\
+                         Remote persona:  {remote_p_did}\n\
+                         Using R-DIDs:    {}\n\
+                         Routed via:      mediator",
+                        if using_rdid { "yes" } else { "no" },
+                    ),
+                },
             );
         }
         Err(e) => {
@@ -752,13 +757,15 @@ async fn handle_remove(
         return;
     }
     state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
-    state.main_page.content_panel.relationships.status_message =
-        Some("Relationship removed".to_string());
-    if let Err(e) = settings_actions::save_config(config, profile) {
-        state.main_page.log_error("Failed to save config", &e);
-    }
-    state.main_page.sync_from_config(config);
-    state.main_page.log("Relationship removed");
+    dispatch_util::save_and_sync(
+        &mut state.main_page,
+        config,
+        profile,
+        dispatch_util::Persist::SaveAndSync,
+        |mp| &mut mp.content_panel.relationships.status_message,
+        "Relationship removed",
+        dispatch_util::SyncLog::Plain("Relationship removed".to_string()),
+    );
 }
 
 fn handle_edit_alias(
@@ -817,8 +824,15 @@ fn handle_edit_alias(
         index,
         selected_vrc: None,
     };
-    state.main_page.content_panel.relationships.status_message = Some("Alias updated".to_string());
-    state.main_page.log("Alias updated");
+    dispatch_util::save_and_sync(
+        &mut state.main_page,
+        config,
+        profile,
+        dispatch_util::Persist::None,
+        |mp| &mut mp.content_panel.relationships.status_message,
+        "Alias updated",
+        dispatch_util::SyncLog::Plain("Alias updated".to_string()),
+    );
 }
 
 async fn handle_request_vrc(
@@ -832,20 +846,22 @@ async fn handle_request_vrc(
     let display_name = resolve_did_to_display(config, remote_p_did);
     match credential_actions::send_vrc_request(config, tdk, service, remote_p_did, None).await {
         Ok(()) => {
-            state.main_page.content_panel.relationships.status_message =
-                Some(format!("VRC requested from {display_name}"));
-            if let Err(e) = settings_actions::save_config(config, profile) {
-                state.main_page.log_error("Failed to save config", &e);
-            }
-            state.main_page.sync_from_config(config);
-            state.main_page.log_detailed(
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::SaveAndSync,
+                |mp| &mut mp.content_panel.relationships.status_message,
                 format!("VRC requested from {display_name}"),
-                format!(
-                    "VRC Request Sent\n\
-                     ────────────────\n\
-                     To:      {display_name}\n\
-                     DID:     {remote_p_did}",
-                ),
+                dispatch_util::SyncLog::Detailed {
+                    summary: format!("VRC requested from {display_name}"),
+                    detail: format!(
+                        "VRC Request Sent\n\
+                         ────────────────\n\
+                         To:      {display_name}\n\
+                         DID:     {remote_p_did}",
+                    ),
+                },
             );
         }
         Err(e) => {

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -171,6 +171,7 @@ pub fn remove_contact(config: &mut Config, profile: &str, did: &str) -> Result<(
 use crate::state_handler::{
     actions::{ContactAction, SettingsAction},
     didcomm::{self, ReconnectOutcome},
+    dispatch_util,
     main_page::content::SettingsMode,
     state::{self, State},
 };
@@ -325,16 +326,25 @@ fn handle_submit_edit(
                 _ => "Setting",
             };
             state.main_page.content_panel.settings.mode = SettingsMode::View;
-            state.main_page.content_panel.settings.status_message =
-                Some("Setting saved".to_string());
-            state.main_page.sync_from_config(config);
-            state.main_page.log(format!("{} updated", setting_name));
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::SyncOnly,
+                |mp| &mut mp.content_panel.settings.status_message,
+                "Setting saved",
+                dispatch_util::SyncLog::Plain(format!("{} updated", setting_name)),
+            );
             // Mediator DID is index 1 — caller should trigger reconnect
             idx == 1
         }
         Err(e) => {
-            state.main_page.content_panel.settings.status_message = Some(format!("Error: {e:#}"));
-            state.main_page.log_error("Failed to save setting", &e);
+            dispatch_util::record_error(
+                &mut state.main_page,
+                |mp| &mut mp.content_panel.settings.status_message,
+                "Failed to save setting",
+                &e,
+            );
             false
         }
     }
@@ -359,9 +369,15 @@ fn handle_export_config_action(
                     .log_error("Failed to persist export-log entry", &e);
             }
             state.main_page.content_panel.settings.mode = SettingsMode::View;
-            state.main_page.content_panel.settings.status_message =
-                Some(format!("Config exported to {}", path));
-            state.main_page.log(format!("Config exported to {}", path));
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::None,
+                |mp| &mut mp.content_panel.settings.status_message,
+                format!("Config exported to {}", path),
+                dispatch_util::SyncLog::Plain(format!("Config exported to {}", path)),
+            );
         }
         Err(e) => {
             state.main_page.content_panel.settings.status_message =
@@ -390,8 +406,15 @@ fn handle_import_config_action(
                     .log_error("Failed to persist import-log entry", &e);
             }
             state.main_page.content_panel.settings.mode = SettingsMode::View;
-            state.main_page.content_panel.settings.status_message = Some(msg.clone());
-            state.main_page.log(msg);
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::None,
+                |mp| &mut mp.content_panel.settings.status_message,
+                msg.clone(),
+                dispatch_util::SyncLog::Plain(msg),
+            );
         }
         Err(e) => {
             state.main_page.content_panel.settings.status_message =
@@ -419,14 +442,23 @@ fn handle_set_passphrase(
     match set_passphrase(config, profile, passphrase) {
         Ok(()) => {
             state.main_page.content_panel.settings.mode = SettingsMode::View;
-            state.main_page.content_panel.settings.status_message =
-                Some("Passphrase protection enabled".to_string());
-            state.main_page.sync_from_config(config);
-            state.main_page.log("Passphrase protection enabled");
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::SyncOnly,
+                |mp| &mut mp.content_panel.settings.status_message,
+                "Passphrase protection enabled",
+                dispatch_util::SyncLog::Plain("Passphrase protection enabled".to_string()),
+            );
         }
         Err(e) => {
-            state.main_page.content_panel.settings.status_message = Some(format!("Error: {e:#}"));
-            state.main_page.log_error("Failed to set passphrase", &e);
+            dispatch_util::record_error(
+                &mut state.main_page,
+                |mp| &mut mp.content_panel.settings.status_message,
+                "Failed to set passphrase",
+                &e,
+            );
         }
     }
 }
@@ -435,14 +467,23 @@ fn handle_remove_passphrase(config: &mut Box<Config>, state: &mut State, profile
     match remove_passphrase(config, profile) {
         Ok(()) => {
             state.main_page.content_panel.settings.mode = SettingsMode::View;
-            state.main_page.content_panel.settings.status_message =
-                Some("Protection reverted to keyring only".to_string());
-            state.main_page.sync_from_config(config);
-            state.main_page.log("Protection reverted to keyring only");
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                profile,
+                dispatch_util::Persist::SyncOnly,
+                |mp| &mut mp.content_panel.settings.status_message,
+                "Protection reverted to keyring only",
+                dispatch_util::SyncLog::Plain("Protection reverted to keyring only".to_string()),
+            );
         }
         Err(e) => {
-            state.main_page.content_panel.settings.status_message = Some(format!("Error: {e:#}"));
-            state.main_page.log_error("Failed to remove passphrase", &e);
+            dispatch_util::record_error(
+                &mut state.main_page,
+                |mp| &mut mp.content_panel.settings.status_message,
+                "Failed to remove passphrase",
+                &e,
+            );
         }
     }
 }


### PR DESCRIPTION
**Task R8** (remediation plan, Phase R1). Pure refactor, no behavior change.

## Problem
The save → set-status → `save_config` (log on failure) → `sync_from_config` → `log` ritual was copy-pasted at ~10 sites across `relationship_actions.rs`, `credential_actions.rs`, `settings_actions.rs`, and `inbox_actions.rs` (whose private `save_and_sync`/`record_error` were the only generalized version).

## Fix
Hoist generalized helpers into a new `state_handler/dispatch_util.rs` module (so this PR stays off the lines PR for R9 edits in `mod.rs` — `mod.rs` gains only `mod dispatch_util;`). The status slot is generalized via an accessor closure; a `Persist` enum (`SaveAndSync`/`SyncOnly`/`None`) and `SyncLog` (`Plain`/`Detailed`) faithfully preserve the three distinct rituals and `log` vs `log_detailed` per site. Custom-status error arms left inline where they don't fit the generic shape.

## Verification
`fmt` / `clippy -D warnings` / `test --workspace` green (332 passed). All status/log strings preserved (grep-verified).

Part of the Phase-R1 helper groundwork that Phase R2 (`Config::save` off the loop) builds on. Verified to integrate cleanly with the R0 PRs (#82–#88) and the sibling R1 PRs.
