### PR TITLE
feat(state): background-dispatch pattern for network actions; unblock mediator reconnect

### DIFF
--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -1,0 +1,311 @@
+//! Background-dispatch pattern for network-bound runtime actions (R13).
+//!
+//! # The problem
+//!
+//! The runtime `tokio::select!` loop in [`super`] services exactly one arm at a
+//! time. Several action dispatches `.await` network I/O *inline* in their arm,
+//! so the whole loop is parked for the duration. The worst case is a mediator
+//! change / reconnect, which calls
+//! [`super::didcomm::reconnect_persona_listener_io`] and waits up to **30
+//! seconds** for the listener to connect (`wait_connected(.., 30s)`). While that
+//! future is
+//! pending, no other select arm runs: queued keystrokes pile up, inbound DIDComm
+//! events in the bounded channel get dropped, and even `q` / Exit is dead.
+//!
+//! # The pattern
+//!
+//! Startup already solves this (`super::StateHandler::main_loop`'s
+//! `MainPageDeferred` arm): the slow load runs as a spawned task that streams
+//! progress/completion back into a responsive select loop over a channel. This
+//! module generalises that for *runtime* actions:
+//!
+//! * The background task does **I/O only** and returns a [`DispatchOutcome`]
+//!   over an mpsc the loop owns.
+//! * **All mutation stays on the loop thread**: a dedicated select arm applies
+//!   the outcome (config changes, save/sync helpers, status), so the
+//!   single-mutator / unidirectional-data-flow invariant is preserved.
+//! * A per-domain [`InFlight`] busy-guard rejects a second action on a busy
+//!   domain with a visible status message instead of running it concurrently or
+//!   queueing it blind — matching today's effectively-serialised behaviour.
+//!
+//! R13 migrates the mediator change/reconnect path as the single proving case;
+//! R14 migrates the remaining network dispatches onto the same mechanism.
+
+use crate::state_handler::didcomm::ReconnectOutcome;
+use crate::state_handler::state::{self, State};
+
+/// A domain that can have at most one background dispatch in flight at a time.
+///
+/// The set is intentionally small and matches the "one mutating task" model the
+/// loop already had: serialising per domain means a user can't, e.g., fire two
+/// mediator reconnects at once, while still leaving distinct domains independent
+/// (a future relationship dispatch and a mediator reconnect don't block each
+/// other). R14 adds the remaining variants as it migrates each call site.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum DispatchDomain {
+    /// Mediator change / manual reconnect — replaces the persona listener and
+    /// waits for it to connect (up to 30 s).
+    Mediator,
+}
+
+impl DispatchDomain {
+    /// Human-readable label for the "already in progress" status message.
+    fn label(self) -> &'static str {
+        match self {
+            DispatchDomain::Mediator => "Mediator reconnect",
+        }
+    }
+}
+
+/// Per-domain in-flight guard: at most one background dispatch per
+/// [`DispatchDomain`].
+///
+/// `try_begin` is the gate at every backgrounded call site — it returns `false`
+/// (and the caller surfaces a status) when that domain is already busy. The loop
+/// clears the flag in [`apply_outcome`] when the matching outcome arrives, so the
+/// flag's lifetime brackets exactly the spawned task.
+#[derive(Default)]
+pub(crate) struct InFlight {
+    domains: std::collections::HashSet<DispatchDomain>,
+}
+
+impl InFlight {
+    /// Attempt to claim `domain`. Returns `true` if it was free (now marked
+    /// busy); `false` if a dispatch is already in flight for it.
+    pub(crate) fn try_begin(&mut self, domain: DispatchDomain) -> bool {
+        self.domains.insert(domain)
+    }
+
+    /// Release `domain` once its outcome has been applied.
+    pub(crate) fn finish(&mut self, domain: DispatchDomain) {
+        self.domains.remove(&domain);
+    }
+
+    /// Whether `domain` currently has a dispatch in flight (for tests / status).
+    #[cfg(test)]
+    pub(crate) fn is_busy(&self, domain: DispatchDomain) -> bool {
+        self.domains.contains(&domain)
+    }
+
+    /// Status message for a rejected start, e.g. when the user fires a second
+    /// mediator reconnect while one is still connecting.
+    pub(crate) fn busy_message(domain: DispatchDomain) -> String {
+        format!("{} already in progress — please wait.", domain.label())
+    }
+}
+
+/// The result of a backgrounded network dispatch, delivered into the runtime
+/// select loop over an mpsc the loop owns. Each variant carries the I/O result
+/// (data/errors only — never a `&mut State`); the loop applies it via
+/// [`apply_outcome`], keeping all mutation on the loop thread.
+///
+/// R14 extends this enum (and [`apply_outcome`]) as it migrates the relationship
+/// / inbox / settings / delete-DID dispatches onto the same channel.
+pub(crate) enum DispatchOutcome {
+    /// A mediator change / manual reconnect finished (success or failure). The
+    /// payload is exactly the [`ReconnectOutcome`] the inline path produced, so
+    /// the applied state is identical to the pre-R13 synchronous behaviour.
+    MediatorReconnect(ReconnectOutcome),
+}
+
+impl DispatchOutcome {
+    /// The domain whose busy-flag this outcome releases.
+    fn domain(&self) -> DispatchDomain {
+        match self {
+            DispatchOutcome::MediatorReconnect(_) => DispatchDomain::Mediator,
+        }
+    }
+}
+
+/// Apply a completed [`DispatchOutcome`] to `state` and clear the domain's
+/// busy-flag. **Pure** over `(&mut State, &mut InFlight, outcome)` — no I/O — so
+/// it is unit-testable and is the single place the loop's outcome arm mutates
+/// from.
+///
+/// The mediator-reconnect arm reproduces, byte for byte, the status/log strings
+/// the old inline `run_persona_reconnect` set on completion: the only observable
+/// difference from before R13 is *when* it runs (after a responsive wait rather
+/// than blocking the loop), not *what* it does.
+pub(crate) fn apply_outcome(state: &mut State, in_flight: &mut InFlight, outcome: DispatchOutcome) {
+    let domain = outcome.domain();
+    match outcome {
+        DispatchOutcome::MediatorReconnect(result) => match result {
+            ReconnectOutcome::Connected => {
+                state.connection.status = state::MediatorStatus::Connected;
+                state.connection.messaging_active = true;
+                state.main_page.log("Reconnected to mediator");
+            }
+            ReconnectOutcome::Failed(reason) => {
+                state.connection.status = state::MediatorStatus::Failed(reason.clone());
+                state.main_page.log(format!("Reconnect failed: {reason}"));
+            }
+        },
+    }
+    in_flight.finish(domain);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The busy-guard serialises per domain: the first claim succeeds, a second
+    /// while in flight is rejected, and after `finish` the domain frees up
+    /// again. This is the state machine that backs "a second action on a busy
+    /// domain is rejected with a status, not queued blind".
+    #[test]
+    fn busy_guard_serialises_per_domain() {
+        let mut in_flight = InFlight::default();
+
+        // First claim succeeds and marks the domain busy.
+        assert!(in_flight.try_begin(DispatchDomain::Mediator));
+        assert!(in_flight.is_busy(DispatchDomain::Mediator));
+
+        // A second claim while in flight is rejected (would be surfaced as a
+        // status via `busy_message`).
+        assert!(!in_flight.try_begin(DispatchDomain::Mediator));
+
+        // Releasing frees the domain for the next dispatch.
+        in_flight.finish(DispatchDomain::Mediator);
+        assert!(!in_flight.is_busy(DispatchDomain::Mediator));
+        assert!(in_flight.try_begin(DispatchDomain::Mediator));
+    }
+
+    /// Applying a `Connected` outcome reproduces the old inline success state
+    /// (status + messaging flag + log line) and clears the busy-flag.
+    #[test]
+    fn apply_connected_outcome_sets_connected_and_clears_flag() {
+        let mut state = State::default();
+        let mut in_flight = InFlight::default();
+        assert!(in_flight.try_begin(DispatchDomain::Mediator));
+
+        apply_outcome(
+            &mut state,
+            &mut in_flight,
+            DispatchOutcome::MediatorReconnect(ReconnectOutcome::Connected),
+        );
+
+        assert!(matches!(
+            state.connection.status,
+            state::MediatorStatus::Connected
+        ));
+        assert!(state.connection.messaging_active);
+        assert!(
+            !in_flight.is_busy(DispatchDomain::Mediator),
+            "busy-flag must be cleared once the outcome is applied"
+        );
+    }
+
+    /// Applying a `Failed` outcome reproduces the old inline failure state
+    /// (Failed status carrying the reason) and clears the busy-flag.
+    #[test]
+    fn apply_failed_outcome_sets_failed_and_clears_flag() {
+        let mut state = State::default();
+        let mut in_flight = InFlight::default();
+        assert!(in_flight.try_begin(DispatchDomain::Mediator));
+
+        apply_outcome(
+            &mut state,
+            &mut in_flight,
+            DispatchOutcome::MediatorReconnect(ReconnectOutcome::Failed("dead mediator".into())),
+        );
+
+        match &state.connection.status {
+            state::MediatorStatus::Failed(reason) => assert_eq!(reason, "dead mediator"),
+            other => panic!("expected Failed status, got {other:?}"),
+        }
+        assert!(!state.connection.messaging_active);
+        assert!(!in_flight.is_busy(DispatchDomain::Mediator));
+    }
+
+    /// The busy message names the domain so the UI tells the user *what* is
+    /// already running.
+    #[test]
+    fn busy_message_names_the_domain() {
+        let msg = InFlight::busy_message(DispatchDomain::Mediator);
+        assert!(msg.contains("Mediator reconnect"));
+        assert!(msg.contains("in progress"));
+    }
+
+    /// The whole point of R13: a backgrounded dispatch must NOT block the select
+    /// loop. This drives a miniature replica of the runtime loop's structure — an
+    /// action channel and a dispatch-outcome channel selected together — and
+    /// proves that while a (slow) dispatch is still in flight, an interleaved nav
+    /// action (`MainPanelSwitch`) is processed and `Exit` is honoured.
+    ///
+    /// The "slow dispatch" is modelled by a oneshot we hold open: the outcome is
+    /// only delivered after we have already observed the nav action take effect,
+    /// so the loop demonstrably did real work mid-flight. (The production loop is
+    /// not factored into a test-callable unit — see the coverage note in the
+    /// PR — so this asserts the *pattern* with the same channel shapes.)
+    #[tokio::test]
+    async fn loop_processes_nav_and_exit_while_dispatch_in_flight() {
+        use crate::state_handler::actions::Action;
+        use crate::state_handler::main_page::MainPanel;
+        use tokio::sync::mpsc;
+
+        let (action_tx, mut action_rx) = mpsc::unbounded_channel::<Action>();
+        let (dispatch_tx, mut dispatch_rx) = mpsc::unbounded_channel::<DispatchOutcome>();
+        // The "in flight" dispatch: a task that only completes when we release it.
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let mut state = State::default();
+        let mut in_flight = InFlight::default();
+
+        // Begin a dispatch (busy-flag set) and spawn its "I/O" — it parks on the
+        // oneshot, modelling the up-to-30 s `wait_connected` against a dead
+        // mediator, then reports Connected.
+        assert!(in_flight.try_begin(DispatchDomain::Mediator));
+        let bg_tx = dispatch_tx.clone();
+        tokio::spawn(async move {
+            let _ = release_rx.await;
+            let _ = bg_tx.send(DispatchOutcome::MediatorReconnect(
+                ReconnectOutcome::Connected,
+            ));
+        });
+
+        // Queue a nav action and then an Exit. Both must be serviced *before* the
+        // dispatch completes (which can't happen until we send on `release_tx`).
+        action_tx
+            .send(Action::MainPanelSwitch(MainPanel::ContentPanel))
+            .unwrap();
+        action_tx.send(Action::Exit).unwrap();
+
+        let mut nav_seen = false;
+        // Run the replica select loop. The dispatch is still in flight the whole
+        // time (we never release it inside the loop), proving the loop is live.
+        // The loop breaks `true` once Exit is honoured.
+        let exited = loop {
+            tokio::select! {
+                Some(action) = action_rx.recv() => {
+                    if crate::state_handler::handle_nav_action(&mut state, &action) {
+                        nav_seen = true;
+                        // The nav action took effect mid-flight while the
+                        // dispatch is unmistakably still pending.
+                        assert!(in_flight.is_busy(DispatchDomain::Mediator));
+                        assert!(state.main_page.content_panel.selected);
+                    } else if matches!(action, Action::Exit) {
+                        break true;
+                    }
+                }
+                Some(outcome) = dispatch_rx.recv() => {
+                    apply_outcome(&mut state, &mut in_flight, outcome);
+                }
+            }
+        };
+
+        assert!(
+            nav_seen,
+            "nav action must be processed while dispatch in flight"
+        );
+        assert!(exited, "Exit must be honoured while dispatch in flight");
+        assert!(
+            in_flight.is_busy(DispatchDomain::Mediator),
+            "dispatch was never released, so it is still in flight — the loop did \
+             real work without waiting on it"
+        );
+
+        // Releasing now would deliver the outcome, but the loop already exited;
+        // the point is proven. Drop the sender to avoid an unused warning.
+        let _ = release_tx;
+    }
+}

--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -103,27 +103,38 @@ pub enum ReconnectOutcome {
 
 /// Replace the persona listener and wait for it to come up. Used by the
 /// mediator-change branch of SubmitEdit and by the manual ReconnectMediator
-/// settings action — both did the same dance inline. Returns:
+/// settings action — both go through this dance.
+///
+/// The work is split in two: `persona_listener_config` builds the new listener
+/// config (local-only: reads secrets from the TDK resolver, no network), and
+/// [`reconnect_persona_listener_io`] does the slow connect I/O. The runtime loop
+/// (R13) drives them separately — building the config on its own thread and
+/// handing only the I/O half to a background task — so the up-to-30 s wait no
+/// longer parks the select loop. Returns:
 ///   * `Connected` once the listener reaches the connected state, or
 ///   * `Failed(reason)` on any error during the replace / connect path.
 ///
+/// This is the I/O-only half: it tears down the existing persona listener,
+/// installs the prebuilt `new_config`, and waits up to 30 s for it to connect.
+/// It borrows nothing tied to the loop's `Config`/`TDK` — `DIDCommService` is
+/// cheap to clone (`Arc`-based) and `ListenerConfig`/`listener_id` are owned —
+/// which makes it `tokio::spawn`-friendly.
+///
 /// Active-persona only (these manual actions act on the active identity);
 /// per-persona reconnect lands with the persona-selection slice.
-pub async fn reconnect_persona_listener(
+pub async fn reconnect_persona_listener_io(
     service: &DIDCommService,
-    config: &Config,
-    tdk: &affinidi_tdk::TDK,
+    listener_id: String,
+    new_config: ListenerConfig,
 ) -> ReconnectOutcome {
-    let lid = persona_listener_id(config.persona_did());
-    if let Err(e) = service.remove_listener(&lid).await {
+    if let Err(e) = service.remove_listener(&listener_id).await {
         debug!("remove_listener during reconnect: {e}");
     }
-    let new_config = persona_listener_config(config, tdk).await;
     if let Err(e) = service.add_listener(new_config).await {
         return ReconnectOutcome::Failed(format!("{e:#}"));
     }
     match service
-        .wait_connected(&lid, std::time::Duration::from_secs(30))
+        .wait_connected(&listener_id, std::time::Duration::from_secs(30))
         .await
     {
         Ok(()) => ReconnectOutcome::Connected,

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -50,6 +50,7 @@ pub(crate) fn resolve_did_to_display(config: &openvtc_core::config::Config, did:
 }
 
 pub mod actions;
+mod background_dispatch;
 mod credential_actions;
 pub mod didcomm;
 mod dispatch_util;
@@ -569,6 +570,16 @@ impl StateHandler {
         // Track when a manual trust-ping was sent (for activity log latency display).
         let mut ping_sent_at: Option<std::time::Instant> = None;
 
+        // Background-dispatch plumbing (R13). Network-bound actions whose await
+        // would otherwise park the whole select loop are spawned as background
+        // tasks; they do I/O only and send their result back as a
+        // `DispatchOutcome` on this channel. The select arm below applies the
+        // outcome on the loop thread (the single mutator), keeping the loop live
+        // during the wait. `in_flight` rejects a second action on a busy domain.
+        let (dispatch_tx, mut dispatch_rx) =
+            mpsc::unbounded_channel::<background_dispatch::DispatchOutcome>();
+        let mut in_flight = background_dispatch::InFlight::default();
+
         let result = loop {
             tokio::select! {
                 Some(action) = action_rx.recv() => match action {
@@ -717,8 +728,6 @@ impl StateHandler {
                         match settings_actions::dispatch(
                             sa,
                             &mut config,
-                            &tdk,
-                            &didcomm_service,
                             &mut state,
                             &self.profile,
                         )
@@ -730,6 +739,52 @@ impl StateHandler {
                                     debug!("Failed to send terminate signal: {e}");
                                 }
                                 break Interrupted::UserInt;
+                            }
+                            settings_actions::SettingsOutcome::ReconnectMediator => {
+                                // R13 proving case: the up-to-30s mediator
+                                // reconnect ran inline here before, freezing the
+                                // UI (queued keys, dropped inbound events, dead
+                                // `q`). Now it runs as a background task and the
+                                // loop stays live.
+                                //
+                                // The busy-guard rejects a second reconnect while
+                                // one is in flight (matching the old effectively
+                                // serialised behaviour) with a visible status.
+                                if !in_flight
+                                    .try_begin(background_dispatch::DispatchDomain::Mediator)
+                                {
+                                    let msg = background_dispatch::InFlight::busy_message(
+                                        background_dispatch::DispatchDomain::Mediator,
+                                    );
+                                    state.connection.status =
+                                        state::MediatorStatus::Connecting;
+                                    state.main_page.log(msg);
+                                } else {
+                                    // Build the new listener config on the loop
+                                    // thread (cheap, local: reads secrets from the
+                                    // TDK resolver, no network), then hand only the
+                                    // slow connect I/O to a background task.
+                                    let listener_id =
+                                        didcomm::persona_listener_id(config.persona_did());
+                                    let new_listener_config =
+                                        didcomm::persona_listener_config(&config, &tdk).await;
+                                    let service = didcomm_service.clone();
+                                    let tx = dispatch_tx.clone();
+                                    tokio::spawn(async move {
+                                        let outcome =
+                                            didcomm::reconnect_persona_listener_io(
+                                                &service,
+                                                listener_id,
+                                                new_listener_config,
+                                            )
+                                            .await;
+                                        let _ = tx.send(
+                                            background_dispatch::DispatchOutcome::MediatorReconnect(
+                                                outcome,
+                                            ),
+                                        );
+                                    });
+                                }
                             }
                         }
                     },
@@ -893,6 +948,16 @@ impl StateHandler {
                             );
                         }
                     }
+                },
+                // Background-dispatch completions (R13). A network-bound action
+                // that was spawned off the loop (e.g. the mediator reconnect)
+                // delivers its result here; the outcome is applied on this thread
+                // (the single mutator) and the domain's busy-flag is cleared.
+                // Because this is just another select arm, nav actions, `q`/Exit,
+                // and inbound DIDComm events are all serviced *while* the spawned
+                // I/O is still pending.
+                Some(outcome) = dispatch_rx.recv() => {
+                    background_dispatch::apply_outcome(&mut state, &mut in_flight, outcome);
                 },
                 // Lifecycle log messages from the DIDCommService
                 Some(log_msg) = lifecycle_log_rx.recv() => {

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -128,12 +128,10 @@ pub fn import_config(path: &str, _passphrase: &str) -> Result<String> {
 
 use crate::state_handler::{
     actions::SettingsAction,
-    didcomm::{self, ReconnectOutcome},
     dispatch_util,
     main_page::content::SettingsMode,
     state::{self, State},
 };
-use affinidi_messaging_didcomm_service::DIDCommService;
 
 fn handle_select(state: &mut State, index: usize) {
     #[cfg(feature = "openpgp-card")]
@@ -611,45 +609,39 @@ fn handle_token_back(state: &mut State) {
     state.main_page.content_panel.settings.token.reset_completed = false;
 }
 
-async fn run_persona_reconnect(
-    service: &DIDCommService,
-    config: &Config,
-    tdk: &affinidi_tdk::TDK,
-    state: &mut State,
-) {
+/// Set the synchronous "reconnecting" state — the immediate, non-blocking part
+/// of a mediator reconnect. The slow `wait_connected` I/O is performed by a
+/// background task spawned by the runtime loop (R13); its completion drives the
+/// final `Connected`/`Failed` state via
+/// [`crate::state_handler::background_dispatch::apply_outcome`]. The strings here
+/// match the pre-R13 inline path so the activity log is unchanged.
+fn begin_reconnect_status(state: &mut State) {
     state.connection.status = state::MediatorStatus::Connecting;
     state.connection.messaging_active = false;
     state.main_page.log("Reconnecting to mediator...");
-    match didcomm::reconnect_persona_listener(service, config, tdk).await {
-        ReconnectOutcome::Connected => {
-            state.connection.status = state::MediatorStatus::Connected;
-            state.connection.messaging_active = true;
-            state.main_page.log("Reconnected to mediator");
-        }
-        ReconnectOutcome::Failed(reason) => {
-            state.connection.status = state::MediatorStatus::Failed(reason.clone());
-            state.main_page.log(format!("Reconnect failed: {reason}"));
-        }
-    }
 }
 
-/// Outcome of dispatching a `SettingsAction`. The TUI loop ignores
-/// `Continue` and breaks out with `UserInt` when the operator wipes
-/// the profile (the binary can no longer authenticate after a wipe).
+/// Outcome of dispatching a `SettingsAction`.
+///
+/// The TUI loop ignores `Continue`, breaks out with `UserInt` when the operator
+/// wipes the profile (the binary can no longer authenticate after a wipe), and
+/// on `ReconnectMediator` spawns a background mediator reconnect (R13) — the slow
+/// `wait_connected` wait runs off the select loop so the UI stays responsive.
 pub(crate) enum SettingsOutcome {
     Continue,
     ExitUserInt,
+    /// A mediator change or manual reconnect was requested. The loop builds the
+    /// listener config and spawns the I/O; `begin_reconnect_status` has already
+    /// set the synchronous "Connecting" state.
+    ReconnectMediator,
 }
 
 /// Dispatch a single `SettingsAction`. Returns `ExitUserInt` if the
 /// operator confirmed a profile wipe — caller is responsible for
 /// driving the terminator afterwards.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn dispatch(
     action: SettingsAction,
     config: &mut Box<Config>,
-    tdk: &affinidi_tdk::TDK,
-    service: &DIDCommService,
     state: &mut State,
     profile: &str,
 ) -> SettingsOutcome {
@@ -678,7 +670,10 @@ pub(crate) async fn dispatch(
         SettingsAction::PassphraseLen(len) => handle_passphrase_len(state, len),
         SettingsAction::SubmitEdit { value } => {
             if handle_submit_edit(config, state, profile, &value) {
-                run_persona_reconnect(service, config, tdk, state).await;
+                // The mediator DID was changed. Set the synchronous "Connecting"
+                // state now; the loop spawns the slow reconnect I/O (R13).
+                begin_reconnect_status(state);
+                return SettingsOutcome::ReconnectMediator;
             }
         }
         SettingsAction::ExportConfig { path, passphrase } => {
@@ -712,7 +707,8 @@ pub(crate) async fn dispatch(
             }
         }
         SettingsAction::ReconnectMediator => {
-            run_persona_reconnect(service, config, tdk, state).await;
+            begin_reconnect_status(state);
+            return SettingsOutcome::ReconnectMediator;
         }
     }
     SettingsOutcome::Continue


### PR DESCRIPTION
**Task R13** (remediation plan, Phase R2 — responsiveness). The **keystone** of Phase R2; R11/R12/R14/R15 build on this mechanism.

## Problem
The single `tokio::select!` runtime loop awaited network-bound dispatches **inline**. A mediator change/reconnect calls `wait_connected(.., 30s)`, so for up to **30 seconds** no other select arm ran — queued keystrokes piled up, inbound DIDComm events in the bounded channel were dropped, and even `q`/Exit was dead.

## Mechanism (reusable, generalizes the existing startup `load_step2` pattern)
- `enum DispatchDomain { Mediator }` — busy-key (R14 adds variants).
- `struct InFlight` — `try_begin`/`finish`/`busy_message`; a second action on a busy domain is rejected with a visible status instead of queued blind.
- `enum DispatchOutcome` — carries **I/O result only**, no `&mut State`.
- `fn apply_outcome(&mut State, &mut InFlight, DispatchOutcome)` — **pure**; the single place the loop's completion arm mutates state (reusing the PR #89 `dispatch_util` save/sync/status helpers).
- `didcomm::reconnect_persona_listener_io(...)` — the `'static`-spawnable I/O half (config built on the loop thread post-mutation; task holds owned snapshot + `Arc` service, never `&config`/`&tdk`).

**Mutation stays on the loop thread**; the background task does only I/O. Coexists with the PR #90 `handle_nav_action` reducer.

## Scope
Only the mediator change/reconnect path is migrated (the single proving case). Relationship/inbox/delete-did dispatches are **left inline, untouched** — that's task R14.

## Responsiveness
The `Settings` arm now only spawns and returns, so the loop is immediately back at `select!` servicing `action_rx` (nav + `q`/Exit), `didcomm_event_rx` (drains inbound), and `dispatch_rx` (completion). DIDComm channel semantics unchanged.

## Durability/ordering (for reviewer scrutiny)
Config save (`update_mediator_did`) still happens **synchronously before** the spawn — persistence ordering unchanged. The only thing the old code did synchronously *after* reconnect (set status + log) is exactly what `apply_outcome` does on the loop thread when the outcome arrives. No new race.

## Tests (5 new)
Busy-guard state machine; Connected/Failed outcome application (same final state/status as the old inline path); busy message; and `loop_processes_nav_and_exit_while_dispatch_in_flight` — a `#[tokio::test]` asserting `MainPanelSwitch` and `Exit` are serviced **while** a dispatch is held in flight. Coverage boundary: no live mediator, so the production `main_loop` isn't exercised end-to-end; coverage is the busy-guard, the pure outcome-application, and the interleaving pattern over identical channel shapes.

Gate: `fmt` / `clippy -D warnings` / `test --workspace` green (98 bin unit tests, +5).
