### PR TITLE
feat(state): migrate relationship/inbox/delete-did dispatches off the event loop

### DIFF
--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -31,7 +31,11 @@
 //! R13 migrates the mediator change/reconnect path as the single proving case;
 //! R14 migrates the remaining network dispatches onto the same mechanism.
 
+use openvtc_core::config::Config;
+
 use crate::state_handler::didcomm::ReconnectOutcome;
+use crate::state_handler::inbox_actions::InboxOutcome;
+use crate::state_handler::relationship_actions::{DidDeleteOutcome, RelationshipOutcome};
 use crate::state_handler::state::{self, State};
 
 /// A domain that can have at most one background dispatch in flight at a time.
@@ -39,13 +43,28 @@ use crate::state_handler::state::{self, State};
 /// The set is intentionally small and matches the "one mutating task" model the
 /// loop already had: serialising per domain means a user can't, e.g., fire two
 /// mediator reconnects at once, while still leaving distinct domains independent
-/// (a future relationship dispatch and a mediator reconnect don't block each
-/// other). R14 adds the remaining variants as it migrates each call site.
+/// (a relationship dispatch and a mediator reconnect don't block each other).
+///
+/// R14 keeps the granularity conservative: every relationship-panel network
+/// action (create / ping / remove) shares one `Relationship` domain, and every
+/// inbox network action (accept / reject) shares one `Inbox` domain. Two actions
+/// on the *same* domain — even if they target different relationships — are
+/// serialised (the second is rejected with a status), matching the loop's
+/// pre-R14 "one in-flight mutating await at a time" behaviour. Distinct domains
+/// stay independent (a ping and an inbox accept can run concurrently).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum DispatchDomain {
     /// Mediator change / manual reconnect — replaces the persona listener and
     /// waits for it to connect (up to 30 s).
     Mediator,
+    /// Relationship-panel network actions: create (VTA round-trip + send), ping
+    /// (`send_message_with_retry` ~6 s on a dead peer), remove (`remove_listener`).
+    Relationship,
+    /// Inbox network actions: accept/reject a relationship request, accept/reject
+    /// a VRC request — all do a (retrying) DIDComm send.
+    Inbox,
+    /// Context-DID deletion: `delete_did_webvh` at the VTA + listener teardown.
+    Did,
 }
 
 impl DispatchDomain {
@@ -53,6 +72,9 @@ impl DispatchDomain {
     fn label(self) -> &'static str {
         match self {
             DispatchDomain::Mediator => "Mediator reconnect",
+            DispatchDomain::Relationship => "Relationship action",
+            DispatchDomain::Inbox => "Inbox action",
+            DispatchDomain::Did => "Identity deletion",
         }
     }
 }
@@ -106,6 +128,17 @@ pub(crate) enum DispatchOutcome {
     /// payload is exactly the [`ReconnectOutcome`] the inline path produced, so
     /// the applied state is identical to the pre-R13 synchronous behaviour.
     MediatorReconnect(ReconnectOutcome),
+    /// A relationship-panel network action (create / ping / remove) finished.
+    /// The payload owns the send result plus the data the post-send config
+    /// mutation needs; [`RelationshipOutcome::apply`] reproduces the old inline
+    /// success/error block exactly.
+    Relationship(RelationshipOutcome),
+    /// An inbox network action (accept/reject relationship, accept/reject VRC)
+    /// finished. [`InboxOutcome::apply`] reproduces the old inline block.
+    Inbox(InboxOutcome),
+    /// A context-DID deletion finished (VTA delete + listener teardown done in
+    /// the task; local cleanup + save applied here).
+    Did(DidDeleteOutcome),
 }
 
 impl DispatchOutcome {
@@ -113,6 +146,9 @@ impl DispatchOutcome {
     fn domain(&self) -> DispatchDomain {
         match self {
             DispatchOutcome::MediatorReconnect(_) => DispatchDomain::Mediator,
+            DispatchOutcome::Relationship(_) => DispatchDomain::Relationship,
+            DispatchOutcome::Inbox(_) => DispatchDomain::Inbox,
+            DispatchOutcome::Did(_) => DispatchDomain::Did,
         }
     }
 }
@@ -126,7 +162,21 @@ impl DispatchOutcome {
 /// the old inline `run_persona_reconnect` set on completion: the only observable
 /// difference from before R13 is *when* it runs (after a responsive wait rather
 /// than blocking the loop), not *what* it does.
-pub(crate) fn apply_outcome(state: &mut State, in_flight: &mut InFlight, outcome: DispatchOutcome) {
+///
+/// R14 widens the signature to also take `&mut Config` + `profile`: unlike the
+/// mediator reconnect (which mutates `State` only), the migrated relationship /
+/// inbox / delete-DID paths persist config changes (the relationship record, the
+/// task removal, the issued VRC) that today happen *after* the network send.
+/// Doing them here — on the loop thread, only on success — preserves the
+/// pre-R14 ordering and durability: a send failure leaves config untouched, just
+/// as the old inline `match … { Ok => persist, Err => status }` did.
+pub(crate) fn apply_outcome(
+    state: &mut State,
+    config: &mut Config,
+    profile: &str,
+    in_flight: &mut InFlight,
+    outcome: DispatchOutcome,
+) {
     let domain = outcome.domain();
     match outcome {
         DispatchOutcome::MediatorReconnect(result) => match result {
@@ -140,6 +190,9 @@ pub(crate) fn apply_outcome(state: &mut State, in_flight: &mut InFlight, outcome
                 state.main_page.log(format!("Reconnect failed: {reason}"));
             }
         },
+        DispatchOutcome::Relationship(outcome) => outcome.apply(state, config, profile),
+        DispatchOutcome::Inbox(outcome) => outcome.apply(state, config, profile),
+        DispatchOutcome::Did(outcome) => outcome.apply(state, config, profile),
     }
     in_flight.finish(domain);
 }
@@ -147,6 +200,7 @@ pub(crate) fn apply_outcome(state: &mut State, in_flight: &mut InFlight, outcome
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state_handler::dispatch_util::test_config;
 
     /// The busy-guard serialises per domain: the first claim succeeds, a second
     /// while in flight is rejected, and after `finish` the domain frees up
@@ -170,16 +224,54 @@ mod tests {
         assert!(in_flight.try_begin(DispatchDomain::Mediator));
     }
 
+    /// The R14 domains (Relationship / Inbox / Did) each serialise independently:
+    /// claiming one does not block another, but a re-claim of the same domain is
+    /// rejected until it is `finish`ed. This backs the "one in-flight per domain"
+    /// model for the migrated network dispatches.
+    #[test]
+    fn r14_domains_serialise_independently() {
+        let mut in_flight = InFlight::default();
+        for domain in [
+            DispatchDomain::Relationship,
+            DispatchDomain::Inbox,
+            DispatchDomain::Did,
+        ] {
+            // Each domain is independent: claiming it succeeds regardless of the
+            // others already being busy.
+            assert!(in_flight.try_begin(domain), "{domain:?} should be free");
+            // A second claim on the same domain is rejected while in flight.
+            assert!(
+                !in_flight.try_begin(domain),
+                "{domain:?} second claim must be rejected"
+            );
+        }
+        // All three are concurrently in flight without blocking each other.
+        assert!(in_flight.is_busy(DispatchDomain::Relationship));
+        assert!(in_flight.is_busy(DispatchDomain::Inbox));
+        assert!(in_flight.is_busy(DispatchDomain::Did));
+        // …and a Mediator dispatch is still independently available.
+        assert!(in_flight.try_begin(DispatchDomain::Mediator));
+
+        // Releasing one frees only that domain.
+        in_flight.finish(DispatchDomain::Inbox);
+        assert!(!in_flight.is_busy(DispatchDomain::Inbox));
+        assert!(in_flight.is_busy(DispatchDomain::Relationship));
+        assert!(in_flight.try_begin(DispatchDomain::Inbox));
+    }
+
     /// Applying a `Connected` outcome reproduces the old inline success state
     /// (status + messaging flag + log line) and clears the busy-flag.
     #[test]
     fn apply_connected_outcome_sets_connected_and_clears_flag() {
         let mut state = State::default();
+        let mut config = test_config();
         let mut in_flight = InFlight::default();
         assert!(in_flight.try_begin(DispatchDomain::Mediator));
 
         apply_outcome(
             &mut state,
+            &mut config,
+            "test",
             &mut in_flight,
             DispatchOutcome::MediatorReconnect(ReconnectOutcome::Connected),
         );
@@ -200,11 +292,14 @@ mod tests {
     #[test]
     fn apply_failed_outcome_sets_failed_and_clears_flag() {
         let mut state = State::default();
+        let mut config = test_config();
         let mut in_flight = InFlight::default();
         assert!(in_flight.try_begin(DispatchDomain::Mediator));
 
         apply_outcome(
             &mut state,
+            &mut config,
+            "test",
             &mut in_flight,
             DispatchOutcome::MediatorReconnect(ReconnectOutcome::Failed("dead mediator".into())),
         );
@@ -249,6 +344,7 @@ mod tests {
         let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
 
         let mut state = State::default();
+        let mut config = test_config();
         let mut in_flight = InFlight::default();
 
         // Begin a dispatch (busy-flag set) and spawn its "I/O" — it parks on the
@@ -288,7 +384,7 @@ mod tests {
                     }
                 }
                 Some(outcome) = dispatch_rx.recv() => {
-                    apply_outcome(&mut state, &mut in_flight, outcome);
+                    apply_outcome(&mut state, &mut config, "test", &mut in_flight, outcome);
                 }
             }
         };

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -139,6 +139,12 @@ pub(crate) enum DispatchOutcome {
     /// A context-DID deletion finished (VTA delete + listener teardown done in
     /// the task; local cleanup + save applied here).
     Did(DidDeleteOutcome),
+    /// A spawned dispatch job panicked (or was cancelled) and so never produced a
+    /// real outcome. Synthesised by [`spawn_dispatch`] from the `JoinError` so the
+    /// domain's busy-flag is still cleared (a panicking job that sent nothing would
+    /// otherwise leave its domain busy forever) and a generic failure status is
+    /// surfaced. Carries the domain to release + label.
+    Panicked(DispatchDomain),
 }
 
 impl DispatchOutcome {
@@ -149,8 +155,34 @@ impl DispatchOutcome {
             DispatchOutcome::Relationship(_) => DispatchDomain::Relationship,
             DispatchOutcome::Inbox(_) => DispatchDomain::Inbox,
             DispatchOutcome::Did(_) => DispatchDomain::Did,
+            DispatchOutcome::Panicked(domain) => *domain,
         }
     }
+}
+
+/// Spawn a background dispatch job whose future resolves to a [`DispatchOutcome`],
+/// delivering the result over `tx`. **Resilience guarantee:** if the job panics or
+/// is cancelled it produces no outcome, which would leave `domain`'s busy-flag set
+/// forever (every subsequent action on that domain rejected as "in progress").
+/// This wrapper joins the inner task and, on a `JoinError`, synthesises a
+/// [`DispatchOutcome::Panicked`] so `apply_outcome` always clears the flag.
+pub(crate) fn spawn_dispatch<F>(
+    tx: tokio::sync::mpsc::UnboundedSender<DispatchOutcome>,
+    domain: DispatchDomain,
+    fut: F,
+) where
+    F: std::future::Future<Output = DispatchOutcome> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let outcome = match tokio::spawn(fut).await {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                tracing::error!(domain = ?domain, error = %e, "dispatch job panicked/cancelled");
+                DispatchOutcome::Panicked(domain)
+            }
+        };
+        let _ = tx.send(outcome);
+    });
 }
 
 /// Apply a completed [`DispatchOutcome`] to `state` and clear the domain's
@@ -168,8 +200,18 @@ impl DispatchOutcome {
 /// inbox / delete-DID paths persist config changes (the relationship record, the
 /// task removal, the issued VRC) that today happen *after* the network send.
 /// Doing them here — on the loop thread, only on success — preserves the
-/// pre-R14 ordering and durability: a send failure leaves config untouched, just
-/// as the old inline `match … { Ok => persist, Err => status }` did.
+/// pre-R14 ordering and durability.
+///
+/// A send failure records an error status and creates no *task/record that the
+/// old inline `Ok` branch would have created* — matching the pre-R14
+/// `match … { Ok => persist, Err => status }`. It is not a literal no-op on
+/// `Config`, and was never meant to be: it mirrors the in-memory state the old
+/// inline path had reached *before* the send. Specifically, the relationship
+/// Create path records the minted R-DID `key_info` on both success and failure
+/// (key creation happened before the send pre-R14; only the success save
+/// persists it), and removes the provisional `RequestSent` record it pre-inserted
+/// (see [`RelationshipOutcome::apply`]) so a failed send leaves no relationship
+/// record — exactly the pre-R14 net state.
 pub(crate) fn apply_outcome(
     state: &mut State,
     config: &mut Config,
@@ -193,6 +235,13 @@ pub(crate) fn apply_outcome(
         DispatchOutcome::Relationship(outcome) => outcome.apply(state, config, profile),
         DispatchOutcome::Inbox(outcome) => outcome.apply(state, config, profile),
         DispatchOutcome::Did(outcome) => outcome.apply(state, config, profile),
+        DispatchOutcome::Panicked(domain) => {
+            // The job panicked and produced no real outcome. Surface a generic
+            // failure so the user isn't left staring at a stuck "in progress"; the
+            // busy-flag is cleared below (via `domain()`), freeing the domain.
+            let msg = format!("{} failed (internal error)", domain.label());
+            state.main_page.log(msg);
+        }
     }
     in_flight.finish(domain);
 }
@@ -310,6 +359,50 @@ mod tests {
         }
         assert!(!state.connection.messaging_active);
         assert!(!in_flight.is_busy(DispatchDomain::Mediator));
+    }
+
+    /// Applying a `Panicked` outcome clears the busy-flag (so the domain isn't
+    /// stuck "in progress" forever) and surfaces a generic failure log line. This
+    /// backs the Fix-3 resilience guarantee: a spawned job that panics still frees
+    /// its domain.
+    #[test]
+    fn apply_panicked_outcome_clears_flag() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut in_flight = InFlight::default();
+        assert!(in_flight.try_begin(DispatchDomain::Relationship));
+
+        apply_outcome(
+            &mut state,
+            &mut config,
+            "test",
+            &mut in_flight,
+            DispatchOutcome::Panicked(DispatchDomain::Relationship),
+        );
+
+        assert!(
+            !in_flight.is_busy(DispatchDomain::Relationship),
+            "a panicked job's domain must be freed, not left busy forever"
+        );
+    }
+
+    /// `spawn_dispatch` converts a panicking job into a synthetic
+    /// [`DispatchOutcome::Panicked`] for the right domain, rather than silently
+    /// dropping the outcome (which would leave the domain busy forever).
+    #[tokio::test]
+    async fn spawn_dispatch_panic_yields_panicked_outcome() {
+        use tokio::sync::mpsc;
+        let (tx, mut rx) = mpsc::unbounded_channel::<DispatchOutcome>();
+        spawn_dispatch(tx, DispatchDomain::Inbox, async {
+            panic!("boom");
+            #[allow(unreachable_code)]
+            DispatchOutcome::Panicked(DispatchDomain::Inbox)
+        });
+        let outcome = rx.recv().await.expect("an outcome must be delivered");
+        assert!(matches!(
+            outcome,
+            DispatchOutcome::Panicked(DispatchDomain::Inbox)
+        ));
     }
 
     /// The busy message names the domain so the UI tells the user *what* is

--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -574,15 +574,17 @@ fn short_did_id(did: &str) -> String {
     hex::encode(&hash[..8])
 }
 
-/// Create a `ListenerConfig` for a relationship R-DID.
-pub async fn relationship_listener_config(
-    config: &Config,
-    tdk: &affinidi_tdk::TDK,
+/// Build a relationship R-DID `ListenerConfig` from already-owned secrets.
+///
+/// Config/TDK-free, so a backgrounded relationship-creation task (R14) can build
+/// the new R-DID listener from the secrets it just minted — no resolver lookup,
+/// no `Config` borrow — keeping the task `'static` + `Send`.
+pub fn relationship_listener_config_from_secrets(
     our_did: &str,
     remote_p_did: &str,
     mediator_did: &str,
+    secrets: Vec<affinidi_tdk::secrets_resolver::secrets::Secret>,
 ) -> ListenerConfig {
-    let secrets = get_secrets_for_did(tdk, config, our_did).await;
     ListenerConfig {
         id: format!("rel-{}", short_did_id(our_did)),
         profile: make_profile(

--- a/openvtc/src/state_handler/dispatch_util.rs
+++ b/openvtc/src/state_handler/dispatch_util.rs
@@ -91,3 +91,32 @@ pub(crate) fn record_error(
     *status(main_page) = Some(format!("Error: {err:#}"));
     main_page.log_error(context, err);
 }
+
+/// Build a minimal BIP32-backed [`Config`] for the pure `apply`/`apply_outcome`
+/// tests across the `state_handler` modules. Mirrors openvtc-core's own (private)
+/// `test_config`; all fields are public so no cross-crate test constructor is
+/// needed.
+#[cfg(test)]
+pub(crate) fn test_config() -> Config {
+    use openvtc_core::config::{
+        KeyBackend, account::Account, protected_config::ProtectedConfig,
+        public_config::PublicConfig, secured_config::ProtectionMethod,
+    };
+    Config {
+        public: PublicConfig::default(),
+        private: ProtectedConfig::default(),
+        key_backend: KeyBackend::Bip32 {
+            root: ed25519_dalek_bip32::ExtendedSigningKey::from_seed(&[7u8; 32]).unwrap(),
+            seed: secrecy::SecretString::new("seed".into()),
+        },
+        key_info: std::collections::HashMap::new(),
+        protection_method: ProtectionMethod::default(),
+        #[cfg(feature = "openpgp-card")]
+        token_admin_pin: None,
+        #[cfg(feature = "openpgp-card")]
+        token_user_pin: secrecy::SecretString::new("".into()),
+        unlock_code: None,
+        account: Account::default(),
+        identities: std::collections::BTreeMap::new(),
+    }
+}

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -14,207 +14,16 @@ use chrono::Utc;
 use openvtc_core::{
     config::Config,
     logs::LogFamily,
-    relationships::{
-        Relationship, RelationshipAcceptBody, RelationshipRejectBody, RelationshipState,
-    },
+    relationships::{RelationshipAcceptBody, RelationshipRejectBody, RelationshipState},
     tasks::TaskType,
 };
 use serde_json::json;
 use tracing::{debug, info, warn};
 
-/// Accept an inbound relationship request.
-///
-/// When `generate_r_did` is true and the key backend is BIP32, a unique
-/// relationship DID (did:peer) is derived for privacy. Otherwise the
-/// persona DID is used directly.
-pub async fn accept_relationship_request(
-    config: &mut Config,
-    tdk: &TDK,
-    service: &DIDCommService,
-    task_id: &str,
-    generate_r_did: bool,
-    admin_vta: Option<&vta_sdk::client::VtaClient>,
-) -> Result<()> {
-    let task_id = Arc::new(task_id.to_string());
-
-    // Find the task and extract request data
-    let (from_did, their_did, sender_name) = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {}", task_id))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        match &task.type_ {
-            TaskType::RelationshipRequestInbound { from, request, .. } => {
-                // Sanitize the sender-supplied name before it persists as a
-                // contact alias — strips ANSI / control chars / bidi-overrides
-                // / zero-width chars. Hard-cap at 64 chars so a hostile peer
-                // can't dominate the relationships list.
-                let sanitized_name = request
-                    .name
-                    .as_deref()
-                    .map(|n| super::main_page::sanitize_display(n, 64));
-                (Arc::clone(from), request.did.clone(), sanitized_name)
-            }
-            _ => anyhow::bail!("task {} is not an inbound relationship request", task_id),
-        }
-    };
-
-    // Optionally generate a random relationship DID for privacy.
-    // The R-DID is exchanged in the message body but NOT used for routing
-    // during the handshake — all handshake messages use persona DIDs for
-    // from/to so the mediator can route them and sender validation is simple.
-    // The R-DID listener is registered for post-establishment communication.
-    let our_did = if generate_r_did {
-        // Snapshot the mediator before the &mut config borrow below.
-        let mediator = config.mediator_did().to_string();
-        let r_did = Arc::new(
-            super::relationship_actions::create_relationship_did(tdk, config, &mediator, admin_vta)
-                .await?,
-        );
-        // Register listener for post-establishment use (no need to wait for connection)
-        let listener_config = super::didcomm::relationship_listener_config(
-            config,
-            tdk,
-            &r_did,
-            &from_did,
-            config.mediator_did(),
-        )
-        .await;
-        if let Err(e) = service.add_listener(listener_config).await {
-            tracing::warn!(did = %r_did, error = %e, "failed to add R-DID listener");
-        }
-        r_did
-    } else {
-        config.persona_did_arc()
-    };
-
-    // Add or update contact with sender's name as alias
-    if let Some(existing) = config.private.contacts.find_contact(&from_did) {
-        // Contact exists — update alias if sender provided a name and contact has no alias
-        if existing.alias.is_none() && sender_name.is_some() {
-            // Remove and re-add with the alias
-            config
-                .private
-                .contacts
-                .remove_contact(&mut config.public.logs, &from_did);
-            config
-                .private
-                .contacts
-                .add_contact(
-                    tdk,
-                    &from_did,
-                    sender_name.clone(),
-                    false,
-                    &mut config.public.logs,
-                )
-                .await?;
-        }
-    } else {
-        config
-            .private
-            .contacts
-            .add_contact(
-                tdk,
-                &from_did,
-                sender_name.clone(),
-                false,
-                &mut config.public.logs,
-            )
-            .await?;
-    }
-
-    // Build and send acceptance using persona DIDs for routing.
-    // The R-DID is carried in the body — the mediator only sees persona DIDs.
-    // from/to use persona DIDs so encryption keys match the persona listener.
-    let msg = build_accept_message(
-        config.persona_did(), // from: our persona
-        &from_did,            // to: their persona
-        &our_did,             // body.did: our R-DID (or persona if no R-DID)
-        &task_id,
-    )?;
-    super::didcomm::send_message(service, config, &msg, config.persona_did(), &from_did)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to send acceptance: {e}"))?;
-
-    // Create relationship entry
-    config.private.relationships.relationships.insert(
-        Arc::clone(&from_did),
-        Arc::new(Mutex::new(Relationship {
-            task_id: Arc::clone(&task_id),
-            remote_did: Arc::new(their_did),
-            remote_p_did: Arc::clone(&from_did),
-            our_did,
-            created: Utc::now(),
-            state: RelationshipState::RequestAccepted,
-        })),
-    );
-
-    // Remove the task
-    config.private.tasks.remove(&task_id);
-
-    config.public.logs.insert(
-        LogFamily::Relationship,
-        format!("Accepted relationship request from ({})", from_did),
-    );
-    info!(from = %from_did, "relationship request accepted");
-    Ok(())
-}
-
-/// Reject an inbound relationship request.
-///
-/// Sends rejection message to the remote party and removes the task.
-pub async fn reject_relationship_request(
-    config: &mut Config,
-    service: &DIDCommService,
-    task_id: &str,
-    reason: Option<&str>,
-) -> Result<()> {
-    let task_id = Arc::new(task_id.to_string());
-
-    // Find the task and extract sender
-    let from_did = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {}", task_id))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        match &task.type_ {
-            TaskType::RelationshipRequestInbound { from, .. } => Arc::clone(from),
-            _ => anyhow::bail!("task {} is not an inbound relationship request", task_id),
-        }
-    };
-
-    // Build and send rejection message
-    let msg = build_reject_message(config.persona_did(), &from_did, reason, &task_id)?;
-    super::didcomm::send_message(service, config, &msg, config.persona_did(), &from_did)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to send rejection: {e}"))?;
-
-    // Remove the task
-    config.private.tasks.remove(&task_id);
-
-    config.public.logs.insert(
-        LogFamily::Relationship,
-        format!(
-            "Rejected relationship request from ({}). Reason: {}",
-            from_did,
-            reason.unwrap_or("none")
-        ),
-    );
-    info!(from = %from_did, "relationship request rejected");
-    Ok(())
-}
+// NOTE (R14): the formerly-inline `accept_relationship_request` /
+// `reject_relationship_request` are now split into a loop-thread `prepare_*`
+// (below, in the dispatch-wrapper section) and an I/O-only job, so the slow
+// VTA round-trip + handshake send no longer park the runtime select loop.
 
 /// Accept a received VRC — store it in vrcs_received and remove the task.
 pub fn accept_vrc(config: &mut Config, task_id: &str) -> Result<()> {
@@ -256,157 +65,10 @@ pub fn accept_vrc(config: &mut Config, task_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Accept an inbound VRC request — create, sign, and send a VRC back to the requester.
-///
-/// Uses current timestamp as valid_from and no valid_until (simplest default).
-pub async fn accept_vrc_request(
-    config: &mut Config,
-    tdk: &TDK,
-    service: &DIDCommService,
-    task_id: &str,
-) -> Result<()> {
-    use dtg_credentials::DTGCredential;
-    use openvtc_core::vrc::DtgCredentialMessage;
-
-    let task_id = Arc::new(task_id.to_string());
-
-    // Find the task and extract relationship info
-    let relationship = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {}", task_id))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        match &task.type_ {
-            TaskType::VRCRequestInbound { relationship, .. } => Arc::clone(relationship),
-            _ => anyhow::bail!("task {} is not an inbound VRC request", task_id),
-        }
-    };
-
-    let (our_r_did, their_p_did, their_r_did) = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        (
-            Arc::clone(&lock.our_did),
-            Arc::clone(&lock.remote_p_did),
-            Arc::clone(&lock.remote_did),
-        )
-    };
-
-    // Create VRC with current timestamp
-    let valid_from = Utc::now();
-    let mut vrc = DTGCredential::new_vrc(
-        config.persona_did().to_string(),
-        their_r_did.to_string(),
-        valid_from,
-        None, // no valid_until
-    );
-
-    // Sign the VRC with our persona signing key. Goes through dtg-credentials'
-    // own signing helper to keep the proof type aligned with the version of
-    // affinidi-data-integrity that dtg-credentials brings in.
-    let persona_keys = config.get_persona_keys(tdk).await?;
-    vrc.sign(&persona_keys.signing.secret, None).await?;
-
-    // Send VRC back to the requester
-    let msg = vrc.message(&our_r_did, &their_r_did, Some(&task_id))?;
-
-    super::didcomm::send_message(service, config, &msg, &our_r_did, &their_r_did)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to send VRC: {e}"))?;
-
-    // Store in issued VRCs
-    config
-        .private
-        .vrcs_issued
-        .insert(&their_p_did, Arc::new(vrc))?;
-
-    // Remove the task
-    config.private.tasks.remove(&task_id);
-
-    config.public.logs.insert(
-        LogFamily::Task,
-        format!("Issued VRC to ({}) Task ID ({})", their_p_did, task_id),
-    );
-
-    info!(to = %their_p_did, "VRC issued and sent");
-    Ok(())
-}
-
-/// Reject an inbound VRC request.
-///
-/// Sends a rejection message to the requester and removes the task.
-pub async fn reject_vrc_request(
-    config: &mut Config,
-    service: &DIDCommService,
-    task_id: &str,
-    reason: Option<&str>,
-) -> Result<()> {
-    use openvtc_core::vrc::VRCRequestReject;
-
-    let task_id = Arc::new(task_id.to_string());
-
-    // Find the task and extract relationship info
-    let relationship = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {}", task_id))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        match &task.type_ {
-            TaskType::VRCRequestInbound { relationship, .. } => Arc::clone(relationship),
-            _ => anyhow::bail!("task {} is not an inbound VRC request", task_id),
-        }
-    };
-
-    let (our_r_did, their_r_did, their_p_did) = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        (
-            Arc::clone(&lock.our_did),
-            Arc::clone(&lock.remote_did),
-            Arc::clone(&lock.remote_p_did),
-        )
-    };
-
-    // Build and send rejection message
-    let msg = VRCRequestReject::create_message(
-        &their_r_did,
-        &our_r_did,
-        &task_id,
-        reason.map(|s| s.to_string()),
-    )?;
-
-    super::didcomm::send_message(service, config, &msg, &our_r_did, &their_r_did)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to send VRC rejection: {e}"))?;
-
-    // Remove the task
-    config.private.tasks.remove(&task_id);
-
-    config.public.logs.insert(
-        LogFamily::Task,
-        format!(
-            "Rejected VRC request from ({}). Reason: {}",
-            their_p_did,
-            reason.unwrap_or("none")
-        ),
-    );
-    info!(from = %their_p_did, "VRC request rejected");
-    Ok(())
-}
+// NOTE (R14): the formerly-inline `accept_vrc_request` / `reject_vrc_request`
+// are now split into a loop-thread `prepare_*` (in the dispatch-wrapper section
+// below) + an I/O-only send job, so the DIDComm send no longer parks the loop.
+// The VRC create + sign stays on the loop thread (local crypto, not network).
 
 /// Clear all tasks from the inbox.
 pub fn clear_all_tasks(config: &mut Config) -> Result<()> {
@@ -473,7 +135,6 @@ use crate::state_handler::{
     settings_actions,
     state::State,
 };
-use tokio::sync::watch;
 
 fn handle_inbox_select(state: &mut State, index: usize) {
     state.main_page.content_panel.inbox.selected_index = index;
@@ -555,65 +216,6 @@ fn record_error(state: &mut State, context: &str, err: &anyhow::Error) {
     );
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn handle_accept_relationship(
-    config: &mut Box<Config>,
-    tdk: &TDK,
-    service: &DIDCommService,
-    state: &mut State,
-    state_tx: &watch::Sender<State>,
-    profile: &str,
-    task_id: &str,
-    generate_r_did: bool,
-    admin_vta: Option<&vta_sdk::client::VtaClient>,
-) {
-    if generate_r_did {
-        state.main_page.content_panel.inbox.status_message =
-            Some("Accepting with R-DID — creating keys...".to_string());
-        state
-            .main_page
-            .log("Accepting relationship request (creating R-DID)...");
-    } else {
-        state.main_page.content_panel.inbox.status_message =
-            Some("Accepting relationship request...".to_string());
-        state.main_page.log("Accepting relationship request...");
-    }
-    let _ = state_tx.send(state.clone());
-
-    match accept_relationship_request(config, tdk, service, task_id, generate_r_did, admin_vta)
-        .await
-    {
-        Ok(()) => save_and_sync(
-            config,
-            state,
-            profile,
-            "Relationship request accepted",
-            "Accepted relationship request",
-        ),
-        Err(e) => record_error(state, "Failed to accept relationship", &e),
-    }
-}
-
-async fn handle_reject_relationship(
-    config: &mut Box<Config>,
-    service: &DIDCommService,
-    state: &mut State,
-    profile: &str,
-    task_id: &str,
-    reason: Option<&str>,
-) {
-    match reject_relationship_request(config, service, task_id, reason).await {
-        Ok(()) => save_and_sync(
-            config,
-            state,
-            profile,
-            "Relationship request rejected",
-            "Rejected relationship request",
-        ),
-        Err(e) => record_error(state, "Failed to reject relationship", &e),
-    }
-}
-
 fn handle_accept_vrc(config: &mut Box<Config>, state: &mut State, profile: &str, task_id: &str) {
     match accept_vrc(config, task_id) {
         Ok(()) => save_and_sync(
@@ -627,44 +229,582 @@ fn handle_accept_vrc(config: &mut Box<Config>, state: &mut State, profile: &str,
     }
 }
 
-async fn handle_accept_vrc_request(
+// ============================================================
+// R14 backgrounded inbox network dispatch
+// ============================================================
+
+use openvtc_core::relationships::Relationship as RelRecord;
+
+/// A backgrounded inbox network action, ready to run off the loop thread.
+pub(crate) enum InboxJob {
+    /// Accept a relationship request: optionally mint an R-DID + listener (VTA /
+    /// BIP32, off-loop), then send the acceptance via the persona listener.
+    AcceptRelationship(Box<AcceptJob>),
+    /// A single DIDComm send (reject-relationship, accept/reject VRC request).
+    Send(InboxSend),
+}
+
+impl InboxJob {
+    pub(crate) async fn run(self) -> InboxOutcome {
+        match self {
+            InboxJob::AcceptRelationship(job) => job.run().await,
+            InboxJob::Send(send) => send.run().await,
+        }
+    }
+}
+
+/// Owned inputs for a backgrounded relationship-acceptance.
+pub(crate) struct AcceptJob {
+    tdk: TDK,
+    service: DIDCommService,
+    /// `Some` ⇒ mint an R-DID first; `None` ⇒ use the persona DID directly.
+    rdid_plan: Option<crate::state_handler::relationship_actions::RDidPlan>,
+    persona_did: Arc<String>,
+    persona_listener_id: String,
+    task_id: Arc<String>,
+    from_did: Arc<String>,
+    their_did: String,
+}
+
+impl AcceptJob {
+    async fn run(self) -> InboxOutcome {
+        let AcceptJob {
+            tdk,
+            service,
+            rdid_plan,
+            persona_did,
+            persona_listener_id,
+            task_id,
+            from_did,
+            their_did,
+        } = self;
+
+        // 1. Mint the R-DID + listener off the loop (if requested).
+        let (our_did, key_info) = match rdid_plan {
+            Some(plan) => match plan.create_io(&tdk, &service, &from_did).await {
+                Ok(created) => (Arc::new(created.r_did), created.key_info),
+                Err(e) => {
+                    return InboxOutcome {
+                        effect: InboxEffect::AcceptRelationship {
+                            task_id,
+                            from_did,
+                            their_did,
+                            our_did: persona_did,
+                            key_info: Vec::new(),
+                        },
+                        result: Err(format!("{e}")),
+                    };
+                }
+            },
+            None => (Arc::clone(&persona_did), Vec::new()),
+        };
+
+        // 2. Build + send the acceptance via the persona listener (handshake uses
+        //    persona DIDs for routing; the R-DID is carried in the body).
+        let result = match build_accept_message(&persona_did, &from_did, &our_did, &task_id) {
+            Ok(msg) => {
+                super::didcomm::send_message_via(&service, &msg, &persona_listener_id, &from_did)
+                    .await
+                    .map_err(|e| format!("{e}"))
+            }
+            Err(e) => Err(format!("{e}")),
+        };
+
+        InboxOutcome {
+            effect: InboxEffect::AcceptRelationship {
+                task_id,
+                from_did,
+                their_did,
+                our_did,
+                key_info,
+            },
+            result,
+        }
+    }
+}
+
+/// A single backgrounded inbox DIDComm send + the post-send effect.
+pub(crate) struct InboxSend {
+    service: DIDCommService,
+    listener_id: String,
+    to_did: Arc<String>,
+    message: Box<Message>,
+    effect: InboxEffect,
+}
+
+impl InboxSend {
+    async fn run(self) -> InboxOutcome {
+        let InboxSend {
+            service,
+            listener_id,
+            to_did,
+            message,
+            effect,
+        } = self;
+        let result = super::didcomm::send_message_via(&service, &message, &listener_id, &to_did)
+            .await
+            .map_err(|e| format!("{e}"));
+        InboxOutcome { effect, result }
+    }
+}
+
+/// Post-send mutation for an inbox network action, owning the data the old
+/// inline success block referenced.
+pub(crate) enum InboxEffect {
+    /// Accept relationship: insert relationship + remove task + log.
+    AcceptRelationship {
+        task_id: Arc<String>,
+        from_did: Arc<String>,
+        their_did: String,
+        our_did: Arc<String>,
+        /// R-DID `key_info` to record (empty when the persona DID was used).
+        key_info: Vec<(String, openvtc_core::config::secured_config::KeyInfoConfig)>,
+    },
+    /// Reject relationship: remove task + log.
+    RejectRelationship {
+        task_id: Arc<String>,
+        from_did: Arc<String>,
+        reason: Option<String>,
+    },
+    /// Accept VRC request: store the signed issued VRC + remove task + log.
+    AcceptVrcRequest {
+        task_id: Arc<String>,
+        their_p_did: Arc<String>,
+        vrc: Box<dtg_credentials::DTGCredential>,
+    },
+    /// Reject VRC request: remove task + log.
+    RejectVrcRequest {
+        task_id: Arc<String>,
+        their_p_did: Arc<String>,
+        reason: Option<String>,
+    },
+}
+
+/// Completed inbox network dispatch: the post-send effect + the send result.
+pub(crate) struct InboxOutcome {
+    effect: InboxEffect,
+    result: Result<(), String>,
+}
+
+impl InboxOutcome {
+    /// Apply the post-send mutation on the loop thread, reproducing the old
+    /// inline success/error block. The status slot is `inbox.status_message`; on
+    /// success the active task is cleared (as `save_and_sync` did before).
+    pub(crate) fn apply(self, state: &mut State, config: &mut Config, profile: &str) {
+        match self.effect {
+            InboxEffect::AcceptRelationship {
+                task_id,
+                from_did,
+                their_did,
+                our_did,
+                key_info,
+            } => {
+                // Record minted R-DID key metadata (success + failure, matching
+                // the pre-R14 in-memory state; only success persists via save).
+                for (id, info) in key_info {
+                    config.key_info.insert(id, info);
+                }
+                match self.result {
+                    Ok(()) => {
+                        config.private.relationships.relationships.insert(
+                            Arc::clone(&from_did),
+                            Arc::new(Mutex::new(RelRecord {
+                                task_id: Arc::clone(&task_id),
+                                remote_did: Arc::new(their_did),
+                                remote_p_did: Arc::clone(&from_did),
+                                our_did,
+                                created: Utc::now(),
+                                state: RelationshipState::RequestAccepted,
+                            })),
+                        );
+                        config.private.tasks.remove(&task_id);
+                        config.public.logs.insert(
+                            LogFamily::Relationship,
+                            format!("Accepted relationship request from ({from_did})"),
+                        );
+                        info!(from = %from_did, "relationship request accepted");
+                        save_and_sync(
+                            config,
+                            state,
+                            profile,
+                            "Relationship request accepted",
+                            "Accepted relationship request",
+                        );
+                    }
+                    Err(e) => record_error(
+                        state,
+                        "Failed to accept relationship",
+                        &anyhow::anyhow!("failed to send acceptance: {e}"),
+                    ),
+                }
+            }
+            InboxEffect::RejectRelationship {
+                task_id,
+                from_did,
+                reason,
+            } => match self.result {
+                Ok(()) => {
+                    config.private.tasks.remove(&task_id);
+                    config.public.logs.insert(
+                        LogFamily::Relationship,
+                        format!(
+                            "Rejected relationship request from ({from_did}). Reason: {}",
+                            reason.as_deref().unwrap_or("none")
+                        ),
+                    );
+                    info!(from = %from_did, "relationship request rejected");
+                    save_and_sync(
+                        config,
+                        state,
+                        profile,
+                        "Relationship request rejected",
+                        "Rejected relationship request",
+                    );
+                }
+                Err(e) => record_error(
+                    state,
+                    "Failed to reject relationship",
+                    &anyhow::anyhow!("failed to send rejection: {e}"),
+                ),
+            },
+            InboxEffect::AcceptVrcRequest {
+                task_id,
+                their_p_did,
+                vrc,
+            } => match self.result {
+                Ok(()) => {
+                    // Store the issued VRC (a fallible op today, surfaced as an
+                    // error if it fails — matching the old inline `?`).
+                    if let Err(e) = config
+                        .private
+                        .vrcs_issued
+                        .insert(&their_p_did, Arc::new(*vrc))
+                    {
+                        record_error(state, "Failed to issue VRC", &anyhow::anyhow!("{e}"));
+                        return;
+                    }
+                    config.private.tasks.remove(&task_id);
+                    config.public.logs.insert(
+                        LogFamily::Task,
+                        format!("Issued VRC to ({their_p_did}) Task ID ({task_id})"),
+                    );
+                    info!(to = %their_p_did, "VRC issued and sent");
+                    save_and_sync(
+                        config,
+                        state,
+                        profile,
+                        "VRC issued and sent",
+                        "VRC issued and sent",
+                    );
+                }
+                Err(e) => record_error(
+                    state,
+                    "Failed to issue VRC",
+                    &anyhow::anyhow!("failed to send VRC: {e}"),
+                ),
+            },
+            InboxEffect::RejectVrcRequest {
+                task_id,
+                their_p_did,
+                reason,
+            } => match self.result {
+                Ok(()) => {
+                    config.private.tasks.remove(&task_id);
+                    config.public.logs.insert(
+                        LogFamily::Task,
+                        format!(
+                            "Rejected VRC request from ({their_p_did}). Reason: {}",
+                            reason.as_deref().unwrap_or("none")
+                        ),
+                    );
+                    info!(from = %their_p_did, "VRC request rejected");
+                    save_and_sync(
+                        config,
+                        state,
+                        profile,
+                        "VRC request rejected",
+                        "Rejected VRC request",
+                    );
+                }
+                Err(e) => record_error(
+                    state,
+                    "Failed to reject VRC request",
+                    &anyhow::anyhow!("failed to send VRC rejection: {e}"),
+                ),
+            },
+        }
+    }
+}
+
+/// Loop-thread preparation for `AcceptRelationship`. Extracts the request data,
+/// reserves the R-DID plan, updates the contact, and snapshots message inputs.
+/// The slow VTA round-trip + handshake send run in the returned job.
+async fn prepare_accept_relationship(
+    config: &mut Box<Config>,
+    tdk: &TDK,
+    state: &mut State,
+    service: &DIDCommService,
+    task_id: &str,
+    generate_r_did: bool,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
+) -> Result<InboxJob> {
+    let task_id = Arc::new(task_id.to_string());
+
+    let (from_did, their_did, sender_name) = {
+        let task_arc = Arc::clone(
+            config
+                .private
+                .tasks
+                .get_by_id(&task_id)
+                .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?,
+        );
+        let task = task_arc
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        match &task.type_ {
+            TaskType::RelationshipRequestInbound { from, request, .. } => {
+                let sanitized_name = request
+                    .name
+                    .as_deref()
+                    .map(|n| super::main_page::sanitize_display(n, 64));
+                (Arc::clone(from), request.did.clone(), sanitized_name)
+            }
+            _ => anyhow::bail!("task {task_id} is not an inbound relationship request"),
+        }
+    };
+
+    // Reserve the R-DID plan (BIP32 path-pointer reservation only; the key
+    // creation runs in the task).
+    let rdid_plan = if generate_r_did {
+        let mediator = config.mediator_did().to_string();
+        Some(
+            crate::state_handler::relationship_actions::plan_relationship_did(
+                config, &mediator, admin_vta,
+            )?,
+        )
+    } else {
+        None
+    };
+
+    // Add or update contact with sender's name as alias (done before the send).
+    if let Some(existing) = config.private.contacts.find_contact(&from_did) {
+        if existing.alias.is_none() && sender_name.is_some() {
+            config
+                .private
+                .contacts
+                .remove_contact(&mut config.public.logs, &from_did);
+            config
+                .private
+                .contacts
+                .add_contact(tdk, &from_did, sender_name, false, &mut config.public.logs)
+                .await?;
+        }
+    } else {
+        config
+            .private
+            .contacts
+            .add_contact(tdk, &from_did, sender_name, false, &mut config.public.logs)
+            .await?;
+    }
+
+    let persona_did = config.persona_did_arc();
+    let persona_listener_id = super::didcomm::listener_id_for_did(&persona_did, config);
+
+    if generate_r_did {
+        state.main_page.content_panel.inbox.status_message =
+            Some("Accepting with R-DID — creating keys...".to_string());
+        state
+            .main_page
+            .log("Accepting relationship request (creating R-DID)...");
+    } else {
+        state.main_page.content_panel.inbox.status_message =
+            Some("Accepting relationship request...".to_string());
+        state.main_page.log("Accepting relationship request...");
+    }
+
+    Ok(InboxJob::AcceptRelationship(Box::new(AcceptJob {
+        tdk: tdk.clone(),
+        service: service.clone(),
+        rdid_plan,
+        persona_did,
+        persona_listener_id,
+        task_id,
+        from_did,
+        their_did,
+    })))
+}
+
+/// Loop-thread preparation for `RejectRelationship`: build the rejection message
+/// + resolve the persona listener; the task sends it.
+fn prepare_reject_relationship(
+    config: &mut Box<Config>,
+    service: &DIDCommService,
+    state: &mut State,
+    task_id: &str,
+    reason: Option<&str>,
+) -> Result<InboxJob> {
+    let task_id = Arc::new(task_id.to_string());
+    let from_did = {
+        let task_arc = Arc::clone(
+            config
+                .private
+                .tasks
+                .get_by_id(&task_id)
+                .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?,
+        );
+        let task = task_arc
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        match &task.type_ {
+            TaskType::RelationshipRequestInbound { from, .. } => Arc::clone(from),
+            _ => anyhow::bail!("task {task_id} is not an inbound relationship request"),
+        }
+    };
+    let persona_did = config.persona_did_arc();
+    let listener_id = super::didcomm::listener_id_for_did(&persona_did, config);
+    let msg = build_reject_message(&persona_did, &from_did, reason, &task_id)?;
+    state.main_page.content_panel.inbox.status_message =
+        Some("Rejecting relationship request...".to_string());
+    Ok(InboxJob::Send(InboxSend {
+        service: service.clone(),
+        listener_id,
+        to_did: Arc::clone(&from_did),
+        message: Box::new(msg),
+        effect: InboxEffect::RejectRelationship {
+            task_id,
+            from_did,
+            reason: reason.map(|s| s.to_string()),
+        },
+    }))
+}
+
+/// Loop-thread preparation for `AcceptVrcRequest`: create + sign the VRC (local
+/// crypto), build the message; the task sends it and `apply` stores the issued
+/// VRC on success.
+async fn prepare_accept_vrc_request(
     config: &mut Box<Config>,
     tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    profile: &str,
     task_id: &str,
-) {
-    match accept_vrc_request(config, tdk, service, task_id).await {
-        Ok(()) => save_and_sync(
-            config,
-            state,
-            profile,
-            "VRC issued and sent",
-            "VRC issued and sent",
-        ),
-        Err(e) => record_error(state, "Failed to issue VRC", &e),
-    }
+) -> Result<InboxJob> {
+    use dtg_credentials::DTGCredential;
+    use openvtc_core::vrc::DtgCredentialMessage;
+
+    let task_id = Arc::new(task_id.to_string());
+    let relationship = {
+        let task_arc = Arc::clone(
+            config
+                .private
+                .tasks
+                .get_by_id(&task_id)
+                .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?,
+        );
+        let task = task_arc
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        match &task.type_ {
+            TaskType::VRCRequestInbound { relationship, .. } => Arc::clone(relationship),
+            _ => anyhow::bail!("task {task_id} is not an inbound VRC request"),
+        }
+    };
+    let (our_r_did, their_p_did, their_r_did) = {
+        let lock = relationship
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        (
+            Arc::clone(&lock.our_did),
+            Arc::clone(&lock.remote_p_did),
+            Arc::clone(&lock.remote_did),
+        )
+    };
+
+    // Create + sign the VRC on the loop thread (local crypto, not network).
+    let valid_from = Utc::now();
+    let mut vrc = DTGCredential::new_vrc(
+        config.persona_did().to_string(),
+        their_r_did.to_string(),
+        valid_from,
+        None,
+    );
+    let persona_keys = config.get_persona_keys(tdk).await?;
+    vrc.sign(&persona_keys.signing.secret, None).await?;
+    let msg = vrc.message(&our_r_did, &their_r_did, Some(&task_id))?;
+    let listener_id = super::didcomm::listener_id_for_did(&our_r_did, config);
+
+    state.main_page.content_panel.inbox.status_message = Some("Issuing VRC...".to_string());
+
+    Ok(InboxJob::Send(InboxSend {
+        service: service.clone(),
+        listener_id,
+        to_did: their_r_did,
+        message: Box::new(msg),
+        effect: InboxEffect::AcceptVrcRequest {
+            task_id,
+            their_p_did,
+            vrc: Box::new(vrc),
+        },
+    }))
 }
 
-async fn handle_reject_vrc_request(
+/// Loop-thread preparation for `RejectVrcRequest`: build the rejection message;
+/// the task sends it.
+fn prepare_reject_vrc_request(
     config: &mut Box<Config>,
     service: &DIDCommService,
     state: &mut State,
-    profile: &str,
     task_id: &str,
     reason: Option<&str>,
-) {
-    match reject_vrc_request(config, service, task_id, reason).await {
-        Ok(()) => save_and_sync(
-            config,
-            state,
-            profile,
-            "VRC request rejected",
-            "Rejected VRC request",
-        ),
-        Err(e) => record_error(state, "Failed to reject VRC request", &e),
-    }
+) -> Result<InboxJob> {
+    use openvtc_core::vrc::VRCRequestReject;
+
+    let task_id = Arc::new(task_id.to_string());
+    let relationship = {
+        let task_arc = Arc::clone(
+            config
+                .private
+                .tasks
+                .get_by_id(&task_id)
+                .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?,
+        );
+        let task = task_arc
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        match &task.type_ {
+            TaskType::VRCRequestInbound { relationship, .. } => Arc::clone(relationship),
+            _ => anyhow::bail!("task {task_id} is not an inbound VRC request"),
+        }
+    };
+    let (our_r_did, their_r_did, their_p_did) = {
+        let lock = relationship
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        (
+            Arc::clone(&lock.our_did),
+            Arc::clone(&lock.remote_did),
+            Arc::clone(&lock.remote_p_did),
+        )
+    };
+    let msg = VRCRequestReject::create_message(
+        &their_r_did,
+        &our_r_did,
+        &task_id,
+        reason.map(|s| s.to_string()),
+    )?;
+    let listener_id = super::didcomm::listener_id_for_did(&our_r_did, config);
+    state.main_page.content_panel.inbox.status_message =
+        Some("Rejecting VRC request...".to_string());
+    Ok(InboxJob::Send(InboxSend {
+        service: service.clone(),
+        listener_id,
+        to_did: their_r_did,
+        message: Box::new(msg),
+        effect: InboxEffect::RejectVrcRequest {
+            task_id,
+            their_p_did,
+            reason: reason.map(|s| s.to_string()),
+        },
+    }))
 }
 
 fn handle_dismiss_task(config: &mut Box<Config>, state: &mut State, profile: &str, task_id: &str) {
@@ -693,8 +833,33 @@ fn handle_clear_all(config: &mut Box<Config>, state: &mut State, profile: &str) 
     state.main_page.log("All inbox tasks cleared");
 }
 
-/// Dispatch a single `InboxAction` to its handler. Centralizes what was
-/// previously a >30-line nested match in `state_handler::main_loop`.
+/// Outcome of synchronously dispatching an `InboxAction` on the loop thread.
+/// Local actions are `Handled`; network actions return a spawnable [`InboxJob`].
+pub(crate) enum InboxDispatch {
+    Handled,
+    Spawn(InboxJob),
+}
+
+/// Whether an `InboxAction` is a network-bound action the loop should run
+/// off-thread (claiming the `Inbox` busy-domain first). Checked *before*
+/// `dispatch` does any pre-send config mutation.
+pub(crate) fn is_network(action: &InboxAction) -> bool {
+    matches!(
+        action,
+        InboxAction::AcceptRelationship { .. }
+            | InboxAction::RejectRelationship { .. }
+            | InboxAction::AcceptVrcRequest { .. }
+            | InboxAction::RejectVrcRequest { .. }
+    )
+}
+
+/// Dispatch a single `InboxAction`.
+///
+/// Local actions (`AcceptVrc`, dismiss, clear, nav) are `Handled` synchronously;
+/// network actions do their loop-thread pre-send work and return
+/// [`InboxDispatch::Spawn`] for the loop to run off-thread (post-send mutation in
+/// [`InboxOutcome::apply`]). A pre-send failure is recorded as a status and
+/// returns `Handled` (no job spawned → the loop releases the busy-domain).
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn dispatch(
     action: InboxAction,
@@ -702,10 +867,10 @@ pub(crate) async fn dispatch(
     tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    state_tx: &watch::Sender<State>,
     profile: &str,
     admin_vta: Option<&vta_sdk::client::VtaClient>,
-) {
+) -> InboxDispatch {
+    let _ = profile;
     match action {
         InboxAction::SelectTask(index) => handle_inbox_select(state, index),
         InboxAction::OpenDetail(index) => handle_inbox_open_detail(state, index),
@@ -716,34 +881,208 @@ pub(crate) async fn dispatch(
             task_id,
             generate_r_did,
         } => {
-            handle_accept_relationship(
+            match prepare_accept_relationship(
                 config,
                 tdk,
-                service,
                 state,
-                state_tx,
-                profile,
+                service,
                 &task_id,
                 generate_r_did,
                 admin_vta,
             )
             .await
+            {
+                Ok(job) => return InboxDispatch::Spawn(job),
+                Err(e) => record_error(state, "Failed to accept relationship", &e),
+            }
         }
         InboxAction::RejectRelationship { task_id, reason } => {
-            handle_reject_relationship(config, service, state, profile, &task_id, reason.as_deref())
-                .await
+            match prepare_reject_relationship(config, service, state, &task_id, reason.as_deref()) {
+                Ok(job) => return InboxDispatch::Spawn(job),
+                Err(e) => record_error(state, "Failed to reject relationship", &e),
+            }
         }
         InboxAction::AcceptVrc { task_id } => handle_accept_vrc(config, state, profile, &task_id),
         InboxAction::AcceptVrcRequest { task_id } => {
-            handle_accept_vrc_request(config, tdk, service, state, profile, &task_id).await
+            match prepare_accept_vrc_request(config, tdk, service, state, &task_id).await {
+                Ok(job) => return InboxDispatch::Spawn(job),
+                Err(e) => record_error(state, "Failed to issue VRC", &e),
+            }
         }
         InboxAction::RejectVrcRequest { task_id, reason } => {
-            handle_reject_vrc_request(config, service, state, profile, &task_id, reason.as_deref())
-                .await
+            match prepare_reject_vrc_request(config, service, state, &task_id, reason.as_deref()) {
+                Ok(job) => return InboxDispatch::Spawn(job),
+                Err(e) => record_error(state, "Failed to reject VRC request", &e),
+            }
         }
         InboxAction::DismissTask { task_id } => {
             handle_dismiss_task(config, state, profile, &task_id)
         }
         InboxAction::ClearAll => handle_clear_all(config, state, profile),
+    }
+    InboxDispatch::Handled
+}
+
+#[cfg(test)]
+mod r14_tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+
+    /// Accept-relationship success inserts the relationship (RequestAccepted),
+    /// removes the task, records minted R-DID key_info, and sets the status —
+    /// reproducing the post-send tail of `accept_relationship_request`.
+    #[test]
+    fn accept_relationship_success_inserts_relationship() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let from = Arc::new("did:peer:from".to_string());
+        let task_id = Arc::new("task-acc".to_string());
+        config
+            .private
+            .tasks
+            .new_task(&task_id, TaskType::RelationshipRequestRejected); // any placeholder
+
+        let outcome = InboxOutcome {
+            effect: InboxEffect::AcceptRelationship {
+                task_id: Arc::clone(&task_id),
+                from_did: Arc::clone(&from),
+                their_did: "did:peer:their".to_string(),
+                our_did: Arc::new("did:peer:our-rdid".to_string()),
+                key_info: vec![(
+                    "z-acc-key".to_string(),
+                    openvtc_core::config::secured_config::KeyInfoConfig {
+                        path: openvtc_core::config::secured_config::KeySourceMaterial::Derived {
+                            path: "m/3'/1'/1'/0'".to_string(),
+                        },
+                        create_time: Utc::now(),
+                        purpose: openvtc_core::config::KeyTypes::RelationshipVerification,
+                    },
+                )],
+            },
+            result: Ok(()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert!(
+            config.private.relationships.get(&from).is_some(),
+            "relationship inserted on accept success"
+        );
+        assert!(
+            config.private.tasks.get_by_id(&task_id).is_none(),
+            "task removed on accept success"
+        );
+        assert!(config.key_info.contains_key("z-acc-key"));
+        assert_eq!(
+            state
+                .main_page
+                .content_panel
+                .inbox
+                .status_message
+                .as_deref(),
+            Some("Relationship request accepted")
+        );
+    }
+
+    /// Accept-relationship failure records key_info but inserts NO relationship
+    /// and keeps the task; the error status is surfaced.
+    #[test]
+    fn accept_relationship_failure_keeps_task_and_no_relationship() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let from = Arc::new("did:peer:from".to_string());
+        let task_id = Arc::new("task-acc".to_string());
+        config
+            .private
+            .tasks
+            .new_task(&task_id, TaskType::RelationshipRequestRejected);
+
+        let outcome = InboxOutcome {
+            effect: InboxEffect::AcceptRelationship {
+                task_id: Arc::clone(&task_id),
+                from_did: Arc::clone(&from),
+                their_did: "did:peer:their".to_string(),
+                our_did: Arc::new("did:peer:our-rdid".to_string()),
+                key_info: Vec::new(),
+            },
+            result: Err("send failed".to_string()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert!(
+            config.private.relationships.get(&from).is_none(),
+            "no relationship on accept failure"
+        );
+        assert!(
+            config.private.tasks.get_by_id(&task_id).is_some(),
+            "task retained on accept failure"
+        );
+        let status = state
+            .main_page
+            .content_panel
+            .inbox
+            .status_message
+            .clone()
+            .unwrap_or_default();
+        assert!(status.starts_with("Error:"), "got: {status}");
+    }
+
+    /// Reject-relationship success removes the task and sets the status.
+    #[test]
+    fn reject_relationship_success_removes_task() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let task_id = Arc::new("task-rej".to_string());
+        config
+            .private
+            .tasks
+            .new_task(&task_id, TaskType::RelationshipRequestRejected);
+
+        let outcome = InboxOutcome {
+            effect: InboxEffect::RejectRelationship {
+                task_id: Arc::clone(&task_id),
+                from_did: Arc::new("did:peer:from".to_string()),
+                reason: Some("no thanks".to_string()),
+            },
+            result: Ok(()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert!(config.private.tasks.get_by_id(&task_id).is_none());
+        assert_eq!(
+            state
+                .main_page
+                .content_panel
+                .inbox
+                .status_message
+                .as_deref(),
+            Some("Relationship request rejected")
+        );
+    }
+
+    /// Reject-relationship failure keeps the task and surfaces the error.
+    #[test]
+    fn reject_relationship_failure_keeps_task() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let task_id = Arc::new("task-rej".to_string());
+        config
+            .private
+            .tasks
+            .new_task(&task_id, TaskType::RelationshipRequestRejected);
+
+        let outcome = InboxOutcome {
+            effect: InboxEffect::RejectRelationship {
+                task_id: Arc::clone(&task_id),
+                from_did: Arc::new("did:peer:from".to_string()),
+                reason: None,
+            },
+            result: Err("send failed".to_string()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert!(
+            config.private.tasks.get_by_id(&task_id).is_some(),
+            "task retained on reject failure"
+        );
     }
 }

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -647,14 +647,33 @@ impl StateHandler {
                         }
                     },
                     Action::DeleteDid(i) => {
-                        self.delete_context_did(
+                        // Identity deletion does a VTA `delete_did_webvh` + listener
+                        // teardown (R14): claim the Did domain, run the guards +
+                        // extraction on-thread, then spawn the I/O; local config
+                        // cleanup + save apply on the outcome. Guard failures (DID
+                        // bound to a community, not found) are surfaced inline and
+                        // spawn nothing.
+                        let domain = background_dispatch::DispatchDomain::Did;
+                        if !in_flight.try_begin(domain) {
+                            let msg = background_dispatch::InFlight::busy_message(domain);
+                            state.main_page.log(msg);
+                        } else if let Some(job) = self.prepare_delete_context_did(
                             &mut state,
                             &mut config,
                             admin_vta.as_ref(),
                             &didcomm_service,
                             i,
-                        )
-                        .await;
+                        ) {
+                            let tx = dispatch_tx.clone();
+                            tokio::spawn(async move {
+                                let _ = tx.send(background_dispatch::DispatchOutcome::Did(
+                                    job.run().await,
+                                ));
+                            });
+                        } else {
+                            // Guard rejected the delete (logged inline); release.
+                            in_flight.finish(domain);
+                        }
                     },
                     Action::StartJoin => {
                         // State-B join from the live runtime: reuse the always-on
@@ -687,31 +706,122 @@ impl StateHandler {
                         }
                     },
                     Action::Inbox(ia) => {
-                        inbox_actions::dispatch(
-                            ia,
-                            &mut config,
-                            &tdk,
-                            &didcomm_service,
-                            &mut state,
-                            &self.state_tx,
-                            &self.profile,
-                            admin_vta.as_ref(),
-                        )
-                        .await;
+                        // Network inbox actions (accept/reject relationship or VRC
+                        // request) run off the loop (R14): claim the Inbox domain,
+                        // do the loop-thread pre-send work, then spawn the send;
+                        // the outcome arm applies the post-send mutation. A second
+                        // inbox network action while one is in flight is rejected
+                        // with a status. Local actions run inline as before.
+                        if inbox_actions::is_network(&ia) {
+                            let domain = background_dispatch::DispatchDomain::Inbox;
+                            if !in_flight.try_begin(domain) {
+                                let msg = background_dispatch::InFlight::busy_message(domain);
+                                state.main_page.content_panel.inbox.status_message =
+                                    Some(msg.clone());
+                                state.main_page.log(msg);
+                            } else {
+                                match inbox_actions::dispatch(
+                                    ia,
+                                    &mut config,
+                                    &tdk,
+                                    &didcomm_service,
+                                    &mut state,
+                                    &self.profile,
+                                    admin_vta.as_ref(),
+                                )
+                                .await
+                                {
+                                    inbox_actions::InboxDispatch::Spawn(job) => {
+                                        let tx = dispatch_tx.clone();
+                                        tokio::spawn(async move {
+                                            let _ = tx.send(
+                                                background_dispatch::DispatchOutcome::Inbox(
+                                                    job.run().await,
+                                                ),
+                                            );
+                                        });
+                                    }
+                                    // Pre-send failure recorded a status; nothing
+                                    // was spawned, so release the domain now.
+                                    inbox_actions::InboxDispatch::Handled => {
+                                        in_flight.finish(domain);
+                                    }
+                                }
+                            }
+                        } else {
+                            let _ = inbox_actions::dispatch(
+                                ia,
+                                &mut config,
+                                &tdk,
+                                &didcomm_service,
+                                &mut state,
+                                &self.profile,
+                                admin_vta.as_ref(),
+                            )
+                            .await;
+                        }
                     },
                     Action::Relationship(ra) => {
-                        relationship_actions::dispatch(
-                            ra,
-                            &mut config,
-                            &tdk,
-                            &didcomm_service,
-                            &mut state,
-                            &self.state_tx,
-                            &self.profile,
-                            &mut ping_sent_at,
-                            admin_vta.as_ref(),
-                        )
-                        .await;
+                        // Network relationship actions (create/ping/remove/request
+                        // VRC) run off the loop (R14). Same pattern as Inbox: claim
+                        // the Relationship domain, prepare on-thread, spawn the I/O,
+                        // apply the outcome later. `is_ping` stamps `ping_sent_at`
+                        // for pong-latency display.
+                        if relationship_actions::is_network(&ra) {
+                            let domain = background_dispatch::DispatchDomain::Relationship;
+                            if !in_flight.try_begin(domain) {
+                                let msg = background_dispatch::InFlight::busy_message(domain);
+                                state
+                                    .main_page
+                                    .content_panel
+                                    .relationships
+                                    .status_message = Some(msg.clone());
+                                state.main_page.log(msg);
+                            } else {
+                                match relationship_actions::dispatch(
+                                    ra,
+                                    &mut config,
+                                    &tdk,
+                                    &didcomm_service,
+                                    &mut state,
+                                    &self.profile,
+                                    admin_vta.as_ref(),
+                                )
+                                .await
+                                {
+                                    relationship_actions::RelationshipDispatch::Spawn {
+                                        job,
+                                        is_ping,
+                                    } => {
+                                        if is_ping {
+                                            ping_sent_at = Some(std::time::Instant::now());
+                                        }
+                                        let tx = dispatch_tx.clone();
+                                        tokio::spawn(async move {
+                                            let _ = tx.send(
+                                                background_dispatch::DispatchOutcome::Relationship(
+                                                    job.run().await,
+                                                ),
+                                            );
+                                        });
+                                    }
+                                    relationship_actions::RelationshipDispatch::Handled => {
+                                        in_flight.finish(domain);
+                                    }
+                                }
+                            }
+                        } else {
+                            let _ = relationship_actions::dispatch(
+                                ra,
+                                &mut config,
+                                &tdk,
+                                &didcomm_service,
+                                &mut state,
+                                &self.profile,
+                                admin_vta.as_ref(),
+                            )
+                            .await;
+                        }
                     },
                     Action::Credential(ca) => {
                         credential_actions::dispatch(
@@ -957,7 +1067,13 @@ impl StateHandler {
                 // and inbound DIDComm events are all serviced *while* the spawned
                 // I/O is still pending.
                 Some(outcome) = dispatch_rx.recv() => {
-                    background_dispatch::apply_outcome(&mut state, &mut in_flight, outcome);
+                    background_dispatch::apply_outcome(
+                        &mut state,
+                        &mut config,
+                        &self.profile,
+                        &mut in_flight,
+                        outcome,
+                    );
                 },
                 // Lifecycle log messages from the DIDCommService
                 Some(log_msg) = lifecycle_log_rx.recv() => {
@@ -1052,36 +1168,38 @@ impl StateHandler {
         }
     }
 
-    /// Delete an **orphan** context identity (persona DID) at `index` in the
-    /// VTA DID manager: remove it at the VTA (`delete_did_webvh`), then locally
-    /// (persona record + runtime identity + key info), tear down its listener,
-    /// and re-save. Guarded to personas presenting **no** community — a
-    /// community-bound identity must not be deleted out from under its
-    /// membership. Feedback goes to the activity log.
-    async fn delete_context_did(
+    /// Loop-thread preparation for deleting an **orphan** context identity
+    /// (persona DID) at `index` in the VTA DID manager. Runs the guards (DID
+    /// resolution + the community-bound check — a community-bound identity must
+    /// not be deleted out from under its membership) and snapshots the persona /
+    /// key ids, then returns a [`relationship_actions::DidDeleteJob`] for the loop
+    /// to run off-thread (VTA `delete_did_webvh` + listener teardown). The local
+    /// cleanup (persona/identity/key removal + save + sync) is applied later by
+    /// [`relationship_actions::DidDeleteOutcome`].
+    ///
+    /// Returns `None` (and logs inline) when a guard rejects the delete, so the
+    /// caller can release the busy-domain without spawning anything.
+    fn prepare_delete_context_did(
         &self,
         state: &mut State,
         config: &mut Config,
         admin_vta: Option<&vta_sdk::client::VtaClient>,
         didcomm_service: &affinidi_messaging_didcomm_service::DIDCommService,
         index: usize,
-    ) {
+    ) -> Option<relationship_actions::DidDeleteJob> {
         state.main_page.content_panel.vta.confirm_delete_did = None;
-        let Some(did) = state
+        let did = state
             .main_page
             .content_panel
             .vta
             .context_dids
             .get(index)
-            .map(|d| d.did.clone())
-        else {
-            return;
-        };
+            .map(|d| d.did.clone())?;
 
         // Resolve the persona for this DID + its key ids.
         let Some(persona) = config.account.personas.values().find(|p| p.did == did) else {
             state.main_page.log("DID not found — nothing removed.");
-            return;
+            return None;
         };
         let persona_id = persona.persona_id;
         let key_ids: Vec<String> = persona.key_refs.iter().map(|k| k.key_id.clone()).collect();
@@ -1098,41 +1216,18 @@ impl StateHandler {
                 "Can't delete — {bound} communit{} still use this identity; leave them first.",
                 if bound == 1 { "y" } else { "ies" }
             ));
-            return;
+            return None;
         }
 
-        // Delete at the VTA. Best-effort: a missing/already-deleted DID at the
-        // VTA must not block removing the local orphan, so log and continue.
-        if let Some(vta) = admin_vta
-            && let Err(e) = vta.delete_did_webvh(&did).await
-        {
-            debug!("delete_did_webvh({did}) failed (continuing local cleanup): {e}");
-        }
+        state.main_page.log(format!("Removing identity {did}…"));
 
-        // Local cleanup.
-        config.account.personas.remove(&persona_id);
-        config.identities.remove(&persona_id);
-        for kid in &key_ids {
-            config.key_info.remove(kid);
-        }
-        if let Err(e) = config.save(
-            &self.profile,
-            #[cfg(feature = "openpgp-card")]
-            &|| eprintln!("Touch confirmation needed for decryption"),
-        ) {
-            state
-                .main_page
-                .log_error("Failed to save after removing DID", &e);
-        }
-
-        // Tear down the orphan's listener if one was running (best-effort).
-        let listener_id = didcomm::persona_listener_id(&did);
-        if let Err(e) = didcomm_service.remove_listener(&listener_id).await {
-            debug!("remove_listener after DID delete: {e}");
-        }
-
-        state.main_page.sync_from_config(config);
-        state.main_page.log(format!("Removed identity {did}"));
+        Some(relationship_actions::DidDeleteJob {
+            admin_vta: admin_vta.cloned(),
+            service: didcomm_service.clone(),
+            did,
+            persona_id,
+            key_ids,
+        })
     }
 
     /// Minimal event loop for when there is no active community / messaging

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -664,12 +664,13 @@ impl StateHandler {
                             &didcomm_service,
                             i,
                         ) {
-                            let tx = dispatch_tx.clone();
-                            tokio::spawn(async move {
-                                let _ = tx.send(background_dispatch::DispatchOutcome::Did(
-                                    job.run().await,
-                                ));
-                            });
+                            background_dispatch::spawn_dispatch(
+                                dispatch_tx.clone(),
+                                domain,
+                                async move {
+                                    background_dispatch::DispatchOutcome::Did(job.run().await)
+                                },
+                            );
                         } else {
                             // Guard rejected the delete (logged inline); release.
                             in_flight.finish(domain);
@@ -732,14 +733,15 @@ impl StateHandler {
                                 .await
                                 {
                                     inbox_actions::InboxDispatch::Spawn(job) => {
-                                        let tx = dispatch_tx.clone();
-                                        tokio::spawn(async move {
-                                            let _ = tx.send(
+                                        background_dispatch::spawn_dispatch(
+                                            dispatch_tx.clone(),
+                                            domain,
+                                            async move {
                                                 background_dispatch::DispatchOutcome::Inbox(
                                                     job.run().await,
-                                                ),
-                                            );
-                                        });
+                                                )
+                                            },
+                                        );
                                     }
                                     // Pre-send failure recorded a status; nothing
                                     // was spawned, so release the domain now.
@@ -796,14 +798,15 @@ impl StateHandler {
                                         if is_ping {
                                             ping_sent_at = Some(std::time::Instant::now());
                                         }
-                                        let tx = dispatch_tx.clone();
-                                        tokio::spawn(async move {
-                                            let _ = tx.send(
+                                        background_dispatch::spawn_dispatch(
+                                            dispatch_tx.clone(),
+                                            domain,
+                                            async move {
                                                 background_dispatch::DispatchOutcome::Relationship(
                                                     job.run().await,
-                                                ),
-                                            );
-                                        });
+                                                )
+                                            },
+                                        );
                                     }
                                     relationship_actions::RelationshipDispatch::Handled => {
                                         in_flight.finish(domain);
@@ -879,21 +882,22 @@ impl StateHandler {
                                     let new_listener_config =
                                         didcomm::persona_listener_config(&config, &tdk).await;
                                     let service = didcomm_service.clone();
-                                    let tx = dispatch_tx.clone();
-                                    tokio::spawn(async move {
-                                        let outcome =
-                                            didcomm::reconnect_persona_listener_io(
-                                                &service,
-                                                listener_id,
-                                                new_listener_config,
-                                            )
-                                            .await;
-                                        let _ = tx.send(
+                                    background_dispatch::spawn_dispatch(
+                                        dispatch_tx.clone(),
+                                        background_dispatch::DispatchDomain::Mediator,
+                                        async move {
+                                            let outcome =
+                                                didcomm::reconnect_persona_listener_io(
+                                                    &service,
+                                                    listener_id,
+                                                    new_listener_config,
+                                                )
+                                                .await;
                                             background_dispatch::DispatchOutcome::MediatorReconnect(
                                                 outcome,
-                                            ),
-                                        );
-                                    });
+                                            )
+                                        },
+                                    );
                                 }
                             }
                         }

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -663,19 +663,56 @@ impl RelationshipOutcome {
                 }
                 match self.result {
                     Ok(()) => {
-                        // Insert the relationship + outbound task (post-send tail of
+                        // Finalise the provisional record `prepare_submit` inserted.
+                        // We must NOT blindly re-insert: a racing
+                        // `RelationshipRequestAccepted` (the event loop kept draining
+                        // while the send ran off-loop) may have already advanced this
+                        // record to `Established`. Re-inserting a fresh `RequestSent`
+                        // would clobber that established state and create a stale
+                        // outbound task.
+                        // Returns `Some(still_request_sent)` if the record exists,
+                        // `None` if it went missing.
+                        let outcome =
+                            config
+                                .private
+                                .relationships
+                                .get(&respondent_did)
+                                .and_then(|rel| {
+                                    rel.lock().ok().map(|mut lock| {
+                                        // Always record the real local DID so future
+                                        // messages use the correct `our_did`.
+                                        lock.our_did = Arc::clone(&our_did);
+                                        if lock.state == RelationshipState::RequestSent {
+                                            // No accept raced us: fill in the real
+                                            // `task_id` (the send's msg_id) too.
+                                            lock.task_id = Arc::clone(&msg_id);
+                                            true
+                                        } else {
+                                            // A racing accept already finalised this
+                                            // relationship; leave its state + task_id.
+                                            false
+                                        }
+                                    })
+                                });
+
+                        if outcome != Some(true) {
+                            // Either the provisional record was raced to
+                            // `Established` (the accept handler already logged +
+                            // finalised, and creating an outbound task now would be
+                            // stale) or it went missing — skip the outbound task +
+                            // "request sent" UI. If the record exists, persist the
+                            // `our_did` update made above; otherwise nothing changed.
+                            if outcome == Some(false) {
+                                if let Err(e) = settings_actions::save_config(config, profile) {
+                                    state.main_page.log_error("Failed to save config", &e);
+                                }
+                                state.main_page.sync_from_config(config);
+                            }
+                            return;
+                        }
+
+                        // No race: create the outbound task + log (post-send tail of
                         // `send_relationship_request`).
-                        config.private.relationships.relationships.insert(
-                            Arc::clone(&respondent_did),
-                            Arc::new(Mutex::new(RelRecord {
-                                task_id: Arc::clone(&msg_id),
-                                our_did: Arc::clone(&our_did),
-                                remote_p_did: Arc::clone(&respondent_did),
-                                remote_did: Arc::clone(&respondent_did),
-                                created: Utc::now(),
-                                state: RelationshipState::RequestSent,
-                            })),
-                        );
                         config.private.tasks.new_task(
                             &msg_id,
                             TaskType::RelationshipRequestOutbound {
@@ -717,6 +754,30 @@ impl RelationshipOutcome {
                         );
                     }
                     Err(e) => {
+                        // The send failed, so the peer never received the request and
+                        // no accept can have arrived — remove the provisional record
+                        // so the failure state matches pre-R14 (contact + key_info
+                        // in-memory, but NO relationship record). Guard on
+                        // `RequestSent` defensively: should always hold here (an
+                        // accept implies the send reached the peer), but never clobber
+                        // a record an accept somehow advanced.
+                        let still_request_sent = config
+                            .private
+                            .relationships
+                            .get(&respondent_did)
+                            .and_then(|rel| {
+                                rel.lock()
+                                    .ok()
+                                    .map(|lock| lock.state == RelationshipState::RequestSent)
+                            })
+                            .unwrap_or(false);
+                        if still_request_sent {
+                            config
+                                .private
+                                .relationships
+                                .relationships
+                                .remove(&respondent_did);
+                        }
                         let err = anyhow::anyhow!("failed to send relationship request: {e}");
                         dispatch_util::record_error(
                             &mut state.main_page,
@@ -1060,6 +1121,31 @@ async fn prepare_submit(
     };
     let persona_did = config.persona_did_arc();
     let persona_listener_id = super::didcomm::listener_id_for_did(&persona_did, config);
+
+    // Insert a *provisional* `RequestSent` record keyed by the respondent's
+    // persona DID, BEFORE the send is even spawned. This closes a lost-update
+    // race: the send runs off-loop while `didcomm_event_rx` keeps draining, so a
+    // peer's `RelationshipRequestAccepted` can arrive before the Create outcome is
+    // applied. The accept handler looks up `find_by_task_id(thid).or_else(get(
+    // from_did))`; without this record both miss and the accept is dropped,
+    // leaving the relationship stuck. We don't yet know the real `task_id`
+    // (the send's msg_id) or any minted R-DID, so use placeholders: `task_id` is
+    // empty (the accept's primary `find_by_task_id` misses harmlessly and falls
+    // back to `get(from_did)`), and `our_did`/`remote_did`/`remote_p_did` are the
+    // respondent DID. The accept's `from_did` equals this respondent DID, so the
+    // `get(from_did)` fallback finds it and the `remote_p_did == from_did` check
+    // passes. The Create outcome later fills in the real `task_id`/`our_did`.
+    config.private.relationships.relationships.insert(
+        Arc::clone(&respondent_arc),
+        Arc::new(Mutex::new(RelRecord {
+            task_id: Arc::new(String::new()),
+            our_did: Arc::clone(&persona_did),
+            remote_p_did: Arc::clone(&respondent_arc),
+            remote_did: Arc::clone(&respondent_arc),
+            created: Utc::now(),
+            state: RelationshipState::RequestSent,
+        })),
+    );
 
     // In-progress status (shown by the loop's post-arm state send).
     if generate_r_did {
@@ -1549,14 +1635,34 @@ mod tests {
         );
     }
 
-    /// A successful Create outcome inserts the relationship + outbound task and
-    /// records the minted R-DID key_info, reproducing the post-send tail of
+    /// Insert the provisional `RequestSent` record that `prepare_submit` writes
+    /// before the send is spawned (placeholder `task_id`, persona DID as
+    /// `our_did`). Tests that exercise the Create `apply` start from this record,
+    /// mirroring the real flow.
+    fn insert_provisional(config: &mut Config, respondent: &Arc<String>) {
+        config.private.relationships.relationships.insert(
+            Arc::clone(respondent),
+            Arc::new(Mutex::new(RelRecord {
+                task_id: Arc::new(String::new()),
+                our_did: Arc::clone(respondent),
+                remote_p_did: Arc::clone(respondent),
+                remote_did: Arc::clone(respondent),
+                created: Utc::now(),
+                state: RelationshipState::RequestSent,
+            })),
+        );
+    }
+
+    /// A successful Create outcome finalises the provisional record (real
+    /// `task_id`/`our_did`), creates the outbound task, and records the minted
+    /// R-DID key_info, reproducing the post-send tail of
     /// `send_relationship_request`.
     #[test]
     fn create_success_inserts_relationship_and_keyinfo() {
         let mut config = test_config();
         let mut state = State::default();
         let respondent = Arc::new("did:peer:respondent".to_string());
+        insert_provisional(&mut config, &respondent);
         let our_did = Arc::new("did:peer:our-rdid".to_string());
         let key_info = vec![(
             "z-some-key".to_string(),
@@ -1582,9 +1688,36 @@ mod tests {
         };
         outcome.apply(&mut state, &mut config, "test");
 
+        let rel = config
+            .private
+            .relationships
+            .get(&respondent)
+            .expect("relationship record present on success");
+        {
+            let lock = rel.lock().unwrap();
+            assert_eq!(
+                lock.state,
+                RelationshipState::RequestSent,
+                "stays RequestSent (no accept raced)"
+            );
+            assert_eq!(
+                lock.task_id.as_str(),
+                "req-msg",
+                "provisional placeholder task_id replaced by the real msg_id"
+            );
+            assert_eq!(
+                lock.our_did.as_str(),
+                "did:peer:our-rdid",
+                "provisional persona our_did replaced by the minted R-DID"
+            );
+        }
         assert!(
-            config.private.relationships.get(&respondent).is_some(),
-            "relationship record inserted on success"
+            config
+                .private
+                .tasks
+                .get_by_id(&Arc::new("req-msg".to_string()))
+                .is_some(),
+            "an outbound RelationshipRequestOutbound task is created on success"
         );
         assert!(
             config.key_info.contains_key("z-some-key"),
@@ -1601,14 +1734,74 @@ mod tests {
         );
     }
 
+    /// Race guard: if a peer's `RelationshipRequestAccepted` advances the
+    /// provisional record to `Established` *before* the Create SUCCESS outcome is
+    /// applied, the success apply must NOT clobber that state back to
+    /// `RequestSent`, must NOT create a stale outbound task, but must still update
+    /// `our_did` to the real minted local DID.
+    #[test]
+    fn create_success_does_not_clobber_raced_established() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let respondent = Arc::new("did:peer:respondent".to_string());
+        insert_provisional(&mut config, &respondent);
+        // Simulate the racing accept: advance the provisional record to
+        // Established (as the accept handler's `get(from_did)` fallback does).
+        {
+            let rel = config.private.relationships.get(&respondent).unwrap();
+            let mut lock = rel.lock().unwrap();
+            lock.state = RelationshipState::Established;
+            lock.remote_did = Arc::new("did:peer:respondent-rdid".to_string());
+        }
+
+        let our_did = Arc::new("did:peer:our-rdid".to_string());
+        let outcome = RelationshipOutcome {
+            effect: RelationshipEffect::Create {
+                respondent_did: Arc::clone(&respondent),
+                our_did,
+                msg_id: Arc::new("req-msg".to_string()),
+                used_r_did: true,
+                key_info: Vec::new(),
+                contact_to_add: None,
+            },
+            result: Ok(()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        let rel = config.private.relationships.get(&respondent).unwrap();
+        let lock = rel.lock().unwrap();
+        assert_eq!(
+            lock.state,
+            RelationshipState::Established,
+            "raced Established state must be preserved, not reset to RequestSent"
+        );
+        assert_eq!(
+            lock.our_did.as_str(),
+            "did:peer:our-rdid",
+            "our_did is still updated to the real minted local DID"
+        );
+        assert!(
+            config
+                .private
+                .tasks
+                .get_by_id(&Arc::new("req-msg".to_string()))
+                .is_none(),
+            "no stale outbound task for an already-established relationship"
+        );
+    }
+
     /// A failed Create still records the minted key_info in-memory (matching the
-    /// pre-R14 ordering where key creation happened before the send) but inserts
-    /// NO relationship record, and surfaces the error status.
+    /// pre-R14 ordering where key creation happened before the send) but removes
+    /// the provisional relationship record (failure parity: contact + key_info
+    /// in-memory, NO relationship record), and surfaces the error status.
     #[test]
     fn create_failure_records_keyinfo_but_no_relationship() {
         let mut config = test_config();
         let mut state = State::default();
         let respondent = Arc::new("did:peer:respondent".to_string());
+        // `prepare_submit` pre-inserted a provisional record; a send failure must
+        // remove it so no stuck `RequestSent` relationship is left behind.
+        insert_provisional(&mut config, &respondent);
 
         let outcome = RelationshipOutcome {
             effect: RelationshipEffect::Create {
@@ -1634,7 +1827,15 @@ mod tests {
 
         assert!(
             config.private.relationships.get(&respondent).is_none(),
-            "no relationship on a failed send"
+            "provisional relationship removed on a failed send"
+        );
+        assert!(
+            config
+                .private
+                .tasks
+                .get_by_id(&Arc::new("req-msg".to_string()))
+                .is_none(),
+            "no outbound task on a failed send"
         );
         assert!(
             config.key_info.contains_key("z-orphan"),

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -10,7 +10,7 @@ use affinidi_tdk::{
     dids::{DID, PeerKeyRole},
     secrets_resolver::{SecretsResolver, secrets::Secret},
 };
-use anyhow::{Result, bail};
+use anyhow::Result;
 use chrono::Utc;
 use ed25519_dalek_bip32::DerivationPath;
 use openvtc_core::{
@@ -19,437 +19,226 @@ use openvtc_core::{
         secured_config::{KeyInfoConfig, KeySourceMaterial},
     },
     logs::LogFamily,
-    relationships::{Relationship, RelationshipRequestBody, RelationshipState},
+    relationships::{RelationshipRequestBody, RelationshipState},
     tasks::TaskType,
 };
 use serde_json::json;
 use tracing::info;
 use uuid::Uuid;
 
-/// Create and send a new relationship request to a remote party.
-///
-/// When `generate_r_did` is true and the key backend is BIP32, a unique
-/// relationship DID (did:peer) is derived for privacy. Otherwise the
-/// persona DID is used directly.
-#[allow(clippy::too_many_arguments)]
-pub async fn send_relationship_request(
-    config: &mut Config,
-    tdk: &TDK,
-    service: &DIDCommService,
-    respondent_did: &str,
-    alias: &str,
-    reason: Option<&str>,
-    generate_r_did: bool,
-    admin_vta: Option<&vta_sdk::client::VtaClient>,
-) -> Result<()> {
-    // Validate DID format
-    if !respondent_did.starts_with("did:") {
-        anyhow::bail!("Invalid DID: must start with 'did:'");
-    }
+/// Build a trust-ping DIDComm message (used by the backgrounded ping path).
+fn build_ping_message(from: &str, to: &str) -> Result<Message> {
+    use std::time::SystemTime;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_secs();
+    Ok(affinidi_tdk::didcomm::Message::build(
+        Uuid::new_v4().to_string(),
+        "https://didcomm.org/trust-ping/2.0/ping".to_string(),
+        serde_json::json!({"response_requested": true}),
+    )
+    .from(from.to_string())
+    .to(to.to_string())
+    .created_time(now)
+    .expires_time(now + 60 * 5)
+    .finalize())
+}
 
-    // Check for existing established relationship
-    let respondent_arc = Arc::new(respondent_did.to_string());
-    if let Some(rel) = config.private.relationships.get(&respondent_arc) {
-        let lock = rel
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        if lock.state == RelationshipState::Established {
-            anyhow::bail!("An established relationship already exists with this DID");
+/// Loop-thread plan for creating a relationship DID, plus everything the
+/// *I/O-only* [`RDidPlan::create_io`] needs to run off the loop without touching
+/// `Config`. Building this is the only step that reads/mutates `Config` (the
+/// BIP32 path-pointer reservation); the actual key creation (VTA round-trip or
+/// BIP32 derivation), did:peer build, and resolver insert all run in the task.
+pub(crate) enum RDidPlan {
+    /// BIP32: paths reserved on the loop thread (pointer already advanced); the
+    /// task derives the keys from a clone of the root. The root is boxed to keep
+    /// the enum compact (it is the largest field by far).
+    Bip32 {
+        root: Box<ed25519_dalek_bip32::ExtendedSigningKey>,
+        v_path: String,
+        e_path: String,
+        mediator: String,
+    },
+    /// VTA: the task creates the keys on the always-on admin session (cloned —
+    /// cheap, shares the connection pool).
+    Vta {
+        admin_vta: vta_sdk::client::VtaClient,
+        mediator: String,
+    },
+}
+
+/// The created relationship DID plus the `key_info` entries to record in
+/// `Config` on the loop thread. The secrets themselves were already inserted into
+/// the (shared, `Arc`-based) TDK resolver inside the task, so they are visible to
+/// the loop's TDK; only the `Config` bookkeeping is left for `apply`.
+pub(crate) struct CreatedRDid {
+    pub(crate) r_did: String,
+    pub(crate) key_info: Vec<(String, KeyInfoConfig)>,
+}
+
+/// Build the [`RDidPlan`] on the loop thread. For BIP32 this reserves two unique
+/// derivation paths and advances `path_pointer` (the only `Config` mutation the
+/// pre-send step makes); for VTA it just snapshots the owned client/backend.
+pub(crate) fn plan_relationship_did(
+    config: &mut Config,
+    mediator: &str,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
+) -> Result<RDidPlan> {
+    match &config.key_backend {
+        KeyBackend::Bip32 { root, .. } => {
+            let root = Box::new(root.clone());
+            let v_path = format!("m/3'/1'/1'/{}'", config.private.relationships.path_pointer);
+            config.private.relationships.path_pointer += 1;
+            let e_path = format!("m/3'/1'/1'/{}'", config.private.relationships.path_pointer);
+            config.private.relationships.path_pointer += 1;
+            Ok(RDidPlan::Bip32 {
+                root,
+                v_path,
+                e_path,
+                mediator: mediator.to_string(),
+            })
+        }
+        KeyBackend::Vta { .. } => {
+            // The runtime always holds an admin VTA session for a VTA backend
+            // (built at startup). If it doesn't, R-DID creation can't proceed —
+            // surface that up front rather than parking the loop to open one.
+            let admin_vta = admin_vta.cloned().ok_or_else(|| {
+                anyhow::anyhow!("no VTA session available to create a relationship DID")
+            })?;
+            Ok(RDidPlan::Vta {
+                admin_vta,
+                mediator: mediator.to_string(),
+            })
+        }
+    }
+}
+
+impl RDidPlan {
+    fn mediator(&self) -> &str {
+        match self {
+            RDidPlan::Bip32 { mediator, .. } | RDidPlan::Vta { mediator, .. } => mediator,
         }
     }
 
-    // Add or find contact
-    let alias_opt = if alias.trim().is_empty() {
-        None
-    } else {
-        Some(alias.trim().to_string())
-    };
+    /// I/O-only relationship-DID creation, run inside the spawned task. Creates
+    /// the keys (BIP32 derivation or VTA round-trip), builds the did:peer,
+    /// registers the secrets in the shared TDK resolver, **and registers the new
+    /// R-DID listener** (built from the just-minted secrets — no resolver lookup,
+    /// no `Config`). Returns the `Config` `key_info` entries for the loop thread
+    /// to record. Never touches `Config`.
+    ///
+    /// `service` + `remote_p_did` are only used to register the post-establishment
+    /// R-DID listener, exactly as the old inline path did right after key creation.
+    pub(crate) async fn create_io(
+        self,
+        tdk: &TDK,
+        service: &DIDCommService,
+        remote_p_did: &str,
+    ) -> Result<CreatedRDid> {
+        let mediator = self.mediator().to_string();
+        let (mut v_secret, mut e_secret, key_info) = match self {
+            RDidPlan::Bip32 {
+                root,
+                v_path,
+                e_path,
+                ..
+            } => {
+                let v_key = root.derive(&v_path.parse::<DerivationPath>()?)?;
+                let e_key = root.derive(&e_path.parse::<DerivationPath>()?)?;
+                let v_secret = Secret::generate_ed25519(None, Some(v_key.signing_key.as_bytes()));
+                let e_secret = Secret::generate_x25519(
+                    None,
+                    Some(&ed25519_private_to_x25519(e_key.signing_key.as_bytes())),
+                )?;
+                // NOTE: v_key/e_key hold BIP32-derived signing-key bytes on the
+                // stack; ed25519-dalek-bip32 does not Zeroize, a known limitation.
+                drop(v_key);
+                drop(e_key);
+                let key_info = vec![
+                    (
+                        v_secret.id.clone(),
+                        KeySourceMaterial::Derived { path: v_path },
+                    ),
+                    (
+                        e_secret.id.clone(),
+                        KeySourceMaterial::Derived { path: e_path },
+                    ),
+                ];
+                (v_secret, e_secret, key_info)
+            }
+            RDidPlan::Vta { admin_vta, .. } => {
+                let (v_secret, e_secret, sign_key_id, enc_key_id) =
+                    create_relationship_keys(&admin_vta).await?;
+                let key_info = vec![
+                    (
+                        v_secret.id.clone(),
+                        KeySourceMaterial::VtaManaged {
+                            key_id: sign_key_id,
+                        },
+                    ),
+                    (
+                        e_secret.id.clone(),
+                        KeySourceMaterial::VtaManaged { key_id: enc_key_id },
+                    ),
+                ];
+                (v_secret, e_secret, key_info)
+            }
+        };
 
-    if config
-        .private
-        .contacts
-        .find_contact(respondent_did)
-        .is_none()
-    {
-        config
-            .private
-            .contacts
-            .add_contact(
-                tdk,
-                respondent_did,
-                alias_opt,
-                true,
-                &mut config.public.logs,
-            )
-            .await?;
-    }
+        // Build the did:peer from the secrets.
+        let mut keys = vec![
+            (PeerKeyRole::Verification, &mut v_secret),
+            (PeerKeyRole::Encryption, &mut e_secret),
+        ];
+        let r_did = DID::generate_did_peer_from_secrets(&mut keys, Some(mediator.clone()))
+            .map_err(|e| anyhow::anyhow!("Failed to create relationship DID: {e}"))?;
+        drop(keys);
 
-    // Optionally generate a random relationship DID for privacy
-    let our_did: Arc<String> = if generate_r_did {
-        // Snapshot the mediator before the &mut config borrow below.
-        let mediator = config.mediator_did().to_string();
-        let r_did = Arc::new(create_relationship_did(tdk, config, &mediator, admin_vta).await?);
-        // Register a listener for the new R-DID
-        let listener_config = super::didcomm::relationship_listener_config(
-            config,
-            tdk,
+        // Pair each secret id with its config-level metadata (verification first,
+        // encryption second — same order the old inline path inserted them).
+        let key_info: Vec<(String, KeyInfoConfig)> = key_info
+            .into_iter()
+            .zip([
+                KeyTypes::RelationshipVerification,
+                KeyTypes::RelationshipEncryption,
+            ])
+            .map(|((id, path), purpose)| {
+                (
+                    id,
+                    KeyInfoConfig {
+                        path,
+                        create_time: Utc::now(),
+                        purpose,
+                    },
+                )
+            })
+            .collect();
+
+        // Register the new R-DID listener from the just-minted secrets (the old
+        // inline path did this right after key creation; failure is non-fatal).
+        let listener_config = super::didcomm::relationship_listener_config_from_secrets(
             &r_did,
-            respondent_did,
-            config.mediator_did(),
-        )
-        .await;
+            remote_p_did,
+            &mediator,
+            vec![v_secret.clone(), e_secret.clone()],
+        );
         if let Err(e) = service.add_listener(listener_config).await {
             tracing::warn!(did = %r_did, error = %e, "failed to add R-DID listener");
         }
-        r_did
-    } else {
-        config.persona_did_arc()
-    };
 
-    // Build the relationship request message
-    let friendly_name = if config.public.friendly_name.is_empty() {
-        None
-    } else {
-        Some(config.public.friendly_name.as_str())
-    };
-    let msg = create_request_message(
-        config.persona_did(),
-        respondent_did,
-        reason,
-        &our_did,
-        friendly_name,
-    )?;
-    let msg_id = Arc::new(msg.id.clone());
+        // Register the secrets in the shared TDK resolver (visible to the loop's
+        // TDK — same `Arc`-backed resolver).
+        tdk.get_shared_state()
+            .secrets_resolver()
+            .insert(v_secret)
+            .await;
+        tdk.get_shared_state()
+            .secrets_resolver()
+            .insert(e_secret)
+            .await;
 
-    super::didcomm::send_message(service, config, &msg, config.persona_did(), respondent_did)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to send relationship request: {e}"))?;
-
-    // Create relationship entry
-    config.private.relationships.relationships.insert(
-        Arc::clone(&respondent_arc),
-        Arc::new(Mutex::new(Relationship {
-            task_id: Arc::clone(&msg_id),
-            our_did,
-            remote_p_did: Arc::clone(&respondent_arc),
-            remote_did: Arc::clone(&respondent_arc),
-            created: Utc::now(),
-            state: RelationshipState::RequestSent,
-        })),
-    );
-
-    // Create tracking task
-    config.private.tasks.new_task(
-        &msg_id,
-        TaskType::RelationshipRequestOutbound {
-            to: Arc::clone(&respondent_arc),
-        },
-    );
-
-    config.public.logs.insert(
-        LogFamily::Relationship,
-        format!(
-            "Relationship requested: remote DID({}) Task ID({})",
-            respondent_did, msg_id
-        ),
-    );
-
-    info!(to = %respondent_did, "relationship request sent");
-    Ok(())
-}
-
-/// Send a trust-ping to a relationship.
-pub async fn ping_relationship(
-    config: &mut Config,
-    _tdk: &TDK,
-    service: &DIDCommService,
-    remote_p_did: &str,
-) -> Result<()> {
-    let remote_key = Arc::new(remote_p_did.to_string());
-
-    let relationship = config
-        .private
-        .relationships
-        .get(&remote_key)
-        .ok_or_else(|| anyhow::anyhow!("No relationship found for {}", remote_p_did))?;
-
-    let (our_did, remote_did) = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        (Arc::clone(&lock.our_did), Arc::clone(&lock.remote_did))
-    };
-
-    // Build ping message using the relationship DIDs (R-DIDs if available)
-    info!(
-        our_did = %our_did,
-        remote_did = %remote_did,
-        is_r_did = !config.is_persona_did(our_did.as_str()),
-        "ping using relationship DIDs"
-    );
-    let ping_msg = {
-        use std::time::SystemTime;
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)?
-            .as_secs();
-        affinidi_tdk::didcomm::Message::build(
-            Uuid::new_v4().to_string(),
-            "https://didcomm.org/trust-ping/2.0/ping".to_string(),
-            serde_json::json!({"response_requested": true}),
-        )
-        .from(our_did.to_string())
-        .to(remote_did.to_string())
-        .created_time(now)
-        .expires_time(now + 60 * 5)
-        .finalize()
-    };
-    let msg_id = ping_msg.id.clone();
-
-    // Send via the correct listener (R-DID listener if our_did != persona_did)
-    super::didcomm::send_message(service, config, &ping_msg, &our_did, &remote_did)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to send trust-ping: {e}"))?;
-
-    config.public.logs.insert(
-        LogFamily::Relationship,
-        format!("Sent ping to {} via {}", remote_did, our_did),
-    );
-
-    config.private.tasks.new_task(
-        &Arc::new(msg_id),
-        TaskType::TrustPing {
-            from: our_did,
-            to: remote_did,
-            relationship,
-        },
-    );
-
-    info!(to = %remote_p_did, "trust-ping sent");
-    Ok(())
-}
-
-/// Remove a relationship, clean up associated VRCs, and remove the R-DID listener.
-pub async fn remove_relationship(
-    config: &mut Config,
-    service: &affinidi_messaging_didcomm_service::DIDCommService,
-    remote_p_did: &str,
-) -> Result<()> {
-    let key = Arc::new(remote_p_did.to_string());
-
-    // Clean up R-DID listener before removing the relationship data
-    // Extract listener ID before any async work to avoid holding MutexGuard across await
-    let listener_to_remove = if let Some(rel_arc) = config.private.relationships.get(&key)
-        && let Ok(lock) = rel_arc.lock()
-        && !config.is_persona_did(lock.our_did.as_str())
-    {
-        Some(super::didcomm::listener_id_for_did(&lock.our_did, config))
-    } else {
-        None
-    };
-    if let Some(lid) = listener_to_remove
-        && let Err(e) = service.remove_listener(&lid).await
-    {
-        tracing::warn!(listener = %lid, error = %e, "failed to remove R-DID listener");
+        Ok(CreatedRDid { r_did, key_info })
     }
-
-    config.private.relationships.remove(
-        &key,
-        &mut config.private.vrcs_issued,
-        &mut config.private.vrcs_received,
-    );
-
-    // Also remove the associated contact (and its alias mapping). Without this,
-    // the alias remains registered and re-creating the relationship with the
-    // same alias fails with a duplicate-alias error.
-    config
-        .private
-        .contacts
-        .remove_contact(&mut config.public.logs, remote_p_did);
-
-    config.public.logs.insert(
-        LogFamily::Relationship,
-        format!("Removed relationship with ({})", remote_p_did),
-    );
-
-    info!(remote = %remote_p_did, "relationship removed");
-    Ok(())
-}
-
-/// Creates a random did:peer DID representing a relationship DID.
-///
-/// Dispatches to the appropriate backend-specific implementation based on
-/// the configured key backend (BIP32 or VTA).
-pub(crate) async fn create_relationship_did(
-    tdk: &TDK,
-    config: &mut Config,
-    mediator: &str,
-    admin_vta: Option<&vta_sdk::client::VtaClient>,
-) -> Result<String> {
-    match &config.key_backend {
-        KeyBackend::Bip32 { .. } => create_relationship_did_bip32(tdk, config, mediator).await,
-        KeyBackend::Vta { .. } => {
-            create_relationship_did_vta(tdk, config, mediator, admin_vta).await
-        }
-    }
-}
-
-/// BIP32 backend: derives signing and encryption keys from the BIP32 root
-/// using the relationship path pointer, registers the secrets with the TDK
-/// resolver, and records key metadata in the configuration.
-async fn create_relationship_did_bip32(
-    tdk: &TDK,
-    config: &mut Config,
-    mediator: &str,
-) -> Result<String> {
-    // Derive a key path for the verification (signing) key
-    let v_path = [
-        "m/3'/1'/1'/",
-        config
-            .private
-            .relationships
-            .path_pointer
-            .to_string()
-            .as_str(),
-        "'",
-    ]
-    .concat();
-    config.private.relationships.path_pointer += 1;
-
-    // Derive a key path for the encryption key
-    let e_path = [
-        "m/3'/1'/1'/",
-        config
-            .private
-            .relationships
-            .path_pointer
-            .to_string()
-            .as_str(),
-        "'",
-    ]
-    .concat();
-    config.private.relationships.path_pointer += 1;
-
-    let bip32_root = match &config.key_backend {
-        KeyBackend::Bip32 { root, .. } => root,
-        _ => bail!("create_relationship_did_bip32 requires a BIP32 key backend"),
-    };
-
-    let v_key = bip32_root.derive(&v_path.parse::<DerivationPath>()?)?;
-    let e_key = bip32_root.derive(&e_path.parse::<DerivationPath>()?)?;
-
-    let mut v_secret = Secret::generate_ed25519(None, Some(v_key.signing_key.as_bytes()));
-    let mut e_secret = Secret::generate_x25519(
-        None,
-        Some(&ed25519_private_to_x25519(e_key.signing_key.as_bytes())),
-    )?;
-
-    let mut keys = vec![
-        (PeerKeyRole::Verification, &mut v_secret),
-        (PeerKeyRole::Encryption, &mut e_secret),
-    ];
-    let r_did = DID::generate_did_peer_from_secrets(&mut keys, Some(mediator.to_string()))
-        .map_err(|e| anyhow::anyhow!("Failed to create relationship DID: {e}"))?;
-
-    // Add the secrets to the config
-    config.key_info.insert(
-        v_secret.id.clone(),
-        KeyInfoConfig {
-            path: KeySourceMaterial::Derived { path: v_path },
-            create_time: Utc::now(),
-            purpose: KeyTypes::RelationshipVerification,
-        },
-    );
-    config.key_info.insert(
-        e_secret.id.clone(),
-        KeyInfoConfig {
-            path: KeySourceMaterial::Derived { path: e_path },
-            create_time: Utc::now(),
-            purpose: KeyTypes::RelationshipEncryption,
-        },
-    );
-
-    // Add the secrets to the TDK secret resolver
-    tdk.get_shared_state()
-        .secrets_resolver()
-        .insert(v_secret)
-        .await;
-    tdk.get_shared_state()
-        .secrets_resolver()
-        .insert(e_secret)
-        .await;
-
-    // NOTE: v_key and e_key contain BIP32-derived signing key bytes on the stack.
-    // ed25519-dalek-bip32 does not implement Zeroize, so these bytes may persist
-    // in memory after this function returns. This is a known limitation.
-    // The Secret structs (v_secret, e_secret) are now owned by the TDK resolver.
-    drop(v_key);
-    drop(e_key);
-
-    Ok(r_did)
-}
-
-/// VTA backend: creates signing and encryption keys via the VTA service,
-/// builds a did:peer from the resulting secrets, and registers everything
-/// in the TDK resolver and config.
-async fn create_relationship_did_vta(
-    tdk: &TDK,
-    config: &mut Config,
-    mediator: &str,
-    admin_vta: Option<&vta_sdk::client::VtaClient>,
-) -> Result<String> {
-    // Create the relationship signing (Ed25519) + encryption (X25519) keys via
-    // the VTA. Reuse the always-on admin session when the runtime provides one;
-    // otherwise open a transient session (guaranteed to shut down on every exit).
-    let (mut v_secret, mut e_secret, sign_key_id, enc_key_id) = match admin_vta {
-        Some(client) => create_relationship_keys(client).await?,
-        None => {
-            openvtc_core::config::with_runtime_vta_client::<_, _, _, anyhow::Error>(
-                &config.key_backend,
-                |client| async move { create_relationship_keys(&client).await },
-            )
-            .await?
-        }
-    };
-
-    // Build did:peer from secrets
-    let mut keys = vec![
-        (PeerKeyRole::Verification, &mut v_secret),
-        (PeerKeyRole::Encryption, &mut e_secret),
-    ];
-    let r_did = DID::generate_did_peer_from_secrets(&mut keys, Some(mediator.to_string()))
-        .map_err(|e| anyhow::anyhow!("Failed to create relationship DID: {e}"))?;
-
-    // Register key info in config
-    config.key_info.insert(
-        v_secret.id.clone(),
-        KeyInfoConfig {
-            path: KeySourceMaterial::VtaManaged {
-                key_id: sign_key_id,
-            },
-            create_time: Utc::now(),
-            purpose: KeyTypes::RelationshipVerification,
-        },
-    );
-    config.key_info.insert(
-        e_secret.id.clone(),
-        KeyInfoConfig {
-            path: KeySourceMaterial::VtaManaged { key_id: enc_key_id },
-            create_time: Utc::now(),
-            purpose: KeyTypes::RelationshipEncryption,
-        },
-    );
-
-    // Register secrets in TDK resolver
-    tdk.get_shared_state()
-        .secrets_resolver()
-        .insert(v_secret)
-        .await;
-    tdk.get_shared_state()
-        .secrets_resolver()
-        .insert(e_secret)
-        .await;
-
-    Ok(r_did)
 }
 
 /// Create a relationship's signing (Ed25519) + encryption (X25519) keys via the
@@ -504,6 +293,38 @@ async fn create_relationship_keys(
     Ok((v_secret, e_secret, sign_resp.key_id, enc_resp.key_id))
 }
 
+/// Insert a brand-new contact for `did` with `alias`, mirroring the insert tail
+/// of `ProtectedConfig::add_contact` (the DID-resolution validation and the
+/// duplicate-alias check both already happened — resolution in the task, the
+/// dup-alias check on the loop thread in `prepare_submit`). Infallible by the
+/// time it runs.
+fn insert_contact(config: &mut Config, did: &Arc<String>, alias: Option<String>) {
+    let contact = Arc::new(Contact {
+        did: Arc::clone(did),
+        alias: alias.clone(),
+    });
+    config
+        .private
+        .contacts
+        .contacts
+        .insert(Arc::clone(did), Arc::clone(&contact));
+    if let Some(a) = &alias {
+        config
+            .private
+            .contacts
+            .aliases
+            .insert(a.clone(), Arc::clone(&contact));
+    }
+    config.public.logs.insert(
+        LogFamily::Contact,
+        format!(
+            "Added contact ({}) alias({})",
+            did,
+            alias.as_deref().unwrap_or("N/A")
+        ),
+    );
+}
+
 /// Build a DIDComm relationship request message.
 fn create_request_message(
     from: &str,
@@ -530,12 +351,597 @@ fn create_request_message(
 // ============================================================
 
 use crate::state_handler::{
-    actions::RelationshipAction, credential_actions, dispatch_util, log_did,
-    main_page::content::RelationshipsMode, resolve_did_to_display, settings_actions, state::State,
+    actions::RelationshipAction, dispatch_util, log_did, main_page::content::RelationshipsMode,
+    resolve_did_to_display, settings_actions, state::State,
 };
 use openvtc_core::config::protected_config::Contact;
-use std::time::Instant;
-use tokio::sync::watch;
+use openvtc_core::relationships::Relationship as RelRecord;
+
+/// Owned inputs for the *I/O-only* half of a relationship network dispatch.
+///
+/// R14: the loop thread builds this (doing the fast, local pre-send work — DID
+/// validation, contact add, R-DID key creation + listener registration), then a
+/// `tokio::spawn`ed task does the slow network send with these owned values and
+/// reports the result back as a [`RelationshipOutcome`]. It borrows nothing tied
+/// to the loop's `Config`/`TDK`: `DIDCommService` is `Arc`-cheap to clone and the
+/// message/ids are owned, so the future is `'static` + `Send`.
+pub(crate) struct RelationshipSend {
+    service: DIDCommService,
+    /// The listener id the message is sent through, resolved on the loop thread
+    /// (`listener_id_for_did`) so the task needs no `Config`. Persona listener for
+    /// handshake messages; R-DID listener once established.
+    listener_id: String,
+    to_did: Arc<String>,
+    message: Box<Message>,
+    /// What to mutate + log once the send result is known, applied on the loop
+    /// thread by [`RelationshipOutcome::apply`].
+    effect: RelationshipEffect,
+}
+
+/// A relationship network dispatch ready to run off the loop thread.
+///
+/// The loop thread builds one of these (pre-send work done synchronously) and
+/// `tokio::spawn`s [`RelationshipJob::run`]; the resulting [`RelationshipOutcome`]
+/// is applied back on the loop thread. Both variants own everything they touch.
+pub(crate) enum RelationshipJob {
+    /// Ping / request-VRC: a single DIDComm send (no key creation). Boxed to keep
+    /// the enum small (the effect payload carries several owned ids).
+    Send(Box<RelationshipSend>),
+    /// Create a relationship request: optionally mint an R-DID + listener first
+    /// (the VTA round-trip / BIP32 derivation runs off the loop), then send the
+    /// request via the persona listener.
+    Create(Box<CreateJob>),
+    /// Remove: tear down the (optional) R-DID listener, then the loop thread
+    /// removes the relationship/contact records.
+    Remove {
+        service: DIDCommService,
+        /// `Some` only when the relationship used a dedicated R-DID listener.
+        listener_id: Option<String>,
+        remote_p_did: String,
+    },
+}
+
+/// Owned inputs for the backgrounded "create relationship request" job. All
+/// `Config`/`TDK` reads are snapshotted on the loop thread into owned values so
+/// the task is `'static` + `Send`.
+pub(crate) struct CreateJob {
+    tdk: TDK,
+    service: DIDCommService,
+    /// `Some` ⇒ mint an R-DID first; `None` ⇒ use the persona DID directly.
+    rdid_plan: Option<RDidPlan>,
+    /// Our persona DID (message `from`, and the listener the request is sent via).
+    persona_did: Arc<String>,
+    persona_listener_id: String,
+    respondent_did: Arc<String>,
+    reason: Option<String>,
+    friendly_name: Option<String>,
+    /// Contact to add for the respondent (the alias the user entered), when no
+    /// contact exists yet. `None` ⇒ a contact already exists; don't touch it.
+    /// The DID **resolution** validation runs in the task (it is the create
+    /// path's only network call besides the send) so it stays off the loop; the
+    /// contact insert itself happens in `apply` on the loop thread.
+    add_contact_alias: Option<Option<String>>,
+}
+
+impl CreateJob {
+    async fn run(self) -> RelationshipOutcome {
+        let CreateJob {
+            tdk,
+            service,
+            rdid_plan,
+            persona_did,
+            persona_listener_id,
+            respondent_did,
+            reason,
+            friendly_name,
+            add_contact_alias,
+        } = self;
+
+        // 0. Validate the respondent DID resolves (the create path's only
+        //    non-send network call). Today this happened inside `add_contact`
+        //    *before* the send; on resolve failure no contact was added and the
+        //    create bailed — reproduce that by failing here before any mutation
+        //    is applied (the contact is only inserted in `apply` on a non-failed
+        //    resolve). Only when we'd add a brand-new contact (the user supplied
+        //    an alias / it didn't exist) does the old path resolve.
+        let contact_to_add = if let Some(alias) = add_contact_alias {
+            if let Err(e) = tdk.did_resolver().resolve(&respondent_did).await {
+                return RelationshipOutcome {
+                    effect: RelationshipEffect::Create {
+                        respondent_did,
+                        our_did: persona_did,
+                        msg_id: Arc::new(String::new()),
+                        used_r_did: rdid_plan.is_some(),
+                        key_info: Vec::new(),
+                        contact_to_add: None,
+                    },
+                    result: Err(format!("Couldn't resolve DID: {e}")),
+                };
+            }
+            Some(alias)
+        } else {
+            None
+        };
+
+        // 1. Mint the R-DID + listener off the loop (if requested). A failure here
+        //    aborts before any send and is reported as the create error.
+        let (our_did, key_info, used_r_did) = match rdid_plan {
+            Some(plan) => match plan.create_io(&tdk, &service, &respondent_did).await {
+                Ok(created) => (Arc::new(created.r_did), created.key_info, true),
+                Err(e) => {
+                    return RelationshipOutcome {
+                        effect: RelationshipEffect::Create {
+                            respondent_did,
+                            our_did: persona_did,
+                            msg_id: Arc::new(String::new()),
+                            used_r_did: true,
+                            key_info: Vec::new(),
+                            contact_to_add,
+                        },
+                        result: Err(format!("{e}")),
+                    };
+                }
+            },
+            None => (Arc::clone(&persona_did), Vec::new(), false),
+        };
+
+        // 2. Build + send the request via the persona listener (handshake uses
+        //    persona DIDs for routing; the R-DID is carried in the body).
+        let msg = match create_request_message(
+            &persona_did,
+            &respondent_did,
+            reason.as_deref(),
+            &our_did,
+            friendly_name.as_deref(),
+        ) {
+            Ok(m) => m,
+            Err(e) => {
+                return RelationshipOutcome {
+                    effect: RelationshipEffect::Create {
+                        respondent_did,
+                        our_did,
+                        msg_id: Arc::new(String::new()),
+                        used_r_did,
+                        key_info,
+                        contact_to_add,
+                    },
+                    result: Err(format!("{e}")),
+                };
+            }
+        };
+        let msg_id = Arc::new(msg.id.clone());
+        let result =
+            super::didcomm::send_message_via(&service, &msg, &persona_listener_id, &respondent_did)
+                .await
+                .map_err(|e| format!("{e}"));
+
+        RelationshipOutcome {
+            effect: RelationshipEffect::Create {
+                respondent_did,
+                our_did,
+                msg_id,
+                used_r_did,
+                key_info,
+                contact_to_add,
+            },
+            result,
+        }
+    }
+}
+
+impl RelationshipJob {
+    /// Run the network I/O (send, or listener teardown) and package the result
+    /// for the loop. Called inside the spawned task; never touches `Config`/`TDK`.
+    pub(crate) async fn run(self) -> RelationshipOutcome {
+        match self {
+            RelationshipJob::Send(send) => send.run().await,
+            RelationshipJob::Create(job) => job.run().await,
+            RelationshipJob::Remove {
+                service,
+                listener_id,
+                remote_p_did,
+            } => {
+                if let Some(lid) = listener_id
+                    && let Err(e) = service.remove_listener(&lid).await
+                {
+                    tracing::warn!(listener = %lid, error = %e, "failed to remove R-DID listener");
+                }
+                RelationshipOutcome {
+                    effect: RelationshipEffect::Remove { remote_p_did },
+                    result: Ok(()),
+                }
+            }
+        }
+    }
+}
+
+impl RelationshipSend {
+    /// Run the slow send (I/O only) and package the result for the loop. Called
+    /// inside the spawned task; never touches `Config`/`TDK`.
+    pub(crate) async fn run(self) -> RelationshipOutcome {
+        let RelationshipSend {
+            service,
+            listener_id,
+            to_did,
+            message,
+            effect,
+        } = self;
+        let result = super::didcomm::send_message_via(&service, &message, &listener_id, &to_did)
+            .await
+            .map_err(|e| format!("{e}"));
+        RelationshipOutcome { effect, result }
+    }
+}
+
+/// The post-send mutation a relationship network action applies on the loop
+/// thread once its send completes. Each variant owns exactly the data the old
+/// inline success/error block referenced, so [`RelationshipOutcome::apply`]
+/// reproduces the pre-R14 final state byte-for-byte.
+pub(crate) enum RelationshipEffect {
+    /// `SubmitRequest`: on success, insert the relationship + outbound task and
+    /// save; on failure, record the error. Mirrors `send_relationship_request`'s
+    /// post-send tail + `handle_submit`'s UI block.
+    Create {
+        respondent_did: Arc<String>,
+        our_did: Arc<String>,
+        msg_id: Arc<String>,
+        used_r_did: bool,
+        /// `key_info` entries minted for a new R-DID (empty when the persona DID
+        /// was used). Recorded into `config.key_info` on the loop thread — on
+        /// success *and* failure, matching the pre-R14 in-memory state where key
+        /// creation happened before the send (only success persists, via save).
+        key_info: Vec<(String, KeyInfoConfig)>,
+        /// A brand-new contact to insert for the respondent (the alias the user
+        /// entered). `Some` only when the DID resolved and no contact existed;
+        /// inserted on success *and* send-failure (the old path added it before
+        /// the send). `None` when a contact already existed.
+        contact_to_add: Option<Option<String>>,
+    },
+    /// `Ping`: on success, log + create the TrustPing task and save.
+    Ping {
+        our_did: Arc<String>,
+        remote_did: Arc<String>,
+        remote_p_did: String,
+        msg_id: Arc<String>,
+        relationship: Arc<Mutex<RelRecord>>,
+        display_name: String,
+        using_rdid: bool,
+    },
+    /// `RequestVrc`: on success, create the outbound VRC-request task and save.
+    RequestVrc {
+        remote_p_did: String,
+        msg_id: Arc<String>,
+        relationship: Arc<Mutex<RelRecord>>,
+        display_name: String,
+    },
+    /// `Remove`: the R-DID listener (if any) was torn down in the task; remove
+    /// the relationship + contact records here and save.
+    Remove { remote_p_did: String },
+}
+
+/// The completed result of a relationship network dispatch: the post-send effect
+/// plus the send's `Result` (stringified so it is `Send`/`'static`).
+pub(crate) struct RelationshipOutcome {
+    effect: RelationshipEffect,
+    result: Result<(), String>,
+}
+
+impl RelationshipOutcome {
+    /// Apply the post-send mutation on the loop thread. On send success this
+    /// performs exactly the config mutation + save + status/log the old inline
+    /// handler did *after* the await; on failure it records the same error
+    /// status, leaving config untouched (so a failed send records no
+    /// relationship/task — matching the pre-R14 ordering and durability).
+    pub(crate) fn apply(self, state: &mut State, config: &mut Config, profile: &str) {
+        // Accessor for the relationships-panel status slot, used by the
+        // `dispatch_util` save/error helpers below (a free fn so its HRTB is
+        // inferred correctly).
+        fn status(mp: &mut crate::state_handler::main_page::MainPageState) -> &mut Option<String> {
+            &mut mp.content_panel.relationships.status_message
+        }
+        match self.effect {
+            RelationshipEffect::Create {
+                respondent_did,
+                our_did,
+                msg_id,
+                used_r_did,
+                key_info,
+                contact_to_add,
+            } => {
+                // Insert the brand-new contact (the DID resolved in the task; the
+                // old path added it *before* the send, so do it on both success
+                // and send-failure). `None` ⇒ a contact already existed.
+                if let Some(alias) = contact_to_add {
+                    insert_contact(config, &respondent_did, alias);
+                }
+                // Record any minted R-DID key metadata next — done on both
+                // success and failure to match the pre-R14 in-memory state (the
+                // secrets are already in the shared resolver; only `Config`
+                // bookkeeping is left, and it only persists on the success save).
+                for (id, info) in key_info {
+                    config.key_info.insert(id, info);
+                }
+                match self.result {
+                    Ok(()) => {
+                        // Insert the relationship + outbound task (post-send tail of
+                        // `send_relationship_request`).
+                        config.private.relationships.relationships.insert(
+                            Arc::clone(&respondent_did),
+                            Arc::new(Mutex::new(RelRecord {
+                                task_id: Arc::clone(&msg_id),
+                                our_did: Arc::clone(&our_did),
+                                remote_p_did: Arc::clone(&respondent_did),
+                                remote_did: Arc::clone(&respondent_did),
+                                created: Utc::now(),
+                                state: RelationshipState::RequestSent,
+                            })),
+                        );
+                        config.private.tasks.new_task(
+                            &msg_id,
+                            TaskType::RelationshipRequestOutbound {
+                                to: Arc::clone(&respondent_did),
+                            },
+                        );
+                        config.public.logs.insert(
+                        LogFamily::Relationship,
+                        format!(
+                            "Relationship requested: remote DID({respondent_did}) Task ID({msg_id})"
+                        ),
+                    );
+                        info!(to = %respondent_did, "relationship request sent");
+
+                        state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
+                        let detail = format!(
+                            "Relationship Request Sent\n\
+                         ─────────────────────────\n\
+                         To (persona):  {respondent_did}\n\
+                         Our DID:       {our_did}\n\
+                         R-DID used:    {}\n\
+                         Task ID:       {msg_id}",
+                            if used_r_did { "yes" } else { "no" },
+                        );
+                        dispatch_util::save_and_sync(
+                            &mut state.main_page,
+                            config,
+                            profile,
+                            dispatch_util::Persist::SaveAndSync,
+                            status,
+                            format!("Request sent to {}", log_did(&respondent_did)),
+                            dispatch_util::SyncLog::Detailed {
+                                summary: format!(
+                                    "Relationship request sent to {}",
+                                    log_did(&respondent_did)
+                                ),
+                                detail,
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        let err = anyhow::anyhow!("failed to send relationship request: {e}");
+                        dispatch_util::record_error(
+                            &mut state.main_page,
+                            status,
+                            "Failed to send relationship request",
+                            &err,
+                        );
+                    }
+                }
+            }
+            RelationshipEffect::Ping {
+                our_did,
+                remote_did,
+                remote_p_did,
+                msg_id,
+                relationship,
+                display_name,
+                using_rdid,
+            } => match self.result {
+                Ok(()) => {
+                    config.public.logs.insert(
+                        LogFamily::Relationship,
+                        format!("Sent ping to {remote_did} via {our_did}"),
+                    );
+                    config.private.tasks.new_task(
+                        &msg_id,
+                        TaskType::TrustPing {
+                            from: Arc::clone(&our_did),
+                            to: Arc::clone(&remote_did),
+                            relationship,
+                        },
+                    );
+                    info!(to = %remote_p_did, "trust-ping sent");
+
+                    state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
+                    dispatch_util::save_and_sync(
+                        &mut state.main_page,
+                        config,
+                        profile,
+                        dispatch_util::Persist::SaveAndSync,
+                        status,
+                        "Ping sent",
+                        dispatch_util::SyncLog::Detailed {
+                            summary: format!(
+                                "Trust-ping sent to {display_name}{}",
+                                if using_rdid { " (via R-DID)" } else { "" }
+                            ),
+                            detail: format!(
+                                "Trust-Ping Sent\n\
+                                 ───────────────\n\
+                                 To:              {display_name}\n\
+                                 Sent to DID:     {remote_did}\n\
+                                 Sent from DID:   {our_did}\n\
+                                 Remote persona:  {remote_p_did}\n\
+                                 Using R-DIDs:    {}\n\
+                                 Routed via:      mediator",
+                                if using_rdid { "yes" } else { "no" },
+                            ),
+                        },
+                    );
+                }
+                Err(e) => {
+                    state.main_page.content_panel.relationships.status_message =
+                        Some(format!("Ping failed: {e:#}"));
+                    state.main_page.log_detailed(
+                        format!("Ping to {display_name} failed: {e}"),
+                        format!(
+                            "Trust-Ping Failed\n\
+                             ─────────────────\n\
+                             To (persona):    {remote_p_did}\n\
+                             To (R-DID):      {remote_did}\n\
+                             From (our DID):  {our_did}\n\
+                             Error:           {e:#}",
+                        ),
+                    );
+                }
+            },
+            RelationshipEffect::RequestVrc {
+                remote_p_did,
+                msg_id,
+                relationship,
+                display_name,
+            } => match self.result {
+                Ok(()) => {
+                    config
+                        .private
+                        .tasks
+                        .new_task(&msg_id, TaskType::VRCRequestOutbound { relationship });
+                    config.public.logs.insert(
+                        LogFamily::Relationship,
+                        format!("Requested VRC from ({remote_p_did}) Task ID ({msg_id})"),
+                    );
+                    info!(to = %remote_p_did, "VRC request sent");
+                    dispatch_util::save_and_sync(
+                        &mut state.main_page,
+                        config,
+                        profile,
+                        dispatch_util::Persist::SaveAndSync,
+                        status,
+                        format!("VRC requested from {display_name}"),
+                        dispatch_util::SyncLog::Detailed {
+                            summary: format!("VRC requested from {display_name}"),
+                            detail: format!(
+                                "VRC Request Sent\n\
+                                 ────────────────\n\
+                                 To:      {display_name}\n\
+                                 DID:     {remote_p_did}",
+                            ),
+                        },
+                    );
+                }
+                Err(e) => {
+                    let err = anyhow::anyhow!("{e}");
+                    state.main_page.content_panel.relationships.status_message =
+                        Some(format!("VRC request failed: {err:#}"));
+                    state
+                        .main_page
+                        .log_error(format!("VRC request to {display_name} failed"), &err);
+                }
+            },
+            RelationshipEffect::Remove { remote_p_did } => {
+                // Listener teardown already ran in the task. Remove the records
+                // here (post-`remove_listener` tail of `remove_relationship`).
+                let key = Arc::new(remote_p_did.clone());
+                config.private.relationships.remove(
+                    &key,
+                    &mut config.private.vrcs_issued,
+                    &mut config.private.vrcs_received,
+                );
+                config
+                    .private
+                    .contacts
+                    .remove_contact(&mut config.public.logs, &remote_p_did);
+                config.public.logs.insert(
+                    LogFamily::Relationship,
+                    format!("Removed relationship with ({remote_p_did})"),
+                );
+                info!(remote = %remote_p_did, "relationship removed");
+
+                state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
+                dispatch_util::save_and_sync(
+                    &mut state.main_page,
+                    config,
+                    profile,
+                    dispatch_util::Persist::SaveAndSync,
+                    status,
+                    "Relationship removed",
+                    dispatch_util::SyncLog::Plain("Relationship removed".to_string()),
+                );
+            }
+        }
+    }
+}
+
+/// Backgrounded context-DID deletion: the VTA `delete_did_webvh` + listener
+/// teardown run off the loop, then the local config cleanup + save apply on the
+/// loop thread via [`DidDeleteOutcome`]. The guards (community-bound check, DID
+/// resolution) ran on the loop thread before this was built.
+pub(crate) struct DidDeleteJob {
+    pub(crate) admin_vta: Option<vta_sdk::client::VtaClient>,
+    pub(crate) service: DIDCommService,
+    pub(crate) did: String,
+    pub(crate) persona_id: openvtc_core::config::account::PersonaId,
+    pub(crate) key_ids: Vec<String>,
+}
+
+impl DidDeleteJob {
+    /// I/O-only: best-effort VTA delete + listener teardown (failures logged, not
+    /// fatal — matching the old inline path), then hand the local cleanup back.
+    pub(crate) async fn run(self) -> DidDeleteOutcome {
+        let DidDeleteJob {
+            admin_vta,
+            service,
+            did,
+            persona_id,
+            key_ids,
+        } = self;
+        if let Some(vta) = admin_vta
+            && let Err(e) = vta.delete_did_webvh(&did).await
+        {
+            tracing::debug!("delete_did_webvh({did}) failed (continuing local cleanup): {e}");
+        }
+        let listener_id = super::didcomm::persona_listener_id(&did);
+        if let Err(e) = service.remove_listener(&listener_id).await {
+            tracing::debug!("remove_listener after DID delete: {e}");
+        }
+        DidDeleteOutcome {
+            did,
+            persona_id,
+            key_ids,
+        }
+    }
+}
+
+/// Deletion of an orphan context-DID (persona) completed off the loop: the VTA
+/// `delete_did_webvh` + listener teardown ran in the spawned task; the local
+/// config cleanup + save are applied here on the loop thread.
+pub(crate) struct DidDeleteOutcome {
+    pub(crate) did: String,
+    pub(crate) persona_id: openvtc_core::config::account::PersonaId,
+    pub(crate) key_ids: Vec<String>,
+}
+
+impl DidDeleteOutcome {
+    /// Apply the local cleanup (persona/identity/key removal + save + log),
+    /// mirroring the tail of the old inline `delete_context_did`. The VTA delete
+    /// and listener teardown already happened in the task (best-effort, as before
+    /// — failures there were logged and did not block local cleanup).
+    pub(crate) fn apply(self, state: &mut State, config: &mut Config, profile: &str) {
+        config.account.personas.remove(&self.persona_id);
+        config.identities.remove(&self.persona_id);
+        for kid in &self.key_ids {
+            config.key_info.remove(kid);
+        }
+        if let Err(e) = settings_actions::save_config(config, profile) {
+            state
+                .main_page
+                .log_error("Failed to save after removing DID", &e);
+        }
+        state.main_page.sync_from_config(config);
+        state
+            .main_page
+            .log(format!("Removed identity {}", self.did));
+    }
+}
 
 fn handle_open_detail(state: &mut State, index: usize) {
     state.main_page.content_panel.relationships.selected_index = index;
@@ -586,20 +992,76 @@ fn handle_toggle_r_did(state: &mut State) {
     }
 }
 
+/// Loop-thread preparation for `SubmitRequest`. Does the fast, local checks +
+/// contact add (all done *before* the send today), reserves the R-DID plan, and
+/// snapshots the message inputs into owned values. Returns the spawnable
+/// [`RelationshipJob::Create`], or `Err` (recorded as a status) if a pre-send
+/// validation fails — in which case no domain should have been claimed.
 #[allow(clippy::too_many_arguments)]
-async fn handle_submit(
+async fn prepare_submit(
     config: &mut Box<Config>,
     tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    state_tx: &watch::Sender<State>,
-    profile: &str,
     did: &str,
     alias: &str,
     reason: Option<&str>,
     generate_r_did: bool,
     admin_vta: Option<&vta_sdk::client::VtaClient>,
-) {
+) -> Result<RelationshipJob> {
+    // Validate DID format.
+    if !did.starts_with("did:") {
+        anyhow::bail!("Invalid DID: must start with 'did:'");
+    }
+    // Reject a duplicate established relationship.
+    let respondent_arc = Arc::new(did.to_string());
+    if let Some(rel) = config.private.relationships.get(&respondent_arc) {
+        let lock = rel
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        if lock.state == RelationshipState::Established {
+            anyhow::bail!("An established relationship already exists with this DID");
+        }
+    }
+
+    // Decide whether a brand-new contact must be added. The DID *resolution*
+    // (the create path's only non-send network call) is deferred to the task so
+    // it doesn't park the loop; the duplicate-alias check is local, so do it here
+    // up front (it must reject *before* the send, as the old inline path did).
+    let alias_opt = if alias.trim().is_empty() {
+        None
+    } else {
+        Some(alias.trim().to_string())
+    };
+    let add_contact_alias = if config.private.contacts.find_contact(did).is_none() {
+        if let Some(a) = &alias_opt
+            && config.private.contacts.aliases.contains_key(a)
+        {
+            anyhow::bail!("Duplicate alias ({a}) detected! Existing alias must be removed first!");
+        }
+        Some(alias_opt)
+    } else {
+        None
+    };
+
+    // Reserve the R-DID plan (BIP32 path-pointer reservation is the only config
+    // mutation; the VTA round-trip / derivation runs in the task).
+    let rdid_plan = if generate_r_did {
+        let mediator = config.mediator_did().to_string();
+        Some(plan_relationship_did(config, &mediator, admin_vta)?)
+    } else {
+        None
+    };
+
+    let friendly_name = if config.public.friendly_name.is_empty() {
+        None
+    } else {
+        Some(config.public.friendly_name.clone())
+    };
+    let persona_did = config.persona_did_arc();
+    let persona_listener_id = super::didcomm::listener_id_for_did(&persona_did, config);
+
+    // In-progress status (shown by the loop's post-arm state send).
     if generate_r_did {
         state.main_page.content_panel.relationships.status_message =
             Some("Creating relationship DID...".to_string());
@@ -610,162 +1072,139 @@ async fn handle_submit(
         state.main_page.content_panel.relationships.status_message =
             Some("Sending request...".to_string());
     }
-    let _ = state_tx.send(state.clone());
 
-    match send_relationship_request(
-        config,
-        tdk,
-        service,
-        did,
-        alias,
-        reason,
-        generate_r_did,
-        admin_vta,
-    )
-    .await
-    {
-        Ok(()) => {
-            state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
-            let detail = {
-                let rel_key = std::sync::Arc::new(did.to_string());
-                if let Some(rel_arc) = config.private.relationships.get(&rel_key)
-                    && let Ok(r) = rel_arc.lock()
-                {
-                    format!(
-                        "Relationship Request Sent\n\
-                         ─────────────────────────\n\
-                         To (persona):  {}\n\
-                         Our DID:       {}\n\
-                         R-DID used:    {}\n\
-                         Task ID:       {}",
-                        r.remote_p_did,
-                        r.our_did,
-                        if !config.is_persona_did(r.our_did.as_str()) {
-                            "yes"
-                        } else {
-                            "no"
-                        },
-                        r.task_id,
-                    )
-                } else {
-                    String::new()
-                }
-            };
-            dispatch_util::save_and_sync(
-                &mut state.main_page,
-                config,
-                profile,
-                dispatch_util::Persist::SaveAndSync,
-                |mp| &mut mp.content_panel.relationships.status_message,
-                format!("Request sent to {}", log_did(did)),
-                dispatch_util::SyncLog::Detailed {
-                    summary: format!("Relationship request sent to {}", log_did(did)),
-                    detail,
-                },
-            );
-        }
-        Err(e) => {
-            dispatch_util::record_error(
-                &mut state.main_page,
-                |mp| &mut mp.content_panel.relationships.status_message,
-                "Failed to send relationship request",
-                &e,
-            );
-        }
-    }
+    Ok(RelationshipJob::Create(Box::new(CreateJob {
+        tdk: tdk.clone(),
+        service: service.clone(),
+        rdid_plan,
+        persona_did,
+        persona_listener_id,
+        respondent_did: respondent_arc,
+        reason: reason.map(|s| s.to_string()),
+        friendly_name,
+        add_contact_alias,
+    })))
 }
 
-async fn handle_ping(
+/// Loop-thread preparation for `Ping`. Builds the ping message + resolves the
+/// listener (all `Config` reads), then hands the slow `send_message_with_retry`
+/// (~6 s on a dead peer) to the task. The TrustPing task + log are created in
+/// `apply` on success.
+fn prepare_ping(
     config: &mut Box<Config>,
-    tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    profile: &str,
     remote_p_did: &str,
-) {
-    let rel_key = std::sync::Arc::new(remote_p_did.to_string());
-    let (our_did_str, remote_did_str) = if let Some(rel_arc) =
-        config.private.relationships.get(&rel_key)
-        && let Ok(r) = rel_arc.lock()
-    {
-        (r.our_did.to_string(), r.remote_did.to_string())
-    } else {
-        (String::new(), String::new())
+) -> Result<RelationshipJob> {
+    let remote_key = Arc::new(remote_p_did.to_string());
+    let relationship = config
+        .private
+        .relationships
+        .get(&remote_key)
+        .ok_or_else(|| anyhow::anyhow!("No relationship found for {remote_p_did}"))?;
+    let (our_did, remote_did) = {
+        let lock = relationship
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        (Arc::clone(&lock.our_did), Arc::clone(&lock.remote_did))
     };
+    let using_rdid = !config.is_persona_did(our_did.as_str());
+    info!(our_did = %our_did, remote_did = %remote_did, is_r_did = using_rdid, "ping using relationship DIDs");
+
+    let ping_msg = build_ping_message(&our_did, &remote_did)?;
+    let msg_id = Arc::new(ping_msg.id.clone());
+    let listener_id = super::didcomm::listener_id_for_did(&our_did, config);
     let display_name = resolve_did_to_display(config, remote_p_did);
 
-    match ping_relationship(config, tdk, service, remote_p_did).await {
-        Ok(()) => {
-            state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
-            let using_rdid = !config.is_persona_did(&our_did_str);
-            dispatch_util::save_and_sync(
-                &mut state.main_page,
-                config,
-                profile,
-                dispatch_util::Persist::SaveAndSync,
-                |mp| &mut mp.content_panel.relationships.status_message,
-                "Ping sent",
-                dispatch_util::SyncLog::Detailed {
-                    summary: format!(
-                        "Trust-ping sent to {display_name}{}",
-                        if using_rdid { " (via R-DID)" } else { "" }
-                    ),
-                    detail: format!(
-                        "Trust-Ping Sent\n\
-                         ───────────────\n\
-                         To:              {display_name}\n\
-                         Sent to DID:     {remote_did_str}\n\
-                         Sent from DID:   {our_did_str}\n\
-                         Remote persona:  {remote_p_did}\n\
-                         Using R-DIDs:    {}\n\
-                         Routed via:      mediator",
-                        if using_rdid { "yes" } else { "no" },
-                    ),
-                },
-            );
-        }
-        Err(e) => {
-            state.main_page.content_panel.relationships.status_message =
-                Some(format!("Ping failed: {e:#}"));
-            state.main_page.log_detailed(
-                format!("Ping to {display_name} failed: {e}"),
-                format!(
-                    "Trust-Ping Failed\n\
-                     ─────────────────\n\
-                     To (persona):    {remote_p_did}\n\
-                     To (R-DID):      {remote_did_str}\n\
-                     From (our DID):  {our_did_str}\n\
-                     Error:           {e:#}\n\n\
-                     Debug:\n{e:?}",
-                ),
-            );
-        }
-    }
+    state.main_page.content_panel.relationships.status_message =
+        Some("Sending ping...".to_string());
+
+    Ok(RelationshipJob::Send(Box::new(RelationshipSend {
+        service: service.clone(),
+        listener_id,
+        to_did: Arc::clone(&remote_did),
+        message: Box::new(ping_msg),
+        effect: RelationshipEffect::Ping {
+            our_did,
+            remote_did,
+            remote_p_did: remote_p_did.to_string(),
+            msg_id,
+            relationship,
+            display_name,
+            using_rdid,
+        },
+    })))
 }
 
-async fn handle_remove(
+/// Loop-thread preparation for `Remove`. Extracts the R-DID listener id (if any),
+/// then the task tears the listener down; the record removal happens in `apply`.
+fn prepare_remove(
     config: &mut Box<Config>,
     service: &DIDCommService,
     state: &mut State,
-    profile: &str,
     remote_p_did: &str,
-) {
-    if let Err(e) = remove_relationship(config, service, remote_p_did).await {
-        state
-            .main_page
-            .log_error("Failed to remove relationship", &e);
-        return;
+) -> RelationshipJob {
+    let key = Arc::new(remote_p_did.to_string());
+    let listener_id = if let Some(rel_arc) = config.private.relationships.get(&key)
+        && let Ok(lock) = rel_arc.lock()
+        && !config.is_persona_did(lock.our_did.as_str())
+    {
+        Some(super::didcomm::listener_id_for_did(&lock.our_did, config))
+    } else {
+        None
+    };
+    state.main_page.content_panel.relationships.status_message =
+        Some("Removing relationship...".to_string());
+    RelationshipJob::Remove {
+        service: service.clone(),
+        listener_id,
+        remote_p_did: remote_p_did.to_string(),
     }
-    state.main_page.content_panel.relationships.mode = RelationshipsMode::List;
-    dispatch_util::save_and_sync(
-        &mut state.main_page,
-        config,
-        profile,
-        dispatch_util::Persist::SaveAndSync,
-        |mp| &mut mp.content_panel.relationships.status_message,
-        "Relationship removed",
-        dispatch_util::SyncLog::Plain("Relationship removed".to_string()),
-    );
+}
+
+/// Loop-thread preparation for `RequestVrc`. Builds the VRC-request message +
+/// resolves the listener; the task sends it and `apply` records the task on
+/// success. Mirrors the pre-R14 `credential_actions::send_vrc_request` split.
+fn prepare_request_vrc(
+    config: &mut Box<Config>,
+    service: &DIDCommService,
+    state: &mut State,
+    remote_p_did: &str,
+) -> Result<RelationshipJob> {
+    use openvtc_core::vrc::VrcRequest;
+
+    let remote_key = Arc::new(remote_p_did.to_string());
+    let relationship = config
+        .private
+        .relationships
+        .get(&remote_key)
+        .ok_or_else(|| anyhow::anyhow!("No relationship found for {remote_p_did}"))?;
+    let (our_did, remote_did) = {
+        let lock = relationship
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        (Arc::clone(&lock.our_did), Arc::clone(&lock.remote_did))
+    };
+    let message = VrcRequest { reason: None }.create_message(&remote_did, &our_did)?;
+    let msg_id = Arc::new(message.id.clone());
+    let listener_id = super::didcomm::listener_id_for_did(&our_did, config);
+    let display_name = resolve_did_to_display(config, remote_p_did);
+
+    state.main_page.content_panel.relationships.status_message =
+        Some("Requesting VRC...".to_string());
+
+    Ok(RelationshipJob::Send(Box::new(RelationshipSend {
+        service: service.clone(),
+        listener_id,
+        to_did: remote_did,
+        message: Box::new(message),
+        effect: RelationshipEffect::RequestVrc {
+            remote_p_did: remote_p_did.to_string(),
+            msg_id,
+            relationship,
+            display_name,
+        },
+    })))
 }
 
 fn handle_edit_alias(
@@ -835,47 +1274,39 @@ fn handle_edit_alias(
     );
 }
 
-async fn handle_request_vrc(
-    config: &mut Box<Config>,
-    tdk: &TDK,
-    service: &DIDCommService,
-    state: &mut State,
-    profile: &str,
-    remote_p_did: &str,
-) {
-    let display_name = resolve_did_to_display(config, remote_p_did);
-    match credential_actions::send_vrc_request(config, tdk, service, remote_p_did, None).await {
-        Ok(()) => {
-            dispatch_util::save_and_sync(
-                &mut state.main_page,
-                config,
-                profile,
-                dispatch_util::Persist::SaveAndSync,
-                |mp| &mut mp.content_panel.relationships.status_message,
-                format!("VRC requested from {display_name}"),
-                dispatch_util::SyncLog::Detailed {
-                    summary: format!("VRC requested from {display_name}"),
-                    detail: format!(
-                        "VRC Request Sent\n\
-                         ────────────────\n\
-                         To:      {display_name}\n\
-                         DID:     {remote_p_did}",
-                    ),
-                },
-            );
-        }
-        Err(e) => {
-            state.main_page.content_panel.relationships.status_message =
-                Some(format!("VRC request failed: {e:#}"));
-            state
-                .main_page
-                .log_error(format!("VRC request to {display_name} failed"), &e);
-        }
-    }
+/// Outcome of synchronously dispatching a `RelationshipAction` on the loop
+/// thread (R14). Local actions are fully `Handled` here; network actions return
+/// a `Spawn`able [`RelationshipJob`] for the loop to run off-thread, plus whether
+/// it is a ping (so the loop can stamp `ping_sent_at` for pong-latency display).
+pub(crate) enum RelationshipDispatch {
+    /// Done synchronously (nav, input, edit-alias) — nothing to background.
+    Handled,
+    /// A network job to spawn; `is_ping` drives the `ping_sent_at` latency stamp.
+    Spawn { job: RelationshipJob, is_ping: bool },
 }
 
-/// Dispatch a single `RelationshipAction`. `ping_sent_at` is updated when
-/// a Ping action runs so the main loop can correlate the inbound pong.
+/// Whether a `RelationshipAction` is a network-bound action that the loop should
+/// run off-thread (claiming the `Relationship` busy-domain first). Lets the loop
+/// reject a busy domain *before* `dispatch` does any pre-send config mutation.
+pub(crate) fn is_network(action: &RelationshipAction) -> bool {
+    matches!(
+        action,
+        RelationshipAction::SubmitRequest { .. }
+            | RelationshipAction::Ping { .. }
+            | RelationshipAction::Remove { .. }
+            | RelationshipAction::RequestVrc { .. }
+    )
+}
+
+/// Dispatch a single `RelationshipAction`.
+///
+/// Local actions mutate `state` and return [`RelationshipDispatch::Handled`].
+/// Network actions do the fast, loop-thread pre-send work (validation, contact
+/// add, R-DID path reservation, message build) and return
+/// [`RelationshipDispatch::Spawn`] for the loop to run off-thread; the post-send
+/// config mutation is applied later by [`RelationshipOutcome::apply`]. A pre-send
+/// failure is recorded as a status here and returns `Handled` (no job spawned, so
+/// the loop releases the busy-domain immediately).
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn dispatch(
     action: RelationshipAction,
@@ -883,11 +1314,9 @@ pub(crate) async fn dispatch(
     tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    state_tx: &watch::Sender<State>,
     profile: &str,
-    ping_sent_at: &mut Option<Instant>,
     admin_vta: Option<&vta_sdk::client::VtaClient>,
-) {
+) -> RelationshipDispatch {
     match action {
         RelationshipAction::Select(index) => {
             state.main_page.content_panel.relationships.selected_index = index;
@@ -916,13 +1345,11 @@ pub(crate) async fn dispatch(
             reason,
             generate_r_did,
         } => {
-            handle_submit(
+            match prepare_submit(
                 config,
                 tdk,
                 service,
                 state,
-                state_tx,
-                profile,
                 &did,
                 &alias,
                 reason.as_deref(),
@@ -930,13 +1357,38 @@ pub(crate) async fn dispatch(
                 admin_vta,
             )
             .await
+            {
+                Ok(job) => {
+                    return RelationshipDispatch::Spawn {
+                        job,
+                        is_ping: false,
+                    };
+                }
+                Err(e) => {
+                    dispatch_util::record_error(
+                        &mut state.main_page,
+                        |mp| &mut mp.content_panel.relationships.status_message,
+                        "Failed to send relationship request",
+                        &e,
+                    );
+                }
+            }
         }
         RelationshipAction::Ping { remote_p_did } => {
-            handle_ping(config, tdk, service, state, profile, &remote_p_did).await;
-            *ping_sent_at = Some(Instant::now());
+            match prepare_ping(config, service, state, &remote_p_did) {
+                Ok(job) => return RelationshipDispatch::Spawn { job, is_ping: true },
+                Err(e) => {
+                    state.main_page.content_panel.relationships.status_message =
+                        Some(format!("Ping failed: {e:#}"));
+                    state.main_page.log_error("Failed to send trust-ping", &e);
+                }
+            }
         }
         RelationshipAction::Remove { remote_p_did } => {
-            handle_remove(config, service, state, profile, &remote_p_did).await
+            return RelationshipDispatch::Spawn {
+                job: prepare_remove(config, service, state, &remote_p_did),
+                is_ping: false,
+            };
         }
         RelationshipAction::StartEditAlias {
             index,
@@ -967,7 +1419,301 @@ pub(crate) async fn dispatch(
             };
         }
         RelationshipAction::RequestVrc { remote_p_did } => {
-            handle_request_vrc(config, tdk, service, state, profile, &remote_p_did).await
+            match prepare_request_vrc(config, service, state, &remote_p_did) {
+                Ok(job) => {
+                    return RelationshipDispatch::Spawn {
+                        job,
+                        is_ping: false,
+                    };
+                }
+                Err(e) => {
+                    state.main_page.content_panel.relationships.status_message =
+                        Some(format!("VRC request failed: {e:#}"));
+                    let display_name = resolve_did_to_display(config, &remote_p_did);
+                    state
+                        .main_page
+                        .log_error(format!("VRC request to {display_name} failed"), &e);
+                }
+            }
         }
+    }
+    RelationshipDispatch::Handled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+
+    /// Build a relationship record (persona DID used as our_did, so it is *not*
+    /// an R-DID) and register it in `config`. Returns the shared Arc.
+    fn register_relationship(config: &mut Config, remote_p_did: &str) -> Arc<Mutex<RelRecord>> {
+        let key = Arc::new(remote_p_did.to_string());
+        let rel = Arc::new(Mutex::new(RelRecord {
+            task_id: Arc::new("task-1".to_string()),
+            our_did: config.persona_did_arc(),
+            remote_p_did: Arc::clone(&key),
+            remote_did: Arc::clone(&key),
+            created: Utc::now(),
+            state: RelationshipState::Established,
+        }));
+        config
+            .private
+            .relationships
+            .relationships
+            .insert(key, Arc::clone(&rel));
+        rel
+    }
+
+    /// A successful Ping outcome creates the TrustPing task + activity log and
+    /// sets the panel status to "Ping sent" — the same final state the old inline
+    /// `handle_ping` success arm produced.
+    #[test]
+    fn ping_success_applies_task_and_status() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let remote = "did:peer:remote";
+        let rel = register_relationship(&mut config, remote);
+
+        let outcome = RelationshipOutcome {
+            effect: RelationshipEffect::Ping {
+                our_did: config.persona_did_arc(),
+                remote_did: Arc::new(remote.to_string()),
+                remote_p_did: remote.to_string(),
+                msg_id: Arc::new("ping-msg".to_string()),
+                relationship: rel,
+                display_name: "Remote".to_string(),
+                using_rdid: false,
+            },
+            result: Ok(()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert_eq!(
+            state
+                .main_page
+                .content_panel
+                .relationships
+                .status_message
+                .as_deref(),
+            Some("Ping sent")
+        );
+        assert!(
+            config
+                .private
+                .tasks
+                .get_by_id(&Arc::new("ping-msg".to_string()))
+                .is_some(),
+            "a TrustPing task must be created on success"
+        );
+    }
+
+    /// A failed Ping outcome sets the "Ping failed" status and creates NO task —
+    /// matching the old inline error arm (no config mutation on a failed send).
+    #[test]
+    fn ping_failure_sets_status_and_creates_no_task() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let remote = "did:peer:remote";
+        let rel = register_relationship(&mut config, remote);
+
+        let outcome = RelationshipOutcome {
+            effect: RelationshipEffect::Ping {
+                our_did: config.persona_did_arc(),
+                remote_did: Arc::new(remote.to_string()),
+                remote_p_did: remote.to_string(),
+                msg_id: Arc::new("ping-msg".to_string()),
+                relationship: rel,
+                display_name: "Remote".to_string(),
+                using_rdid: false,
+            },
+            result: Err("dead peer".to_string()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        let status = state
+            .main_page
+            .content_panel
+            .relationships
+            .status_message
+            .clone()
+            .unwrap_or_default();
+        assert!(status.starts_with("Ping failed"), "got: {status}");
+        assert!(
+            config
+                .private
+                .tasks
+                .get_by_id(&Arc::new("ping-msg".to_string()))
+                .is_none(),
+            "no task must be created on a failed send"
+        );
+    }
+
+    /// A successful Create outcome inserts the relationship + outbound task and
+    /// records the minted R-DID key_info, reproducing the post-send tail of
+    /// `send_relationship_request`.
+    #[test]
+    fn create_success_inserts_relationship_and_keyinfo() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let respondent = Arc::new("did:peer:respondent".to_string());
+        let our_did = Arc::new("did:peer:our-rdid".to_string());
+        let key_info = vec![(
+            "z-some-key".to_string(),
+            KeyInfoConfig {
+                path: KeySourceMaterial::Derived {
+                    path: "m/3'/1'/1'/0'".to_string(),
+                },
+                create_time: Utc::now(),
+                purpose: KeyTypes::RelationshipVerification,
+            },
+        )];
+
+        let outcome = RelationshipOutcome {
+            effect: RelationshipEffect::Create {
+                respondent_did: Arc::clone(&respondent),
+                our_did,
+                msg_id: Arc::new("req-msg".to_string()),
+                used_r_did: true,
+                key_info,
+                contact_to_add: Some(Some("Respondent".to_string())),
+            },
+            result: Ok(()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert!(
+            config.private.relationships.get(&respondent).is_some(),
+            "relationship record inserted on success"
+        );
+        assert!(
+            config.key_info.contains_key("z-some-key"),
+            "minted R-DID key_info recorded"
+        );
+        assert_eq!(
+            state
+                .main_page
+                .content_panel
+                .relationships
+                .status_message
+                .as_deref(),
+            Some("Request sent to did:peer:respondent")
+        );
+    }
+
+    /// A failed Create still records the minted key_info in-memory (matching the
+    /// pre-R14 ordering where key creation happened before the send) but inserts
+    /// NO relationship record, and surfaces the error status.
+    #[test]
+    fn create_failure_records_keyinfo_but_no_relationship() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let respondent = Arc::new("did:peer:respondent".to_string());
+
+        let outcome = RelationshipOutcome {
+            effect: RelationshipEffect::Create {
+                respondent_did: Arc::clone(&respondent),
+                our_did: Arc::new("did:peer:our-rdid".to_string()),
+                msg_id: Arc::new("req-msg".to_string()),
+                used_r_did: true,
+                key_info: vec![(
+                    "z-orphan".to_string(),
+                    KeyInfoConfig {
+                        path: KeySourceMaterial::Derived {
+                            path: "m/3'/1'/1'/0'".to_string(),
+                        },
+                        create_time: Utc::now(),
+                        purpose: KeyTypes::RelationshipVerification,
+                    },
+                )],
+                contact_to_add: None,
+            },
+            result: Err("send failed".to_string()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert!(
+            config.private.relationships.get(&respondent).is_none(),
+            "no relationship on a failed send"
+        );
+        assert!(
+            config.key_info.contains_key("z-orphan"),
+            "key_info recorded in-memory even on failure (matches pre-R14)"
+        );
+        let status = state
+            .main_page
+            .content_panel
+            .relationships
+            .status_message
+            .clone()
+            .unwrap_or_default();
+        assert!(status.starts_with("Error:"), "got: {status}");
+    }
+
+    /// A Remove outcome removes the relationship record and sets the status —
+    /// the post-`remove_listener` tail of `remove_relationship` + `handle_remove`.
+    #[test]
+    fn remove_applies_record_removal() {
+        let mut config = test_config();
+        let mut state = State::default();
+        let remote = "did:peer:remote";
+        register_relationship(&mut config, remote);
+
+        let outcome = RelationshipOutcome {
+            effect: RelationshipEffect::Remove {
+                remote_p_did: remote.to_string(),
+            },
+            result: Ok(()),
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert!(
+            config
+                .private
+                .relationships
+                .get(&Arc::new(remote.to_string()))
+                .is_none(),
+            "relationship removed"
+        );
+        assert_eq!(
+            state
+                .main_page
+                .content_panel
+                .relationships
+                .status_message
+                .as_deref(),
+            Some("Relationship removed")
+        );
+    }
+
+    /// `DidDeleteOutcome::apply` removes the persona / identity / key_info and
+    /// logs — the local-cleanup tail of the old inline `delete_context_did`.
+    #[test]
+    fn did_delete_applies_local_cleanup() {
+        use openvtc_core::config::account::PersonaId;
+        let mut config = test_config();
+        let mut state = State::default();
+        config.key_info.insert(
+            "z-persona-key".to_string(),
+            KeyInfoConfig {
+                path: KeySourceMaterial::Derived {
+                    path: "m/0'".to_string(),
+                },
+                create_time: Utc::now(),
+                purpose: KeyTypes::PersonaSigning,
+            },
+        );
+
+        let outcome = DidDeleteOutcome {
+            did: "did:webvh:example".to_string(),
+            persona_id: PersonaId::new(),
+            key_ids: vec!["z-persona-key".to_string()],
+        };
+        outcome.apply(&mut state, &mut config, "test");
+
+        assert!(
+            !config.key_info.contains_key("z-persona-key"),
+            "key_info entry removed"
+        );
     }
 }


### PR DESCRIPTION
**Task R14** (remediation plan, Phase R2 — responsiveness). Builds on the PR #92 background-dispatch mechanism.

## What
Migrates the remaining inline-awaited network dispatches off the `tokio::select!` event loop onto the R13 prepare→spawn(I/O)→`apply_outcome` pattern:
- **Relationship**: create (VTA R-DID mint + send), ping (`send_message_with_retry` ≈ 6s on a dead peer), remove, request-VRC.
- **Inbox**: accept/reject relationship, accept/reject VRC request.
- **delete-DID**: `delete_did_webvh` + listener teardown.

New `DispatchDomain` variants `Relationship`/`Inbox`/`Did` (conservative one-in-flight-per-domain; a second same-domain action is rejected with a status). New `DispatchOutcome` variants apply on the loop thread, reusing the PR #89 `dispatch_util` helpers. Local-only handlers (edit-alias, stored-VRC accept, dismiss, nav) stay synchronous. Mutation stays on the loop thread; spawned jobs do I/O only and return owned data.

Result: ping-to-dead-peer and accept-relationship no longer freeze the UI; nav + `q`/Exit + inbound DIDComm drain stay live throughout.

## Ordering/durability
Post-network config writes (relationship/task records, issued-VRC store, key_info) happen in `apply_outcome` on the loop thread; success/error final state matches pre-R14 (verified against `git show main:` for every migrated handler). Accept-relationship key material is minted in the task, recorded to `config.key_info` in `apply` (in-memory on both paths, persisted only on the success save — matching the old pre-send in-memory behavior).

## Review fixes folded in (commit 2)
A code review found one regression + two hardening gaps, all fixed here:
- **Create-path accept-race (correctness):** the send now runs off-loop, so a peer's `RelationshipRequestAccepted` could arrive before the Create outcome was applied and be dropped (relationship stuck at `RequestSent`). Fixed by pre-inserting a provisional `RequestSent` record (keyed by the respondent DID, so the inbound handler's `get(from_did)` fallback finds it) in `prepare_submit`; success-apply **guards against clobbering** a state a racing accept already advanced to `Established` (updates `our_did` only, no stale task); failure-apply removes the provisional record (peer never received the request, so no accept can race) — net failure state identical to pre-R14.
- **Doc accuracy:** corrected the `apply_outcome` doc re: key_info/record on the failure path.
- **Panic resilience:** a panicking spawned job previously left its domain busy forever; added `DispatchOutcome::Panicked` + a `spawn_dispatch` wrapper that converts a `JoinError` into a synthetic failure outcome that clears the flag. All four spawn sites route through it.

## Tests
Per-domain busy-guard; pure-`apply` success+error for each outcome; **`create_success_does_not_clobber_raced_established`** (race guard); panic→`Panicked` outcome + flag-clear. Coverage boundary: no live VTA/mediator, so live async paths aren't end-to-end exercised; coverage is the pure outcome-application + busy-guard + the interleaving pattern (per R13).

Gate: `fmt` / `clippy -D warnings` / `test --workspace` green (112 bin unit tests).
