### PR TITLE
feat(state): coalesce + offload Config::save off the event loop

### DIFF
--- a/openvtc-core/src/config/saving.rs
+++ b/openvtc-core/src/config/saving.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     config::{
-        Config, ConfigProtectionType, ExportedConfig,
+        Config, ConfigProtectionType, ExportedConfig, KeyBackend,
         public_config::PublicConfig,
         secured_config::{SecuredConfig, passphrase_encrypt_v2},
     },
@@ -10,13 +10,109 @@ use crate::{
     logs::LogFamily,
 };
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
-use secrecy::{ExposeSecret, SecretString};
+use ed25519_dalek_bip32::ExtendedSigningKey;
+use secrecy::{ExposeSecret, SecretBox, SecretString};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::{fs, sync::Arc};
+use std::{collections::BTreeMap, fs, sync::Arc};
 use tracing::warn;
 
+/// Deep-clone a [`KeyBackend`] for a save snapshot.
+///
+/// Re-wraps the non-`Clone` `SecretBox<Vec<u8>>` encryption seed by value, and
+/// rebuilds the non-`Clone` BIP32 `ExtendedSigningKey` root from the stored
+/// base64url seed exactly as the load path does
+/// ([`crate::config::Config::load_step2`]). Used by [`Config::clone_for_save`]
+/// to build an owned, `Send`-able save snapshot.
+///
+/// # Errors
+///
+/// Returns [`OpenVTCError::BIP32`] if the stored seed cannot be decoded or the
+/// root cannot be re-derived from it.
+fn clone_key_backend(backend: &KeyBackend) -> Result<KeyBackend, OpenVTCError> {
+    Ok(match backend {
+        KeyBackend::Bip32 { seed, .. } => {
+            // The `ExtendedSigningKey` root is not `Clone` (ed25519-dalek-bip32
+            // 0.3), so reconstruct it from the persisted seed, mirroring the load
+            // path. The seed is the source of truth and the root is a pure
+            // function of it, so the snapshot's root is identical to the live one.
+            let root = ExtendedSigningKey::from_seed(
+                BASE64_URL_SAFE_NO_PAD
+                    .decode(seed.expose_secret())
+                    .map_err(|e| {
+                        OpenVTCError::BIP32(format!("Couldn't decode BIP32 seed for save: {e}"))
+                    })?
+                    .as_slice(),
+            )
+            .map_err(|e| {
+                OpenVTCError::BIP32(format!("Couldn't rebuild BIP32 root for save: {e}"))
+            })?;
+            KeyBackend::Bip32 {
+                root,
+                seed: seed.clone(),
+            }
+        }
+        KeyBackend::Vta {
+            credential_bundle,
+            credential_did,
+            credential_private_key,
+            vta_did,
+            vta_url,
+            mediator_did,
+            encryption_seed,
+        } => KeyBackend::Vta {
+            credential_bundle: credential_bundle.clone(),
+            credential_did: credential_did.clone(),
+            credential_private_key: credential_private_key.clone(),
+            vta_did: vta_did.clone(),
+            vta_url: vta_url.clone(),
+            mediator_did: mediator_did.clone(),
+            encryption_seed: SecretBox::new(Box::new(encryption_seed.expose_secret().clone())),
+        },
+    })
+}
+
 impl Config {
+    /// Produce an owned, `Send + 'static` snapshot of everything [`Config::save`]
+    /// reads, so the (blocking) serialize + encrypt + file/keyring/card I/O can be
+    /// moved off the async runtime onto a `spawn_blocking` thread (R11).
+    ///
+    /// `Config` is deliberately not `Clone` (it holds non-`Clone`
+    /// `SecretBox<Vec<u8>>` secrets and runtime-only `identities`), so this
+    /// deep-clones the persisted tiers and re-wraps the secret material by value.
+    /// The `identities` map is *not* persisted — it is rebuilt at load — so it is
+    /// dropped from the snapshot (replaced with an empty map) rather than cloned.
+    ///
+    /// The snapshot is taken on the loop thread (the single mutator) and then
+    /// owned by the blocking closure: the live `Config` is never borrowed across
+    /// an `.await`, preserving the single-mutator / unidirectional-data-flow
+    /// invariant.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OpenVTCError::BIP32`] if a BIP32 backend's root cannot be
+    /// rebuilt from its seed (the same failure the load path would surface).
+    pub fn clone_for_save(&self) -> Result<Config, OpenVTCError> {
+        Ok(Config {
+            public: self.public.clone(),
+            private: self.private.clone(),
+            key_backend: clone_key_backend(&self.key_backend)?,
+            key_info: self.key_info.clone(),
+            protection_method: self.protection_method.clone(),
+            #[cfg(feature = "openpgp-card")]
+            token_admin_pin: self.token_admin_pin.clone(),
+            #[cfg(feature = "openpgp-card")]
+            token_user_pin: self.token_user_pin.clone(),
+            unlock_code: self
+                .unlock_code
+                .as_ref()
+                .map(|s| SecretBox::new(Box::new(s.expose_secret().clone()))),
+            account: self.account.clone(),
+            // Runtime-only; rebuilt at load and unused by `save`.
+            identities: BTreeMap::new(),
+        })
+    }
+
     /// Persists the full configuration (public, protected, and secured) to disk.
     ///
     /// - `profile`: Configuration profile name (determines file paths).

--- a/openvtc-core/src/config/saving.rs
+++ b/openvtc-core/src/config/saving.rs
@@ -88,6 +88,16 @@ impl Config {
     /// an `.await`, preserving the single-mutator / unidirectional-data-flow
     /// invariant.
     ///
+    /// Note: the per-record `Arc<Mutex<Relationship>>` / `Arc<Mutex<Task>>` inside
+    /// the protected tier are clone-of-`Arc` (the snapshot *shares* those Mutexes
+    /// with the live config), not deep copies. This is intentional and safe: each
+    /// record's `Mutex` gives per-record exclusion, so a concurrent loop-thread
+    /// mutation can never tear a single record mid-serialize; and any post-snapshot
+    /// mutation re-runs `mark_dirty()`, so cross-record skew self-heals via the next
+    /// coalesced save (and the shutdown force-flush captures the final state). The
+    /// loop never holds a record lock across the `.await` where a save is spawned,
+    /// so there is no deadlock between the save thread and the loop.
+    ///
     /// # Errors
     ///
     /// Returns [`OpenVTCError::BIP32`] if a BIP32 backend's root cannot be

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -88,6 +88,11 @@ linux-keyutils-keyring-store.workspace = true
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store.workspace = true
 
+[dev-dependencies]
+# `test-util` enables tokio's paused clock (`start_paused`) used by the R11
+# save-coalescing debounce tests; test-only, not pulled into the binary build.
+tokio = { workspace = true, features = ["test-util"] }
+
 [[bin]]
 name = "openvtc"
 path = "src/main.rs"

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -36,6 +36,7 @@ use openvtc_core::config::Config;
 use crate::state_handler::didcomm::ReconnectOutcome;
 use crate::state_handler::inbox_actions::InboxOutcome;
 use crate::state_handler::relationship_actions::{DidDeleteOutcome, RelationshipOutcome};
+use crate::state_handler::save_coalesce::SaveScheduler;
 use crate::state_handler::state::{self, State};
 
 /// A domain that can have at most one background dispatch in flight at a time.
@@ -215,7 +216,7 @@ pub(crate) fn spawn_dispatch<F>(
 pub(crate) fn apply_outcome(
     state: &mut State,
     config: &mut Config,
-    profile: &str,
+    save: &mut SaveScheduler,
     in_flight: &mut InFlight,
     outcome: DispatchOutcome,
 ) {
@@ -232,9 +233,9 @@ pub(crate) fn apply_outcome(
                 state.main_page.log(format!("Reconnect failed: {reason}"));
             }
         },
-        DispatchOutcome::Relationship(outcome) => outcome.apply(state, config, profile),
-        DispatchOutcome::Inbox(outcome) => outcome.apply(state, config, profile),
-        DispatchOutcome::Did(outcome) => outcome.apply(state, config, profile),
+        DispatchOutcome::Relationship(outcome) => outcome.apply(state, config, save),
+        DispatchOutcome::Inbox(outcome) => outcome.apply(state, config, save),
+        DispatchOutcome::Did(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Panicked(domain) => {
             // The job panicked and produced no real outcome. Surface a generic
             // failure so the user isn't left staring at a stuck "in progress"; the
@@ -314,13 +315,14 @@ mod tests {
     fn apply_connected_outcome_sets_connected_and_clears_flag() {
         let mut state = State::default();
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut in_flight = InFlight::default();
         assert!(in_flight.try_begin(DispatchDomain::Mediator));
 
         apply_outcome(
             &mut state,
             &mut config,
-            "test",
+            &mut save,
             &mut in_flight,
             DispatchOutcome::MediatorReconnect(ReconnectOutcome::Connected),
         );
@@ -342,13 +344,14 @@ mod tests {
     fn apply_failed_outcome_sets_failed_and_clears_flag() {
         let mut state = State::default();
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut in_flight = InFlight::default();
         assert!(in_flight.try_begin(DispatchDomain::Mediator));
 
         apply_outcome(
             &mut state,
             &mut config,
-            "test",
+            &mut save,
             &mut in_flight,
             DispatchOutcome::MediatorReconnect(ReconnectOutcome::Failed("dead mediator".into())),
         );
@@ -369,13 +372,14 @@ mod tests {
     fn apply_panicked_outcome_clears_flag() {
         let mut state = State::default();
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut in_flight = InFlight::default();
         assert!(in_flight.try_begin(DispatchDomain::Relationship));
 
         apply_outcome(
             &mut state,
             &mut config,
-            "test",
+            &mut save,
             &mut in_flight,
             DispatchOutcome::Panicked(DispatchDomain::Relationship),
         );
@@ -438,6 +442,7 @@ mod tests {
 
         let mut state = State::default();
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut in_flight = InFlight::default();
 
         // Begin a dispatch (busy-flag set) and spawn its "I/O" — it parks on the
@@ -477,7 +482,7 @@ mod tests {
                     }
                 }
                 Some(outcome) = dispatch_rx.recv() => {
-                    apply_outcome(&mut state, &mut config, "test", &mut in_flight, outcome);
+                    apply_outcome(&mut state, &mut config, &mut save, &mut in_flight, outcome);
                 }
             }
         };

--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -80,6 +80,7 @@ use crate::state_handler::{
     actions::CredentialAction,
     dispatch_util, log_did,
     main_page::content::{CredentialTab, CredentialsMode},
+    save_coalesce::SaveScheduler,
     state::State,
 };
 
@@ -145,7 +146,7 @@ async fn handle_submit_request(
     tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    profile: &str,
+    save: &mut SaveScheduler,
     relationship_p_did: &str,
     reason: Option<&str>,
 ) {
@@ -155,7 +156,7 @@ async fn handle_submit_request(
             dispatch_util::save_and_sync(
                 &mut state.main_page,
                 config,
-                profile,
+                save,
                 dispatch_util::Persist::SaveAndSync,
                 |mp| &mut mp.content_panel.credentials.status_message,
                 format!("VRC request sent to {}", log_did(relationship_p_did)),
@@ -176,7 +177,12 @@ async fn handle_submit_request(
     }
 }
 
-fn handle_remove(config: &mut Box<Config>, state: &mut State, profile: &str, vrc_id: &str) {
+fn handle_remove(
+    config: &mut Box<Config>,
+    state: &mut State,
+    save: &mut SaveScheduler,
+    vrc_id: &str,
+) {
     if let Err(e) = remove_vrc(config, vrc_id) {
         state.main_page.log_error("Failed to remove VRC", &e);
         return;
@@ -186,7 +192,7 @@ fn handle_remove(config: &mut Box<Config>, state: &mut State, profile: &str, vrc
     dispatch_util::save_and_sync(
         &mut state.main_page,
         config,
-        profile,
+        save,
         dispatch_util::Persist::SaveAndSync,
         |mp| &mut mp.content_panel.credentials.status_message,
         "VRC removed",
@@ -201,7 +207,7 @@ pub(crate) async fn dispatch(
     tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    profile: &str,
+    save: &mut SaveScheduler,
 ) {
     match action {
         CredentialAction::SwitchTab => handle_switch_tab(state),
@@ -222,12 +228,12 @@ pub(crate) async fn dispatch(
                 tdk,
                 service,
                 state,
-                profile,
+                save,
                 &relationship_p_did,
                 reason.as_deref(),
             )
             .await
         }
-        CredentialAction::Remove { vrc_id } => handle_remove(config, state, profile, &vrc_id),
+        CredentialAction::Remove { vrc_id } => handle_remove(config, state, save, &vrc_id),
     }
 }

--- a/openvtc/src/state_handler/dispatch_util.rs
+++ b/openvtc/src/state_handler/dispatch_util.rs
@@ -17,7 +17,7 @@
 use openvtc_core::config::Config;
 
 use crate::state_handler::main_page::MainPageState;
-use crate::state_handler::settings_actions;
+use crate::state_handler::save_coalesce::SaveScheduler;
 
 /// Activity-log entry to write after an action completes.
 pub(crate) enum SyncLog {
@@ -38,21 +38,26 @@ impl SyncLog {
 
 /// How to persist + refresh UI after a successful action.
 pub(crate) enum Persist {
-    /// Save the config (logging on failure), then sync UI from config.
+    /// Request a **coalesced** save (mark the config dirty — R11), then sync UI
+    /// from config immediately. The persistence is debounced + offloaded to a
+    /// blocking thread by the loop's [`SaveScheduler`]; the UI rebuild still
+    /// happens synchronously on the loop thread, exactly as before.
     SaveAndSync,
-    /// The action already saved the config itself; only sync UI from config.
+    /// The action already requested/performed the save itself; only sync UI from
+    /// config.
     SyncOnly,
-    /// The action already saved the config and no UI sync is required.
+    /// The action already requested/performed the save and no UI sync is required.
     None,
 }
 
 impl Persist {
-    fn apply(self, main_page: &mut MainPageState, config: &Config, profile: &str) {
+    fn apply(self, main_page: &mut MainPageState, config: &Config, save: &mut SaveScheduler) {
         match self {
+            // R11: was a synchronous `Config::save` on the loop thread. Now it
+            // only marks the config dirty — the actual save is debounced and run
+            // on a blocking thread. The UI sync stays immediate.
             Persist::SaveAndSync => {
-                if let Err(e) = settings_actions::save_config(config, profile) {
-                    main_page.log_error("Failed to save config", &e);
-                }
+                save.mark_dirty();
                 main_page.sync_from_config(config);
             }
             Persist::SyncOnly => main_page.sync_from_config(config),
@@ -66,17 +71,21 @@ impl Persist {
 ///
 /// `status` returns a mutable reference to the panel's status slot, e.g.
 /// `|mp| &mut mp.content_panel.inbox.status_message`.
+///
+/// R11: `save` is the loop's coalescing scheduler. A `Persist::SaveAndSync`
+/// marks it dirty rather than saving inline; the loop persists later (debounced,
+/// off the runtime).
 pub(crate) fn save_and_sync(
     main_page: &mut MainPageState,
     config: &Config,
-    profile: &str,
+    save: &mut SaveScheduler,
     persist: Persist,
     status: impl FnOnce(&mut MainPageState) -> &mut Option<String>,
     success_status: impl Into<String>,
     log: SyncLog,
 ) {
     *status(main_page) = Some(success_status.into());
-    persist.apply(main_page, config, profile);
+    persist.apply(main_page, config, save);
     log.write(main_page);
 }
 

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -132,7 +132,7 @@ use crate::state_handler::{
     actions::InboxAction,
     dispatch_util,
     main_page::content::{ActiveTaskView, TaskKind},
-    settings_actions,
+    save_coalesce::SaveScheduler,
     state::State,
 };
 
@@ -191,7 +191,7 @@ fn handle_inbox_open_detail(state: &mut State, index: usize) {
 fn save_and_sync(
     config: &Config,
     state: &mut State,
-    profile: &str,
+    save: &mut SaveScheduler,
     success_status: &str,
     success_log: &str,
 ) {
@@ -199,7 +199,7 @@ fn save_and_sync(
     dispatch_util::save_and_sync(
         &mut state.main_page,
         config,
-        profile,
+        save,
         dispatch_util::Persist::SaveAndSync,
         |mp| &mut mp.content_panel.inbox.status_message,
         success_status.to_string(),
@@ -216,12 +216,17 @@ fn record_error(state: &mut State, context: &str, err: &anyhow::Error) {
     );
 }
 
-fn handle_accept_vrc(config: &mut Box<Config>, state: &mut State, profile: &str, task_id: &str) {
+fn handle_accept_vrc(
+    config: &mut Box<Config>,
+    state: &mut State,
+    save: &mut SaveScheduler,
+    task_id: &str,
+) {
     match accept_vrc(config, task_id) {
         Ok(()) => save_and_sync(
             config,
             state,
-            profile,
+            save,
             "VRC accepted and stored",
             "VRC accepted and stored",
         ),
@@ -390,7 +395,7 @@ impl InboxOutcome {
     /// Apply the post-send mutation on the loop thread, reproducing the old
     /// inline success/error block. The status slot is `inbox.status_message`; on
     /// success the active task is cleared (as `save_and_sync` did before).
-    pub(crate) fn apply(self, state: &mut State, config: &mut Config, profile: &str) {
+    pub(crate) fn apply(self, state: &mut State, config: &mut Config, save: &mut SaveScheduler) {
         match self.effect {
             InboxEffect::AcceptRelationship {
                 task_id,
@@ -426,7 +431,7 @@ impl InboxOutcome {
                         save_and_sync(
                             config,
                             state,
-                            profile,
+                            save,
                             "Relationship request accepted",
                             "Accepted relationship request",
                         );
@@ -456,7 +461,7 @@ impl InboxOutcome {
                     save_and_sync(
                         config,
                         state,
-                        profile,
+                        save,
                         "Relationship request rejected",
                         "Rejected relationship request",
                     );
@@ -492,7 +497,7 @@ impl InboxOutcome {
                     save_and_sync(
                         config,
                         state,
-                        profile,
+                        save,
                         "VRC issued and sent",
                         "VRC issued and sent",
                     );
@@ -521,7 +526,7 @@ impl InboxOutcome {
                     save_and_sync(
                         config,
                         state,
-                        profile,
+                        save,
                         "VRC request rejected",
                         "Rejected VRC request",
                     );
@@ -807,28 +812,31 @@ fn prepare_reject_vrc_request(
     }))
 }
 
-fn handle_dismiss_task(config: &mut Box<Config>, state: &mut State, profile: &str, task_id: &str) {
+fn handle_dismiss_task(
+    config: &mut Box<Config>,
+    state: &mut State,
+    save: &mut SaveScheduler,
+    task_id: &str,
+) {
     if let Err(e) = dismiss_task(config, task_id) {
         state.main_page.log_error("Failed to dismiss task", &e);
         return;
     }
     state.main_page.content_panel.inbox.active_task = None;
-    if let Err(e) = settings_actions::save_config(config, profile) {
-        state.main_page.log_error("Failed to save config", &e);
-    }
+    // R11: coalesced save (was inline `save_config`).
+    save.mark_dirty();
     state.main_page.sync_from_config(config);
     state.main_page.log("Task dismissed");
 }
 
-fn handle_clear_all(config: &mut Box<Config>, state: &mut State, profile: &str) {
+fn handle_clear_all(config: &mut Box<Config>, state: &mut State, save: &mut SaveScheduler) {
     if let Err(e) = clear_all_tasks(config) {
         state.main_page.log_error("Failed to clear inbox", &e);
         return;
     }
     state.main_page.content_panel.inbox.active_task = None;
-    if let Err(e) = settings_actions::save_config(config, profile) {
-        state.main_page.log_error("Failed to save config", &e);
-    }
+    // R11: coalesced save (was inline `save_config`).
+    save.mark_dirty();
     state.main_page.sync_from_config(config);
     state.main_page.log("All inbox tasks cleared");
 }
@@ -867,10 +875,9 @@ pub(crate) async fn dispatch(
     tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    profile: &str,
+    save: &mut SaveScheduler,
     admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) -> InboxDispatch {
-    let _ = profile;
     match action {
         InboxAction::SelectTask(index) => handle_inbox_select(state, index),
         InboxAction::OpenDetail(index) => handle_inbox_open_detail(state, index),
@@ -902,7 +909,7 @@ pub(crate) async fn dispatch(
                 Err(e) => record_error(state, "Failed to reject relationship", &e),
             }
         }
-        InboxAction::AcceptVrc { task_id } => handle_accept_vrc(config, state, profile, &task_id),
+        InboxAction::AcceptVrc { task_id } => handle_accept_vrc(config, state, save, &task_id),
         InboxAction::AcceptVrcRequest { task_id } => {
             match prepare_accept_vrc_request(config, tdk, service, state, &task_id).await {
                 Ok(job) => return InboxDispatch::Spawn(job),
@@ -915,10 +922,8 @@ pub(crate) async fn dispatch(
                 Err(e) => record_error(state, "Failed to reject VRC request", &e),
             }
         }
-        InboxAction::DismissTask { task_id } => {
-            handle_dismiss_task(config, state, profile, &task_id)
-        }
-        InboxAction::ClearAll => handle_clear_all(config, state, profile),
+        InboxAction::DismissTask { task_id } => handle_dismiss_task(config, state, save, &task_id),
+        InboxAction::ClearAll => handle_clear_all(config, state, save),
     }
     InboxDispatch::Handled
 }
@@ -934,6 +939,7 @@ mod r14_tests {
     #[test]
     fn accept_relationship_success_inserts_relationship() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let from = Arc::new("did:peer:from".to_string());
         let task_id = Arc::new("task-acc".to_string());
@@ -961,7 +967,7 @@ mod r14_tests {
             },
             result: Ok(()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         assert!(
             config.private.relationships.get(&from).is_some(),
@@ -988,6 +994,7 @@ mod r14_tests {
     #[test]
     fn accept_relationship_failure_keeps_task_and_no_relationship() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let from = Arc::new("did:peer:from".to_string());
         let task_id = Arc::new("task-acc".to_string());
@@ -1006,7 +1013,7 @@ mod r14_tests {
             },
             result: Err("send failed".to_string()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         assert!(
             config.private.relationships.get(&from).is_none(),
@@ -1030,6 +1037,7 @@ mod r14_tests {
     #[test]
     fn reject_relationship_success_removes_task() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let task_id = Arc::new("task-rej".to_string());
         config
@@ -1045,7 +1053,7 @@ mod r14_tests {
             },
             result: Ok(()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         assert!(config.private.tasks.get_by_id(&task_id).is_none());
         assert_eq!(
@@ -1063,6 +1071,7 @@ mod r14_tests {
     #[test]
     fn reject_relationship_failure_keeps_task() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let task_id = Arc::new("task-rej".to_string());
         config
@@ -1078,7 +1087,7 @@ mod r14_tests {
             },
             result: Err("send failed".to_string()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         assert!(
             config.private.tasks.get_by_id(&task_id).is_some(),

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1161,7 +1161,9 @@ impl StateHandler {
                     match &result {
                         Ok(()) => {}
                         Err(reason) => {
-                            state.main_page.log(format!("Failed to save config: {reason}"));
+                            state
+                                .main_page
+                                .log_error("Failed to save config", &anyhow::anyhow!("{reason}"));
                         }
                     }
                     save.finish(result.is_ok());
@@ -1174,6 +1176,21 @@ impl StateHandler {
             }
             let _ = self.state_tx.send(state.clone());
         };
+
+        // R11: if a backgrounded coalesced save was still running when the loop
+        // broke, wait for it to complete before the force-flush below. A
+        // `spawn_blocking` task is NOT cancelled when its `JoinHandle` is dropped,
+        // so that save is still live; running the shutdown save concurrently would
+        // mean two `Config::save`s racing the same (non-atomic) file + keyring
+        // writes. Draining the completion channel serialises shutdown after it.
+        // After `finish`, `needs_flush()` is only still true if the config was
+        // dirtied *after* the in-flight save's snapshot — exactly what the
+        // force-flush must persist.
+        if save.in_flight()
+            && let Some(result) = save_done_rx.recv().await
+        {
+            save.finish(result.is_ok());
+        }
 
         // R11 force-flush: persist the latest state before tearing down, so
         // coalescing never loses the final mutation on Exit/interrupt. Runs a

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -60,6 +60,7 @@ mod join_flow;
 pub mod main_page;
 mod message_dispatch;
 mod relationship_actions;
+mod save_coalesce;
 mod settings_actions;
 mod setup_did_actions;
 mod setup_did_git_sign_actions;
@@ -580,6 +581,18 @@ impl StateHandler {
             mpsc::unbounded_channel::<background_dispatch::DispatchOutcome>();
         let mut in_flight = background_dispatch::InFlight::default();
 
+        // Coalesced + offloaded config persistence (R11). Mutation sites mark the
+        // config dirty on the loop thread instead of saving inline; the
+        // `deadline` arm below debounces a burst into a single `spawn_blocking`
+        // save, with at most one in flight at a time. Durability-critical points
+        // (Exit, passphrase/protection change, export) force-flush synchronously.
+        let mut save = save_coalesce::SaveScheduler::new(self.profile.clone());
+        // Channel carrying a completed background save's success flag, so the loop
+        // can clear the in-flight flag and re-arm if the config was dirtied again
+        // while the save ran. Save failures are surfaced as a status/log here,
+        // matching the pre-R11 inline `save_config` failure handling.
+        let (save_done_tx, mut save_done_rx) = mpsc::unbounded_channel::<Result<(), String>>();
+
         let result = loop {
             tokio::select! {
                 Some(action) = action_rx.recv() => match action {
@@ -612,7 +625,7 @@ impl StateHandler {
                             .communities_for_display(false)
                             .get(i)
                             .map(|c| c.persona_ref);
-                        self.remove_community(&mut state, &mut config, i);
+                        self.remove_community(&mut state, &mut config, &mut save, i);
                         // A deleted community must not leave its persona's
                         // mediator connection running. If that persona no longer
                         // has any live community, stop and remove its listener so
@@ -727,7 +740,7 @@ impl StateHandler {
                                     &tdk,
                                     &didcomm_service,
                                     &mut state,
-                                    &self.profile,
+                                    &mut save,
                                     admin_vta.as_ref(),
                                 )
                                 .await
@@ -757,7 +770,7 @@ impl StateHandler {
                                 &tdk,
                                 &didcomm_service,
                                 &mut state,
-                                &self.profile,
+                                &mut save,
                                 admin_vta.as_ref(),
                             )
                             .await;
@@ -786,7 +799,7 @@ impl StateHandler {
                                     &tdk,
                                     &didcomm_service,
                                     &mut state,
-                                    &self.profile,
+                                    &mut save,
                                     admin_vta.as_ref(),
                                 )
                                 .await
@@ -820,7 +833,7 @@ impl StateHandler {
                                 &tdk,
                                 &didcomm_service,
                                 &mut state,
-                                &self.profile,
+                                &mut save,
                                 admin_vta.as_ref(),
                             )
                             .await;
@@ -833,7 +846,7 @@ impl StateHandler {
                             &tdk,
                             &didcomm_service,
                             &mut state,
-                            &self.profile,
+                            &mut save,
                         )
                         .await;
                     },
@@ -842,6 +855,7 @@ impl StateHandler {
                             sa,
                             &mut config,
                             &mut state,
+                            &mut save,
                             &self.profile,
                         )
                         .await
@@ -924,9 +938,13 @@ impl StateHandler {
                             .await
                             {
                                 Ok(true) => {
-                                    if let Err(e) = settings_actions::save_config(&config, &self.profile) {
-                                        state.main_page.log_error("Failed to save config", &e);
-                                    }
+                                    // R11: a config-mutating inbound message used
+                                    // to save inline here — the per-message cost
+                                    // that turned a mediator redelivery burst into
+                                    // N sequential keyring+file+card writes. Now we
+                                    // mark dirty (coalesced + offloaded); the UI
+                                    // sync stays immediate.
+                                    save.mark_dirty();
                                     state.main_page.sync_from_config(&config);
                                     // Extract short type name for summary
                                     let short_type = msg_type.rsplit('/').next().unwrap_or(&msg_type);
@@ -1074,7 +1092,7 @@ impl StateHandler {
                     background_dispatch::apply_outcome(
                         &mut state,
                         &mut config,
-                        &self.profile,
+                        &mut save,
                         &mut in_flight,
                         outcome,
                     );
@@ -1109,6 +1127,45 @@ impl StateHandler {
                         }
                     }
                 },
+                // Coalesced-save debounce (R11). Fires when the debounce window
+                // since the first dirty mark of a burst elapses. Builds an owned
+                // snapshot on this (the single mutator) thread and runs the heavy
+                // serialize+encrypt+keyring+card I/O on a blocking thread so the
+                // loop stays responsive. At most one save is in flight; a mark
+                // that lands while a save runs is re-scheduled on completion.
+                // When nothing is scheduled the arm parks forever (no busy-wait).
+                _ = save.wait_deadline() => {
+                    match save.take_for_save(|| config.clone_for_save()) {
+                        Ok(Ok(pending)) => {
+                            let done_tx = save_done_tx.clone();
+                            tokio::task::spawn_blocking(move || {
+                                let result = pending.run().map_err(|e| format!("{e}"));
+                                let _ = done_tx.send(result);
+                            });
+                        }
+                        // Snapshot failed: surface like an inline save failure.
+                        // The scheduler kept the config dirty + re-armed, so it
+                        // retries on the next deadline.
+                        Ok(Err(e)) => {
+                            state.main_page.log_error("Failed to save config", &e);
+                        }
+                        // NotDirty / InFlight — nothing to start right now.
+                        Err(_) => {}
+                    }
+                },
+                // A backgrounded coalesced save finished (R11). Clear the
+                // in-flight flag and re-arm if the config was dirtied again. A
+                // failed save is surfaced exactly as the old inline `save_config`
+                // failure did (status + log) and left dirty for retry.
+                Some(result) = save_done_rx.recv() => {
+                    match &result {
+                        Ok(()) => {}
+                        Err(reason) => {
+                            state.main_page.log(format!("Failed to save config: {reason}"));
+                        }
+                    }
+                    save.finish(result.is_ok());
+                },
                 // (keepalive removed — WebSocket-level pings handle connectivity)
                 // Catch and handle interrupt signal to gracefully shutdown
                 Ok(interrupted) = interrupt_rx.recv() => {
@@ -1117,6 +1174,28 @@ impl StateHandler {
             }
             let _ = self.state_tx.send(state.clone());
         };
+
+        // R11 force-flush: persist the latest state before tearing down, so
+        // coalescing never loses the final mutation on Exit/interrupt. Runs a
+        // direct blocking save (the loop has broken; there is no runtime arm left
+        // to schedule against). `needs_flush` is true when the config is dirty or
+        // a background save was still in flight when the loop broke.
+        if save.needs_flush() {
+            match save.snapshot_now(&config) {
+                Ok(pending) => {
+                    if let Err(e) = pending.run() {
+                        state
+                            .main_page
+                            .log_error("Failed to save config on exit", &e);
+                    }
+                }
+                Err(e) => {
+                    state
+                        .main_page
+                        .log_error("Failed to snapshot config on exit", &e);
+                }
+            }
+        }
 
         // Shut down the DIDComm service gracefully
         shutdown_token.cancel();
@@ -1134,7 +1213,13 @@ impl StateHandler {
     /// a live (Pending/Active) membership first (R-C-8 — for a pending join this
     /// is the withdrawal), then delete the record, persist, and refresh the
     /// panel. Surfaces the outcome as a status message.
-    fn remove_community(&self, state: &mut State, config: &mut Config, index: usize) {
+    fn remove_community(
+        &self,
+        state: &mut State,
+        config: &mut Config,
+        save: &mut save_coalesce::SaveScheduler,
+        index: usize,
+    ) {
         let Some(vtc) = config
             .account
             .communities_for_display(false)
@@ -1152,15 +1237,10 @@ impl StateHandler {
         }
         match config.account.delete_community(&vtc) {
             Ok(_) => {
-                if let Err(e) = config.save(
-                    &self.profile,
-                    #[cfg(feature = "openpgp-card")]
-                    &|| eprintln!("Touch confirmation needed for decryption"),
-                ) {
-                    state
-                        .main_page
-                        .log_error("Failed to save after removing community", &e);
-                }
+                // R11: coalesced save (was an inline `config.save`). The
+                // Exit/shutdown force-flush guarantees the deletion is persisted
+                // even if the user quits within the debounce window.
+                save.mark_dirty();
                 state.main_page.sync_from_config(config);
                 state.main_page.content_panel.communities.status_message =
                     Some("Community removed.".to_string());
@@ -1255,6 +1335,10 @@ impl StateHandler {
         state: &mut State,
         mut join_ctx: Option<DegradedJoinContext>,
     ) -> Result<DegradedOutcome> {
+        // R11: the degraded loop persists only via `remove_community` (State-A
+        // community withdrawal); `join_flow` saves itself synchronously. Coalesce
+        // here too and force-flush on every exit path so a withdrawal isn't lost.
+        let mut save = save_coalesce::SaveScheduler::new(self.profile.clone());
         let result = loop {
             tokio::select! {
                 Some(action) = action_rx.recv() => match action {
@@ -1277,7 +1361,19 @@ impl StateHandler {
                     }
                     Action::DeleteCommunity(i) => {
                         if let Some(ctx) = join_ctx.as_mut() {
-                            self.remove_community(state, &mut ctx.config, i);
+                            self.remove_community(state, &mut ctx.config, &mut save, i);
+                            // The degraded loop has no debounce arm and a `Joined`
+                            // handoff carries the config into the runtime loop, so
+                            // force-flush this single destructive action now rather
+                            // than risk losing it on handoff. (Low-traffic State-A
+                            // path — no burst to coalesce.)
+                            if save.needs_flush()
+                                && let Err(e) = save.flush(&ctx.config).await
+                            {
+                                state
+                                    .main_page
+                                    .log_error("Failed to save after removing community", &e);
+                            }
                         }
                     }
                     Action::StartJoin => {

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -11,6 +11,7 @@ use affinidi_tdk::{
     secrets_resolver::{SecretsResolver, secrets::Secret},
 };
 use anyhow::Result;
+use base64::Engine;
 use chrono::Utc;
 use ed25519_dalek_bip32::DerivationPath;
 use openvtc_core::{
@@ -85,8 +86,19 @@ pub(crate) fn plan_relationship_did(
     admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) -> Result<RDidPlan> {
     match &config.key_backend {
-        KeyBackend::Bip32 { root, .. } => {
-            let root = Box::new(root.clone());
+        KeyBackend::Bip32 { seed, .. } => {
+            // `ExtendedSigningKey` (ed25519-dalek-bip32 0.3) is not `Clone`, so
+            // reconstruct an owned root from the persisted seed — the same
+            // derivation the load path uses, and a pure function of the seed, so
+            // the rebuilt root is identical to the live one.
+            let root = Box::new(
+                ed25519_dalek_bip32::ExtendedSigningKey::from_seed(
+                    &base64::prelude::BASE64_URL_SAFE_NO_PAD
+                        .decode(secrecy::ExposeSecret::expose_secret(seed))
+                        .map_err(|e| anyhow::anyhow!("couldn't decode BIP32 seed: {e}"))?,
+                )
+                .map_err(|e| anyhow::anyhow!("couldn't rebuild BIP32 root: {e}"))?,
+            );
             let v_path = format!("m/3'/1'/1'/{}'", config.private.relationships.path_pointer);
             config.private.relationships.path_pointer += 1;
             let e_path = format!("m/3'/1'/1'/{}'", config.private.relationships.path_pointer);
@@ -352,7 +364,7 @@ fn create_request_message(
 
 use crate::state_handler::{
     actions::RelationshipAction, dispatch_util, log_did, main_page::content::RelationshipsMode,
-    resolve_did_to_display, settings_actions, state::State,
+    resolve_did_to_display, state::State,
 };
 use openvtc_core::config::protected_config::Contact;
 use openvtc_core::relationships::Relationship as RelRecord;
@@ -632,7 +644,12 @@ impl RelationshipOutcome {
     /// handler did *after* the await; on failure it records the same error
     /// status, leaving config untouched (so a failed send records no
     /// relationship/task — matching the pre-R14 ordering and durability).
-    pub(crate) fn apply(self, state: &mut State, config: &mut Config, profile: &str) {
+    pub(crate) fn apply(
+        self,
+        state: &mut State,
+        config: &mut Config,
+        save: &mut crate::state_handler::save_coalesce::SaveScheduler,
+    ) {
         // Accessor for the relationships-panel status slot, used by the
         // `dispatch_util` save/error helpers below (a free fn so its HRTB is
         // inferred correctly).
@@ -703,9 +720,8 @@ impl RelationshipOutcome {
                             // "request sent" UI. If the record exists, persist the
                             // `our_did` update made above; otherwise nothing changed.
                             if outcome == Some(false) {
-                                if let Err(e) = settings_actions::save_config(config, profile) {
-                                    state.main_page.log_error("Failed to save config", &e);
-                                }
+                                // R11: coalesced save (was inline `save_config`).
+                                save.mark_dirty();
                                 state.main_page.sync_from_config(config);
                             }
                             return;
@@ -740,7 +756,7 @@ impl RelationshipOutcome {
                         dispatch_util::save_and_sync(
                             &mut state.main_page,
                             config,
-                            profile,
+                            save,
                             dispatch_util::Persist::SaveAndSync,
                             status,
                             format!("Request sent to {}", log_did(&respondent_did)),
@@ -816,7 +832,7 @@ impl RelationshipOutcome {
                     dispatch_util::save_and_sync(
                         &mut state.main_page,
                         config,
-                        profile,
+                        save,
                         dispatch_util::Persist::SaveAndSync,
                         status,
                         "Ping sent",
@@ -874,7 +890,7 @@ impl RelationshipOutcome {
                     dispatch_util::save_and_sync(
                         &mut state.main_page,
                         config,
-                        profile,
+                        save,
                         dispatch_util::Persist::SaveAndSync,
                         status,
                         format!("VRC requested from {display_name}"),
@@ -921,7 +937,7 @@ impl RelationshipOutcome {
                 dispatch_util::save_and_sync(
                     &mut state.main_page,
                     config,
-                    profile,
+                    save,
                     dispatch_util::Persist::SaveAndSync,
                     status,
                     "Relationship removed",
@@ -986,17 +1002,20 @@ impl DidDeleteOutcome {
     /// mirroring the tail of the old inline `delete_context_did`. The VTA delete
     /// and listener teardown already happened in the task (best-effort, as before
     /// — failures there were logged and did not block local cleanup).
-    pub(crate) fn apply(self, state: &mut State, config: &mut Config, profile: &str) {
+    pub(crate) fn apply(
+        self,
+        state: &mut State,
+        config: &mut Config,
+        save: &mut crate::state_handler::save_coalesce::SaveScheduler,
+    ) {
         config.account.personas.remove(&self.persona_id);
         config.identities.remove(&self.persona_id);
         for kid in &self.key_ids {
             config.key_info.remove(kid);
         }
-        if let Err(e) = settings_actions::save_config(config, profile) {
-            state
-                .main_page
-                .log_error("Failed to save after removing DID", &e);
-        }
+        // R11: coalesced save (was inline `save_config`). Persisted by the
+        // debounce arm, or by the Exit force-flush if the user quits first.
+        save.mark_dirty();
         state.main_page.sync_from_config(config);
         state
             .main_page
@@ -1296,7 +1315,7 @@ fn prepare_request_vrc(
 fn handle_edit_alias(
     config: &mut Box<Config>,
     state: &mut State,
-    profile: &str,
+    save: &mut crate::state_handler::save_coalesce::SaveScheduler,
     remote_p_did: &str,
     alias: &str,
 ) {
@@ -1333,9 +1352,8 @@ fn handle_edit_alias(
         ),
     );
 
-    if let Err(e) = settings_actions::save_config(config, profile) {
-        state.main_page.log_error("Failed to save config", &e);
-    }
+    // R11: coalesced save (was inline `save_config`).
+    save.mark_dirty();
     state.main_page.sync_from_config(config);
     let index = state
         .main_page
@@ -1352,7 +1370,7 @@ fn handle_edit_alias(
     dispatch_util::save_and_sync(
         &mut state.main_page,
         config,
-        profile,
+        save,
         dispatch_util::Persist::None,
         |mp| &mut mp.content_panel.relationships.status_message,
         "Alias updated",
@@ -1400,7 +1418,7 @@ pub(crate) async fn dispatch(
     tdk: &TDK,
     service: &DIDCommService,
     state: &mut State,
-    profile: &str,
+    save: &mut crate::state_handler::save_coalesce::SaveScheduler,
     admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) -> RelationshipDispatch {
     match action {
@@ -1497,7 +1515,7 @@ pub(crate) async fn dispatch(
         RelationshipAction::EditAlias {
             remote_p_did,
             alias,
-        } => handle_edit_alias(config, state, profile, &remote_p_did, &alias),
+        } => handle_edit_alias(config, state, save, &remote_p_did, &alias),
         RelationshipAction::CancelEditAlias { index } => {
             state.main_page.content_panel.relationships.mode = RelationshipsMode::Detail {
                 index,
@@ -1557,6 +1575,7 @@ mod tests {
     #[test]
     fn ping_success_applies_task_and_status() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let remote = "did:peer:remote";
         let rel = register_relationship(&mut config, remote);
@@ -1573,7 +1592,7 @@ mod tests {
             },
             result: Ok(()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         assert_eq!(
             state
@@ -1599,6 +1618,7 @@ mod tests {
     #[test]
     fn ping_failure_sets_status_and_creates_no_task() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let remote = "did:peer:remote";
         let rel = register_relationship(&mut config, remote);
@@ -1615,7 +1635,7 @@ mod tests {
             },
             result: Err("dead peer".to_string()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         let status = state
             .main_page
@@ -1660,6 +1680,7 @@ mod tests {
     #[test]
     fn create_success_inserts_relationship_and_keyinfo() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let respondent = Arc::new("did:peer:respondent".to_string());
         insert_provisional(&mut config, &respondent);
@@ -1686,7 +1707,7 @@ mod tests {
             },
             result: Ok(()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         let rel = config
             .private
@@ -1742,6 +1763,7 @@ mod tests {
     #[test]
     fn create_success_does_not_clobber_raced_established() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let respondent = Arc::new("did:peer:respondent".to_string());
         insert_provisional(&mut config, &respondent);
@@ -1766,7 +1788,7 @@ mod tests {
             },
             result: Ok(()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         let rel = config.private.relationships.get(&respondent).unwrap();
         let lock = rel.lock().unwrap();
@@ -1797,6 +1819,7 @@ mod tests {
     #[test]
     fn create_failure_records_keyinfo_but_no_relationship() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let respondent = Arc::new("did:peer:respondent".to_string());
         // `prepare_submit` pre-inserted a provisional record; a send failure must
@@ -1823,7 +1846,7 @@ mod tests {
             },
             result: Err("send failed".to_string()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         assert!(
             config.private.relationships.get(&respondent).is_none(),
@@ -1856,6 +1879,7 @@ mod tests {
     #[test]
     fn remove_applies_record_removal() {
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let remote = "did:peer:remote";
         register_relationship(&mut config, remote);
@@ -1866,7 +1890,7 @@ mod tests {
             },
             result: Ok(()),
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         assert!(
             config
@@ -1893,6 +1917,7 @@ mod tests {
     fn did_delete_applies_local_cleanup() {
         use openvtc_core::config::account::PersonaId;
         let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         config.key_info.insert(
             "z-persona-key".to_string(),
@@ -1910,7 +1935,7 @@ mod tests {
             persona_id: PersonaId::new(),
             key_ids: vec!["z-persona-key".to_string()],
         };
-        outcome.apply(&mut state, &mut config, "test");
+        outcome.apply(&mut state, &mut config, &mut save);
 
         assert!(
             !config.key_info.contains_key("z-persona-key"),

--- a/openvtc/src/state_handler/save_coalesce.rs
+++ b/openvtc/src/state_handler/save_coalesce.rs
@@ -133,7 +133,9 @@ impl SaveScheduler {
         self.dirty || self.in_flight || self.deadline.is_some()
     }
 
-    #[cfg(test)]
+    /// Whether a backgrounded save is currently running on a blocking thread.
+    /// Used by the shutdown path to await an in-flight save before the
+    /// force-flush, so the two never run concurrent `Config::save`s.
     pub(crate) fn in_flight(&self) -> bool {
         self.in_flight
     }
@@ -399,6 +401,48 @@ mod tests {
             sched
                 .take_for_save(|| test_config().clone_for_save())
                 .is_ok()
+        );
+    }
+
+    /// Shutdown ordering invariant (R11): the runtime teardown awaits an
+    /// in-flight background save (draining its completion → `finish`) BEFORE its
+    /// force-flush, so the two never run concurrent `Config::save`s against the
+    /// same (non-atomic) file/keyring. This asserts the scheduler bookkeeping
+    /// that decision relies on.
+    #[test]
+    fn shutdown_awaits_inflight_then_flushes_only_if_newly_dirty() {
+        // Case 1: nothing dirtied while the save ran → after awaiting it, the
+        // shutdown force-flush is skipped (no redundant/concurrent save).
+        let mut sched = SaveScheduler::new("test");
+        sched.mark_dirty();
+        let _pending = sched
+            .take_for_save(|| test_config().clone_for_save())
+            .expect("save due")
+            .expect("snapshot ok");
+        assert!(
+            sched.in_flight(),
+            "teardown must observe the in-flight save and await it"
+        );
+        sched.finish(true);
+        assert!(
+            !sched.needs_flush(),
+            "after the awaited in-flight save, no redundant shutdown save is run"
+        );
+
+        // Case 2: a mutation lands while the save is in flight → after awaiting
+        // the save, the shutdown force-flush must still persist the newer state
+        // (now race-free, since the in-flight save already completed).
+        let mut sched = SaveScheduler::new("test");
+        sched.mark_dirty();
+        let _pending = sched
+            .take_for_save(|| test_config().clone_for_save())
+            .expect("save due")
+            .expect("snapshot ok");
+        sched.mark_dirty(); // mutation during the in-flight save
+        sched.finish(true);
+        assert!(
+            sched.needs_flush(),
+            "a mutation during the in-flight save must still be flushed at shutdown"
         );
     }
 

--- a/openvtc/src/state_handler/save_coalesce.rs
+++ b/openvtc/src/state_handler/save_coalesce.rs
@@ -1,0 +1,454 @@
+//! Coalesced, off-runtime `Config` persistence (R11).
+//!
+//! # The problem
+//!
+//! [`openvtc_core::config::Config::save`] is fully synchronous and expensive:
+//! per call it clones the protected tier, serializes + AES-GCM encrypts both the
+//! public/protected and secured tiers, writes + `chmod`s files, performs an OS
+//! **keyring** `Entry::set_secret` syscall, and — on token-protected profiles —
+//! blocking **PC/SC smart-card** I/O. Before R11 every config-mutating site
+//! called it inline on the `tokio::select!` event-loop thread: once per
+//! config-mutating inbound DIDComm message plus ~15 action sites. A mediator
+//! redelivery *burst* therefore ran N sequential keyring+file+card writes,
+//! blocking input the whole time.
+//!
+//! # The mechanism
+//!
+//! This module factors out a small, testable scheduler that the runtime loop
+//! drives. It has three pieces of state — **dirty**, **in-flight**, and a
+//! debounce **deadline** — and it preserves the single-mutator invariant: the
+//! snapshot is taken on the loop thread (the only place `Config` is mutated) and
+//! the actual blocking `save` runs on a `spawn_blocking` thread that owns the
+//! snapshot.
+//!
+//! * Mutation sites call [`SaveScheduler::mark_dirty`] instead of saving inline.
+//!   The first dirty mark arms a deadline `DEBOUNCE` in the future.
+//! * The loop adds one select arm that waits until the deadline
+//!   ([`SaveScheduler::wait_deadline`]). When it fires the loop calls
+//!   [`SaveScheduler::take_for_save`]; if a save is dirty *and* not already in
+//!   flight, that clears the dirty flag, marks in-flight, and returns a
+//!   [`PendingSave`] the loop spawns via `spawn_blocking`.
+//! * At most **one** save is in flight at a time. Marks that land while a save
+//!   runs simply re-set the dirty flag; on completion ([`SaveScheduler::finish`])
+//!   the scheduler re-arms a deadline so exactly one more save is scheduled.
+//! * Durability-critical points call [`SaveScheduler::flush`] for a synchronous
+//!   (awaited, still off-runtime) drain of any pending dirty state.
+//!
+//! The save *decision* logic (`mark_dirty` / `take_for_save` / `finish`) is pure
+//! over the scheduler's own fields and unit-tested in isolation (see the tests
+//! at the bottom and the coalescing/flush tests), following the
+//! pure-handler + mini-loop style established by `background_dispatch`.
+
+use std::time::Duration;
+
+use openvtc_core::config::Config;
+use openvtc_core::errors::OpenVTCError;
+use tokio::time::Instant;
+
+/// Debounce window: mutations within this window of the first dirty mark collapse
+/// into a single save. Kept short (≤1 s, per the R11 plan risk row) so the
+/// worst-case lost-state window on a crash stays small.
+pub(crate) const DEBOUNCE: Duration = Duration::from_millis(750);
+
+/// An owned, `Send + 'static` save request handed to a `spawn_blocking` thread.
+///
+/// Carries the [`Config`] snapshot (taken on the loop thread) and the profile
+/// name. [`PendingSave::run`] performs the blocking `save` and is the *only*
+/// place the heavy serialize/encrypt/keyring/card I/O runs — never on the async
+/// runtime.
+#[derive(Debug)]
+pub(crate) struct PendingSave {
+    snapshot: Config,
+    profile: String,
+}
+
+impl PendingSave {
+    /// Run the blocking save. Intended to be called inside `spawn_blocking` (or,
+    /// on the shutdown force-flush, directly on a blocking context).
+    pub(crate) fn run(self) -> Result<(), OpenVTCError> {
+        self.snapshot.save(
+            &self.profile,
+            #[cfg(feature = "openpgp-card")]
+            &|| {},
+        )
+    }
+}
+
+/// Coalescing scheduler for `Config::save`. Lives on the loop thread; not `Sync`
+/// and never shared — the loop is the single owner/mutator.
+pub(crate) struct SaveScheduler {
+    profile: String,
+    /// Config changed since the last save was *scheduled* and not yet persisted.
+    dirty: bool,
+    /// A save is currently running on a blocking thread.
+    in_flight: bool,
+    /// When the pending debounce fires. `None` when nothing is scheduled.
+    deadline: Option<Instant>,
+}
+
+/// Why [`SaveScheduler::take_for_save`] declined to produce a [`PendingSave`].
+/// Exposed for tests; the loop only cares about the `Some`/`None` distinction.
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) enum SkipReason {
+    /// Nothing has been marked dirty since the last scheduled save.
+    NotDirty,
+    /// A save is already running; the dirty flag is left set so `finish` re-arms.
+    InFlight,
+}
+
+impl SaveScheduler {
+    pub(crate) fn new(profile: impl Into<String>) -> Self {
+        Self {
+            profile: profile.into(),
+            dirty: false,
+            in_flight: false,
+            deadline: None,
+        }
+    }
+
+    /// Mark the config dirty: a coalesced save is requested. Arms the debounce
+    /// deadline if one isn't already pending (so a burst of marks shares one
+    /// deadline). Cheap and non-blocking — safe to call on the loop thread for
+    /// every mutation.
+    pub(crate) fn mark_dirty(&mut self) {
+        self.mark_dirty_at(Instant::now());
+    }
+
+    /// `mark_dirty` with an injectable clock for tests.
+    fn mark_dirty_at(&mut self, now: Instant) {
+        self.dirty = true;
+        // Arm a deadline only if none is pending. An existing deadline is *not*
+        // pushed back by later marks (that would let a steady stream of
+        // mutations starve the save indefinitely); the window is anchored to the
+        // first mark of the burst.
+        if self.deadline.is_none() {
+            self.deadline = Some(now + DEBOUNCE);
+        }
+    }
+
+    /// Whether a save is currently scheduled or running (for status/diagnostics).
+    #[cfg(test)]
+    pub(crate) fn is_pending(&self) -> bool {
+        self.dirty || self.in_flight || self.deadline.is_some()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn in_flight(&self) -> bool {
+        self.in_flight
+    }
+
+    /// A future that resolves when the debounce deadline elapses. Use as a
+    /// `tokio::select!` arm: when nothing is scheduled it stays pending forever
+    /// (so the arm is effectively disabled), so the loop only wakes for a save
+    /// when one is actually due.
+    pub(crate) async fn wait_deadline(&self) {
+        match self.deadline {
+            Some(when) => tokio::time::sleep_until(when).await,
+            // Park forever — no save scheduled. The select arm never fires until
+            // a future `mark_dirty` arms a deadline and the loop re-enters select.
+            None => std::future::pending::<()>().await,
+        }
+    }
+
+    /// Called when the debounce deadline fires. Decides whether to start a save.
+    ///
+    /// Returns `Ok(PendingSave)` (clearing dirty + the deadline and marking
+    /// in-flight) when a save should start; `Err(SkipReason)` otherwise:
+    /// - `NotDirty`: spurious wake, nothing to do.
+    /// - `InFlight`: a save is already running; the deadline is cleared but the
+    ///   dirty flag is left set so [`finish`](Self::finish) re-arms one more save.
+    ///
+    /// `snapshot_fn` builds the owned snapshot from the live config on the loop
+    /// thread (the single mutator). It can fail (e.g. BIP32 root rebuild); on
+    /// failure the dirty flag is *kept* and the deadline re-armed so the save is
+    /// retried, and the error is returned to the caller to surface as today.
+    pub(crate) fn take_for_save(
+        &mut self,
+        snapshot_fn: impl FnOnce() -> Result<Config, OpenVTCError>,
+    ) -> Result<Result<PendingSave, OpenVTCError>, SkipReason> {
+        if self.in_flight {
+            // Leave `dirty` set; clear the deadline so the arm stops firing until
+            // `finish` re-arms. (Should be rare: the deadline is normally cleared
+            // when a save starts.)
+            self.deadline = None;
+            return Err(SkipReason::InFlight);
+        }
+        if !self.dirty {
+            self.deadline = None;
+            return Err(SkipReason::NotDirty);
+        }
+        // Build the snapshot on the loop thread.
+        match snapshot_fn() {
+            Ok(snapshot) => {
+                self.dirty = false;
+                self.deadline = None;
+                self.in_flight = true;
+                Ok(Ok(PendingSave {
+                    snapshot,
+                    profile: self.profile.clone(),
+                }))
+            }
+            Err(e) => {
+                // Snapshot failed: keep dirty + re-arm so we retry, and surface
+                // the error (same as an inline save failure would).
+                self.deadline = Some(Instant::now() + DEBOUNCE);
+                Ok(Err(e))
+            }
+        }
+    }
+
+    /// Called when a spawned save completes (success *or* failure). Clears the
+    /// in-flight flag; if the config was dirtied again while the save ran, re-arms
+    /// exactly one more debounce so the latest state is eventually persisted.
+    ///
+    /// On a save *failure* the caller passes `succeeded = false`: the dirty flag
+    /// is re-set and a deadline re-armed so the failed write is retried rather than
+    /// silently dropped (the failure is also surfaced as a status/log by the
+    /// caller, matching today's behaviour).
+    pub(crate) fn finish(&mut self, succeeded: bool) {
+        self.in_flight = false;
+        if !succeeded {
+            // Retry-on-failure: never silently drop a dirty save.
+            self.dirty = true;
+        }
+        if self.dirty && self.deadline.is_none() {
+            self.deadline = Some(Instant::now() + DEBOUNCE);
+        }
+    }
+
+    /// Synchronous force-flush for durability-critical points (shutdown,
+    /// passphrase/protection change, export, anything whose correctness depends
+    /// on the persisted file being current).
+    ///
+    /// Builds a snapshot and persists it **now**, off the runtime via
+    /// `spawn_blocking`, awaiting completion. This drains any pending dirty state:
+    /// after a successful flush, `dirty` is cleared and the deadline disarmed.
+    ///
+    /// It does not coordinate with an already in-flight background save (the
+    /// caller's mutation may post-date it); flushing unconditionally guarantees
+    /// the *current* live state hits disk, which is the durability guarantee we
+    /// want. The in-flight flag is left untouched so a concurrently completing
+    /// background save still calls `finish` correctly.
+    ///
+    /// # Errors
+    ///
+    /// Propagates a snapshot or save error so the caller can surface it exactly
+    /// as the old inline save did. On error the dirty flag is left set so the
+    /// state is retried by the normal debounce path.
+    pub(crate) async fn flush(&mut self, config: &Config) -> Result<(), OpenVTCError> {
+        let pending = PendingSave {
+            snapshot: config.clone_for_save()?,
+            profile: self.profile.clone(),
+        };
+        // Run the blocking save off the runtime and await it.
+        let result = tokio::task::spawn_blocking(move || pending.run())
+            .await
+            .map_err(|e| OpenVTCError::Config(format!("save task panicked: {e}")))?;
+        if result.is_ok() {
+            self.dirty = false;
+            self.deadline = None;
+        }
+        result
+    }
+
+    /// Build a [`PendingSave`] from the live config without touching the
+    /// scheduler's dirty/in-flight state. Used by the shutdown path, which runs a
+    /// *direct* blocking save after the loop has broken (no runtime arm left to
+    /// schedule against).
+    ///
+    /// # Errors
+    ///
+    /// Propagates a snapshot error (e.g. BIP32 root rebuild failure).
+    pub(crate) fn snapshot_now(&self, config: &Config) -> Result<PendingSave, OpenVTCError> {
+        Ok(PendingSave {
+            snapshot: config.clone_for_save()?,
+            profile: self.profile.clone(),
+        })
+    }
+
+    /// Whether anything still needs persisting (dirty or a save in flight). Used
+    /// by the shutdown path to decide whether a final flush is needed.
+    pub(crate) fn needs_flush(&self) -> bool {
+        self.dirty || self.in_flight
+    }
+
+    /// Drop any pending coalesced dirty state because the caller just persisted
+    /// the *current* config synchronously by another path (a force-flush save,
+    /// e.g. a passphrase/protection change or export). This avoids a redundant
+    /// debounced re-save of state that is already on disk.
+    ///
+    /// It does **not** touch the `in_flight` flag: a concurrently-running
+    /// background save must still call [`finish`](Self::finish). If that
+    /// background save raced ahead of this external save its data is a subset
+    /// (older) of what we just wrote, so clearing `dirty` is safe.
+    pub(crate) fn clear_after_external_save(&mut self) {
+        self.dirty = false;
+        self.deadline = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A burst of N rapid `mark_dirty` calls within the debounce window collapses
+    /// into a single save. We drive the scheduler's pure decision logic directly
+    /// (no real timers): mark N times, then fire the deadline once and assert
+    /// exactly one `PendingSave` is produced — proving ≪N saves for N marks.
+    #[tokio::test(start_paused = true)]
+    async fn coalesces_burst_into_single_save() {
+        let mut sched = SaveScheduler::new("test");
+        let saves = Arc::new(AtomicUsize::new(0));
+
+        // Simulate a 5-message inbound burst: 5 dirty marks in quick succession.
+        let n = 5;
+        for _ in 0..n {
+            sched.mark_dirty();
+        }
+        assert!(sched.is_pending(), "burst should leave a save scheduled");
+
+        // The deadline fires once. Exactly one snapshot/save is produced for the
+        // whole burst.
+        let saves_in = saves.clone();
+        let pending = sched
+            .take_for_save(|| {
+                saves_in.fetch_add(1, Ordering::SeqCst);
+                test_config().clone_for_save()
+            })
+            .expect("a save should be due after a dirty burst")
+            .expect("snapshot should succeed");
+        drop(pending);
+        // Model the spawned save completing: `take_for_save` marked the domain
+        // in-flight, so the loop calls `finish` when the blocking save returns.
+        sched.finish(true);
+
+        // A second deadline fire with nothing newly dirty produces no save.
+        let skip = sched.take_for_save(|| test_config().clone_for_save());
+        assert_eq!(skip.unwrap_err(), SkipReason::NotDirty);
+
+        assert_eq!(
+            saves.load(Ordering::SeqCst),
+            1,
+            "5 dirty marks must coalesce into exactly 1 save (≪N)"
+        );
+    }
+
+    /// At most one save in flight: while a save is running, the deadline firing
+    /// must NOT start a second one. A mark that lands during the in-flight save
+    /// is remembered and scheduled by `finish`.
+    #[test]
+    fn at_most_one_in_flight_and_reschedules() {
+        let mut sched = SaveScheduler::new("test");
+
+        // First save starts.
+        sched.mark_dirty();
+        let _pending = sched
+            .take_for_save(|| test_config().clone_for_save())
+            .expect("first save due")
+            .expect("snapshot ok");
+        assert!(sched.in_flight());
+
+        // A mutation lands while the save is in flight.
+        sched.mark_dirty();
+        // The deadline firing now must be rejected — only one save at a time.
+        assert_eq!(
+            sched
+                .take_for_save(|| test_config().clone_for_save())
+                .unwrap_err(),
+            SkipReason::InFlight
+        );
+
+        // The in-flight save completes successfully; because we dirtied again,
+        // `finish` re-arms exactly one more save.
+        sched.finish(true);
+        assert!(!sched.in_flight());
+        assert!(
+            sched.is_pending(),
+            "a save dirtied mid-flight must be re-armed"
+        );
+
+        // …and that re-armed save is now takeable.
+        let _pending = sched
+            .take_for_save(|| test_config().clone_for_save())
+            .expect("re-armed save due")
+            .expect("snapshot ok");
+    }
+
+    /// A failed save is not silently dropped: `finish(false)` re-sets dirty and
+    /// re-arms so the write is retried.
+    #[test]
+    fn failed_save_is_retried_not_dropped() {
+        let mut sched = SaveScheduler::new("test");
+        sched.mark_dirty();
+        let _ = sched
+            .take_for_save(|| test_config().clone_for_save())
+            .expect("save due")
+            .expect("snapshot ok");
+        // The save failed.
+        sched.finish(false);
+        assert!(
+            sched.is_pending(),
+            "a failed save must leave the config dirty for retry, not drop it"
+        );
+        // The retry is takeable.
+        assert!(
+            sched
+                .take_for_save(|| test_config().clone_for_save())
+                .is_ok()
+        );
+    }
+
+    /// `flush` persists the current state synchronously and clears the dirty flag.
+    /// This is the durability backstop for shutdown / settings changes / export.
+    #[tokio::test]
+    async fn flush_persists_and_clears_dirty() {
+        // `test_config` is a BIP32 config whose `save` writes to the *test*
+        // profile's keyring/files. Keyring access may be unavailable in CI, so we
+        // only assert the scheduler bookkeeping: flush attempts a real save and,
+        // on success, clears dirty. If the keyring is unavailable the save errors
+        // and dirty stays set (the retry guarantee) — either way the *scheduler*
+        // contract holds. We therefore assert the post-state matches the result.
+        let config = test_config();
+        let mut sched = SaveScheduler::new("openvtc-r11-flush-test");
+        sched.mark_dirty();
+        assert!(sched.needs_flush());
+
+        match sched.flush(&config).await {
+            Ok(()) => assert!(
+                !sched.needs_flush(),
+                "a successful flush must clear the dirty flag"
+            ),
+            Err(_) => assert!(
+                sched.needs_flush(),
+                "a failed flush must leave the config dirty for retry"
+            ),
+        }
+    }
+
+    /// The deadline arm parks forever when nothing is scheduled (so the select
+    /// arm is effectively disabled until a `mark_dirty` arms it) and fires once
+    /// armed. With paused time we can assert it does not resolve early.
+    #[tokio::test(start_paused = true)]
+    async fn wait_deadline_parks_until_armed_then_fires() {
+        let mut sched = SaveScheduler::new("test");
+        // Nothing scheduled: the deadline future must not resolve.
+        tokio::select! {
+            biased;
+            _ = sched.wait_deadline() => panic!("deadline fired with nothing scheduled"),
+            _ = tokio::time::sleep(Duration::from_secs(10)) => {}
+        }
+
+        // Arm it; now it fires after DEBOUNCE.
+        sched.mark_dirty();
+        let start = Instant::now();
+        sched.wait_deadline().await;
+        assert!(
+            start.elapsed() >= DEBOUNCE,
+            "deadline must wait the full debounce window"
+        );
+    }
+}

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -15,40 +15,45 @@ pub fn save_config(config: &Config, profile: &str) -> Result<()> {
     Ok(())
 }
 
-/// Update the friendly name and save.
-pub fn update_friendly_name(config: &mut Config, profile: &str, name: &str) -> Result<()> {
+/// Update the friendly name.
+///
+/// R11: mutates + logs only; persistence is the caller's responsibility (the
+/// loop marks the config dirty for a coalesced save via `Persist::SaveAndSync`).
+/// This is a routine, non-durability-critical setting (no key re-derivation),
+/// so coalescing is safe — the Exit force-flush guarantees it is persisted.
+pub fn update_friendly_name(config: &mut Config, name: &str) {
     config.public.friendly_name = name.to_string();
     config.public.logs.insert(
         LogFamily::Config,
         format!("Friendly name changed to '{}'", name),
     );
-    save_config(config, profile)?;
     info!(name = %name, "friendly name updated");
-    Ok(())
 }
 
-/// Update the mediator DID and save.
-pub fn update_mediator_did(config: &mut Config, profile: &str, did: &str) -> Result<()> {
+/// Update the mediator DID.
+///
+/// R11: mutates + logs only (see [`update_friendly_name`]). The subsequent
+/// reconnect (R13 background dispatch) does not depend on the file being on disk
+/// yet — it reads the in-memory config — so coalescing the save is safe.
+pub fn update_mediator_did(config: &mut Config, did: &str) {
     config.set_active_mediator_did(did);
     config.public.logs.insert(
         LogFamily::Config,
         format!("Mediator DID changed to '{}'", did),
     );
-    save_config(config, profile)?;
     info!(did = %did, "mediator DID updated (reconnect needed)");
-    Ok(())
 }
 
-/// Update the organization DID and save.
-pub fn update_org_did(config: &mut Config, profile: &str, did: &str) -> Result<()> {
+/// Update the organization DID.
+///
+/// R11: mutates + logs only (see [`update_friendly_name`]).
+pub fn update_org_did(config: &mut Config, did: &str) {
     config.account.org_did = did.to_string();
     config
         .public
         .logs
         .insert(LogFamily::Config, format!("Org DID changed to '{}'", did));
-    save_config(config, profile)?;
     info!(did = %did, "org DID updated");
-    Ok(())
 }
 
 /// Set a passphrase to encrypt the config in the keyring.
@@ -130,6 +135,7 @@ use crate::state_handler::{
     actions::SettingsAction,
     dispatch_util,
     main_page::content::SettingsMode,
+    save_coalesce::SaveScheduler,
     state::{self, State},
 };
 
@@ -260,55 +266,48 @@ fn handle_protection_tab_switch(state: &mut State, next_field: usize) {
 }
 
 /// Returns `true` if the mediator DID was changed and a reconnect is needed.
+///
+/// R11: the per-setting save is now coalesced (`Persist::SaveAndSync` marks the
+/// config dirty rather than saving inline). The mutation can no longer fail
+/// (the `update_*` helpers are infallible now that they don't persist), so the
+/// former `Err` arm is gone.
 fn handle_submit_edit(
     config: &mut Box<Config>,
     state: &mut State,
-    profile: &str,
+    save: &mut SaveScheduler,
     value: &str,
 ) -> bool {
     let idx = state.main_page.content_panel.settings.selected_index;
-    let result = match idx {
-        0 => update_friendly_name(config, profile, value),
-        1 => update_mediator_did(config, profile, value),
-        2 => update_org_did(config, profile, value),
-        _ => Ok(()),
-    };
-    match result {
-        Ok(()) => {
-            let setting_name = match idx {
-                0 => "Friendly name",
-                1 => "Mediator DID",
-                2 => "Organization DID",
-                _ => "Setting",
-            };
-            state.main_page.content_panel.settings.mode = SettingsMode::View;
-            dispatch_util::save_and_sync(
-                &mut state.main_page,
-                config,
-                profile,
-                dispatch_util::Persist::SyncOnly,
-                |mp| &mut mp.content_panel.settings.status_message,
-                "Setting saved",
-                dispatch_util::SyncLog::Plain(format!("{} updated", setting_name)),
-            );
-            // Mediator DID is index 1 — caller should trigger reconnect
-            idx == 1
-        }
-        Err(e) => {
-            dispatch_util::record_error(
-                &mut state.main_page,
-                |mp| &mut mp.content_panel.settings.status_message,
-                "Failed to save setting",
-                &e,
-            );
-            false
-        }
+    match idx {
+        0 => update_friendly_name(config, value),
+        1 => update_mediator_did(config, value),
+        2 => update_org_did(config, value),
+        _ => {}
     }
+    let setting_name = match idx {
+        0 => "Friendly name",
+        1 => "Mediator DID",
+        2 => "Organization DID",
+        _ => "Setting",
+    };
+    state.main_page.content_panel.settings.mode = SettingsMode::View;
+    dispatch_util::save_and_sync(
+        &mut state.main_page,
+        config,
+        save,
+        dispatch_util::Persist::SaveAndSync,
+        |mp| &mut mp.content_panel.settings.status_message,
+        "Setting saved",
+        dispatch_util::SyncLog::Plain(format!("{} updated", setting_name)),
+    );
+    // Mediator DID is index 1 — caller should trigger reconnect
+    idx == 1
 }
 
 fn handle_export_config_action(
     config: &mut Box<Config>,
     state: &mut State,
+    save: &mut SaveScheduler,
     profile: &str,
     path: &str,
     passphrase: &str,
@@ -319,16 +318,24 @@ fn handle_export_config_action(
                 .public
                 .logs
                 .insert(LogFamily::Config, format!("Config exported to {}", path));
+            // R11 force-flush: export is durability-critical (the exported file
+            // must reflect persisted state and the export-log entry must hit
+            // disk now). Keep this save synchronous on the loop thread — it is a
+            // deliberate force-flush point, not the coalesced hot path. It also
+            // clears any pending coalesced dirty state, so we drop the scheduler's
+            // deadline below.
             if let Err(e) = save_config(config, profile) {
                 state
                     .main_page
                     .log_error("Failed to persist export-log entry", &e);
+            } else {
+                save.clear_after_external_save();
             }
             state.main_page.content_panel.settings.mode = SettingsMode::View;
             dispatch_util::save_and_sync(
                 &mut state.main_page,
                 config,
-                profile,
+                save,
                 dispatch_util::Persist::None,
                 |mp| &mut mp.content_panel.settings.status_message,
                 format!("Config exported to {}", path),
@@ -346,6 +353,7 @@ fn handle_export_config_action(
 fn handle_import_config_action(
     config: &mut Box<Config>,
     state: &mut State,
+    save: &mut SaveScheduler,
     profile: &str,
     path: &str,
     passphrase: &str,
@@ -356,16 +364,19 @@ fn handle_import_config_action(
                 .public
                 .logs
                 .insert(LogFamily::Config, format!("Config imported from {}", path));
+            // Force-flush the import-log entry (see export handler).
             if let Err(e) = save_config(config, profile) {
                 state
                     .main_page
                     .log_error("Failed to persist import-log entry", &e);
+            } else {
+                save.clear_after_external_save();
             }
             state.main_page.content_panel.settings.mode = SettingsMode::View;
             dispatch_util::save_and_sync(
                 &mut state.main_page,
                 config,
-                profile,
+                save,
                 dispatch_util::Persist::None,
                 |mp| &mut mp.content_panel.settings.status_message,
                 msg.clone(),
@@ -392,16 +403,26 @@ fn handle_change_protection(state: &mut State) {
 fn handle_set_passphrase(
     config: &mut Box<Config>,
     state: &mut State,
+    save: &mut SaveScheduler,
     profile: &str,
     passphrase: &str,
 ) {
+    // R11 force-flush: a protection change re-derives the unlock key and rewrites
+    // the secured config; it MUST be persisted before reporting success (the
+    // keyring entry now requires the new passphrase to decrypt). `set_passphrase`
+    // saves synchronously — a deliberate force-flush point. (R12 moves its Argon2
+    // derivation off the runtime.)
     match set_passphrase(config, profile, passphrase) {
         Ok(()) => {
+            // The synchronous save above already persisted the latest state;
+            // drop any pending coalesced dirty mark so we don't redundantly
+            // re-save.
+            save.clear_after_external_save();
             state.main_page.content_panel.settings.mode = SettingsMode::View;
             dispatch_util::save_and_sync(
                 &mut state.main_page,
                 config,
-                profile,
+                save,
                 dispatch_util::Persist::SyncOnly,
                 |mp| &mut mp.content_panel.settings.status_message,
                 "Passphrase protection enabled",
@@ -419,14 +440,23 @@ fn handle_set_passphrase(
     }
 }
 
-fn handle_remove_passphrase(config: &mut Box<Config>, state: &mut State, profile: &str) {
+fn handle_remove_passphrase(
+    config: &mut Box<Config>,
+    state: &mut State,
+    save: &mut SaveScheduler,
+    profile: &str,
+) {
+    // R11 force-flush: same rationale as `handle_set_passphrase` — a protection
+    // change must be on disk before reporting success. `remove_passphrase` saves
+    // synchronously.
     match remove_passphrase(config, profile) {
         Ok(()) => {
+            save.clear_after_external_save();
             state.main_page.content_panel.settings.mode = SettingsMode::View;
             dispatch_util::save_and_sync(
                 &mut state.main_page,
                 config,
-                profile,
+                save,
                 dispatch_util::Persist::SyncOnly,
                 |mp| &mut mp.content_panel.settings.status_message,
                 "Protection reverted to keyring only",
@@ -643,6 +673,7 @@ pub(crate) async fn dispatch(
     action: SettingsAction,
     config: &mut Box<Config>,
     state: &mut State,
+    save: &mut SaveScheduler,
     profile: &str,
 ) -> SettingsOutcome {
     match action {
@@ -669,7 +700,7 @@ pub(crate) async fn dispatch(
         }
         SettingsAction::PassphraseLen(len) => handle_passphrase_len(state, len),
         SettingsAction::SubmitEdit { value } => {
-            if handle_submit_edit(config, state, profile, &value) {
+            if handle_submit_edit(config, state, save, &value) {
                 // The mediator DID was changed. Set the synchronous "Connecting"
                 // state now; the loop spawns the slow reconnect I/O (R13).
                 begin_reconnect_status(state);
@@ -677,16 +708,16 @@ pub(crate) async fn dispatch(
             }
         }
         SettingsAction::ExportConfig { path, passphrase } => {
-            handle_export_config_action(config, state, profile, &path, &passphrase)
+            handle_export_config_action(config, state, save, profile, &path, &passphrase)
         }
         SettingsAction::ImportConfig { path, passphrase } => {
-            handle_import_config_action(config, state, profile, &path, &passphrase)
+            handle_import_config_action(config, state, save, profile, &path, &passphrase)
         }
         SettingsAction::ChangeProtection => handle_change_protection(state),
         SettingsAction::SetPassphrase { passphrase } => {
-            handle_set_passphrase(config, state, profile, &passphrase)
+            handle_set_passphrase(config, state, save, profile, &passphrase)
         }
-        SettingsAction::RemovePassphrase => handle_remove_passphrase(config, state, profile),
+        SettingsAction::RemovePassphrase => handle_remove_passphrase(config, state, save, profile),
         #[cfg(feature = "openpgp-card")]
         SettingsAction::TokenManagement => handle_token_management(state),
         #[cfg(feature = "openpgp-card")]


### PR DESCRIPTION
**Task R11** (remediation plan, Phase R2 — responsiveness). Builds on PR #89's `dispatch_util` and the PR #92/#93 background-dispatch mechanism.

## Problem
`Config::save` is fully synchronous and expensive: clone + serialize + AES-GCM encrypt both config tiers + file write/chmod + OS keyring `set_secret` + — on token-protected profiles — blocking **PC/SC smart-card I/O**. It ran inline on the `tokio::select!` event loop once per config-mutating inbound DIDComm message plus ~15 action sites, so a mediator redelivery burst was N sequential keyring/card writes freezing input.

## Mechanism
New `SaveScheduler` (`state_handler/save_coalesce.rs`): a `dirty`/`in-flight`/`deadline` state machine the loop drives.
- Mutation sites call `mark_dirty()` instead of saving inline; `sync_from_config` (UI rebuild) still runs immediately — only *persistence* defers.
- A **750ms debounce** coalesces bursts (anchored to the first mark — no starvation); **at most one save in flight**; a mark during a save re-arms exactly one more.
- The snapshot is taken on the loop thread (single mutator, via new `Config::clone_for_save`) and the blocking save runs on `spawn_blocking`.
- **Force-flush (synchronous) at durability-critical points**: shutdown, passphrase/protection change, export, setup. A failed save re-arms a retry (never silently dropped).

Result: a config-mutating inbound burst no longer blocks input; on a token-protected profile the per-message card/keyring write collapses to a single debounced write. On-disk format unchanged.

## Review fixes folded in (commit 2)
A `code-reviewer` pass on the diff cleared the design (force-flush coverage complete; no lost final save on normal exit paths; no torn-record UB from the shared `Arc<Mutex>` snapshot; debounce can't starve) but caught one **HIGH/merge-blocker**, fixed here:
- **Concurrent shutdown save:** `spawn_blocking` isn't cancelled when its `JoinHandle` drops, so quitting while a background save was in flight ran a *second* `Config::save` concurrently with the orphaned one — two non-atomic file writes racing → possible torn/corrupt config or lost update. Fix: at teardown, if a save is in flight, **drain the completion channel (await it) + `finish()` before** the force-flush, restoring the single-writer invariant. New scheduler test asserts the await-then-flush-only-if-newly-dirty ordering.
- Plus: save-failure now uses `log_error` (parity with all other save sites); documented that `clone_for_save` intentionally shares the per-record `Arc<Mutex<>>` (safe via per-record exclusion + dirty-remark self-healing).

## Tests
Coalescing (5 marks → 1 save), one-in-flight + re-arm, failed-save retry, deadline parking (paused-clock; added a test-only `tokio` `test-util` dev-dep), flush clears dirty, and the shutdown-ordering invariant. Coverage boundary: the real `Config::save` needs a keyring, so the scheduler decision logic is tested in isolation (per R13/R14).

Gate: `fmt` / `clippy -D warnings` / `test --workspace` green (118 bin unit tests).
