### PR TITLE
refactor(core): flatten Arc<Mutex> out of the domain model (R20)

### DIFF
--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -523,14 +523,14 @@ mod tests {
         // Relationship whose DIDs all carry the marker.
         private_cfg.relationships.relationships.insert(
             did.clone(),
-            Arc::new(Mutex::new(Relationship {
+            Relationship {
                 task_id: Arc::new(MARKER.to_string()),
                 our_did: did.clone(),
                 remote_did: did.clone(),
                 remote_p_did: did.clone(),
                 created: chrono::Utc::now(),
                 state: RelationshipState::Established,
-            })),
+            },
         );
 
         let writer = SharedWriter::default();

--- a/openvtc-core/src/relationships.rs
+++ b/openvtc-core/src/relationships.rs
@@ -27,7 +27,7 @@ use serde_json::json;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::SystemTime,
 };
 use tracing::{debug, warn};
@@ -75,7 +75,11 @@ impl Display for RelationshipState {
 #[serde(from = "RelationshipsShadow", into = "RelationshipsShadow")]
 pub struct Relationships {
     /// Map from remote P-DID to the relationship state.
-    pub relationships: HashMap<Arc<String>, Arc<Mutex<Relationship>>>,
+    ///
+    /// Plain values (no `Arc<Mutex>`): there is exactly one mutating task (the
+    /// `StateHandler` loop), so mutation goes through `&mut` and is infallible —
+    /// there are no lock-poisoning paths that can silently drop an entry.
+    pub relationships: HashMap<Arc<String>, Relationship>,
 
     /// Next BIP32 derivation path index to use when creating keys for a new relationship.
     pub path_pointer: u32,
@@ -106,14 +110,11 @@ pub struct Relationship {
 
 impl From<RelationshipsShadow> for Relationships {
     fn from(value: RelationshipsShadow) -> Self {
-        let mut relationships: HashMap<Arc<String>, Arc<Mutex<Relationship>>> = HashMap::new();
+        let mut relationships: HashMap<Arc<String>, Relationship> = HashMap::new();
 
         for relationship in value.relationships {
-            let remote_did = match relationship.lock() {
-                Ok(r) => r.remote_p_did.clone(),
-                Err(e) => e.into_inner().remote_p_did.clone(),
-            };
-            relationships.insert(remote_did.clone(), relationship.clone());
+            let key = relationship.remote_p_did.clone();
+            relationships.insert(key, relationship);
         }
 
         Relationships {
@@ -124,10 +125,16 @@ impl From<RelationshipsShadow> for Relationships {
 }
 
 /// Flat serialization form of [`Relationships`] used for persistence in `SecuredConfig`.
+///
+/// On-disk compatibility note (R20): the previous in-memory model wrapped each
+/// relationship in `Arc<Mutex<…>>`. With serde's `rc` feature both `Arc` and
+/// `Mutex` serialize transparently as their inner value, so a `Vec<Relationship>`
+/// and a `Vec<Arc<Mutex<Relationship>>>` produce **byte-identical** JSON. This
+/// shadow keeps the on-disk format unchanged across the de-mutex refactor.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub(crate) struct RelationshipsShadow {
-    pub(crate) relationships: Vec<Arc<Mutex<Relationship>>>,
+    pub(crate) relationships: Vec<Relationship>,
     pub(crate) path_pointer: u32,
 }
 
@@ -135,9 +142,8 @@ impl From<Relationships> for RelationshipsShadow {
     fn from(value: Relationships) -> Self {
         let relationships = value
             .relationships
-            .values()
-            .cloned()
-            .collect::<Vec<Arc<Mutex<Relationship>>>>();
+            .into_values()
+            .collect::<Vec<Relationship>>();
         RelationshipsShadow {
             relationships,
             path_pointer: value.path_pointer,
@@ -152,7 +158,7 @@ impl Relationships {
     /// # Errors
     ///
     /// Returns an error if the TDK ATM service is not initialized, VTA authentication
-    /// fails, a mutex is poisoned, or secret derivation/import fails.
+    /// fails, or secret derivation/import fails.
     /// `our_p_dids` is the set of *our* persona DIDs. Relationships served
     /// directly by a persona DID (rather than a dedicated R-DID) are skipped
     /// here — that persona's own listener carries them. With multiple personas
@@ -202,20 +208,18 @@ impl Relationships {
         // including the `?` error paths below.
         let profiles_result: Result<(), OpenVTCError> = async {
             // Collect R-DID relationships that need profiles + secrets.
-            // Extract data from Mutex before any async work.
             let r_did_entries: Vec<Arc<String>> = self
                 .relationships
                 .values()
                 .filter_map(|rel| {
-                    let lock = rel.lock().ok()?;
                     if matches!(
-                        lock.state,
+                        rel.state,
                         RelationshipState::Established
                             | RelationshipState::RequestSent
                             | RelationshipState::RequestAccepted
-                    ) && !our_p_dids.contains(lock.our_did.as_str())
+                    ) && !our_p_dids.contains(rel.our_did.as_str())
                     {
-                        Some(lock.our_did.clone())
+                        Some(rel.our_did.clone())
                     } else {
                         None
                     }
@@ -335,34 +339,24 @@ impl Relationships {
 
     /// Removes a relationship by its task ID, along with any associated VRCs.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if the relationship mutex is poisoned.
+    /// Returns the removed relationship if found, or `None` if no match exists.
     pub fn remove_by_task_id(
         &mut self,
         id: &Arc<String>,
         vrcs_issued: &mut Vrcs,
         vrcs_received: &mut Vrcs,
-    ) -> Result<Option<Arc<Mutex<Relationship>>>, OpenVTCError> {
-        let found = self
+    ) -> Option<Relationship> {
+        let key = self
             .relationships
-            .values()
-            .find(|f| f.lock().map(|r| r.task_id == *id).unwrap_or(false))
-            .cloned();
+            .iter()
+            .find(|(_, r)| r.task_id == *id)
+            .map(|(k, _)| k.clone());
 
-        if let Some(relationship) = found {
-            let remote_did = relationship
-                .lock()
-                .map_err(|e| {
-                    warn!("relationship mutex poisoned: {e}");
-                    OpenVTCError::MutexPoisoned(format!("Relationship mutex poisoned: {e}"))
-                })?
-                .remote_did
-                .clone();
+        if let Some(key) = key {
             debug!("relationship removed: task_id={}", id);
-            Ok(self.remove(&remote_did, vrcs_issued, vrcs_received))
+            self.remove(&key, vrcs_issued, vrcs_received)
         } else {
-            Ok(None)
+            None
         }
     }
 
@@ -374,7 +368,7 @@ impl Relationships {
         key: &Arc<String>,
         vrcs_issued: &mut Vrcs,
         vrcs_received: &mut Vrcs,
-    ) -> Option<Arc<Mutex<Relationship>>> {
+    ) -> Option<Relationship> {
         // Find and remove any VRCs associated with this relationship
         vrcs_issued.remove_relationship(key);
         vrcs_received.remove_relationship(key);
@@ -386,43 +380,53 @@ impl Relationships {
         removed
     }
 
-    /// Gets a relationship using the remote P-DID key
-    pub fn get(&self, p_did: &Arc<String>) -> Option<Arc<Mutex<Relationship>>> {
-        self.relationships.get(p_did).cloned()
+    /// Gets a relationship using the remote P-DID key.
+    pub fn get(&self, p_did: &Arc<String>) -> Option<&Relationship> {
+        self.relationships.get(p_did)
+    }
+
+    /// Gets a mutable reference to a relationship using the remote P-DID key.
+    pub fn get_mut(&mut self, p_did: &Arc<String>) -> Option<&mut Relationship> {
+        self.relationships.get_mut(p_did)
     }
 
     /// Finds a relationship by its task ID.
-    pub fn find_by_task_id(&self, task_id: &Arc<String>) -> Option<Arc<Mutex<Relationship>>> {
+    pub fn find_by_task_id(&self, task_id: &Arc<String>) -> Option<&Relationship> {
+        self.relationships.values().find(|r| &r.task_id == task_id)
+    }
+
+    /// Finds the map key (remote P-DID) of a relationship by its task ID.
+    ///
+    /// Useful for "look up → await → re-look-up mutably" flows where a `&mut`
+    /// borrow cannot be held across an `.await`.
+    pub fn find_key_by_task_id(&self, task_id: &Arc<String>) -> Option<Arc<String>> {
         self.relationships
-            .values()
-            .find(|f| f.lock().map(|r| &r.task_id == task_id).unwrap_or(false))
-            .cloned()
+            .iter()
+            .find(|(_, r)| &r.task_id == task_id)
+            .map(|(k, _)| k.clone())
     }
 
     /// Finds a relationship by its remote DID (either P-DID or R-DID).
-    pub fn find_by_remote_did(&self, did: &Arc<String>) -> Option<Arc<Mutex<Relationship>>> {
+    pub fn find_by_remote_did(&self, did: &Arc<String>) -> Option<&Relationship> {
         self.relationships
             .values()
-            .find(|r| {
-                r.lock()
-                    .map(|lock| lock.remote_did == *did || lock.remote_p_did == *did)
-                    .unwrap_or(false)
-            })
-            .cloned()
+            .find(|r| r.remote_did == *did || r.remote_p_did == *did)
+    }
+
+    /// Finds the map key (remote P-DID) of a relationship matching the given
+    /// remote DID (either P-DID or R-DID).
+    pub fn find_key_by_remote_did(&self, did: &Arc<String>) -> Option<Arc<String>> {
+        self.relationships
+            .iter()
+            .find(|(_, r)| r.remote_did == *did || r.remote_p_did == *did)
+            .map(|(k, _)| k.clone())
     }
 
     /// Returns only the relationships in the [`RelationshipState::Established`] state.
-    pub fn get_established_relationships(&self) -> Vec<Arc<Mutex<Relationship>>> {
+    pub fn get_established_relationships(&self) -> Vec<&Relationship> {
         self.relationships
             .values()
-            .filter_map(|r| {
-                let lock = r.lock().ok()?;
-                if lock.state == RelationshipState::Established {
-                    Some(r.clone())
-                } else {
-                    None
-                }
-            })
+            .filter(|r| r.state == RelationshipState::Established)
             .collect()
     }
 }
@@ -612,8 +616,7 @@ mod tests {
             RelationshipState::Established,
         );
         let key = r.remote_p_did.clone();
-        rels.relationships
-            .insert(key.clone(), Arc::new(Mutex::new(r)));
+        rels.relationships.insert(key.clone(), r);
 
         // get by p-did
         let found = rels.get(&key);
@@ -649,10 +652,8 @@ mod tests {
             "did:rp:2",
             RelationshipState::RequestSent,
         );
-        rels.relationships
-            .insert(r1.remote_p_did.clone(), Arc::new(Mutex::new(r1)));
-        rels.relationships
-            .insert(r2.remote_p_did.clone(), Arc::new(Mutex::new(r2)));
+        rels.relationships.insert(r1.remote_p_did.clone(), r1);
+        rels.relationships.insert(r2.remote_p_did.clone(), r2);
 
         let established = rels.get_established_relationships();
         assert_eq!(
@@ -676,8 +677,7 @@ mod tests {
             RelationshipState::Established,
         );
         let key = r.remote_p_did.clone();
-        rels.relationships
-            .insert(key.clone(), Arc::new(Mutex::new(r)));
+        rels.relationships.insert(key.clone(), r);
 
         let removed = rels.remove(&key, &mut vrcs_issued, &mut vrcs_received);
         assert!(removed.is_some(), "Should return the removed relationship");
@@ -715,8 +715,7 @@ mod tests {
             "did:rp:1",
             RelationshipState::Established,
         );
-        rels.relationships
-            .insert(r.remote_p_did.clone(), Arc::new(Mutex::new(r)));
+        rels.relationships.insert(r.remote_p_did.clone(), r);
 
         let shadow: RelationshipsShadow = rels.into();
         assert_eq!(shadow.path_pointer, 42);
@@ -725,5 +724,48 @@ mod tests {
         let restored: Relationships = shadow.into();
         assert_eq!(restored.path_pointer, 42);
         assert_eq!(restored.relationships.len(), 1);
+    }
+
+    /// On-disk compatibility guard (R20): a relationships JSON written by the
+    /// pre-R20 `Arc<Mutex<Relationship>>` model must deserialize into the new
+    /// plain-value model and re-serialize to **byte-identical** JSON.
+    ///
+    /// The fixture below is exactly what the old shadow emitted: `Arc` and
+    /// `Mutex` both serialize transparently (serde `rc`), so each relationship
+    /// is a bare object — no wrapper keys. `Relationships` serializes via
+    /// `RelationshipsShadow`, so we drive the test through the public type.
+    #[test]
+    fn relationships_ondisk_byte_identical_roundtrip() {
+        // A fixed timestamp so the round-trip is deterministic.
+        let fixture = r#"{
+  "relationships": [
+    {
+      "task_id": "task-abc",
+      "our_did": "did:webvh:example:us",
+      "remote_did": "did:webvh:example:them-rdid",
+      "remote_p_did": "did:webvh:example:them",
+      "created": "2024-01-02T03:04:05Z",
+      "state": "Established"
+    }
+  ],
+  "path_pointer": 7
+}"#;
+
+        // Deserialize into the new plain-value model (via the shadow).
+        let rels: Relationships = serde_json::from_str(fixture).expect("fixture deserializes");
+        assert_eq!(rels.path_pointer, 7);
+        assert_eq!(rels.relationships.len(), 1);
+
+        // Re-serialize and compare to the canonical pretty form to prove the
+        // on-disk shape is unchanged across the de-mutex refactor.
+        let reserialized = serde_json::to_string_pretty(&rels).expect("re-serializes");
+        let fixture_value: serde_json::Value =
+            serde_json::from_str(fixture).expect("fixture is valid json");
+        let reserialized_value: serde_json::Value =
+            serde_json::from_str(&reserialized).expect("output is valid json");
+        assert_eq!(
+            reserialized_value, fixture_value,
+            "re-serialized relationships must match the pre-R20 on-disk shape"
+        );
     }
 }

--- a/openvtc-core/src/tasks.rs
+++ b/openvtc-core/src/tasks.rs
@@ -4,11 +4,7 @@
 //! and VRC exchanges. Each task has a unique ID, a [`TaskType`], and a creation
 //! timestamp.
 
-use std::{
-    collections::HashMap,
-    fmt::Display,
-    sync::{Arc, Mutex},
-};
+use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use dtg_credentials::DTGCredential;
@@ -16,10 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use tracing::debug;
 
-use crate::{
-    relationships::{Relationship, RelationshipRequestBody},
-    vrc::VrcRequest,
-};
+use crate::{relationships::RelationshipRequestBody, vrc::VrcRequest};
 
 /// Defined Task Types for OpenVTC.
 ///
@@ -43,21 +36,42 @@ pub enum TaskType {
     /// The relationship handshake has been finalized (fully established).
     RelationshipRequestFinalized,
     /// A trust-ping was sent to verify connectivity with the remote party.
+    ///
+    /// `remote_p_did` is the relationship's remote persona DID — the key into
+    /// `Relationships`. Look the relationship up there at the use site rather
+    /// than holding an embedded snapshot.
+    ///
+    /// On-disk compatibility (R20): pre-R20 configs serialized an embedded
+    /// `relationship` object here instead of `remote_p_did`. Such configs still
+    /// load — `remote_p_did` is `#[serde(default)]` (empty) and the now-extra
+    /// `relationship` field is ignored. The acceptable degradation: a pre-R20
+    /// *in-flight* TrustPing task (these live for seconds) loads with an empty
+    /// `remote_p_did`, so its remote display falls back to blank until the task
+    /// is replaced; the relationship itself still exists in `Relationships`.
     TrustPing {
         from: Arc<String>,
         to: Arc<String>,
-        relationship: Arc<Mutex<Relationship>>,
+        #[serde(default)]
+        remote_p_did: Arc<String>,
     },
     /// A trust-pong response was received from the remote party.
     TrustPong,
     /// We sent a VRC request to a remote party.
+    ///
+    /// `remote_p_did` is the relationship key into `Relationships`. See
+    /// [`TaskType::TrustPing`] for the pre-R20 on-disk compatibility note.
     VRCRequestOutbound {
-        relationship: Arc<Mutex<Relationship>>,
+        #[serde(default)]
+        remote_p_did: Arc<String>,
     },
     /// A remote party sent us a VRC request awaiting our response.
+    ///
+    /// `remote_p_did` is the relationship key into `Relationships`. See
+    /// [`TaskType::TrustPing`] for the pre-R20 on-disk compatibility note.
     VRCRequestInbound {
         request: VrcRequest,
-        relationship: Arc<Mutex<Relationship>>,
+        #[serde(default)]
+        remote_p_did: Arc<String>,
     },
     /// Our VRC request was rejected by the remote party.
     VRCRequestRejected,
@@ -88,7 +102,10 @@ impl Display for TaskType {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Tasks {
     /// key: Task ID
-    pub tasks: HashMap<Arc<String>, Arc<Mutex<Task>>>,
+    ///
+    /// Plain values (no `Arc<Mutex>`): there is exactly one mutating task (the
+    /// `StateHandler` loop), so mutation goes through `&mut` and is infallible.
+    pub tasks: HashMap<Arc<String>, Task>,
 }
 
 impl Tasks {
@@ -101,27 +118,27 @@ impl Tasks {
         removed
     }
 
-    /// Creates a new task with the given ID and type, inserts it, and returns a shared reference.
-    pub fn new_task(&mut self, id: &Arc<String>, type_: TaskType) -> Arc<Mutex<Task>> {
+    /// Creates a new task with the given ID and type, inserts it, and returns a
+    /// reference to it.
+    pub fn new_task(&mut self, id: &Arc<String>, type_: TaskType) -> &Task {
         debug!("task created: type={:?}, id={}", type_, id);
-        let task = Arc::new(Mutex::new(Task {
+        let task = Task {
             id: id.clone(),
             type_,
             created: Utc::now(),
-        }));
-        self.tasks.insert(id.clone(), task.clone());
-        task
+        };
+        self.tasks.entry(id.clone()).insert_entry(task).into_mut()
     }
 
     /// Returns the task at the given iteration position, or `None` if out of bounds.
     ///
     /// Note: HashMap iteration order is not stable across insertions and removals.
-    pub fn get_by_pos(&self, pos: usize) -> Option<Arc<Mutex<Task>>> {
-        self.tasks.iter().nth(pos).map(|(_, task)| task.clone())
+    pub fn get_by_pos(&self, pos: usize) -> Option<&Task> {
+        self.tasks.iter().nth(pos).map(|(_, task)| task)
     }
 
     /// Retrieves a task by ID or returns None
-    pub fn get_by_id(&self, id: &Arc<String>) -> Option<&Arc<Mutex<Task>>> {
+    pub fn get_by_id(&self, id: &Arc<String>) -> Option<&Task> {
         self.tasks.get(id)
     }
 
@@ -154,6 +171,55 @@ mod tests {
     fn test_tasks_default_empty() {
         let tasks = Tasks::default();
         assert!(tasks.tasks.is_empty(), "Default Tasks should have no tasks");
+    }
+
+    /// Forward-load compatibility (R20): a pre-R20 `Tasks` config serialized the
+    /// 3 relationship-embedding variants with an embedded `relationship` object
+    /// instead of the new `remote_p_did` key. Such a config must still LOAD: the
+    /// now-extra `relationship` field is ignored by serde (no
+    /// `deny_unknown_fields`) and the missing `remote_p_did` defaults to empty.
+    /// The acceptable degradation: the in-flight task loses its embedded
+    /// snapshot (the relationship still exists in `Relationships`).
+    #[test]
+    fn pre_r20_task_with_embedded_relationship_still_loads() {
+        // A pre-R20 VRCRequestOutbound task carried an embedded `relationship`
+        // object (an `Arc<Mutex<Relationship>>` serializes as a bare object).
+        let old_json = r#"{
+            "tasks": {
+                "msg-1": {
+                    "id": "msg-1",
+                    "type_": {
+                        "VRCRequestOutbound": {
+                            "relationship": {
+                                "task_id": "t1",
+                                "our_did": "did:webvh:example:us",
+                                "remote_did": "did:webvh:example:them",
+                                "remote_p_did": "did:webvh:example:them",
+                                "created": "2024-01-02T03:04:05Z",
+                                "state": "Established"
+                            }
+                        }
+                    },
+                    "created": "2024-01-02T03:04:05Z"
+                }
+            }
+        }"#;
+
+        let tasks: Tasks = serde_json::from_str(old_json).expect("pre-R20 config still loads");
+        let task = tasks
+            .get_by_id(&Arc::new("msg-1".to_string()))
+            .expect("task present");
+        match &task.type_ {
+            TaskType::VRCRequestOutbound { remote_p_did } => {
+                // The embedded `relationship` was ignored; the new key defaults
+                // to empty (the documented transient degradation).
+                assert!(
+                    remote_p_did.is_empty(),
+                    "remote_p_did defaults to empty when absent from an old config"
+                );
+            }
+            other => panic!("unexpected variant: {other}"),
+        }
     }
 
     #[test]

--- a/openvtc-core/tests/relationships.rs
+++ b/openvtc-core/tests/relationships.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the Relationships struct and related types.
 
 use openvtc_core::relationships::{Relationship, RelationshipState, Relationships};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 fn make_relationship(
     task_id: &str,
@@ -38,8 +38,7 @@ fn add_relationship_and_find_by_did() {
         RelationshipState::Established,
     );
     let key = r.remote_p_did.clone();
-    rels.relationships
-        .insert(key.clone(), Arc::new(Mutex::new(r)));
+    rels.relationships.insert(key.clone(), r);
 
     let found = rels.get(&key);
     assert!(found.is_some(), "Should find relationship by remote P-DID");
@@ -58,8 +57,7 @@ fn find_by_task_id() {
         "did:remote-p:1",
         RelationshipState::RequestSent,
     );
-    rels.relationships
-        .insert(r.remote_p_did.clone(), Arc::new(Mutex::new(r)));
+    rels.relationships.insert(r.remote_p_did.clone(), r);
 
     let found = rels.find_by_task_id(&Arc::new("task-42".to_string()));
     assert!(found.is_some());
@@ -78,8 +76,7 @@ fn find_by_remote_did_matches_both_r_did_and_p_did() {
         "did:remote-p:1",
         RelationshipState::Established,
     );
-    rels.relationships
-        .insert(r.remote_p_did.clone(), Arc::new(Mutex::new(r)));
+    rels.relationships.insert(r.remote_p_did.clone(), r);
 
     // Find by R-DID
     let by_r = rels.find_by_remote_did(&Arc::new("did:remote-r:1".to_string()));
@@ -120,16 +117,12 @@ fn get_established_filters_correctly() {
         RelationshipState::RequestRejected,
     );
 
-    rels.relationships.insert(
-        established.remote_p_did.clone(),
-        Arc::new(Mutex::new(established)),
-    );
     rels.relationships
-        .insert(pending.remote_p_did.clone(), Arc::new(Mutex::new(pending)));
-    rels.relationships.insert(
-        rejected.remote_p_did.clone(),
-        Arc::new(Mutex::new(rejected)),
-    );
+        .insert(established.remote_p_did.clone(), established);
+    rels.relationships
+        .insert(pending.remote_p_did.clone(), pending);
+    rels.relationships
+        .insert(rejected.remote_p_did.clone(), rejected);
 
     let established_list = rels.get_established_relationships();
     assert_eq!(established_list.len(), 1);
@@ -149,8 +142,7 @@ fn remove_relationship_clears_entry() {
         RelationshipState::Established,
     );
     let key = r.remote_p_did.clone();
-    rels.relationships
-        .insert(key.clone(), Arc::new(Mutex::new(r)));
+    rels.relationships.insert(key.clone(), r);
 
     let removed = rels.remove(&key, &mut vrcs_issued, &mut vrcs_received);
     assert!(removed.is_some());
@@ -189,8 +181,7 @@ fn relationships_shadow_roundtrip() {
         "did:rp:1",
         RelationshipState::Established,
     );
-    rels.relationships
-        .insert(r.remote_p_did.clone(), Arc::new(Mutex::new(r)));
+    rels.relationships.insert(r.remote_p_did.clone(), r);
 
     // Roundtrip via JSON serialization (uses RelationshipsShadow internally via serde)
     let json = serde_json::to_string(&rels).expect("serialize");

--- a/openvtc-core/tests/tasks.rs
+++ b/openvtc-core/tests/tasks.rs
@@ -78,10 +78,9 @@ fn clear_non_empty_returns_true_and_empties() {
 fn new_task_returns_arc_to_created_task() {
     let mut tasks = Tasks::default();
     let id = Arc::new("task-ret".to_string());
-    let task_arc = tasks.new_task(&id, TaskType::TrustPong);
+    let task = tasks.new_task(&id, TaskType::TrustPong);
 
-    let lock = task_arc.lock().unwrap();
-    assert_eq!(*lock.id, "task-ret");
+    assert_eq!(*task.id, "task-ret");
 }
 
 #[test]
@@ -124,7 +123,7 @@ fn inserting_duplicate_id_overwrites() {
     // Should still have one entry (same key)
     assert_eq!(tasks.tasks.len(), 1);
 
-    let lock = tasks.get_by_id(&id).unwrap().lock().unwrap();
+    let task = tasks.get_by_id(&id).unwrap();
     // The second insert should have overwritten the first
-    assert_eq!(format!("{}", lock.type_), "VRC Request Rejected");
+    assert_eq!(format!("{}", task.type_), "VRC Request Rejected");
 }

--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -18,17 +18,16 @@ pub async fn send_vrc_request(
 ) -> Result<()> {
     let remote_key = Arc::new(remote_p_did.to_string());
 
-    let relationship = config
-        .private
-        .relationships
-        .get(&remote_key)
-        .ok_or_else(|| anyhow::anyhow!("No relationship found for {}", remote_p_did))?;
-
     let (our_did, remote_did) = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        (Arc::clone(&lock.our_did), Arc::clone(&lock.remote_did))
+        let relationship = config
+            .private
+            .relationships
+            .get(&remote_key)
+            .ok_or_else(|| anyhow::anyhow!("No relationship found for {}", remote_p_did))?;
+        (
+            Arc::clone(&relationship.our_did),
+            Arc::clone(&relationship.remote_did),
+        )
     };
 
     let request_body = VrcRequest {
@@ -43,10 +42,12 @@ pub async fn send_vrc_request(
         .map_err(|e| anyhow::anyhow!("failed to send VRC request: {e}"))?;
 
     // Create tracking task
-    config
-        .private
-        .tasks
-        .new_task(&msg_id, TaskType::VRCRequestOutbound { relationship });
+    config.private.tasks.new_task(
+        &msg_id,
+        TaskType::VRCRequestOutbound {
+            remote_p_did: remote_key,
+        },
+    );
 
     config.public.logs.insert(
         LogFamily::Relationship,

--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -366,8 +366,7 @@ pub async fn build_listener_configs(
         .relationships
         .relationships
         .iter()
-        .filter_map(|(remote_p_did, rel_arc)| {
-            let rel = rel_arc.lock().ok()?;
+        .filter_map(|(remote_p_did, rel)| {
             if matches!(
                 rel.state,
                 RelationshipState::Established

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -4,7 +4,7 @@
 //! relationship requests, accept VRCs, dismiss tasks). They operate on
 //! `&mut Config` and `&TDK` owned by the StateHandler.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::TDK;
@@ -31,16 +31,11 @@ pub fn accept_vrc(config: &mut Config, task_id: &str) -> Result<()> {
 
     // Find the task and extract VRC + sender
     let (vrc, remote_p_did) = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {}", task_id))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        let task = config
+            .private
+            .tasks
+            .get_by_id(&task_id)
+            .ok_or_else(|| anyhow::anyhow!("task not found: {}", task_id))?;
         match &task.type_ {
             TaskType::VRCIssued { vrc } => {
                 // Determine issuer as remote p-did
@@ -413,14 +408,14 @@ impl InboxOutcome {
                     Ok(()) => {
                         config.private.relationships.relationships.insert(
                             Arc::clone(&from_did),
-                            Arc::new(Mutex::new(RelRecord {
+                            RelRecord {
                                 task_id: Arc::clone(&task_id),
                                 remote_did: Arc::new(their_did),
                                 remote_p_did: Arc::clone(&from_did),
                                 our_did,
                                 created: Utc::now(),
                                 state: RelationshipState::RequestAccepted,
-                            })),
+                            },
                         );
                         config.private.tasks.remove(&task_id);
                         config.public.logs.insert(
@@ -556,16 +551,11 @@ async fn prepare_accept_relationship(
     let task_id = Arc::new(task_id.to_string());
 
     let (from_did, their_did, sender_name) = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        let task = config
+            .private
+            .tasks
+            .get_by_id(&task_id)
+            .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?;
         match &task.type_ {
             TaskType::RelationshipRequestInbound { from, request, .. } => {
                 let sanitized_name = request
@@ -650,16 +640,11 @@ fn prepare_reject_relationship(
 ) -> Result<InboxJob> {
     let task_id = Arc::new(task_id.to_string());
     let from_did = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        let task = config
+            .private
+            .tasks
+            .get_by_id(&task_id)
+            .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?;
         match &task.type_ {
             TaskType::RelationshipRequestInbound { from, .. } => Arc::clone(from),
             _ => anyhow::bail!("task {task_id} is not an inbound relationship request"),
@@ -697,30 +682,27 @@ async fn prepare_accept_vrc_request(
     use openvtc_core::vrc::DtgCredentialMessage;
 
     let task_id = Arc::new(task_id.to_string());
-    let relationship = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+    let remote_p_did = {
+        let task = config
+            .private
+            .tasks
+            .get_by_id(&task_id)
+            .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?;
         match &task.type_ {
-            TaskType::VRCRequestInbound { relationship, .. } => Arc::clone(relationship),
+            TaskType::VRCRequestInbound { remote_p_did, .. } => Arc::clone(remote_p_did),
             _ => anyhow::bail!("task {task_id} is not an inbound VRC request"),
         }
     };
     let (our_r_did, their_p_did, their_r_did) = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        let relationship = config
+            .private
+            .relationships
+            .get(&remote_p_did)
+            .ok_or_else(|| anyhow::anyhow!("no relationship for {remote_p_did}"))?;
         (
-            Arc::clone(&lock.our_did),
-            Arc::clone(&lock.remote_p_did),
-            Arc::clone(&lock.remote_did),
+            Arc::clone(&relationship.our_did),
+            Arc::clone(&relationship.remote_p_did),
+            Arc::clone(&relationship.remote_did),
         )
     };
 
@@ -764,30 +746,27 @@ fn prepare_reject_vrc_request(
     use openvtc_core::vrc::VRCRequestReject;
 
     let task_id = Arc::new(task_id.to_string());
-    let relationship = {
-        let task_arc = Arc::clone(
-            config
-                .private
-                .tasks
-                .get_by_id(&task_id)
-                .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?,
-        );
-        let task = task_arc
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+    let remote_p_did = {
+        let task = config
+            .private
+            .tasks
+            .get_by_id(&task_id)
+            .ok_or_else(|| anyhow::anyhow!("task not found: {task_id}"))?;
         match &task.type_ {
-            TaskType::VRCRequestInbound { relationship, .. } => Arc::clone(relationship),
+            TaskType::VRCRequestInbound { remote_p_did, .. } => Arc::clone(remote_p_did),
             _ => anyhow::bail!("task {task_id} is not an inbound VRC request"),
         }
     };
     let (our_r_did, their_r_did, their_p_did) = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        let relationship = config
+            .private
+            .relationships
+            .get(&remote_p_did)
+            .ok_or_else(|| anyhow::anyhow!("no relationship for {remote_p_did}"))?;
         (
-            Arc::clone(&lock.our_did),
-            Arc::clone(&lock.remote_did),
-            Arc::clone(&lock.remote_p_did),
+            Arc::clone(&relationship.our_did),
+            Arc::clone(&relationship.remote_did),
+            Arc::clone(&relationship.remote_p_did),
         )
     };
     let msg = VRCRequestReject::create_message(

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -113,8 +113,7 @@ impl MainPageState {
             .tasks
             .tasks
             .values()
-            .filter_map(|task_arc| {
-                let task = task_arc.lock().ok()?;
+            .map(|task| {
                 let kind = match &task.type_ {
                     TaskType::RelationshipRequestInbound { from, request, .. } => {
                         TaskKind::RelationshipRequestInbound {
@@ -130,7 +129,6 @@ impl MainPageState {
                             .relationships
                             .relationships
                             .get(to)
-                            .and_then(|rel_arc| rel_arc.lock().ok())
                             .map(|rel| rel.our_did.to_string())
                             .unwrap_or_default();
                         TaskKind::RelationshipRequestOutbound { our_did }
@@ -166,30 +164,20 @@ impl MainPageState {
                     }
                     TaskType::RelationshipRequestOutbound { to } => shorten_did(to, 60),
                     TaskType::TrustPing { to, .. } => shorten_did(to, 60),
-                    TaskType::VRCRequestInbound { relationship, .. } => {
-                        if let Ok(lock) = relationship.lock() {
-                            shorten_did(&lock.remote_p_did, 60)
-                        } else {
-                            String::new()
-                        }
+                    TaskType::VRCRequestInbound { remote_p_did, .. } => {
+                        shorten_did(remote_p_did, 60)
                     }
-                    TaskType::VRCRequestOutbound { relationship } => {
-                        if let Ok(lock) = relationship.lock() {
-                            shorten_did(&lock.remote_p_did, 60)
-                        } else {
-                            String::new()
-                        }
-                    }
+                    TaskType::VRCRequestOutbound { remote_p_did } => shorten_did(remote_p_did, 60),
                     TaskType::VRCIssued { vrc } => sanitize_display(vrc.issuer(), 40),
                     _ => String::new(),
                 };
-                Some(TaskSummary {
+                TaskSummary {
                     id: task.id.to_string(),
                     type_display: task.type_.to_string(),
                     kind,
                     remote_did: sanitize_display(&remote_did, 256),
                     created: task.created.format("%Y-%m-%d %H:%M").to_string(),
-                })
+                }
             })
             .collect();
         // Sort tasks by most recent first
@@ -202,8 +190,7 @@ impl MainPageState {
             .relationships
             .relationships
             .iter()
-            .filter_map(|(remote_p_did, rel_arc)| {
-                let rel = rel_arc.lock().ok()?;
+            .map(|(remote_p_did, rel)| {
                 let alias = config
                     .private
                     .contacts
@@ -253,7 +240,7 @@ impl MainPageState {
                             .collect()
                     })
                     .unwrap_or_default();
-                Some(RelationshipSummary {
+                RelationshipSummary {
                     remote_p_did: sanitize_display(remote_p_did, 256),
                     alias: alias.as_deref().map(|a| sanitize_display(a, 256)),
                     state: rel.state.to_string(),
@@ -262,7 +249,7 @@ impl MainPageState {
                     created: rel.created.format("%Y-%m-%d %H:%M").to_string(),
                     vrcs_issued,
                     vrcs_received,
-                })
+                }
             })
             .collect();
 
@@ -322,10 +309,8 @@ impl MainPageState {
                 label: "Persona".to_string(),
             });
         }
-        for (remote_p_did, rel_arc) in &config.private.relationships.relationships {
-            if let Ok(rel) = rel_arc.lock()
-                && !config.is_persona_did(rel.our_did.as_str())
-            {
+        for (remote_p_did, rel) in &config.private.relationships.relationships {
+            if !config.is_persona_did(rel.our_did.as_str()) {
                 let alias = config
                     .private
                     .contacts

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -308,18 +308,13 @@ fn vet_vrc_issued(
     let relationship = relationships
         .find_by_remote_did(from_did)
         .ok_or_else(|| "no relationship with sender".to_string())?;
-    let remote_p_did = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| format!("mutex poisoned: {e}"))?;
-        if lock.state != RelationshipState::Established {
-            return Err(format!(
-                "relationship with sender is not established (state: {})",
-                lock.state
-            ));
-        }
-        Arc::clone(&lock.remote_p_did)
-    };
+    if relationship.state != RelationshipState::Established {
+        return Err(format!(
+            "relationship with sender is not established (state: {})",
+            relationship.state
+        ));
+    }
+    let remote_p_did = Arc::clone(&relationship.remote_p_did);
 
     // Gate 2: issuer must be the authenticated sender's persona DID.
     if vrc.issuer() != remote_p_did.as_str() {
@@ -335,12 +330,13 @@ fn vet_vrc_issued(
     let pending_request = thid.and_then(|thid| {
         let id = Arc::new(thid.to_string());
         let task = tasks.get_by_id(&id)?;
-        let task = task.lock().ok()?;
-        let TaskType::VRCRequestOutbound { relationship } = &task.type_ else {
+        let TaskType::VRCRequestOutbound {
+            remote_p_did: task_remote_p_did,
+        } = &task.type_
+        else {
             return None;
         };
-        let lock = relationship.lock().ok()?;
-        (lock.remote_p_did == remote_p_did).then(|| Arc::clone(&id))
+        (*task_remote_p_did == remote_p_did).then(|| Arc::clone(&id))
     });
 
     Ok(pending_request)
@@ -520,16 +516,16 @@ pub async fn process_inbound_message(
                 return Ok(false);
             }
 
-            // Extract listener ID before async work to avoid holding MutexGuard across await
-            let listener_to_remove = if let Some(rel_arc) =
-                config.private.relationships.find_by_task_id(&task_id)
-                && let Ok(lock) = rel_arc.lock()
-                && !config.is_persona_did(lock.our_did.as_str())
-            {
-                Some(super::didcomm::listener_id_for_did(&lock.our_did, config))
-            } else {
-                None
-            };
+            // Extract the listener's local DID before async work + before any
+            // mutation, so the `&Relationship` borrow ends here.
+            let our_did = config
+                .private
+                .relationships
+                .find_by_task_id(&task_id)
+                .map(|rel| Arc::clone(&rel.our_did))
+                .filter(|our_did| !config.is_persona_did(our_did.as_str()));
+            let listener_to_remove =
+                our_did.map(|our_did| super::didcomm::listener_id_for_did(&our_did, config));
             if let Some(lid) = listener_to_remove
                 && let Err(e) = service.remove_listener(&lid).await
             {
@@ -566,29 +562,42 @@ pub async fn process_inbound_message(
             // All handshake messages use persona DIDs for from/to, so from_did
             // is the remote party's persona DID. Look up by task_id first, then
             // by persona DID. Validate sender matches the expected remote party.
-            let relationship = config
+            //
+            // R20: with plain values we cannot hold a `&mut` across the finalize
+            // `.await` below, so resolve the map key, mutate via `get_mut` (the
+            // borrow ends immediately), then await. The mutation happens before
+            // the await — no re-look-up is needed.
+            let key = config
                 .private
                 .relationships
-                .find_by_task_id(&task_id)
-                .or_else(|| config.private.relationships.get(&from_did));
+                .find_key_by_task_id(&task_id)
+                .or_else(|| {
+                    config
+                        .private
+                        .relationships
+                        .get(&from_did)
+                        .map(|_| Arc::clone(&from_did))
+                });
 
-            if let Some(rel) = relationship {
-                let mut lock = rel
-                    .lock()
-                    .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+            if let Some(key) = key {
+                let rel = config
+                    .private
+                    .relationships
+                    .get_mut(&key)
+                    .expect("key just resolved");
 
                 // Verify sender is the party we sent the request to
-                if *lock.remote_p_did != *from_did {
+                if *rel.remote_p_did != *from_did {
                     warn!(
                         from = %from_did,
-                        expected = %lock.remote_p_did,
+                        expected = %rel.remote_p_did,
                         "accept from unexpected party"
                     );
                     return Ok(false);
                 }
 
-                lock.state = RelationshipState::Established;
-                lock.remote_did = Arc::new(body.did.clone());
+                rel.state = RelationshipState::Established;
+                rel.remote_did = Arc::new(body.did.clone());
             } else {
                 warn!(from = %from_did, task_id = %task_id, "no relationship found for accept message");
                 return Ok(false);
@@ -624,28 +633,36 @@ pub async fn process_inbound_message(
 
             // All handshake messages use persona DIDs, so from_did is the
             // remote persona DID which is the relationship HashMap key.
-            let found = config
+            let key = config
                 .private
                 .relationships
-                .find_by_task_id(&task_id)
-                .or_else(|| config.private.relationships.get(&from_did));
+                .find_key_by_task_id(&task_id)
+                .or_else(|| {
+                    config
+                        .private
+                        .relationships
+                        .get(&from_did)
+                        .map(|_| Arc::clone(&from_did))
+                });
 
-            if let Some(relationship) = found {
-                let mut lock = relationship
-                    .lock()
-                    .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+            if let Some(key) = key {
+                let rel = config
+                    .private
+                    .relationships
+                    .get_mut(&key)
+                    .expect("key just resolved");
 
                 // Verify sender matches expected remote party
-                if *lock.remote_p_did != *from_did {
+                if *rel.remote_p_did != *from_did {
                     warn!(
                         from = %from_did,
-                        expected = %lock.remote_p_did,
+                        expected = %rel.remote_p_did,
                         "finalize from unexpected party"
                     );
                     return Ok(false);
                 }
 
-                lock.state = RelationshipState::Established;
+                rel.state = RelationshipState::Established;
             } else {
                 warn!(from = %from_did, task_id = %task_id, "no relationship found for finalize message");
                 return Ok(false);
@@ -741,12 +758,8 @@ pub async fn process_inbound_message(
             }
 
             // Reject if a pending inbound request from this sender already exists
-            let has_pending = config.private.tasks.tasks.values().any(|t| {
-                t.lock()
-                    .map(|task| {
-                        matches!(&task.type_, TaskType::RelationshipRequestInbound { from, .. } if *from == from_did)
-                    })
-                    .unwrap_or(false)
+            let has_pending = config.private.tasks.tasks.values().any(|task| {
+                matches!(&task.type_, TaskType::RelationshipRequestInbound { from, .. } if *from == from_did)
             });
             if has_pending {
                 warn!(from = %from_did, "duplicate pending relationship request — ignoring");
@@ -783,15 +796,11 @@ pub async fn process_inbound_message(
                 })?;
 
             // Only accept VRC requests from established relationships
-            {
-                let lock = relationship
-                    .lock()
-                    .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-                if lock.state != RelationshipState::Established {
-                    warn!(from = %from_did, state = ?lock.state, "VRC request from non-established relationship");
-                    return Ok(false);
-                }
+            if relationship.state != RelationshipState::Established {
+                warn!(from = %from_did, state = ?relationship.state, "VRC request from non-established relationship");
+                return Ok(false);
             }
+            let remote_p_did = Arc::clone(&relationship.remote_p_did);
 
             if check_task_capacity(config, &task_id, &from_did).is_err() {
                 return Ok(false);
@@ -801,7 +810,7 @@ pub async fn process_inbound_message(
                 &task_id,
                 TaskType::VRCRequestInbound {
                     request: body,
-                    relationship,
+                    remote_p_did,
                 },
             );
 
@@ -886,13 +895,18 @@ pub async fn process_inbound_message(
             }
 
             // Find the relationship for this ping
-            if let Some(relationship) = config.private.relationships.find_by_remote_did(&from_did) {
+            if let Some(remote_p_did) = config
+                .private
+                .relationships
+                .find_by_remote_did(&from_did)
+                .map(|rel| Arc::clone(&rel.remote_p_did))
+            {
                 config.private.tasks.new_task(
                     &task_id,
                     TaskType::TrustPing {
                         from: from_did.clone(),
                         to: to_did,
-                        relationship,
+                        remote_p_did,
                     },
                 );
             }
@@ -1304,27 +1318,22 @@ mod tests {
     use affinidi_tdk::common::config::TDKConfig;
     use affinidi_tdk::dids::{DID, KeyType};
     use openvtc_core::relationships::Relationship;
-    use std::sync::Mutex;
 
-    fn relationship(
-        remote_p: &str,
-        remote_r: &str,
-        state: RelationshipState,
-    ) -> Arc<Mutex<Relationship>> {
-        Arc::new(Mutex::new(Relationship {
+    fn relationship(remote_p: &str, remote_r: &str, state: RelationshipState) -> Relationship {
+        Relationship {
             task_id: Arc::new(Uuid::new_v4().to_string()),
             our_did: Arc::new("did:webvh:example:us".to_string()),
             remote_did: Arc::new(remote_r.to_string()),
             remote_p_did: Arc::new(remote_p.to_string()),
             created: Utc::now(),
             state,
-        }))
+        }
     }
 
-    fn relationships_with(rel: &Arc<Mutex<Relationship>>) -> Relationships {
+    fn relationships_with(rel: &Relationship) -> Relationships {
         let mut rels = Relationships::default();
-        let key = Arc::clone(&rel.lock().unwrap().remote_p_did);
-        rels.relationships.insert(key, Arc::clone(rel));
+        let key = Arc::clone(&rel.remote_p_did);
+        rels.relationships.insert(key, rel.clone());
         rels
     }
 
@@ -1346,7 +1355,12 @@ mod tests {
         // A pending task whose id the attacker guesses as the thid.
         let mut tasks = Tasks::default();
         let pending = Arc::new(Uuid::new_v4().to_string());
-        tasks.new_task(&pending, TaskType::VRCRequestOutbound { relationship: rel });
+        tasks.new_task(
+            &pending,
+            TaskType::VRCRequestOutbound {
+                remote_p_did: Arc::clone(&rel.remote_p_did),
+            },
+        );
 
         let vrc = unsigned_vrc("did:web:ATTACKER_FORGED");
         let result = vet_vrc_issued(&rels, &tasks, &vrc, &sender, Some(pending.as_str()));
@@ -1403,7 +1417,7 @@ mod tests {
         tasks.new_task(
             &other_request,
             TaskType::VRCRequestOutbound {
-                relationship: other_rel,
+                remote_p_did: Arc::clone(&other_rel.remote_p_did),
             },
         );
 
@@ -1431,7 +1445,12 @@ mod tests {
 
         let mut tasks = Tasks::default();
         let request = Arc::new(Uuid::new_v4().to_string());
-        tasks.new_task(&request, TaskType::VRCRequestOutbound { relationship: rel });
+        tasks.new_task(
+            &request,
+            TaskType::VRCRequestOutbound {
+                remote_p_did: Arc::clone(&rel.remote_p_did),
+            },
+        );
 
         let vrc = unsigned_vrc(sender_p);
         let resolved = vet_vrc_issued(&rels, &tasks, &vrc, &from, Some(request.as_str()))

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -35,10 +35,8 @@ pub(crate) fn resolve_did_to_display(config: &openvtc_core::config::Config, did:
     }
     // R-DID → persona DID → contact alias
     let did_arc = std::sync::Arc::new(did.to_string());
-    if let Some(rel) = config.private.relationships.find_by_remote_did(&did_arc)
-        && let Ok(lock) = rel.lock()
-    {
-        let p_did = lock.remote_p_did.to_string();
+    if let Some(rel) = config.private.relationships.find_by_remote_did(&did_arc) {
+        let p_did = rel.remote_p_did.to_string();
         if let Some(contact) = config.private.contacts.find_contact(&p_did)
             && let Some(alias) = &contact.alias
         {
@@ -990,9 +988,7 @@ impl StateHandler {
                                 .relationships
                                 .find_by_remote_did(&sender_arc)
                                 .map(|r| {
-                                    r.lock()
-                                        .map(|l| l.state == openvtc_core::relationships::RelationshipState::Established)
-                                        .unwrap_or(false)
+                                    r.state == openvtc_core::relationships::RelationshipState::Established
                                 })
                                 .unwrap_or(false);
 
@@ -1049,8 +1045,7 @@ impl StateHandler {
                                     .tasks
                                     .tasks
                                     .values()
-                                    .filter_map(|t| {
-                                        let task = t.lock().ok()?;
+                                    .filter_map(|task| {
                                         if let openvtc_core::tasks::TaskType::TrustPing { to, .. } = &task.type_ {
                                             Some(resolve_did_to_display(&config, to))
                                         } else {

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -1,6 +1,6 @@
 //! Relationship action handlers for the TUI.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::{
@@ -615,7 +615,6 @@ pub(crate) enum RelationshipEffect {
         remote_did: Arc<String>,
         remote_p_did: String,
         msg_id: Arc<String>,
-        relationship: Arc<Mutex<RelRecord>>,
         display_name: String,
         using_rdid: bool,
     },
@@ -623,7 +622,6 @@ pub(crate) enum RelationshipEffect {
     RequestVrc {
         remote_p_did: String,
         msg_id: Arc<String>,
-        relationship: Arc<Mutex<RelRecord>>,
         display_name: String,
     },
     /// `Remove`: the R-DID listener (if any) was torn down in the task; remove
@@ -693,23 +691,21 @@ impl RelationshipOutcome {
                             config
                                 .private
                                 .relationships
-                                .get(&respondent_did)
-                                .and_then(|rel| {
-                                    rel.lock().ok().map(|mut lock| {
-                                        // Always record the real local DID so future
-                                        // messages use the correct `our_did`.
-                                        lock.our_did = Arc::clone(&our_did);
-                                        if lock.state == RelationshipState::RequestSent {
-                                            // No accept raced us: fill in the real
-                                            // `task_id` (the send's msg_id) too.
-                                            lock.task_id = Arc::clone(&msg_id);
-                                            true
-                                        } else {
-                                            // A racing accept already finalised this
-                                            // relationship; leave its state + task_id.
-                                            false
-                                        }
-                                    })
+                                .get_mut(&respondent_did)
+                                .map(|rel| {
+                                    // Always record the real local DID so future
+                                    // messages use the correct `our_did`.
+                                    rel.our_did = Arc::clone(&our_did);
+                                    if rel.state == RelationshipState::RequestSent {
+                                        // No accept raced us: fill in the real
+                                        // `task_id` (the send's msg_id) too.
+                                        rel.task_id = Arc::clone(&msg_id);
+                                        true
+                                    } else {
+                                        // A racing accept already finalised this
+                                        // relationship; leave its state + task_id.
+                                        false
+                                    }
                                 });
 
                         if outcome != Some(true) {
@@ -781,11 +777,7 @@ impl RelationshipOutcome {
                             .private
                             .relationships
                             .get(&respondent_did)
-                            .and_then(|rel| {
-                                rel.lock()
-                                    .ok()
-                                    .map(|lock| lock.state == RelationshipState::RequestSent)
-                            })
+                            .map(|rel| rel.state == RelationshipState::RequestSent)
                             .unwrap_or(false);
                         if still_request_sent {
                             config
@@ -809,7 +801,6 @@ impl RelationshipOutcome {
                 remote_did,
                 remote_p_did,
                 msg_id,
-                relationship,
                 display_name,
                 using_rdid,
             } => match self.result {
@@ -823,7 +814,7 @@ impl RelationshipOutcome {
                         TaskType::TrustPing {
                             from: Arc::clone(&our_did),
                             to: Arc::clone(&remote_did),
-                            relationship,
+                            remote_p_did: Arc::new(remote_p_did.clone()),
                         },
                     );
                     info!(to = %remote_p_did, "trust-ping sent");
@@ -874,14 +865,15 @@ impl RelationshipOutcome {
             RelationshipEffect::RequestVrc {
                 remote_p_did,
                 msg_id,
-                relationship,
                 display_name,
             } => match self.result {
                 Ok(()) => {
-                    config
-                        .private
-                        .tasks
-                        .new_task(&msg_id, TaskType::VRCRequestOutbound { relationship });
+                    config.private.tasks.new_task(
+                        &msg_id,
+                        TaskType::VRCRequestOutbound {
+                            remote_p_did: Arc::new(remote_p_did.clone()),
+                        },
+                    );
                     config.public.logs.insert(
                         LogFamily::Relationship,
                         format!("Requested VRC from ({remote_p_did}) Task ID ({msg_id})"),
@@ -1095,13 +1087,10 @@ async fn prepare_submit(
     }
     // Reject a duplicate established relationship.
     let respondent_arc = Arc::new(did.to_string());
-    if let Some(rel) = config.private.relationships.get(&respondent_arc) {
-        let lock = rel
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        if lock.state == RelationshipState::Established {
-            anyhow::bail!("An established relationship already exists with this DID");
-        }
+    if let Some(rel) = config.private.relationships.get(&respondent_arc)
+        && rel.state == RelationshipState::Established
+    {
+        anyhow::bail!("An established relationship already exists with this DID");
     }
 
     // Decide whether a brand-new contact must be added. The DID *resolution*
@@ -1156,14 +1145,14 @@ async fn prepare_submit(
     // passes. The Create outcome later fills in the real `task_id`/`our_did`.
     config.private.relationships.relationships.insert(
         Arc::clone(&respondent_arc),
-        Arc::new(Mutex::new(RelRecord {
+        RelRecord {
             task_id: Arc::new(String::new()),
             our_did: Arc::clone(&persona_did),
             remote_p_did: Arc::clone(&respondent_arc),
             remote_did: Arc::clone(&respondent_arc),
             created: Utc::now(),
             state: RelationshipState::RequestSent,
-        })),
+        },
     );
 
     // In-progress status (shown by the loop's post-arm state send).
@@ -1202,16 +1191,16 @@ fn prepare_ping(
     remote_p_did: &str,
 ) -> Result<RelationshipJob> {
     let remote_key = Arc::new(remote_p_did.to_string());
-    let relationship = config
-        .private
-        .relationships
-        .get(&remote_key)
-        .ok_or_else(|| anyhow::anyhow!("No relationship found for {remote_p_did}"))?;
     let (our_did, remote_did) = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        (Arc::clone(&lock.our_did), Arc::clone(&lock.remote_did))
+        let relationship = config
+            .private
+            .relationships
+            .get(&remote_key)
+            .ok_or_else(|| anyhow::anyhow!("No relationship found for {remote_p_did}"))?;
+        (
+            Arc::clone(&relationship.our_did),
+            Arc::clone(&relationship.remote_did),
+        )
     };
     let using_rdid = !config.is_persona_did(our_did.as_str());
     info!(our_did = %our_did, remote_did = %remote_did, is_r_did = using_rdid, "ping using relationship DIDs");
@@ -1234,7 +1223,6 @@ fn prepare_ping(
             remote_did,
             remote_p_did: remote_p_did.to_string(),
             msg_id,
-            relationship,
             display_name,
             using_rdid,
         },
@@ -1250,14 +1238,13 @@ fn prepare_remove(
     remote_p_did: &str,
 ) -> RelationshipJob {
     let key = Arc::new(remote_p_did.to_string());
-    let listener_id = if let Some(rel_arc) = config.private.relationships.get(&key)
-        && let Ok(lock) = rel_arc.lock()
-        && !config.is_persona_did(lock.our_did.as_str())
-    {
-        Some(super::didcomm::listener_id_for_did(&lock.our_did, config))
-    } else {
-        None
-    };
+    let our_did = config
+        .private
+        .relationships
+        .get(&key)
+        .map(|rel| Arc::clone(&rel.our_did))
+        .filter(|our_did| !config.is_persona_did(our_did.as_str()));
+    let listener_id = our_did.map(|our_did| super::didcomm::listener_id_for_did(&our_did, config));
     state.main_page.content_panel.relationships.status_message =
         Some("Removing relationship...".to_string());
     RelationshipJob::Remove {
@@ -1279,16 +1266,16 @@ fn prepare_request_vrc(
     use openvtc_core::vrc::VrcRequest;
 
     let remote_key = Arc::new(remote_p_did.to_string());
-    let relationship = config
-        .private
-        .relationships
-        .get(&remote_key)
-        .ok_or_else(|| anyhow::anyhow!("No relationship found for {remote_p_did}"))?;
     let (our_did, remote_did) = {
-        let lock = relationship
-            .lock()
-            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
-        (Arc::clone(&lock.our_did), Arc::clone(&lock.remote_did))
+        let relationship = config
+            .private
+            .relationships
+            .get(&remote_key)
+            .ok_or_else(|| anyhow::anyhow!("No relationship found for {remote_p_did}"))?;
+        (
+            Arc::clone(&relationship.our_did),
+            Arc::clone(&relationship.remote_did),
+        )
     };
     let message = VrcRequest { reason: None }.create_message(&remote_did, &our_did)?;
     let msg_id = Arc::new(message.id.clone());
@@ -1306,7 +1293,6 @@ fn prepare_request_vrc(
         effect: RelationshipEffect::RequestVrc {
             remote_p_did: remote_p_did.to_string(),
             msg_id,
-            relationship,
             display_name,
         },
     })))
@@ -1551,22 +1537,17 @@ mod tests {
 
     /// Build a relationship record (persona DID used as our_did, so it is *not*
     /// an R-DID) and register it in `config`. Returns the shared Arc.
-    fn register_relationship(config: &mut Config, remote_p_did: &str) -> Arc<Mutex<RelRecord>> {
+    fn register_relationship(config: &mut Config, remote_p_did: &str) {
         let key = Arc::new(remote_p_did.to_string());
-        let rel = Arc::new(Mutex::new(RelRecord {
+        let rel = RelRecord {
             task_id: Arc::new("task-1".to_string()),
             our_did: config.persona_did_arc(),
             remote_p_did: Arc::clone(&key),
             remote_did: Arc::clone(&key),
             created: Utc::now(),
             state: RelationshipState::Established,
-        }));
-        config
-            .private
-            .relationships
-            .relationships
-            .insert(key, Arc::clone(&rel));
-        rel
+        };
+        config.private.relationships.relationships.insert(key, rel);
     }
 
     /// A successful Ping outcome creates the TrustPing task + activity log and
@@ -1578,7 +1559,7 @@ mod tests {
         let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let remote = "did:peer:remote";
-        let rel = register_relationship(&mut config, remote);
+        register_relationship(&mut config, remote);
 
         let outcome = RelationshipOutcome {
             effect: RelationshipEffect::Ping {
@@ -1586,7 +1567,6 @@ mod tests {
                 remote_did: Arc::new(remote.to_string()),
                 remote_p_did: remote.to_string(),
                 msg_id: Arc::new("ping-msg".to_string()),
-                relationship: rel,
                 display_name: "Remote".to_string(),
                 using_rdid: false,
             },
@@ -1621,7 +1601,7 @@ mod tests {
         let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         let mut state = State::default();
         let remote = "did:peer:remote";
-        let rel = register_relationship(&mut config, remote);
+        register_relationship(&mut config, remote);
 
         let outcome = RelationshipOutcome {
             effect: RelationshipEffect::Ping {
@@ -1629,7 +1609,6 @@ mod tests {
                 remote_did: Arc::new(remote.to_string()),
                 remote_p_did: remote.to_string(),
                 msg_id: Arc::new("ping-msg".to_string()),
-                relationship: rel,
                 display_name: "Remote".to_string(),
                 using_rdid: false,
             },
@@ -1662,14 +1641,14 @@ mod tests {
     fn insert_provisional(config: &mut Config, respondent: &Arc<String>) {
         config.private.relationships.relationships.insert(
             Arc::clone(respondent),
-            Arc::new(Mutex::new(RelRecord {
+            RelRecord {
                 task_id: Arc::new(String::new()),
                 our_did: Arc::clone(respondent),
                 remote_p_did: Arc::clone(respondent),
                 remote_did: Arc::clone(respondent),
                 created: Utc::now(),
                 state: RelationshipState::RequestSent,
-            })),
+            },
         );
     }
 
@@ -1714,24 +1693,21 @@ mod tests {
             .relationships
             .get(&respondent)
             .expect("relationship record present on success");
-        {
-            let lock = rel.lock().unwrap();
-            assert_eq!(
-                lock.state,
-                RelationshipState::RequestSent,
-                "stays RequestSent (no accept raced)"
-            );
-            assert_eq!(
-                lock.task_id.as_str(),
-                "req-msg",
-                "provisional placeholder task_id replaced by the real msg_id"
-            );
-            assert_eq!(
-                lock.our_did.as_str(),
-                "did:peer:our-rdid",
-                "provisional persona our_did replaced by the minted R-DID"
-            );
-        }
+        assert_eq!(
+            rel.state,
+            RelationshipState::RequestSent,
+            "stays RequestSent (no accept raced)"
+        );
+        assert_eq!(
+            rel.task_id.as_str(),
+            "req-msg",
+            "provisional placeholder task_id replaced by the real msg_id"
+        );
+        assert_eq!(
+            rel.our_did.as_str(),
+            "did:peer:our-rdid",
+            "provisional persona our_did replaced by the minted R-DID"
+        );
         assert!(
             config
                 .private
@@ -1770,10 +1746,9 @@ mod tests {
         // Simulate the racing accept: advance the provisional record to
         // Established (as the accept handler's `get(from_did)` fallback does).
         {
-            let rel = config.private.relationships.get(&respondent).unwrap();
-            let mut lock = rel.lock().unwrap();
-            lock.state = RelationshipState::Established;
-            lock.remote_did = Arc::new("did:peer:respondent-rdid".to_string());
+            let rel = config.private.relationships.get_mut(&respondent).unwrap();
+            rel.state = RelationshipState::Established;
+            rel.remote_did = Arc::new("did:peer:respondent-rdid".to_string());
         }
 
         let our_did = Arc::new("did:peer:our-rdid".to_string());
@@ -1791,14 +1766,13 @@ mod tests {
         outcome.apply(&mut state, &mut config, &mut save);
 
         let rel = config.private.relationships.get(&respondent).unwrap();
-        let lock = rel.lock().unwrap();
         assert_eq!(
-            lock.state,
+            rel.state,
             RelationshipState::Established,
             "raced Established state must be preserved, not reset to RequestSent"
         );
         assert_eq!(
-            lock.our_did.as_str(),
+            rel.our_did.as_str(),
             "did:peer:our-rdid",
             "our_did is still updated to the real minted local DID"
         );


### PR DESCRIPTION
**Task R20** (remediation plan, Phase R3 — structural). The most invasive change in the plan; sequenced FIRST in R3 because **T1's supervised multi-session manager would calcify these locks** if they survived into it.

## What & why
`Relationships`/`Tasks` stored `HashMap<Arc<String>, Arc<Mutex<…>>>` even though there is exactly one mutating task (the StateHandler loop). The locks bought nothing and **silently swallowed poisoning** (`.lock().ok()?`, `.unwrap_or(false)` → a poisoned entry just vanished from query results). Now: `HashMap<Arc<String>, Relationship>` / `…, Task>` — plain values, mutation via `&mut`, infallible. **`.lock()` sites: 58 → 13** (the 13 are genuinely-concurrent test-only locks; zero remain on domain values).

## Task→Relationship coupling
`TaskType::{TrustPing, VRCRequestOutbound, VRCRequestInbound}` embedded `Arc<Mutex<Relationship>>`. They now carry `remote_p_did: Arc<String>` (the map key) and look the relationship up on use.

## On-disk compatibility
- **Relationships: byte-identical.** `RelationshipsShadow` now holds `Vec<Relationship>`; under serde `rc`, `Arc<T>`/`Mutex<T>` serialize transparently as `T`, so JSON is unchanged. Test `relationships_ondisk_byte_identical_roundtrip`.
- **Tasks (derive serde directly, no shadow): forward-load compatible.** The new `remote_p_did` is `#[serde(default)]`; an old config's embedded `relationship` object is ignored (no `deny_unknown_fields`). Documented degradation: a pre-R20 *in-flight* (seconds-lived) TrustPing/VRCRequest task loads with an empty `remote_p_did` and degrades gracefully (consumers `.get(&key).ok_or_else(...)?` → clean error, never a panic or empty-DID send); the relationship itself survives in the map. No migration; no forced reset. Test `pre_r20_task_with_embedded_relationship_still_loads`.

## Mutate-after-await restructures (the risky part)
Plain values can't hold `&mut` across `.await`. New `find_key_by_task_id`/`find_key_by_remote_did`/`get_mut` helpers support resolve-key → mutate-via-get_mut → await. Sites: `message_dispatch.rs` `RelationshipRequestAccepted`/`Finalize` (mutation happens before the send-await — same ordering the old scoped `MutexGuard` had), the `RelationshipRequestRejected` listener cleanup, `relationship_actions::prepare_remove`, `credential_actions::send_vrc_request` (owned clones taken before the await).

## Review
Critical-path reviewed (the automated reviewer was unavailable): verified each await-restructure preserves ordering; `get_mut(...).expect("key just resolved")` is synchronously adjacent to resolution (no intervening await/mutation → cannot panic); `find_key_by_task_id` returns the map key; the empty-`remote_p_did` path errors gracefully; relationships serialization is serde-transparent.

Gate: `fmt` / `clippy -D warnings` / `test --workspace` green — **392 passed, 0 failed**.
