### PR TITLE
refactor(ui): data-driven ChoicePage for setup-wizard binary questions (R24)

### DIFF
--- a/openvtc/src/ui/pages/setup_flow/choice_page.rs
+++ b/openvtc/src/ui/pages/setup_flow/choice_page.rs
@@ -1,0 +1,139 @@
+//! Data-driven two-option prompt shared by the setup-wizard "ask" pages.
+//!
+//! Several setup pages are the exact same component: a bordered block with a
+//! title, an intro blurb, and two mutually exclusive options rendered as a
+//! checkbox list (`[✓]` / `[ ]`). The selected option additionally shows one or
+//! more grey description lines. `TAB` / `↑` / `↓` toggle the selection, `ENTER`
+//! confirms it (emitting a [`SetupEvent`]), and `F10` quits.
+//!
+//! Each concrete page is now just *data*: a [`ChoiceSpec`] supplying its title,
+//! intro and the two options. The rendering and key handling live here once.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Layout,
+    },
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+
+use crate::{
+    colors::{COLOR_BORDER, COLOR_SUCCESS, COLOR_TEXT_DEFAULT},
+    state_handler::{actions::Action, setup_sequence::SetupState},
+    ui::pages::setup_flow::{
+        SetupFlow,
+        navigation::{SetupEvent, handle_nav_result, navigate},
+        render_setup_header,
+    },
+};
+
+/// One of the two selectable options on a choice page.
+pub struct ChoiceOption {
+    /// The label shown next to the `[✓]` / `[ ]` checkbox.
+    pub label: &'static str,
+    /// Detail lines shown underneath the label only while this option is
+    /// selected. Each carries its own styling so per-page differences (e.g. a
+    /// bold warning line) are preserved verbatim.
+    pub description: Vec<Line<'static>>,
+    /// The event emitted when this option is confirmed with `ENTER`.
+    pub event: SetupEvent,
+}
+
+/// Full description of a binary choice page.
+pub struct ChoiceSpec {
+    /// Block title. Indexed by the selected option, so a page can show a
+    /// selection-dependent title (most pages just repeat the same string).
+    pub title: [&'static str; 2],
+    /// Intro lines rendered above the options (already fully styled, including
+    /// any trailing blank lines).
+    pub intro: Vec<Line<'static>>,
+    /// The two options, in display order.
+    pub options: [ChoiceOption; 2],
+}
+
+/// Shared `ENTER` / `TAB` / `F10` handling for a binary choice page.
+///
+/// `selected` is the current selection index (0 or 1); `set_selected` flips the
+/// stored selection on the owning [`SetupFlow`]. `spec` supplies the events.
+pub fn handle_key_event(
+    state: &mut SetupFlow,
+    key: KeyEvent,
+    selected: usize,
+    set_selected: impl FnOnce(&mut SetupFlow, usize),
+    spec: ChoiceSpec,
+) {
+    match key.code {
+        KeyCode::F(10) => {
+            let _ = state.action_tx.send(Action::Exit);
+        }
+        KeyCode::Tab | KeyCode::Up | KeyCode::Down => {
+            set_selected(state, 1 - selected);
+        }
+        KeyCode::Enter => {
+            let [opt0, opt1] = spec.options;
+            let event = if selected == 0 {
+                opt0.event
+            } else {
+                opt1.event
+            };
+            handle_nav_result(navigate(event, &state.props.state), state);
+        }
+        _ => {}
+    }
+}
+
+/// Renders a binary choice page. `selected` is the current selection index.
+pub fn render(spec: &ChoiceSpec, selected: usize, state: &SetupState, frame: &mut Frame<'_>) {
+    let [top, middle, bottom] =
+        Layout::vertical([Length(3), Min(0), Length(3)]).areas(frame.area());
+
+    render_setup_header(frame, top, state);
+
+    let block = Block::bordered()
+        .fg(COLOR_BORDER)
+        .padding(Padding::proportional(1))
+        .title(spec.title[selected]);
+
+    let mut lines = spec.intro.clone();
+
+    for (i, option) in spec.options.iter().enumerate() {
+        let chosen = i == selected;
+        let (marker, style) = if chosen {
+            ("[✓] ", Style::new().fg(COLOR_SUCCESS).bold())
+        } else {
+            ("[ ] ", Style::new().fg(COLOR_TEXT_DEFAULT))
+        };
+        lines.push(Line::styled(format!("{marker}{}", option.label), style));
+        if chosen {
+            lines.extend(option.description.iter().cloned());
+        }
+    }
+
+    lines.push(Line::default());
+    lines.push(Line::from(vec![
+        Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
+        Span::styled(" to select  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
+        Span::styled(" to confirm", Style::new().fg(COLOR_TEXT_DEFAULT)),
+    ]));
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        middle,
+    );
+
+    let bottom_line = Line::from(vec![
+        Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+        Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+    ]);
+    frame.render_widget(
+        Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
+        bottom,
+    );
+}

--- a/openvtc/src/ui/pages/setup_flow/did_git_sign_ask.rs
+++ b/openvtc/src/ui/pages/setup_flow/did_git_sign_ask.rs
@@ -6,25 +6,16 @@
 //! No  → skip directly to whatever comes after the git-signing step
 //!       (`after_export()` in the navigation module).
 
-use crate::colors::{COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SUCCESS, COLOR_TEXT_DEFAULT};
-use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{
-    Frame,
-    layout::{
-        Constraint::{Length, Min},
-        Layout,
-    },
-    style::{Style, Stylize},
-    text::{Line, Span},
-    widgets::{Block, Padding, Paragraph, Wrap},
-};
+use crossterm::event::KeyEvent;
+use ratatui::{Frame, style::Style, text::Line};
 
 use crate::{
-    state_handler::{actions::Action, setup_sequence::SetupState},
+    colors::{COLOR_BORDER, COLOR_DARK_GRAY},
+    state_handler::setup_sequence::SetupState,
     ui::pages::setup_flow::{
         SetupFlow,
-        navigation::{SetupEvent, handle_nav_result, navigate},
-        render_setup_header,
+        choice_page::{self, ChoiceOption, ChoiceSpec},
+        navigation::SetupEvent,
     },
 };
 
@@ -36,121 +27,86 @@ pub enum DidGitSignAsk {
 }
 
 impl DidGitSignAsk {
-    fn switch(&self) -> Self {
+    fn index(&self) -> usize {
         match self {
-            DidGitSignAsk::Use => DidGitSignAsk::Skip,
-            DidGitSignAsk::Skip => DidGitSignAsk::Use,
+            DidGitSignAsk::Use => 0,
+            DidGitSignAsk::Skip => 1,
+        }
+    }
+
+    fn from_index(i: usize) -> Self {
+        if i == 0 {
+            DidGitSignAsk::Use
+        } else {
+            DidGitSignAsk::Skip
+        }
+    }
+
+    fn spec() -> ChoiceSpec {
+        ChoiceSpec {
+            title: [
+                " Configure git commit signing ",
+                " Configure git commit signing ",
+            ],
+            intro: vec![
+                Line::styled(
+                    "Your DID persona signing key (Ed25519) can also be used to sign git commits.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::styled(
+                    "OpenVTC will configure `did-git-sign` so your commits sign and verify",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::styled(
+                    "automatically — no extra setup steps in each repository.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::default(),
+                Line::styled(
+                    "Use your DID signing key for git verified signing?",
+                    Style::new().fg(COLOR_BORDER).bold(),
+                ),
+                Line::default(),
+            ],
+            options: [
+                ChoiceOption {
+                    label: "Yes, configure git signing now (recommended)",
+                    description: vec![
+                        Line::styled(
+                            "    Sets up global git config + allowed_signers and stores VTA",
+                            Style::new().fg(COLOR_DARK_GRAY),
+                        ),
+                        Line::styled(
+                            "    credentials in your OS keyring.",
+                            Style::new().fg(COLOR_DARK_GRAY),
+                        ),
+                    ],
+                    event: SetupEvent::DidGitSignAccept,
+                },
+                ChoiceOption {
+                    label: "No, skip git signing setup",
+                    description: vec![Line::styled(
+                        "    You can run `did-git-sign init` later if you change your mind.",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    )],
+                    event: SetupEvent::DidGitSignSkip,
+                },
+            ],
         }
     }
 
     pub fn handle_key_event(state: &mut SetupFlow, key: KeyEvent) {
-        match key.code {
-            KeyCode::F(10) => {
-                let _ = state.action_tx.send(Action::Exit);
-            }
-            KeyCode::Tab | KeyCode::Up | KeyCode::Down => {
-                state.did_git_sign_ask = state.did_git_sign_ask.switch();
-            }
-            KeyCode::Enter => {
-                let event = match state.did_git_sign_ask {
-                    DidGitSignAsk::Use => SetupEvent::DidGitSignAccept,
-                    DidGitSignAsk::Skip => SetupEvent::DidGitSignSkip,
-                };
-                handle_nav_result(navigate(event, &state.props.state), state);
-            }
-            _ => {}
-        }
+        let selected = state.did_git_sign_ask.index();
+        choice_page::handle_key_event(
+            state,
+            key,
+            selected,
+            |s, i| s.did_git_sign_ask = DidGitSignAsk::from_index(i),
+            Self::spec(),
+        );
     }
 
     pub fn render(&self, state: &SetupState, frame: &mut Frame<'_>) {
-        let [top, middle, bottom] =
-            Layout::vertical([Length(3), Min(0), Length(3)]).areas(frame.area());
-
-        render_setup_header(frame, top, state);
-
-        let block = Block::bordered()
-            .fg(COLOR_BORDER)
-            .padding(Padding::proportional(1))
-            .title(" Configure git commit signing ");
-
-        let mut lines = vec![
-            Line::styled(
-                "Your DID persona signing key (Ed25519) can also be used to sign git commits.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ),
-            Line::styled(
-                "OpenVTC will configure `did-git-sign` so your commits sign and verify",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ),
-            Line::styled(
-                "automatically — no extra setup steps in each repository.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ),
-            Line::default(),
-            Line::styled(
-                "Use your DID signing key for git verified signing?",
-                Style::new().fg(COLOR_BORDER).bold(),
-            ),
-            Line::default(),
-        ];
-
-        match self {
-            DidGitSignAsk::Use => {
-                lines.push(Line::styled(
-                    "[✓] Yes, configure git signing now (recommended)",
-                    Style::new().fg(COLOR_SUCCESS).bold(),
-                ));
-                lines.push(Line::styled(
-                    "    Sets up global git config + allowed_signers and stores VTA",
-                    Style::new().fg(COLOR_DARK_GRAY),
-                ));
-                lines.push(Line::styled(
-                    "    credentials in your OS keyring.",
-                    Style::new().fg(COLOR_DARK_GRAY),
-                ));
-                lines.push(Line::styled(
-                    "[ ] No, skip git signing setup",
-                    Style::new().fg(COLOR_TEXT_DEFAULT),
-                ));
-            }
-            DidGitSignAsk::Skip => {
-                lines.push(Line::styled(
-                    "[ ] Yes, configure git signing now (recommended)",
-                    Style::new().fg(COLOR_TEXT_DEFAULT),
-                ));
-                lines.push(Line::styled(
-                    "[✓] No, skip git signing setup",
-                    Style::new().fg(COLOR_SUCCESS).bold(),
-                ));
-                lines.push(Line::styled(
-                    "    You can run `did-git-sign init` later if you change your mind.",
-                    Style::new().fg(COLOR_DARK_GRAY),
-                ));
-            }
-        }
-
-        lines.push(Line::default());
-        lines.push(Line::from(vec![
-            Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to select  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to confirm", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]));
-
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(block)
-                .wrap(Wrap { trim: false }),
-            middle,
-        );
-
-        let bottom_line = Line::from(vec![
-            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]);
-        frame.render_widget(
-            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
-            bottom,
-        );
+        choice_page::render(&Self::spec(), self.index(), state, frame);
     }
 }

--- a/openvtc/src/ui/pages/setup_flow/did_keys_export_ask.rs
+++ b/openvtc/src/ui/pages/setup_flow/did_keys_export_ask.rs
@@ -1,22 +1,13 @@
-use crate::colors::{COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SUCCESS, COLOR_TEXT_DEFAULT};
-use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{
-    Frame,
-    layout::{
-        Constraint::{Length, Min},
-        Layout,
-    },
-    style::{Style, Stylize},
-    text::{Line, Span},
-    widgets::{Block, Padding, Paragraph, Wrap},
-};
+use crossterm::event::KeyEvent;
+use ratatui::{Frame, style::Style, text::Line};
 
 use crate::{
-    state_handler::{actions::Action, setup_sequence::SetupState},
+    colors::{COLOR_BORDER, COLOR_DARK_GRAY},
+    state_handler::setup_sequence::SetupState,
     ui::pages::setup_flow::{
         SetupFlow,
-        navigation::{SetupEvent, handle_nav_result, navigate},
-        render_setup_header,
+        choice_page::{self, ChoiceOption, ChoiceSpec},
+        navigation::SetupEvent,
     },
 };
 
@@ -29,112 +20,74 @@ pub enum DIDKeysExportAsk {
     Skip,
     Export,
 }
-impl DIDKeysExportAsk {
-    /// Switches to the next panel when pressing `TAB`
-    pub fn switch(&self) -> Self {
-        match self {
-            DIDKeysExportAsk::Skip => DIDKeysExportAsk::Export,
-            DIDKeysExportAsk::Export => DIDKeysExportAsk::Skip,
-        }
-    }
-}
 
 impl DIDKeysExportAsk {
-    pub fn handle_key_event(state: &mut SetupFlow, key: KeyEvent) {
-        match key.code {
-            KeyCode::F(10) => {
-                let _ = state.action_tx.send(Action::Exit);
-            }
-            KeyCode::Tab | KeyCode::Up | KeyCode::Down => {
-                state.did_keys_export_ask = state.did_keys_export_ask.switch();
-            }
-            KeyCode::Enter => {
-                let event = match state.did_keys_export_ask {
-                    DIDKeysExportAsk::Skip => SetupEvent::SkipExport,
-                    DIDKeysExportAsk::Export => SetupEvent::StartExport,
-                };
-                handle_nav_result(navigate(event, &state.props.state), state);
-            }
-            _ => {}
+    fn index(&self) -> usize {
+        match self {
+            DIDKeysExportAsk::Skip => 0,
+            DIDKeysExportAsk::Export => 1,
         }
+    }
+
+    fn from_index(i: usize) -> Self {
+        if i == 0 {
+            DIDKeysExportAsk::Skip
+        } else {
+            DIDKeysExportAsk::Export
+        }
+    }
+
+    fn spec() -> ChoiceSpec {
+        ChoiceSpec {
+            title: [
+                " Step 4/4: Export private DID keys ",
+                " Step 4/4: Export private DID keys ",
+            ],
+            intro: vec![
+                Line::styled(
+                    "You may want to export the private key material used by your profile so you can reuse the same keys in other applications or with other DIDs.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::default(),
+                Line::styled(
+                    "Would you like to export your private DID keys now?",
+                    Style::new().fg(COLOR_BORDER).bold(),
+                ),
+                Line::default(),
+            ],
+            options: [
+                ChoiceOption {
+                    label: "Skip for now (recommended)",
+                    description: vec![Line::styled(
+                        "    You can continue setting up your profile and export them later from within OpenVTC if needed.",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    )],
+                    event: SetupEvent::SkipExport,
+                },
+                ChoiceOption {
+                    label: "Export private DID keys",
+                    description: vec![Line::styled(
+                        "    Private keys will be exported in a secure, text-based PGP-armoured format suitable for secure storage and transfer.",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    )],
+                    event: SetupEvent::StartExport,
+                },
+            ],
+        }
+    }
+
+    pub fn handle_key_event(state: &mut SetupFlow, key: KeyEvent) {
+        let selected = state.did_keys_export_ask.index();
+        choice_page::handle_key_event(
+            state,
+            key,
+            selected,
+            |s, i| s.did_keys_export_ask = DIDKeysExportAsk::from_index(i),
+            Self::spec(),
+        );
     }
 
     pub fn render(&self, state: &SetupState, frame: &mut Frame) {
-        let [top, middle, bottom] =
-            Layout::vertical([Length(3), Min(0), Length(3)]).areas(frame.area());
-
-        render_setup_header(frame, top, state);
-
-        let block = Block::bordered()
-            .fg(COLOR_BORDER)
-            .padding(Padding::proportional(1))
-            .title(" Step 4/4: Export private DID keys ");
-
-        let mut lines = vec![
-            Line::styled(
-                "You may want to export the private key material used by your profile so you can reuse the same keys in other applications or with other DIDs.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ),
-            Line::default(),
-            Line::styled(
-                "Would you like to export your private DID keys now?",
-                Style::new().fg(COLOR_BORDER).bold(),
-            ),
-            Line::default(),
-        ];
-
-        // Render the active choice
-        if let DIDKeysExportAsk::Skip = self {
-            lines.push(Line::styled(
-                "[✓] Skip for now (recommended)",
-                Style::new().fg(COLOR_SUCCESS).bold(),
-            ));
-            lines.push(Line::styled(
-                "    You can continue setting up your profile and export them later from within OpenVTC if needed.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ));
-            lines.push(Line::styled(
-                "[ ] Export private DID keys",
-                Style::new().fg(COLOR_TEXT_DEFAULT),
-            ));
-        } else {
-            lines.push(Line::styled(
-                "[ ] Skip for now (recommended)",
-                Style::new().fg(COLOR_TEXT_DEFAULT),
-            ));
-            lines.push(Line::styled(
-                "[✓] Export private DID keys",
-                Style::new().fg(COLOR_SUCCESS).bold(),
-            ));
-            lines.push(Line::styled(
-                "    Private keys will be exported in a secure, text-based PGP-armoured format suitable for secure storage and transfer.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ));
-        }
-
-        lines.push(Line::default());
-        lines.push(Line::from(vec![
-            Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to select  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to confirm", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]));
-
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(block)
-                .wrap(Wrap { trim: false }),
-            middle,
-        );
-
-        let bottom_line = Line::from(vec![
-            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]);
-
-        frame.render_widget(
-            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
-            bottom,
-        );
+        choice_page::render(&Self::spec(), self.index(), state, frame);
     }
 }

--- a/openvtc/src/ui/pages/setup_flow/mediator_ask.rs
+++ b/openvtc/src/ui/pages/setup_flow/mediator_ask.rs
@@ -1,22 +1,13 @@
-use crate::colors::{COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SUCCESS, COLOR_TEXT_DEFAULT};
-use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{
-    Frame,
-    layout::{
-        Constraint::{Length, Min},
-        Layout,
-    },
-    style::{Style, Stylize},
-    text::{Line, Span},
-    widgets::{Block, Padding, Paragraph, Wrap},
-};
+use crossterm::event::KeyEvent;
+use ratatui::{Frame, style::Style, text::Line};
 
 use crate::{
-    state_handler::{actions::Action, setup_sequence::SetupState},
+    colors::{COLOR_BORDER, COLOR_DARK_GRAY},
+    state_handler::setup_sequence::SetupState,
     ui::pages::setup_flow::{
         SetupFlow,
-        navigation::{SetupEvent, handle_nav_result, navigate},
-        render_setup_header,
+        choice_page::{self, ChoiceOption, ChoiceSpec},
+        navigation::SetupEvent,
     },
 };
 
@@ -29,118 +20,75 @@ pub enum MediatorAsk {
     Default,
     Custom,
 }
-impl MediatorAsk {
-    /// Switches to the next panel when pressing `TAB`
-    pub fn switch(&self) -> Self {
-        match self {
-            MediatorAsk::Default => MediatorAsk::Custom,
-            MediatorAsk::Custom => MediatorAsk::Default,
-        }
-    }
-}
 
 impl MediatorAsk {
-    pub fn handle_key_event(state: &mut SetupFlow, key: KeyEvent) {
-        match key.code {
-            KeyCode::F(10) => {
-                let _ = state.action_tx.send(Action::Exit);
-            }
-            KeyCode::Tab | KeyCode::Up | KeyCode::Down => {
-                state.mediator_ask = state.mediator_ask.switch();
-            }
-            KeyCode::Enter => {
-                let event = match state.mediator_ask {
-                    MediatorAsk::Default => SetupEvent::UseDefaultMediator,
-                    MediatorAsk::Custom => SetupEvent::UseCustomMediator,
-                };
-                handle_nav_result(navigate(event, &state.props.state), state);
-            }
-            _ => {}
+    fn index(&self) -> usize {
+        match self {
+            MediatorAsk::Default => 0,
+            MediatorAsk::Custom => 1,
         }
+    }
+
+    fn from_index(i: usize) -> Self {
+        if i == 0 {
+            MediatorAsk::Default
+        } else {
+            MediatorAsk::Custom
+        }
+    }
+
+    fn spec() -> ChoiceSpec {
+        ChoiceSpec {
+            // Title depends on the selected option: the custom path adds a step.
+            title: [
+                " Step 1/1: Configure messaging mediator ",
+                " Step 1/2: Configure messaging mediator ",
+            ],
+            intro: vec![
+                Line::styled(
+                    "Your persona DID requires a mediator (relay service) for reliable DIDComm message delivery.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::default(),
+                Line::styled(
+                    "Use the default VTA mediator, or specify a custom mediator if you prefer a different one.",
+                    Style::new().fg(COLOR_BORDER).bold(),
+                ),
+                Line::default(),
+            ],
+            options: [
+                ChoiceOption {
+                    label: "Use Default VTA Mediator (recommended)",
+                    description: vec![Line::styled(
+                        "    Uses the mediator configured by your VTA service.",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    )],
+                    event: SetupEvent::UseDefaultMediator,
+                },
+                ChoiceOption {
+                    label: "Use Custom Mediator (requires a mediator DID)",
+                    description: vec![Line::styled(
+                        "    Specify a different mediator DID to use instead of the VTA default.",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    )],
+                    event: SetupEvent::UseCustomMediator,
+                },
+            ],
+        }
+    }
+
+    pub fn handle_key_event(state: &mut SetupFlow, key: KeyEvent) {
+        let selected = state.mediator_ask.index();
+        choice_page::handle_key_event(
+            state,
+            key,
+            selected,
+            |s, i| s.mediator_ask = MediatorAsk::from_index(i),
+            Self::spec(),
+        );
     }
 
     pub fn render(&self, state: &SetupState, frame: &mut Frame) {
-        let [top, middle, bottom] =
-            Layout::vertical([Length(3), Min(0), Length(3)]).areas(frame.area());
-
-        render_setup_header(frame, top, state);
-
-        // Dynamically set the title based on selected option
-        let title = match self {
-            MediatorAsk::Default => " Step 1/1: Configure messaging mediator ",
-            MediatorAsk::Custom => " Step 1/2: Configure messaging mediator ",
-        };
-
-        let block = Block::bordered()
-            .fg(COLOR_BORDER)
-            .padding(Padding::proportional(1))
-            .title(title);
-
-        let mut lines = vec![
-            Line::styled(
-                "Your persona DID requires a mediator (relay service) for reliable DIDComm message delivery.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ),
-            Line::default(),
-            Line::styled(
-                "Use the default VTA mediator, or specify a custom mediator if you prefer a different one.",
-                Style::new().fg(COLOR_BORDER).bold(),
-            ),
-            Line::default(),
-        ];
-
-        // Render the active choice
-        if let MediatorAsk::Default = self {
-            lines.push(Line::styled(
-                "[✓] Use Default VTA Mediator (recommended)",
-                Style::new().fg(COLOR_SUCCESS).bold(),
-            ));
-            lines.push(Line::styled(
-                "    Uses the mediator configured by your VTA service.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ));
-            lines.push(Line::styled(
-                "[ ] Use Custom Mediator (requires a mediator DID)",
-                Style::new().fg(COLOR_TEXT_DEFAULT),
-            ));
-        } else {
-            lines.push(Line::styled(
-                "[ ] Use Default VTA Mediator (recommended)",
-                Style::new().fg(COLOR_TEXT_DEFAULT),
-            ));
-            lines.push(Line::styled(
-                "[✓] Use Custom Mediator (requires a mediator DID)",
-                Style::new().fg(COLOR_SUCCESS).bold(),
-            ));
-            lines.push(Line::styled(
-                "    Specify a different mediator DID to use instead of the VTA default.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ));
-        }
-
-        lines.push(Line::default());
-        lines.push(Line::from(vec![
-            Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to select  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to confirm", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]));
-
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(block)
-                .wrap(Wrap { trim: false }),
-            middle,
-        );
-
-        let bottom_line = Line::from(vec![
-            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]);
-
-        frame.render_widget(
-            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
-            bottom,
-        );
+        choice_page::render(&Self::spec(), self.index(), state, frame);
     }
 }

--- a/openvtc/src/ui/pages/setup_flow/mod.rs
+++ b/openvtc/src/ui/pages/setup_flow/mod.rs
@@ -40,6 +40,7 @@ use ratatui::{
 };
 use tokio::sync::mpsc::UnboundedSender;
 
+pub mod choice_page;
 pub mod config_import;
 pub mod did_git_sign_ask;
 pub mod did_git_sign_setup;

--- a/openvtc/src/ui/pages/setup_flow/unlock_code_ask.rs
+++ b/openvtc/src/ui/pages/setup_flow/unlock_code_ask.rs
@@ -1,22 +1,13 @@
-use crate::colors::{COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SUCCESS, COLOR_TEXT_DEFAULT};
-use crossterm::event::{KeyCode, KeyEvent};
-use ratatui::{
-    Frame,
-    layout::{
-        Constraint::{Length, Min},
-        Layout,
-    },
-    style::{Style, Stylize},
-    text::{Line, Span},
-    widgets::{Block, Padding, Paragraph, Wrap},
-};
+use crossterm::event::KeyEvent;
+use ratatui::{Frame, style::Style, text::Line};
 
 use crate::{
-    state_handler::{actions::Action, setup_sequence::SetupState},
+    colors::{COLOR_BORDER, COLOR_DARK_GRAY},
+    state_handler::setup_sequence::SetupState,
     ui::pages::setup_flow::{
         SetupFlow,
-        navigation::{SetupEvent, handle_nav_result, navigate},
-        render_setup_header,
+        choice_page::{self, ChoiceOption, ChoiceSpec},
+        navigation::SetupEvent,
     },
 };
 
@@ -29,116 +20,78 @@ pub enum UnlockCodeAsk {
     UseCode,
     NoCode,
 }
-impl UnlockCodeAsk {
-    /// Switches to the next panel when pressing `TAB`
-    pub fn switch(&self) -> Self {
-        match self {
-            UnlockCodeAsk::UseCode => UnlockCodeAsk::NoCode,
-            UnlockCodeAsk::NoCode => UnlockCodeAsk::UseCode,
-        }
-    }
-}
 
 impl UnlockCodeAsk {
-    pub fn handle_key_event(state: &mut SetupFlow, key: KeyEvent) {
-        match key.code {
-            KeyCode::F(10) => {
-                let _ = state.action_tx.send(Action::Exit);
-            }
-            KeyCode::Tab | KeyCode::Up | KeyCode::Down => {
-                state.unlock_code_ask = state.unlock_code_ask.switch();
-            }
-            KeyCode::Enter => {
-                let event = match state.unlock_code_ask {
-                    UnlockCodeAsk::UseCode => SetupEvent::WantUnlockCode,
-                    UnlockCodeAsk::NoCode => SetupEvent::SkipUnlockCode,
-                };
-                handle_nav_result(navigate(event, &state.props.state), state);
-            }
-            _ => {}
+    fn index(&self) -> usize {
+        match self {
+            UnlockCodeAsk::UseCode => 0,
+            UnlockCodeAsk::NoCode => 1,
         }
+    }
+
+    fn from_index(i: usize) -> Self {
+        if i == 0 {
+            UnlockCodeAsk::UseCode
+        } else {
+            UnlockCodeAsk::NoCode
+        }
+    }
+
+    fn spec() -> ChoiceSpec {
+        ChoiceSpec {
+            title: [
+                " Step 1/2: Set up unlock code ",
+                " Step 1/2: Set up unlock code ",
+            ],
+            intro: vec![
+                Line::styled(
+                    "An unlock code encrypts your cryptographic keys, configuration, and private data stored by OpenVTC.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::styled(
+                    "This prevents unauthorized access even if someone gains access to your device.",
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
+                Line::default(),
+                Line::styled(
+                    "Would you like to set an unlock code?",
+                    Style::new().fg(COLOR_BORDER).bold(),
+                ),
+                Line::default(),
+            ],
+            options: [
+                ChoiceOption {
+                    label: "Yes, require unlock code (recommended)",
+                    description: vec![Line::styled(
+                        "    Encrypts your keys, configuration, and private data for protection against unauthorized access.",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    )],
+                    event: SetupEvent::WantUnlockCode,
+                },
+                ChoiceOption {
+                    label: "No, do not require unlock code",
+                    description: vec![Line::styled(
+                        "    Anyone with access to this device will be able to open OpenVTC and use your keys and access your private data.",
+                        Style::new().fg(COLOR_DARK_GRAY).bold(),
+                    )],
+                    event: SetupEvent::SkipUnlockCode,
+                },
+            ],
+        }
+    }
+
+    pub fn handle_key_event(state: &mut SetupFlow, key: KeyEvent) {
+        let selected = state.unlock_code_ask.index();
+        choice_page::handle_key_event(
+            state,
+            key,
+            selected,
+            |s, i| s.unlock_code_ask = UnlockCodeAsk::from_index(i),
+            Self::spec(),
+        );
     }
 
     pub fn render(&self, state: &SetupState, frame: &mut Frame) {
-        let [top, middle, bottom] =
-            Layout::vertical([Length(3), Min(0), Length(3)]).areas(frame.area());
-
-        render_setup_header(frame, top, state);
-
-        let block = Block::bordered()
-            .fg(COLOR_BORDER)
-            .padding(Padding::proportional(1))
-            .title(" Step 1/2: Set up unlock code ");
-
-        let mut lines = vec![
-            Line::styled(
-                "An unlock code encrypts your cryptographic keys, configuration, and private data stored by OpenVTC.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ),
-            Line::styled(
-                "This prevents unauthorized access even if someone gains access to your device.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ),
-            Line::default(),
-            Line::styled(
-                "Would you like to set an unlock code?",
-                Style::new().fg(COLOR_BORDER).bold(),
-            ),
-            Line::default(),
-        ];
-
-        // Render the active choice
-        if let UnlockCodeAsk::UseCode = self {
-            lines.push(Line::styled(
-                "[✓] Yes, require unlock code (recommended)",
-                Style::new().fg(COLOR_SUCCESS).bold(),
-            ));
-            lines.push(Line::styled(
-                "    Encrypts your keys, configuration, and private data for protection against unauthorized access.",
-                Style::new().fg(COLOR_DARK_GRAY),
-            ));
-            lines.push(Line::styled(
-                "[ ] No, do not require unlock code",
-                Style::new().fg(COLOR_TEXT_DEFAULT),
-            ));
-        } else {
-            lines.push(Line::styled(
-                "[ ] Yes, require unlock code (recommended)",
-                Style::new().fg(COLOR_TEXT_DEFAULT),
-            ));
-            lines.push(Line::styled(
-                "[✓] No, do not require unlock code",
-                Style::new().fg(COLOR_SUCCESS).bold(),
-            ));
-            lines.push(Line::styled(
-                "    Anyone with access to this device will be able to open OpenVTC and use your keys and access your private data.",
-                Style::new().fg(COLOR_DARK_GRAY).bold(),
-            ));
-        }
-
-        lines.push(Line::default());
-        lines.push(Line::from(vec![
-            Span::styled("[TAB]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to select  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to confirm", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]));
-
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(block)
-                .wrap(Wrap { trim: false }),
-            middle,
-        );
-
-        let bottom_line = Line::from(vec![
-            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]);
-
-        frame.render_widget(
-            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
-            bottom,
-        );
+        choice_page::render(&Self::spec(), self.index(), state, frame);
     }
 }


### PR DESCRIPTION
## Problem

The binary "ask" pages in the setup wizard were the same two-option component re-typed: `mediator_ask`, `unlock_code_ask`, `did_keys_export_ask`, and `did_git_sign_ask` duplicated ~320 lines of identical render + key-handling logic.

## Fix

One reusable `ChoicePage` component (`setup_flow/choice_page.rs`): a `ChoiceSpec { title, intro, options: [ChoiceOption; 2] }` plus shared `render` / `handle_key_event`. The four pages become small data constructors supplying their spec; each keeps its 2-variant selection enum so `SetupFlow` fields and the `mod.rs` dispatch tables are untouched.

Per-page differences are preserved as data: mediator's selection-dependent step title (1/1 vs 1/2), unlock-code's bold no-code warning line, and the export page's default = Skip. `start_ask.rs` is intentionally left as-is — it is a genuinely different two-panel layout (horizontal split, Left/Right keys, no checkbox list) that does not fit the `ChoiceSpec` shape.

## Tests

The existing `navigate()` table tests in `setup_flow/navigation.rs` are **untouched and green** — they cover the wizard flow logic this refactor preserves.

## Gate

`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p openvtc` (96 passed) — all green. Net ~−50 source lines; ~457 lines of duplication collapsed into the 139-line component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)