### PR TITLE
perf(ui): Arc heavy MainPageState data; defer credential JSON rendering

### DIFF
--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -1,3 +1,48 @@
+use std::sync::Arc;
+
+use dtg_credentials::DTGCredential;
+
+/// Lazily-rendered raw credential JSON for credential detail views.
+///
+/// Holds the credential *source* (an `Arc`, so cloning a panel state is a
+/// pointer bump) and pretty-prints it only when a detail view is actually
+/// rendered — avoiding a `serde_json::to_string_pretty` per credential on
+/// every `sync_from_config` (i.e. every config mutation / inbound message).
+///
+/// Two source shapes exist because the displayed JSON must be **byte-identical**
+/// to the previous eager output:
+///   - [`RawCredential::Vrc`] serializes the `DTGCommon` returned by
+///     `vrc.credential()` directly, preserving struct field order.
+///   - [`RawCredential::Value`] serializes a `serde_json::Value` (membership /
+///     role credentials are stored as `Value` on the community record).
+///
+/// Routing everything through `serde_json::Value` is *not* equivalent: without
+/// the `preserve_order` feature, `Value::Object` sorts keys alphabetically,
+/// which would reorder the `DTGCommon` fields versus the original
+/// struct-field-order output. Keeping the typed source preserves the bytes.
+#[derive(Clone, Debug)]
+pub enum RawCredential {
+    /// A VRC — serialize its `DTGCommon` credential body directly.
+    Vrc(Arc<DTGCredential>),
+    /// A membership/role credential already held as a JSON value.
+    Value(Arc<serde_json::Value>),
+}
+
+impl RawCredential {
+    /// Pretty-print the credential to JSON, matching the previous eager
+    /// `serde_json::to_string_pretty` output byte-for-byte. Called only at
+    /// detail-render / clipboard-copy time.
+    #[must_use]
+    pub fn to_pretty_json(&self) -> String {
+        match self {
+            RawCredential::Vrc(vrc) => serde_json::to_string_pretty(vrc.credential())
+                .unwrap_or_else(|_| "Failed to serialize credential".to_string()),
+            RawCredential::Value(value) => serde_json::to_string_pretty(value.as_ref())
+                .unwrap_or_else(|_| "Failed to serialize credential".to_string()),
+        }
+    }
+}
+
 // ****************************************************************************
 // Content Panel State
 // ****************************************************************************
@@ -32,7 +77,10 @@ pub struct ContentPanelState {
 #[derive(Clone, Debug, Default)]
 pub struct CommunitiesState {
     /// Display summaries of the (non-archived) communities, in display order.
-    pub items: Vec<CommunitySummary>,
+    /// `Arc<[…]>` so cloning the panel state (per frame / per event) is a
+    /// pointer bump rather than a deep copy; rebuilt wholesale in
+    /// `sync_from_config`.
+    pub items: Arc<[CommunitySummary]>,
     /// Currently selected index in the list.
     pub selected_index: usize,
     /// Number of communities raising the actions-required indicator (R-C-3).
@@ -103,12 +151,14 @@ pub struct VtaState {
     pub relationship_key_count: usize,
     /// Whether the VTA key backend is in use
     pub is_vta_managed: bool,
-    /// DIDs in use (persona + relationship R-DIDs)
-    pub active_dids: Vec<ActiveDid>,
+    /// DIDs in use (persona + relationship R-DIDs). `Arc<[…]>` for cheap
+    /// per-frame clones; rebuilt wholesale in `sync_from_config`.
+    pub active_dids: Arc<[ActiveDid]>,
     /// Every persona DID minted in this context, with how many communities
     /// present it — the manageable set for the DID manager. A persona bound to
     /// zero communities is an orphan (e.g. left by a failed join).
-    pub context_dids: Vec<ManagedDid>,
+    /// `Arc<[…]>` for cheap per-frame clones; rebuilt in `sync_from_config`.
+    pub context_dids: Arc<[ManagedDid]>,
     /// Selected index into [`Self::context_dids`] (DID manager navigation).
     pub did_selected_index: usize,
     /// When `Some(index)`, a deletion of that context DID is awaiting `y`/`n`
@@ -145,8 +195,9 @@ pub struct ActiveDid {
 /// State for the inbox/tasks panel.
 #[derive(Clone, Debug, Default)]
 pub struct InboxState {
-    /// Display summaries of all pending tasks
-    pub tasks: Vec<TaskSummary>,
+    /// Display summaries of all pending tasks. `Arc<[…]>` for cheap per-frame
+    /// clones; rebuilt wholesale in `sync_from_config`.
+    pub tasks: Arc<[TaskSummary]>,
     /// Currently selected task index in the list
     pub selected_index: usize,
     /// When viewing a specific task's details
@@ -244,8 +295,9 @@ pub enum ActiveTaskView {
 /// State for the relationships panel.
 #[derive(Clone, Debug, Default)]
 pub struct RelationshipsState {
-    /// Display summaries of all relationships
-    pub relationships: Vec<RelationshipSummary>,
+    /// Display summaries of all relationships. `Arc<[…]>` for cheap per-frame
+    /// clones; rebuilt wholesale in `sync_from_config`.
+    pub relationships: Arc<[RelationshipSummary]>,
     /// Currently selected index in the list
     pub selected_index: usize,
     /// Current panel mode (list, detail, new request form)
@@ -316,8 +368,8 @@ pub struct RelationshipVrc {
     pub valid_from: String,
     /// Formatted valid_until date (if set)
     pub valid_until: Option<String>,
-    /// Pretty-printed JSON of the raw credential
-    pub raw_json: String,
+    /// Raw credential source, pretty-printed lazily at detail-view time.
+    pub raw_json: RawCredential,
 }
 
 // ****************************************************************************
@@ -327,13 +379,14 @@ pub struct RelationshipVrc {
 /// State for the credentials (VRCs) panel.
 #[derive(Clone, Debug, Default)]
 pub struct CredentialsState {
-    /// VRCs we received
-    pub received: Vec<VrcSummary>,
-    /// VRCs we issued
-    pub issued: Vec<VrcSummary>,
+    /// VRCs we received. `Arc<[…]>` for cheap per-frame clones.
+    pub received: Arc<[VrcSummary]>,
+    /// VRCs we issued. `Arc<[…]>` for cheap per-frame clones.
+    pub issued: Arc<[VrcSummary]>,
     /// Membership (VMC) + role (VEC) credentials issued to us by the VTCs we've
     /// joined, one or two entries per community (reuses [`VrcSummary`]).
-    pub membership: Vec<VrcSummary>,
+    /// `Arc<[…]>` for cheap per-frame clones.
+    pub membership: Arc<[VrcSummary]>,
     /// Which tab is active
     pub selected_tab: CredentialTab,
     /// Currently selected index in the active tab's list
@@ -377,8 +430,8 @@ pub struct VrcSummary {
     pub vrc_id: String,
     /// Remote party's persona DID
     pub remote_p_did: String,
-    /// Pretty-printed JSON of the raw credential
-    pub raw_json: String,
+    /// Raw credential source, pretty-printed lazily at detail-view time.
+    pub raw_json: RawCredential,
     /// Contact alias (if set)
     pub alias: Option<String>,
     /// Issuer DID

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -41,7 +41,12 @@ pub struct MainPageState {
     pub config: MainMenuConfigState,
 
     /// Activity log entries shown in the bottom panel (newest last).
-    pub activity_log: VecDeque<ActivityLogEntry>,
+    ///
+    /// Entries are wrapped in `Arc` so cloning `MainPageState` (which happens
+    /// per frame and per event via the `State` watch channel) shares the
+    /// entries by pointer rather than deep-copying each entry's summary and
+    /// detail strings. Entries are immutable once written.
+    pub activity_log: VecDeque<Arc<ActivityLogEntry>>,
 }
 
 impl MainPageState {
@@ -60,10 +65,10 @@ impl MainPageState {
             self.activity_log.pop_front();
         }
         let timestamp = chrono::Local::now().format("%H:%M:%S");
-        self.activity_log.push_back(ActivityLogEntry {
+        self.activity_log.push_back(Arc::new(ActivityLogEntry {
             summary: format!("[{}] {}", timestamp, message),
             detail,
-        });
+        }));
     }
 
     /// Log an error with a short context line and a detailed pane containing
@@ -103,7 +108,7 @@ impl MainPageState {
         self.config = MainMenuConfigState::from(config);
 
         // Sync inbox tasks
-        self.content_panel.inbox.tasks = config
+        let mut inbox_tasks: Vec<TaskSummary> = config
             .private
             .tasks
             .tasks
@@ -188,10 +193,8 @@ impl MainPageState {
             })
             .collect();
         // Sort tasks by most recent first
-        self.content_panel
-            .inbox
-            .tasks
-            .sort_by(|a, b| b.created.cmp(&a.created));
+        inbox_tasks.sort_by(|a, b| b.created.cmp(&a.created));
+        self.content_panel.inbox.tasks = inbox_tasks.into();
 
         // Sync relationships
         self.content_panel.relationships.relationships = config
@@ -221,8 +224,9 @@ impl MainPageState {
                                 valid_until: vrc
                                     .valid_until()
                                     .map(|d| d.format("%Y-%m-%d").to_string()),
-                                raw_json: serde_json::to_string_pretty(&vrc.credential())
-                                    .unwrap_or_default(),
+                                // Defer pretty-printing to detail-view render
+                                // time; share the credential by Arc pointer.
+                                raw_json: content::RawCredential::Vrc(Arc::clone(vrc)),
                             })
                             .collect()
                     })
@@ -242,8 +246,9 @@ impl MainPageState {
                                 valid_until: vrc
                                     .valid_until()
                                     .map(|d| d.format("%Y-%m-%d").to_string()),
-                                raw_json: serde_json::to_string_pretty(&vrc.credential())
-                                    .unwrap_or_default(),
+                                // Defer pretty-printing to detail-view render
+                                // time; share the credential by Arc pointer.
+                                raw_json: content::RawCredential::Vrc(Arc::clone(vrc)),
                             })
                             .collect()
                     })
@@ -263,9 +268,10 @@ impl MainPageState {
 
         // Sync credentials
         self.content_panel.credentials.received =
-            collect_vrcs(&config.private.vrcs_received, config);
-        self.content_panel.credentials.issued = collect_vrcs(&config.private.vrcs_issued, config);
-        self.content_panel.credentials.membership = collect_membership_creds(config);
+            collect_vrcs(&config.private.vrcs_received, config).into();
+        self.content_panel.credentials.issued =
+            collect_vrcs(&config.private.vrcs_issued, config).into();
+        self.content_panel.credentials.membership = collect_membership_creds(config).into();
 
         // Sync settings
         self.content_panel.settings.friendly_name = config.public.friendly_name.clone();
@@ -332,7 +338,7 @@ impl MainPageState {
                 });
             }
         }
-        self.content_panel.vta.active_dids = active_dids;
+        self.content_panel.vta.active_dids = active_dids.into();
 
         // Context identities: every persona in the account, with how many
         // communities present it. A persona bound to zero communities is an
@@ -355,7 +361,7 @@ impl MainPageState {
             })
             .collect();
         context_dids.sort_by(|a, b| a.did.cmp(&b.did));
-        self.content_panel.vta.context_dids = context_dids;
+        self.content_panel.vta.context_dids = context_dids.into();
 
         self.content_panel.settings.protection_type = match &config.public.protection {
             openvtc_core::config::ConfigProtectionType::Token(id) => {
@@ -410,7 +416,7 @@ impl MainPageState {
         }
         let community_count = community_items.len();
         self.content_panel.communities.actions_required = config.account.actions_required_count();
-        self.content_panel.communities.items = community_items;
+        self.content_panel.communities.items = community_items.into();
         if self.content_panel.communities.selected_index >= community_count {
             self.content_panel.communities.selected_index = community_count.saturating_sub(1);
         }
@@ -443,8 +449,9 @@ fn collect_vrcs(vrcs: &openvtc_core::vrc::Vrcs, config: &Config) -> Vec<VrcSumma
             .and_then(|c| c.alias.clone());
         if let Some(vrc_map) = vrcs.get(remote_p_did) {
             for (vrc_id, vrc) in vrc_map {
-                let raw_json = serde_json::to_string_pretty(vrc.credential())
-                    .unwrap_or_else(|_| "Failed to serialize credential".to_string());
+                // Defer pretty-printing to detail-view render time; share the
+                // credential by Arc pointer (it is already `Arc`-held in config).
+                let raw_json = content::RawCredential::Vrc(Arc::clone(vrc));
                 result.push(VrcSummary {
                     vrc_id: vrc_id.to_string(),
                     remote_p_did: sanitize_display(remote_p_did, 256),
@@ -504,8 +511,10 @@ fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
                 .and_then(|v| v.as_str())
                 .unwrap_or_default()
                 .to_string();
-            let raw_json = serde_json::to_string_pretty(vc)
-                .unwrap_or_else(|_| "Failed to serialize credential".to_string());
+            // Defer pretty-printing to detail-view render time. Share the
+            // already-parsed JSON value by Arc pointer (a `serde_json::Value`
+            // pretty-prints identically whether done now or later).
+            let raw_json = content::RawCredential::Value(Arc::new(vc.clone()));
             result.push(VrcSummary {
                 vrc_id: vc_id,
                 remote_p_did: sanitize_display(&c.vtc_did, 256),
@@ -765,5 +774,89 @@ mod tests {
         assert!(matches!(panel.switch(), MainPanel::ContentPanel));
         let panel = MainPanel::ContentPanel;
         assert!(matches!(panel.switch(), MainPanel::MainMenu));
+    }
+
+    // --- RawCredential lazy rendering (Part 2) ---
+
+    /// The lazy `RawCredential::Vrc` path must pretty-print byte-identically to
+    /// the previous eager `serde_json::to_string_pretty(vrc.credential())`.
+    #[test]
+    fn test_raw_credential_vrc_matches_eager_output() {
+        use chrono::{TimeZone, Utc};
+        use dtg_credentials::DTGCredential;
+
+        let valid_from = Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap();
+        let vrc = DTGCredential::new_vrc(
+            "did:test:issuer".to_string(),
+            "did:test:subject".to_string(),
+            valid_from,
+            Some(Utc.with_ymd_and_hms(2025, 6, 7, 8, 9, 10).unwrap()),
+        );
+        // Old eager output, computed exactly as `sync_from_config` used to.
+        let eager = serde_json::to_string_pretty(vrc.credential()).unwrap();
+
+        let lazy = content::RawCredential::Vrc(Arc::new(vrc)).to_pretty_json();
+        assert_eq!(lazy, eager, "lazy VRC JSON must match the old eager output");
+    }
+
+    /// The lazy `RawCredential::Value` path (membership/role credentials) must
+    /// pretty-print byte-identically to the previous eager
+    /// `serde_json::to_string_pretty(vc)`.
+    #[test]
+    fn test_raw_credential_value_matches_eager_output() {
+        let vc = serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "MembershipCredential"],
+            "issuer": "did:test:vtc",
+            "validFrom": "2024-01-01T00:00:00Z",
+            "credentialSubject": { "id": "did:test:member", "role": "member" }
+        });
+        let eager = serde_json::to_string_pretty(&vc).unwrap();
+
+        let lazy = content::RawCredential::Value(Arc::new(vc)).to_pretty_json();
+        assert_eq!(
+            lazy, eager,
+            "lazy membership JSON must match the old eager output"
+        );
+    }
+
+    // --- Arc pointer-bump cloning (Part 1) ---
+
+    /// Cloning `MainPageState` must share the Arc-wrapped heavy collections by
+    /// pointer (a pointer bump), not deep-copy them — that is the whole point of
+    /// the per-event clone optimisation.
+    #[test]
+    fn test_clone_shares_arc_data() {
+        let mut state = MainPageState::default();
+        // Populate the Arc-wrapped collections with non-empty data so the
+        // pointer identity is meaningful.
+        state.content_panel.inbox.tasks = vec![TaskSummary {
+            id: "t1".to_string(),
+            type_display: "Test".to_string(),
+            kind: TaskKind::Informational("x".to_string()),
+            remote_did: "did:test:remote".to_string(),
+            created: "2024-01-01 00:00".to_string(),
+        }]
+        .into();
+        state.log_detailed("summary", "detail");
+
+        let clone = state.clone();
+
+        // Heavy vectors share the same allocation.
+        assert!(
+            Arc::ptr_eq(
+                &state.content_panel.inbox.tasks,
+                &clone.content_panel.inbox.tasks
+            ),
+            "inbox tasks must be shared by pointer after clone"
+        );
+        // Activity-log entries share the same allocation (per-entry Arc).
+        assert!(
+            Arc::ptr_eq(
+                state.activity_log.front().unwrap(),
+                clone.activity_log.front().unwrap()
+            ),
+            "activity log entries must be shared by pointer after clone"
+        );
     }
 }

--- a/openvtc/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc/src/ui/pages/main/components/content_panel.rs
@@ -46,7 +46,7 @@ impl ContentPanelState {
         rect: Rect,
         menu: &MenuPanelState,
         connection: &ConnectionState,
-        activity_log: &std::collections::VecDeque<ActivityLogEntry>,
+        activity_log: &std::collections::VecDeque<std::sync::Arc<ActivityLogEntry>>,
         logs_selected: usize,
         logs_detail_view: bool,
         scroll_offset: u16,

--- a/openvtc/src/ui/pages/main/components/credentials_panel.rs
+++ b/openvtc/src/ui/pages/main/components/credentials_panel.rs
@@ -175,11 +175,13 @@ fn render_detail(state: &CredentialsState, index: usize) -> Vec<Line<'static>> {
         Span::styled(vrc.vrc_id.clone(), Style::new().fg(COLOR_DARK_GRAY)),
     ]));
 
-    // Raw credential JSON
+    // Raw credential JSON — pretty-printed lazily, only when this detail view
+    // is rendered (not eagerly per credential on every config mutation).
     lines.push(Line::from(""));
     lines.push(Line::from(" Raw Credential").fg(COLOR_SUCCESS).bold());
     lines.push(Line::from(""));
-    for json_line in vrc.raw_json.lines() {
+    let raw_json = vrc.raw_json.to_pretty_json();
+    for json_line in raw_json.lines() {
         lines.push(Line::from(format!("  {}", json_line)).fg(COLOR_DARK_GRAY));
     }
 

--- a/openvtc/src/ui/pages/main/components/logs_panel.rs
+++ b/openvtc/src/ui/pages/main/components/logs_panel.rs
@@ -8,6 +8,7 @@ use ratatui::{
     text::{Line, Span},
 };
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 /// Render the logs panel as a scrollable list of activity log entries.
 ///
@@ -15,7 +16,7 @@ use std::collections::VecDeque;
 /// Hotkeys: Enter = view detail, c = copy selected, a = copy all, Esc = back.
 pub fn render(
     logs_state: &LogsState,
-    activity_log: &VecDeque<ActivityLogEntry>,
+    activity_log: &VecDeque<Arc<ActivityLogEntry>>,
 ) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from("")];
 
@@ -36,7 +37,7 @@ pub fn render(
         return lines;
     }
 
-    let entries: Vec<&ActivityLogEntry> = activity_log.iter().rev().collect();
+    let entries: Vec<&Arc<ActivityLogEntry>> = activity_log.iter().rev().collect();
 
     // Detail view — show full text of the selected entry
     if logs_state.detail_view {

--- a/openvtc/src/ui/pages/main/components/relationships_panel.rs
+++ b/openvtc/src/ui/pages/main/components/relationships_panel.rs
@@ -231,7 +231,10 @@ fn render_detail(
                         Span::styled(validity_detail, Style::new().fg(COLOR_TEXT_DEFAULT)),
                     ]));
                     lines.push(Line::from(""));
-                    for json_line in vrc.raw_json.lines() {
+                    // Pretty-print the credential lazily, only for the expanded
+                    // (selected) VRC — not eagerly per credential on every sync.
+                    let raw_json = vrc.raw_json.to_pretty_json();
+                    for json_line in raw_json.lines() {
                         lines.push(Line::from(format!("      {}", json_line)).fg(COLOR_DARK_GRAY));
                     }
                     lines.push(Line::from(""));
@@ -297,7 +300,10 @@ fn render_detail(
                         Span::styled(validity_detail, Style::new().fg(COLOR_TEXT_DEFAULT)),
                     ]));
                     lines.push(Line::from(""));
-                    for json_line in vrc.raw_json.lines() {
+                    // Pretty-print the credential lazily, only for the expanded
+                    // (selected) VRC — not eagerly per credential on every sync.
+                    let raw_json = vrc.raw_json.to_pretty_json();
+                    for json_line in raw_json.lines() {
                         lines.push(Line::from(format!("      {}", json_line)).fg(COLOR_DARK_GRAY));
                     }
                     lines.push(Line::from(""));

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -131,7 +131,7 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         );
         lines.push(Line::from(""));
 
-        for did_entry in &state.active_dids {
+        for did_entry in state.active_dids.iter() {
             lines.push(Line::from(vec![
                 Span::styled("  ● ", Style::new().fg(COLOR_SUCCESS)),
                 Span::styled(

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -945,7 +945,11 @@ impl MainPage {
                             CredentialTab::Membership => &creds.membership,
                         };
                         if let Some(vrc) = active_list.get(detail_index) {
-                            copy_to_clipboard(&vrc.raw_json, "credential", &self.action_tx);
+                            copy_to_clipboard(
+                                &vrc.raw_json.to_pretty_json(),
+                                "credential",
+                                &self.action_tx,
+                            );
                         }
                         true
                     }


### PR DESCRIPTION
**Task R16** (remediation plan, Phase R2 — responsiveness). **Scoped to the safe parts** by maintainer decision: Arc the heavy data + defer credential JSON; the risky "send-on-change" dirty-tracking is intentionally **skipped** (`state_handler/mod.rs` is untouched — all 13 `state_tx.send` calls unchanged).

## What
`State` is cloned ~3× per event (loop `state_tx.send`, UI `borrow_and_update().clone()`, `Props::from`). `MainPageState` carried heavy owned data deep-copied on every clone, and `sync_from_config` re-ran `to_string_pretty` for **every** credential on **every** config mutation.

- **Arc the heavy data** so each clone is a pointer bump: activity log → `VecDeque<Arc<ActivityLogEntry>>`; the panel vectors (inbox tasks, relationships, the three credential lists, active/context DIDs, communities) → `Arc<[T]>` (immutable after their wholesale `sync_from_config` rebuild; read sites work unchanged via `Deref<[T]>`).
- **Defer credential JSON to view time**: `raw_json: String` → `RawCredential` (`Arc<DTGCredential>` for VRCs — a free clone of the `Arc` already in `Vrcs` — or `Arc<Value>` for membership/role creds). `to_pretty_json()` now runs only in the detail-view render / clipboard-copy, not per-mutation per-credential.

## Output identity (the correctness bar)
Byte-identical rendering. VRCs serialize `vrc.credential()` (`&DTGCommon`) directly rather than via `serde_json::Value` — deliberate, because this workspace doesn't enable serde_json `preserve_order`, so a `Value::Object` (BTreeMap) would alphabetize keys and diverge from the old field-order output. Two tests assert `to_pretty_json()` == the old eager expression; a third asserts `Arc::ptr_eq` after a `MainPageState` clone.

Result: per-frame clones become refcount bumps; the per-mutation credential serialization is gone (pretty-print only for the on-screen credential).

Gate: `fmt` / `clippy -D warnings` / `test --workspace` green (main_page 13 + 3 new; openvtc lib 138).
