### PR TITLE
feat(state): run Argon2 KDF off the async runtime for passphrase change + export

### DIFF
--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -93,6 +93,41 @@ pub fn derive_passphrase_key_v2(passphrase: &[u8], salt: &[u8]) -> Result<[u8; 3
     derive_argon2_key(passphrase, salt)
 }
 
+/// Async wrapper for [`derive_passphrase_key`] that runs the (CPU-bound,
+/// ~0.5–1 s) Argon2id derivation on `tokio::task::spawn_blocking` instead of
+/// inline on the async runtime (R12).
+///
+/// The synchronous [`derive_passphrase_key`] pegs a tokio worker for the full
+/// derive; at the user-initiated set/change-passphrase site that worker is the
+/// event-loop thread, freezing the UI for ~1 s. This helper owns its inputs (so
+/// the closure is `Send + 'static`) and moves the blocking crypto onto the
+/// blocking pool, keeping the runtime / render task live. The KDF, salt
+/// handling (the legacy v1 deterministic info-salt), and result are identical
+/// to the sync path — only *where* the CPU work runs changes.
+///
+/// `passphrase` is taken by value so the secret bytes are moved into the
+/// closure and dropped there; callers should pass an owned copy of the exposed
+/// secret rather than logging or widening its exposure.
+///
+/// # Errors
+///
+/// Returns [`OpenVTCError::Config`] if Argon2 derivation fails, or if the
+/// blocking task panics. The `JoinError` carries only the thread/panic
+/// location — never the passphrase or the derived key — so the secret cannot
+/// leak through the error path.
+pub async fn derive_passphrase_key_blocking(
+    passphrase: Vec<u8>,
+    info: Vec<u8>,
+) -> Result<[u8; 32], OpenVTCError> {
+    // Wrap the moved passphrase copy in `Zeroizing` so the transient plaintext
+    // is wiped when the closure scope ends, preserving the zeroization the
+    // borrowed `SecretString`/`SecretBox` would otherwise give.
+    let passphrase = zeroize::Zeroizing::new(passphrase);
+    tokio::task::spawn_blocking(move || derive_passphrase_key(&passphrase, &info))
+        .await
+        .map_err(|e| OpenVTCError::Config(format!("Argon2 derivation task panicked: {e}")))?
+}
+
 /// Shared Argon2id derivation. OWASP "high-value KEK" profile:
 ///   m = 128 MiB (GPU-resistant; fits comfortably on 4 GiB devices)
 ///   t = 4 iterations

--- a/openvtc-core/src/config/saving.rs
+++ b/openvtc-core/src/config/saving.rs
@@ -4,7 +4,7 @@ use crate::{
     config::{
         Config, ConfigProtectionType, ExportedConfig, KeyBackend,
         public_config::PublicConfig,
-        secured_config::{SecuredConfig, passphrase_encrypt_v2},
+        secured_config::{SecuredConfig, passphrase_encrypt_v2_blocking},
     },
     errors::OpenVTCError,
     logs::LogFamily,
@@ -171,7 +171,13 @@ impl Config {
     ///
     /// Returns an error if passphrase derivation fails, serialization fails,
     /// encryption fails, or the file cannot be written.
-    pub fn export(&self, passphrase: SecretString, file: &str) -> Result<(), OpenVTCError> {
+    ///
+    /// R12: the Argon2id key derivation inside `passphrase_encrypt_v2` (~0.5–1 s
+    /// of pure CPU) runs on a `spawn_blocking` thread via
+    /// [`passphrase_encrypt_v2_blocking`] so the export does not peg the async
+    /// event-loop / render task while the key is derived. The per-export random
+    /// salt and the resulting blob are unchanged from the sync path.
+    pub async fn export(&self, passphrase: SecretString, file: &str) -> Result<(), OpenVTCError> {
         let pc = PublicConfig::from(self);
         let sc = SecuredConfig::from(self);
 
@@ -181,11 +187,16 @@ impl Config {
         // independent ciphertexts (and the same operator exporting twice
         // does too). Decrypt path auto-detects v1/v2 for backward compat
         // with previously-exported files.
-        let secured = passphrase_encrypt_v2(
-            passphrase.expose_secret().as_bytes(),
-            b"openvtc-export-v1",
-            &serialized,
-        )?;
+        //
+        // Own the exposed passphrase bytes so they move into the blocking
+        // closure (and zeroize there); `serialized` is also moved in. Neither
+        // is logged or surfaced in an error.
+        let secured = passphrase_encrypt_v2_blocking(
+            passphrase.expose_secret().as_bytes().to_vec(),
+            b"openvtc-export-v1".to_vec(),
+            serialized,
+        )
+        .await?;
 
         fs::write(file, BASE64_URL_SAFE_NO_PAD.encode(&secured)).map_err(|e| {
             OpenVTCError::Config(format!("Couldn't write to file ({file}). Reason: {e}"))

--- a/openvtc-core/src/config/secured_config.rs
+++ b/openvtc-core/src/config/secured_config.rs
@@ -684,6 +684,42 @@ pub fn passphrase_encrypt_v2(
     Ok(out)
 }
 
+/// Async wrapper for [`passphrase_encrypt_v2`] that runs the (CPU-bound,
+/// ~0.5–1 s) Argon2id key derivation on `tokio::task::spawn_blocking` instead
+/// of inline on the async runtime (R12).
+///
+/// `passphrase_encrypt_v2` derives a fresh-salt Argon2 key before AES-GCM
+/// encrypting; at the config-export site that derive runs on the event-loop
+/// thread and freezes the UI for ~1 s. This helper owns its inputs (so the
+/// closure is `Send + 'static`) and moves the whole encrypt — including the
+/// random per-call salt generation — onto the blocking pool. The salt is still
+/// generated fresh per call inside the closure (not weakened), and the
+/// resulting v2 blob is byte-for-byte the same shape as the sync path: a blob
+/// produced here is decryptable by [`passphrase_decrypt`].
+///
+/// `passphrase` is taken by value so the secret bytes are moved into the
+/// closure and dropped there.
+///
+/// # Errors
+///
+/// Returns [`OpenVTCError`] if derivation/encryption fails, or
+/// [`OpenVTCError::Encrypt`] if the blocking task panics. The `JoinError`
+/// carries only the panic location — never the passphrase, derived key, or
+/// plaintext.
+pub async fn passphrase_encrypt_v2_blocking(
+    passphrase: Vec<u8>,
+    info: Vec<u8>,
+    plaintext: Vec<u8>,
+) -> Result<Vec<u8>, OpenVTCError> {
+    // Wrap the moved secret copies in `Zeroizing` so the transient plaintext
+    // passphrase and config bytes are wiped when the closure scope ends.
+    let passphrase = zeroize::Zeroizing::new(passphrase);
+    let plaintext = zeroize::Zeroizing::new(plaintext);
+    tokio::task::spawn_blocking(move || passphrase_encrypt_v2(&passphrase, &info, &plaintext))
+        .await
+        .map_err(|e| OpenVTCError::Encrypt(format!("Argon2 encrypt task panicked: {e}")))?
+}
+
 /// Decrypt a passphrase-protected blob written by either:
 ///   * `passphrase_encrypt_v2` (v2: random salt embedded in the blob), or
 ///   * the legacy v1 path where the caller derived a key with the

--- a/openvtc-core/tests/config_encryption.rs
+++ b/openvtc-core/tests/config_encryption.rs
@@ -223,6 +223,52 @@ fn v2_roundtrip_succeeds() {
     assert_eq!(recovered, plaintext);
 }
 
+// ── R12: off-runtime (spawn_blocking) Argon2 wrappers ─────────────────────────
+//
+// These prove the async wrappers produce artifacts identical in shape to the
+// sync path (decryptable by the unchanged `passphrase_decrypt` / matching the
+// sync derive), and that the `spawn_blocking` derive runs without panicking
+// under a tokio runtime.
+
+/// `passphrase_encrypt_v2_blocking` must produce a v2 blob decryptable by the
+/// existing (sync) `passphrase_decrypt` — behaviour parity with
+/// `passphrase_encrypt_v2`, only the derive runs off the runtime.
+#[tokio::test]
+async fn v2_blocking_roundtrip_decryptable_by_sync_decrypt() {
+    use openvtc_core::config::secured_config::passphrase_encrypt_v2_blocking;
+    let pass = b"my-passphrase-2026";
+    let info = b"openvtc-export-v1";
+    let plaintext = b"sensitive config blob";
+    let blob = passphrase_encrypt_v2_blocking(pass.to_vec(), info.to_vec(), plaintext.to_vec())
+        .await
+        .expect("blocking encrypt v2 should not panic under a runtime");
+    assert_eq!(
+        &blob[..4],
+        V2_MAGIC,
+        "blocking v2 blob must begin with OPV2 magic, same as sync"
+    );
+    let recovered = passphrase_decrypt(pass, info, &blob).expect("sync decrypt of blocking blob");
+    assert_eq!(recovered, plaintext);
+}
+
+/// `derive_passphrase_key_blocking` must return the *same* key as the sync
+/// `derive_passphrase_key` for the same inputs — only the thread it runs on
+/// changes. Also exercises the `spawn_blocking` path without panicking.
+#[tokio::test]
+async fn derive_passphrase_key_blocking_matches_sync() {
+    use openvtc_core::config::derive_passphrase_key_blocking;
+    let pass = b"unlock-passphrase";
+    let info = b"openvtc-unlock-code-v1";
+    let sync_key = derive_passphrase_key(pass, info).expect("sync derive");
+    let blocking_key = derive_passphrase_key_blocking(pass.to_vec(), info.to_vec())
+        .await
+        .expect("blocking derive should not panic under a runtime");
+    assert_eq!(
+        sync_key, blocking_key,
+        "off-runtime derive must produce an identical key (same KDF params + salt)"
+    );
+}
+
 #[test]
 fn v2_two_encrypts_produce_distinct_blobs() {
     let pass = b"same-passphrase";
@@ -366,8 +412,13 @@ mod export_import {
 
     /// (a) A real `Config::export` output must round-trip through the
     /// import decrypt path on a populated config.
-    #[test]
-    fn export_import_roundtrip_with_populated_config() {
+    ///
+    /// `Config::export` is async (R12 runs its Argon2 derive on
+    /// `spawn_blocking`), so this drives it under a tokio runtime and asserts
+    /// the produced blob is still decryptable by the unchanged import path —
+    /// proving behaviour parity with the old sync export.
+    #[tokio::test]
+    async fn export_import_roundtrip_with_populated_config() {
         let seed_b64 = BASE64_URL_SAFE_NO_PAD.encode([7u8; 32]);
         let config = populated_config(&seed_b64);
         let passphrase = "round-trip-passphrase";
@@ -377,6 +428,7 @@ mod export_import {
         let file = file.to_str().unwrap().to_string();
         config
             .export(SecretString::new(passphrase.into()), &file)
+            .await
             .expect("export should succeed");
 
         let content = std::fs::read_to_string(&file).expect("read export file");
@@ -442,8 +494,8 @@ mod export_import {
     }
 
     /// (c) A tampered v2 export must fail with a clear error — never panic.
-    #[test]
-    fn tampered_v2_export_fails_with_error() {
+    #[tokio::test]
+    async fn tampered_v2_export_fails_with_error() {
         let seed_b64 = BASE64_URL_SAFE_NO_PAD.encode([11u8; 32]);
         let config = populated_config(&seed_b64);
         let passphrase = "tamper-test-passphrase";
@@ -452,6 +504,7 @@ mod export_import {
         let file = file.to_str().unwrap().to_string();
         config
             .export(SecretString::new(passphrase.into()), &file)
+            .await
             .expect("export should succeed");
         let content = std::fs::read_to_string(&file).expect("read export file");
         let _ = std::fs::remove_file(&file);

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -855,6 +855,7 @@ impl StateHandler {
                             sa,
                             &mut config,
                             &mut state,
+                            &self.state_tx,
                             &mut save,
                             &self.profile,
                         )

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -57,11 +57,25 @@ pub fn update_org_did(config: &mut Config, did: &str) {
 }
 
 /// Set a passphrase to encrypt the config in the keyring.
-pub fn set_passphrase(config: &mut Config, profile: &str, passphrase: &str) -> Result<()> {
-    use openvtc_core::config::{ConfigProtectionType, derive_passphrase_key, validate_passphrase};
+///
+/// R12: the Argon2id unlock-key derivation (~0.5–1 s of pure CPU) runs on a
+/// `spawn_blocking` thread via [`derive_passphrase_key_blocking`] so it does
+/// not peg the async event-loop / render task. The passphrase bytes are owned
+/// by the blocking closure and zeroized there; the derived key is the only
+/// thing returned. The subsequent `save_config` does not run Argon2 (it
+/// AES-encrypts with the already-derived key), so this is the only KDF on this
+/// path.
+pub async fn set_passphrase(config: &mut Config, profile: &str, passphrase: &str) -> Result<()> {
+    use openvtc_core::config::{
+        ConfigProtectionType, derive_passphrase_key_blocking, validate_passphrase,
+    };
 
     validate_passphrase(passphrase)?;
-    let key = derive_passphrase_key(passphrase.as_bytes(), b"openvtc-unlock-code-v1")?;
+    let key = derive_passphrase_key_blocking(
+        passphrase.as_bytes().to_vec(),
+        b"openvtc-unlock-code-v1".to_vec(),
+    )
+    .await?;
     config.unlock_code = Some(SecretBox::new(Box::new(key.to_vec())));
     config.public.protection = ConfigProtectionType::Encrypted;
     config.public.logs.insert(
@@ -100,10 +114,13 @@ fn validate_file_path(path: &str) -> Result<()> {
 }
 
 /// Export the config to a file, encrypted with the given passphrase.
-pub fn export_config(config: &Config, path: &str, passphrase: &str) -> Result<()> {
+///
+/// R12: `Config::export` now derives its Argon2 export key off the runtime
+/// (`spawn_blocking`), so this awaits it instead of blocking the loop.
+pub async fn export_config(config: &Config, path: &str, passphrase: &str) -> Result<()> {
     validate_file_path(path)?;
     let secret = SecretString::new(passphrase.to_string().into());
-    config.export(secret, path)?;
+    config.export(secret, path).await?;
     info!(path = %path, "config exported");
     Ok(())
 }
@@ -138,6 +155,7 @@ use crate::state_handler::{
     save_coalesce::SaveScheduler,
     state::{self, State},
 };
+use tokio::sync::watch;
 
 fn handle_select(state: &mut State, index: usize) {
     #[cfg(feature = "openpgp-card")]
@@ -304,15 +322,25 @@ fn handle_submit_edit(
     idx == 1
 }
 
-fn handle_export_config_action(
+async fn handle_export_config_action(
     config: &mut Box<Config>,
     state: &mut State,
+    state_tx: &watch::Sender<State>,
     save: &mut SaveScheduler,
     profile: &str,
     path: &str,
     passphrase: &str,
 ) {
-    match export_config(config, path, passphrase) {
+    // R12: surface a "deriving" status *before* the blocking Argon2 derive so
+    // the user sees progress while the key is computed off the runtime. Push it
+    // to the render task now — `export_config` then awaits a `spawn_blocking`
+    // derive, during which the loop is parked here but the render task keeps
+    // drawing this status (the runtime is no longer pegged by the KDF).
+    state.main_page.content_panel.settings.status_message =
+        Some("Deriving encryption key…".to_string());
+    let _ = state_tx.send(state.clone());
+
+    match export_config(config, path, passphrase).await {
         Ok(()) => {
             config
                 .public
@@ -400,19 +428,28 @@ fn handle_change_protection(state: &mut State) {
     };
 }
 
-fn handle_set_passphrase(
+async fn handle_set_passphrase(
     config: &mut Box<Config>,
     state: &mut State,
+    state_tx: &watch::Sender<State>,
     save: &mut SaveScheduler,
     profile: &str,
     passphrase: &str,
 ) {
+    // R12: surface a "deriving" status *before* the blocking Argon2 derive so
+    // the user sees progress while the unlock key is computed off the runtime.
+    // Push it to the render task now; `set_passphrase` then awaits a
+    // `spawn_blocking` derive, during which the render task keeps drawing.
+    state.main_page.content_panel.settings.status_message =
+        Some("Deriving encryption key…".to_string());
+    let _ = state_tx.send(state.clone());
+
     // R11 force-flush: a protection change re-derives the unlock key and rewrites
     // the secured config; it MUST be persisted before reporting success (the
     // keyring entry now requires the new passphrase to decrypt). `set_passphrase`
     // saves synchronously — a deliberate force-flush point. (R12 moves its Argon2
     // derivation off the runtime.)
-    match set_passphrase(config, profile, passphrase) {
+    match set_passphrase(config, profile, passphrase).await {
         Ok(()) => {
             // The synchronous save above already persisted the latest state;
             // drop any pending coalesced dirty mark so we don't redundantly
@@ -673,6 +710,7 @@ pub(crate) async fn dispatch(
     action: SettingsAction,
     config: &mut Box<Config>,
     state: &mut State,
+    state_tx: &watch::Sender<State>,
     save: &mut SaveScheduler,
     profile: &str,
 ) -> SettingsOutcome {
@@ -708,14 +746,15 @@ pub(crate) async fn dispatch(
             }
         }
         SettingsAction::ExportConfig { path, passphrase } => {
-            handle_export_config_action(config, state, save, profile, &path, &passphrase)
+            handle_export_config_action(config, state, state_tx, save, profile, &path, &passphrase)
+                .await
         }
         SettingsAction::ImportConfig { path, passphrase } => {
             handle_import_config_action(config, state, save, profile, &path, &passphrase)
         }
         SettingsAction::ChangeProtection => handle_change_protection(state),
         SettingsAction::SetPassphrase { passphrase } => {
-            handle_set_passphrase(config, state, save, profile, &passphrase)
+            handle_set_passphrase(config, state, state_tx, save, profile, &passphrase).await
         }
         SettingsAction::RemovePassphrase => handle_remove_passphrase(config, state, save, profile),
         #[cfg(feature = "openpgp-card")]


### PR DESCRIPTION
**Task R12** (remediation plan, Phase R2 — responsiveness).

## Problem
The Argon2id KDF (128 MiB / t=4, ~0.5–1s of pure CPU) ran **synchronously on the async event-loop thread** at two user-initiated sites — set/change passphrase and config export — both pegging a tokio worker (starving the render task) and freezing the UI ~1s.

## Fix
Move the derivation onto `tokio::spawn_blocking` via two thin async wrappers in `openvtc-core` (where tokio is already a dep and the secret bytes are cleanest to own/zeroize): `derive_passphrase_key_blocking` (passphrase change) and `passphrase_encrypt_v2_blocking` (export). `Config::export` becomes async; the one production call site is awaited. The handlers push a "Deriving encryption key…" status into the watch channel **before** the blocking await (same interim-`state_tx.send` pattern `setup_vta_actions` uses), so the render task stays alive and draws it during the derive.

## Unchanged / safe
Same KDF params, same legacy-v1 deterministic info-salt and per-call random v2 salt, byte-compatible artifacts (proven by `v2_blocking_roundtrip_decryptable_by_sync_decrypt` + `derive_passphrase_key_blocking_matches_sync`). Owned passphrase/plaintext copies handed to the closures are `Zeroizing`; `JoinError` paths format only the panic location — never the secret.

Residual (intentional): the loop still serializes on this one explicit `.await` (the user is focused on the single action) and the AES-GCM/keyring `save_config` after a passphrase change stays sync (R11's domain, no Argon2).

Gate: `fmt` / `clippy -D warnings` / `test --workspace` green (core 138 + config_encryption 26 incl. 2 new/2 migrated; openvtc 118).
