### PR TITLE
test(state): table tests for pure action handlers + join_flow decisions (R26)

### DIFF
--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -238,3 +238,113 @@ pub(crate) async fn dispatch(
         CredentialAction::Remove { vrc_id } => handle_remove(config, state, save, &vrc_id),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Table-driven tests for the pure mode-transition handlers in this module.
+    //! Each is a pure function of `&mut State`; the tables drive the handler from
+    //! a starting `State` and assert on the resulting credentials-panel mode/tab.
+    //! Mirrors the table-test style in `ui/pages/setup_flow/navigation.rs`.
+    use super::*;
+
+    /// `handle_switch_tab` cycles Received → Issued → Membership → Received and
+    /// resets the selection index each time.
+    #[test]
+    fn switch_tab_cycles_and_resets_index() {
+        // (starting tab, expected next tab)
+        let cases: &[(CredentialTab, CredentialTab)] = &[
+            (CredentialTab::Received, CredentialTab::Issued),
+            (CredentialTab::Issued, CredentialTab::Membership),
+            (CredentialTab::Membership, CredentialTab::Received),
+        ];
+        for (start, expected) in cases {
+            let mut state = State::default();
+            state.main_page.content_panel.credentials.selected_tab = *start;
+            state.main_page.content_panel.credentials.selected_index = 5;
+            handle_switch_tab(&mut state);
+            assert_eq!(
+                state.main_page.content_panel.credentials.selected_tab, *expected,
+                "from {start:?}"
+            );
+            assert_eq!(
+                state.main_page.content_panel.credentials.selected_index, 0,
+                "index reset on tab switch from {start:?}"
+            );
+        }
+    }
+
+    /// `handle_open_detail` enters `Detail { index }` and tracks the index;
+    /// `handle_back` returns to `List` resetting the index.
+    #[test]
+    fn open_detail_and_back_transitions() {
+        for index in [0usize, 3, 42] {
+            let mut state = State::default();
+            handle_open_detail(&mut state, index);
+            assert!(
+                matches!(
+                    state.main_page.content_panel.credentials.mode,
+                    CredentialsMode::Detail { index: i } if i == index
+                ),
+                "open_detail({index}) enters Detail"
+            );
+            assert_eq!(
+                state.main_page.content_panel.credentials.selected_index,
+                index
+            );
+
+            handle_back(&mut state);
+            assert!(
+                matches!(
+                    state.main_page.content_panel.credentials.mode,
+                    CredentialsMode::List
+                ),
+                "back returns to List"
+            );
+            assert_eq!(state.main_page.content_panel.credentials.selected_index, 0);
+        }
+    }
+
+    /// `handle_start_new_request` enters the `NewRequest` form with a zeroed
+    /// relationship index and an empty reason.
+    #[test]
+    fn start_new_request_enters_form() {
+        let mut state = State::default();
+        handle_start_new_request(&mut state);
+        match &state.main_page.content_panel.credentials.mode {
+            CredentialsMode::NewRequest {
+                relationship_index,
+                reason_input,
+            } => {
+                assert_eq!(*relationship_index, 0);
+                assert!(reason_input.is_empty());
+            }
+            other => panic!("expected NewRequest, got {other:?}"),
+        }
+    }
+
+    /// `handle_reason_update` writes the reason only while in `NewRequest`, and is
+    /// a no-op in other modes. Table-driven over the starting mode.
+    #[test]
+    fn reason_update_only_in_new_request() {
+        // In NewRequest: the reason is written.
+        let mut state = State::default();
+        handle_start_new_request(&mut state);
+        handle_reason_update(&mut state, "because".to_string());
+        assert!(matches!(
+            &state.main_page.content_panel.credentials.mode,
+            CredentialsMode::NewRequest { reason_input, .. } if reason_input == "because"
+        ));
+
+        // In List / Detail: a no-op (mode unchanged).
+        for mode in [CredentialsMode::List, CredentialsMode::Detail { index: 1 }] {
+            let mut state = State::default();
+            state.main_page.content_panel.credentials.mode = mode.clone();
+            handle_reason_update(&mut state, "ignored".to_string());
+            assert_eq!(
+                std::mem::discriminant(&state.main_page.content_panel.credentials.mode),
+                std::mem::discriminant(&mode),
+                "reason_update is a no-op outside NewRequest"
+            );
+        }
+    }
+}

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -75,10 +75,9 @@ impl StateHandler {
                             return Ok(JoinExit::Returned);
                         }
                         Action::JoinSubmitVtc(vtc_did) => {
-                            let vtc_did = vtc_did.trim().to_string();
-                            if vtc_did.is_empty() {
+                            let Some(vtc_did) = validate_join_input(&vtc_did) else {
                                 continue;
-                            }
+                            };
                             // Move to the progress page and lock input.
                             state.join.page = JoinPage::Progress;
                             state.join.processing = true;
@@ -167,6 +166,57 @@ pub(crate) enum JoinExit {
     Exit(Interrupted),
 }
 
+/// Validate the raw VTC DID the operator submitted on the EnterDid page.
+///
+/// Pure decision peeled out of the `JoinSubmitVtc` arm: trims surrounding
+/// whitespace and rejects an empty input (the loop `continue`s, staying on the
+/// EnterDid page). Returns the cleaned DID to drive the sequence with, or `None`
+/// when there is nothing to submit.
+fn validate_join_input(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Idempotency decision (R-B-9): is there already a *live* (Active/Pending)
+/// membership for this VTC?
+///
+/// Pure decision peeled out of step 1 of [`run_join_sequence`]; a `true` result
+/// surfaces the "already a member" failure instead of submitting a duplicate.
+/// Delegates to [`Account::live_community`] so the live/inactive policy stays in
+/// one place.
+fn is_duplicate_membership(config: &Config, vtc_did: &str) -> bool {
+    config
+        .account
+        .live_community(&vtc_did.to_string())
+        .is_some()
+}
+
+/// Build the `Pending` [`CommunityRecord`] recorded on a successful submit.
+///
+/// Pure decision peeled out of step 9 of [`run_join_sequence`]; delegates to
+/// [`CommunityRecord::new_pending`] so the record shape stays defined in core.
+fn build_pending_record(
+    vtc_did: String,
+    display_name: Option<String>,
+    sub_context_id: String,
+    persona_id: PersonaId,
+    request_id: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> CommunityRecord {
+    CommunityRecord::new_pending(
+        vtc_did,
+        display_name,
+        sub_context_id,
+        persona_id,
+        request_id,
+        now,
+    )
+}
+
 /// Run the automated mint → sub-context → join-submit → persist sequence.
 ///
 /// All progress and errors land in `state.join`. On success
@@ -188,7 +238,7 @@ async fn run_join_sequence(
     minted_persona: &mut Option<PersonaId>,
 ) {
     // 1. Idempotency (R-B-9): refuse a duplicate live/pending membership.
-    if config.account.live_community(&vtc_did).is_some() {
+    if is_duplicate_membership(config, &vtc_did) {
         state
             .join
             .fail("Already a member of (or have a pending request for) this community.");
@@ -416,7 +466,7 @@ async fn run_join_sequence(
     };
 
     // 9. Record the pending membership and persist.
-    let record = CommunityRecord::new_pending(
+    let record = build_pending_record(
         vtc_did.clone(),
         display_name,
         sub_context_id,
@@ -524,10 +574,113 @@ mod tests {
     //! (`join_flow` → `rollback_minted_persona` when `!persona_referenced`).
 
     use super::race_against_interrupt;
+    use super::{build_pending_record, is_duplicate_membership, validate_join_input};
     use crate::Interrupted;
+    use crate::state_handler::dispatch_util::test_config;
+    use openvtc_core::config::account::{CommunityRecord, CommunityStatus, PersonaId};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::sync::broadcast;
+
+    // ---- Pure-decision tests (peeled out of the join sequence) ----
+
+    /// `validate_join_input` trims and rejects empties; otherwise returns the
+    /// cleaned DID. Table-driven over (raw input, expected).
+    #[test]
+    fn validate_join_input_table() {
+        let cases: &[(&str, Option<&str>)] = &[
+            ("", None),
+            ("   ", None),
+            ("\t\n", None),
+            ("did:webvh:example", Some("did:webvh:example")),
+            ("  did:webvh:example  ", Some("did:webvh:example")),
+            ("\tdid:peer:abc\n", Some("did:peer:abc")),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(
+                validate_join_input(raw).as_deref(),
+                *expected,
+                "validate_join_input({raw:?})"
+            );
+        }
+    }
+
+    /// `is_duplicate_membership` mirrors `Account::live_community`: live
+    /// (Active/Pending) memberships are duplicates; inactive ones and unknown
+    /// DIDs are not. Table-driven over the membership status.
+    #[test]
+    fn is_duplicate_membership_table() {
+        // (status to register for "did:vtc:known", is_duplicate?)
+        let cases: &[(Option<CommunityStatus>, bool)] = &[
+            (None, false),
+            (
+                Some(CommunityStatus::Pending {
+                    request_id: uuid::Uuid::new_v4(),
+                }),
+                true,
+            ),
+            (Some(CommunityStatus::Active), true),
+            (Some(CommunityStatus::Left), false),
+            (Some(CommunityStatus::Rejected), false),
+            (Some(CommunityStatus::Removed), false),
+            (Some(CommunityStatus::Expired), false),
+        ];
+        let vtc = "did:vtc:known";
+        for (status, expected) in cases {
+            let mut config = test_config();
+            if let Some(status) = status {
+                let mut rec = CommunityRecord::new_pending(
+                    vtc.to_string(),
+                    None,
+                    "ctx/slug".to_string(),
+                    PersonaId::new(),
+                    uuid::Uuid::new_v4(),
+                    chrono::Utc::now(),
+                );
+                rec.status = status.clone();
+                config.account.communities.insert(vtc.to_string(), rec);
+            }
+            assert_eq!(
+                is_duplicate_membership(&config, vtc),
+                *expected,
+                "is_duplicate_membership for status {status:?}"
+            );
+            // An unrelated DID is never a duplicate regardless of registered state.
+            assert!(
+                !is_duplicate_membership(&config, "did:vtc:other"),
+                "unknown DID is not a duplicate (status {status:?})"
+            );
+        }
+    }
+
+    /// `build_pending_record` produces a `Pending` record carrying the submit
+    /// inputs (vtc/display name/sub-context/persona/request id/requested_at).
+    #[test]
+    fn build_pending_record_carries_inputs() {
+        let persona = PersonaId::new();
+        let request_id = uuid::Uuid::new_v4();
+        let now = chrono::Utc::now();
+        let rec = build_pending_record(
+            "did:vtc:c".to_string(),
+            Some("Community".to_string()),
+            "top/slug".to_string(),
+            persona,
+            request_id,
+            now,
+        );
+        assert_eq!(rec.vtc_did, "did:vtc:c");
+        assert_eq!(rec.display_name.as_deref(), Some("Community"));
+        assert_eq!(rec.sub_context_id, "top/slug");
+        assert_eq!(rec.persona_ref, persona);
+        assert_eq!(rec.requested_at, Some(now));
+        assert!(rec.is_live(), "a fresh Pending record is live");
+        match rec.status {
+            CommunityStatus::Pending { request_id: got } => {
+                assert_eq!(got, request_id, "request id is carried into the status");
+            }
+            other => panic!("expected Pending status, got {other:?}"),
+        }
+    }
 
     #[tokio::test]
     async fn completes_when_no_interrupt() {

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -1916,4 +1916,151 @@ mod tests {
             "key_info entry removed"
         );
     }
+
+    // ----------------------------------------------------------------
+    // Table tests for the pure mode-transition handlers. Each is a pure
+    // function of `&mut State`; the tables drive the handler from a starting
+    // `State` and assert on the resulting relationships-panel mode. Mirrors the
+    // table-test style in `ui/pages/setup_flow/navigation.rs`.
+    // ----------------------------------------------------------------
+
+    fn rel_mode(state: &State) -> &RelationshipsMode {
+        &state.main_page.content_panel.relationships.mode
+    }
+
+    /// Enter `NewRequest` with empty fields; `handle_cancel_or_back` returns to
+    /// `List` clearing the status. Table over a couple of starting modes.
+    #[test]
+    fn start_new_request_and_cancel_back() {
+        let mut state = State::default();
+        handle_start_new_request(&mut state);
+        assert!(matches!(
+            rel_mode(&state),
+            RelationshipsMode::NewRequest {
+                generate_r_did: false,
+                active_field: 0,
+                ..
+            }
+        ));
+
+        // Cancel/back from any mode lands on List and clears the status.
+        for start in [
+            RelationshipsMode::NewRequest {
+                did_input: "x".to_string(),
+                alias_input: String::new(),
+                reason_input: String::new(),
+                generate_r_did: true,
+                active_field: 2,
+            },
+            RelationshipsMode::Detail {
+                index: 3,
+                selected_vrc: None,
+            },
+        ] {
+            let mut state = State::default();
+            state.main_page.content_panel.relationships.mode = start;
+            state.main_page.content_panel.relationships.status_message = Some("stale".to_string());
+            handle_cancel_or_back(&mut state);
+            assert!(matches!(rel_mode(&state), RelationshipsMode::List));
+            assert!(
+                state
+                    .main_page
+                    .content_panel
+                    .relationships
+                    .status_message
+                    .is_none(),
+                "cancel/back clears the status"
+            );
+        }
+    }
+
+    /// `handle_open_detail` enters `Detail { index, selected_vrc: None }` and
+    /// records the selected index. Table over a few indices.
+    #[test]
+    fn open_detail_enters_detail() {
+        for index in [0usize, 2, 17] {
+            let mut state = State::default();
+            handle_open_detail(&mut state, index);
+            assert!(
+                matches!(
+                    rel_mode(&state),
+                    RelationshipsMode::Detail { index: i, selected_vrc: None } if *i == index
+                ),
+                "open_detail({index})"
+            );
+            assert_eq!(
+                state.main_page.content_panel.relationships.selected_index,
+                index
+            );
+        }
+    }
+
+    /// `handle_input_update` routes by field index into the `NewRequest` form's
+    /// did/alias/reason inputs, and is a no-op outside `NewRequest`.
+    #[test]
+    fn input_update_routes_by_field() {
+        // (field, expected (did, alias, reason))
+        let cases: &[(usize, (&str, &str, &str))] = &[
+            (0, ("the-did", "", "")),
+            (1, ("", "the-alias", "")),
+            (2, ("", "", "the-reason")),
+            (9, ("", "", "the-reason")), // default arm writes reason
+        ];
+        for (field, (did, alias, reason)) in cases {
+            let mut state = State::default();
+            handle_start_new_request(&mut state);
+            let value = match field {
+                0 => "the-did",
+                1 => "the-alias",
+                _ => "the-reason",
+            };
+            handle_input_update(&mut state, *field, value.to_string());
+            match rel_mode(&state) {
+                RelationshipsMode::NewRequest {
+                    did_input,
+                    alias_input,
+                    reason_input,
+                    ..
+                } => {
+                    assert_eq!(did_input, did, "field {field} did_input");
+                    assert_eq!(alias_input, alias, "field {field} alias_input");
+                    assert_eq!(reason_input, reason, "field {field} reason_input");
+                }
+                other => panic!("expected NewRequest, got {other:?}"),
+            }
+        }
+
+        // No-op outside NewRequest.
+        let mut state = State::default();
+        handle_input_update(&mut state, 0, "ignored".to_string());
+        assert!(matches!(rel_mode(&state), RelationshipsMode::List));
+    }
+
+    /// `handle_toggle_r_did` flips the `generate_r_did` flag only in `NewRequest`.
+    #[test]
+    fn toggle_r_did_flips_flag() {
+        let mut state = State::default();
+        handle_start_new_request(&mut state);
+        handle_toggle_r_did(&mut state);
+        assert!(matches!(
+            rel_mode(&state),
+            RelationshipsMode::NewRequest {
+                generate_r_did: true,
+                ..
+            }
+        ));
+        handle_toggle_r_did(&mut state);
+        assert!(matches!(
+            rel_mode(&state),
+            RelationshipsMode::NewRequest {
+                generate_r_did: false,
+                ..
+            }
+        ));
+
+        // No-op outside NewRequest.
+        let mut state = State::default();
+        handle_toggle_r_did(&mut state);
+        assert!(matches!(rel_mode(&state), RelationshipsMode::List));
+    }
 }

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -815,4 +815,227 @@ mod tests {
     fn test_validate_file_path_rejects_hidden_traversal() {
         assert!(validate_file_path("/tmp/safe/../../../etc/shadow").is_err());
     }
+
+    // ----------------------------------------------------------------
+    // Table tests for the pure mode-transition handlers. Each is a pure
+    // function of `&mut State`; the tables drive the handler from a starting
+    // `State` and assert on the resulting settings-panel mode. Mirrors the
+    // table-test style in `ui/pages/setup_flow/navigation.rs`.
+    // ----------------------------------------------------------------
+
+    fn settings(state: &State) -> &super::SettingsMode {
+        &state.main_page.content_panel.settings.mode
+    }
+
+    /// A constructor for a representative `SettingsMode`, used by the tables to
+    /// seed a starting mode / check a target discriminant.
+    type ModeFn = fn() -> SettingsMode;
+
+    /// `handle_start_edit` maps the selected setting index to the matching edit
+    /// mode, seeding the input from the current value; unknown indices fall back
+    /// to `View`. Table-driven over (selected_index, expected mode discriminant).
+    #[test]
+    fn start_edit_maps_index_to_mode() {
+        // Closures returning a representative mode for the discriminant check.
+        let cases: &[(usize, ModeFn)] = &[
+            (0, || SettingsMode::EditFriendlyName {
+                input: String::new(),
+            }),
+            (1, || SettingsMode::EditMediatorDid {
+                input: String::new(),
+            }),
+            (2, || SettingsMode::EditOrgDid {
+                input: String::new(),
+            }),
+            (5, || SettingsMode::ExportConfig {
+                path_input: String::new(),
+                passphrase_len: 0,
+                active_field: 0,
+            }),
+            (6, || SettingsMode::ImportConfig {
+                path_input: String::new(),
+                passphrase_len: 0,
+                active_field: 0,
+            }),
+            (3, || SettingsMode::View),
+            (99, || SettingsMode::View),
+        ];
+        for (idx, expected) in cases {
+            let mut state = State::default();
+            state.main_page.content_panel.settings.friendly_name = "Alice".to_string();
+            state.main_page.content_panel.settings.mediator_did = "did:med".to_string();
+            state.main_page.content_panel.settings.org_did = "did:org".to_string();
+            state.main_page.content_panel.settings.selected_index = *idx;
+            handle_start_edit(&mut state);
+            assert_eq!(
+                std::mem::discriminant(settings(&state)),
+                std::mem::discriminant(&expected()),
+                "start_edit index {idx}"
+            );
+        }
+        // The edit modes seed `input` from the current value.
+        let mut state = State::default();
+        state.main_page.content_panel.settings.friendly_name = "Alice".to_string();
+        state.main_page.content_panel.settings.selected_index = 0;
+        handle_start_edit(&mut state);
+        assert!(matches!(
+            settings(&state),
+            SettingsMode::EditFriendlyName { input } if input == "Alice"
+        ));
+    }
+
+    /// `handle_field_update` writes the single-line input for the three edit
+    /// modes and is a no-op elsewhere.
+    #[test]
+    fn field_update_writes_edit_input() {
+        let edit_modes: &[ModeFn] = &[
+            || SettingsMode::EditFriendlyName {
+                input: String::new(),
+            },
+            || SettingsMode::EditMediatorDid {
+                input: String::new(),
+            },
+            || SettingsMode::EditOrgDid {
+                input: String::new(),
+            },
+        ];
+        for make in edit_modes {
+            let mut state = State::default();
+            state.main_page.content_panel.settings.mode = make();
+            handle_field_update(&mut state, "new-value".to_string());
+            let input = match settings(&state) {
+                SettingsMode::EditFriendlyName { input }
+                | SettingsMode::EditMediatorDid { input }
+                | SettingsMode::EditOrgDid { input } => input.clone(),
+                other => panic!("unexpected mode {other:?}"),
+            };
+            assert_eq!(input, "new-value");
+        }
+        // No-op in View.
+        let mut state = State::default();
+        handle_field_update(&mut state, "ignored".to_string());
+        assert!(matches!(settings(&state), SettingsMode::View));
+    }
+
+    /// `handle_change_protection` enters the `ChangeProtection` form zeroed, and
+    /// the protection sub-field handlers then mutate exactly their field.
+    #[test]
+    fn change_protection_form_field_transitions() {
+        let mut state = State::default();
+        handle_change_protection(&mut state);
+        assert!(matches!(
+            settings(&state),
+            SettingsMode::ChangeProtection {
+                selected_option: 0,
+                passphrase_len: 0,
+                confirm_len: 0,
+                active_field: 0,
+            }
+        ));
+
+        handle_protection_option_select(&mut state, 1);
+        handle_protection_passphrase_len(&mut state, 7);
+        handle_protection_confirm_len(&mut state, 9);
+        handle_protection_tab_switch(&mut state, 2);
+        assert!(matches!(
+            settings(&state),
+            SettingsMode::ChangeProtection {
+                selected_option: 1,
+                passphrase_len: 7,
+                confirm_len: 9,
+                active_field: 2,
+            }
+        ));
+
+        // `handle_protection_start_input` forces the active field to the
+        // passphrase (1).
+        let mut state = State::default();
+        handle_change_protection(&mut state);
+        handle_protection_start_input(&mut state);
+        assert!(matches!(
+            settings(&state),
+            SettingsMode::ChangeProtection {
+                active_field: 1,
+                ..
+            }
+        ));
+    }
+
+    /// `handle_form_tab_switch` toggles the export/import form active field
+    /// between 0 and 1; `handle_form_field_update`/`handle_passphrase_len`
+    /// populate the path/passphrase-length.
+    #[test]
+    fn export_import_form_field_transitions() {
+        for make in [
+            (|| SettingsMode::ExportConfig {
+                path_input: String::new(),
+                passphrase_len: 0,
+                active_field: 0,
+            }) as ModeFn,
+            || SettingsMode::ImportConfig {
+                path_input: String::new(),
+                passphrase_len: 0,
+                active_field: 0,
+            },
+        ] {
+            let mut state = State::default();
+            state.main_page.content_panel.settings.mode = make();
+            handle_form_field_update(&mut state, 0, "backup.enc".to_string());
+            handle_passphrase_len(&mut state, 4);
+            handle_form_tab_switch(&mut state); // 0 -> 1
+            let (path, plen, field) = match settings(&state) {
+                SettingsMode::ExportConfig {
+                    path_input,
+                    passphrase_len,
+                    active_field,
+                }
+                | SettingsMode::ImportConfig {
+                    path_input,
+                    passphrase_len,
+                    active_field,
+                } => (path_input.clone(), *passphrase_len, *active_field),
+                other => panic!("unexpected mode {other:?}"),
+            };
+            assert_eq!(path, "backup.enc");
+            assert_eq!(plen, 4);
+            assert_eq!(field, 1, "tab switch toggled 0 -> 1");
+            handle_form_tab_switch(&mut state); // 1 -> 0
+            let field = match settings(&state) {
+                SettingsMode::ExportConfig { active_field, .. }
+                | SettingsMode::ImportConfig { active_field, .. } => *active_field,
+                other => panic!("unexpected mode {other:?}"),
+            };
+            assert_eq!(field, 0, "tab switch toggled 1 -> 0");
+        }
+    }
+
+    /// `handle_wipe_start` enters `WipeConfirm` (empty input) and
+    /// `handle_wipe_input` records the typed confirmation token.
+    #[test]
+    fn wipe_start_and_input_transitions() {
+        let mut state = State::default();
+        handle_wipe_start(&mut state);
+        assert!(matches!(
+            settings(&state),
+            SettingsMode::WipeConfirm { confirm_input } if confirm_input.is_empty()
+        ));
+        handle_wipe_input(&mut state, "WIPE".to_string());
+        assert!(matches!(
+            settings(&state),
+            SettingsMode::WipeConfirm { confirm_input } if confirm_input == "WIPE"
+        ));
+
+        // `handle_wipe_input` is a no-op outside WipeConfirm.
+        let mut state = State::default();
+        handle_wipe_input(&mut state, "WIPE".to_string());
+        assert!(matches!(settings(&state), SettingsMode::View));
+    }
+
+    /// `handle_select` updates the selected index in `View`.
+    #[test]
+    fn select_updates_index() {
+        let mut state = State::default();
+        handle_select(&mut state, 4);
+        assert_eq!(state.main_page.content_panel.settings.selected_index, 4);
+    }
 }


### PR DESCRIPTION
## What

A first slice of R26 (tests are ongoing, landed in slices). Adds direct tests for the pure mode-transition handlers that previously had none, and peels `join_flow.rs`'s pure decisions into testable free functions.

## Tests added (17)

Following the `setup_flow/navigation.rs` table-test pattern:

- **settings_actions** (7) — `handle_start_edit` index→mode map (incl. View fallback + input seeding), `handle_field_update`, `handle_change_protection` + sub-field handlers, export/import form field + tab-switch, `handle_wipe_start`/`handle_wipe_input`, `handle_select`.
- **credential_actions** (4) — tab cycle + index reset, open-detail/back, start-new-request, reason-update (incl. no-op outside `NewRequest`).
- **relationship_actions** (4) — start-new-request + cancel/back, open-detail, input-update field routing, toggle-R-DID.
- **join_flow** (3) — the extracted free functions below.

## join_flow.rs extraction (mechanical, behavior-neutral)

No client trait or mock introduced. Three pure decisions peeled out of the existing call sites, which now delegate to them:
- `validate_join_input` — the trim + empty-reject from the submit arm.
- `is_duplicate_membership` — wraps the step-1 idempotency check.
- `build_pending_record` — wraps the step-9 `CommunityRecord::new_pending`.

## Scope

`main/mod.rs` is untouched (its key-handler tests are a later slice). Handlers that do I/O (token/keyring/filesystem, network) are left out of the pure table tests; the network ones are already covered by existing `*Outcome::apply` tests.

## Gate

Rebased onto current `main`; `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p openvtc` (113 passed) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)