### PR TITLE
refactor(vta): adopt vta-sdk connect_auto, delete duplicated transport branch (R22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,7 +2284,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.2",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -5192,7 +5192,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.2",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5241,7 +5241,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.10.0",
+ "vta-sdk 0.11.2",
  "x25519-dalek",
  "zeroize",
 ]
@@ -5871,7 +5871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8532,9 +8532,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1e8bd4a1747816874aacfe79f868331875e5f432976990fc6c97511d7b5c45"
+checksum = "3e910424bff341e8e6e064256317d48216390399b3c991bd4240788818c9a7b7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-vta-sdk = { version = "0.10", features = [
+vta-sdk = { version = "0.11", features = [
   "session",
   "client",
   "didcomm",

--- a/did-git-sign/src/vta.rs
+++ b/did-git-sign/src/vta.rs
@@ -1,8 +1,5 @@
 use anyhow::{Context, Result, bail};
-use vta_sdk::{
-    client::VtaClient,
-    session::{TokenResult, challenge_response},
-};
+use vta_sdk::client::{AutoConnect, ConnectedVta, VtaClient};
 use zeroize::Zeroize;
 
 use crate::config::{self, SigningConfig, VtaCredentials};
@@ -25,55 +22,35 @@ pub async fn authenticate(cfg: &SigningConfig) -> Result<(VtaClient, VtaCredenti
     let creds = config::load_vta_credentials(&cfg.did_key_id)?;
     validate_credentials(&creds)?;
 
-    if let Some(mediator) = &creds.mediator_did {
-        // DIDComm transport. Each `git commit` opens a fresh session;
-        // VtaClient::connect_didcomm handles the handshake and the
-        // resulting client routes get_key_secret over DIDComm via the
-        // SDK's built-in rpc() dispatch.
-        let rest_fallback = if creds.vta_url.is_empty() {
-            None
-        } else {
-            Some(creds.vta_url.clone())
-        };
-        let client = VtaClient::connect_didcomm(
-            &creds.credential_did,
-            &creds.private_key_multibase,
-            &creds.vta_did,
-            mediator,
-            rest_fallback,
-        )
-        .await
-        .map_err(|e| anyhow::anyhow!("DIDComm session open failed: {e}"))?;
-        return Ok((client, creds));
-    }
-
-    // REST transport.
-    let client = VtaClient::new(&creds.vta_url);
-
-    // Try cached token first
-    if let Some(token) = config::load_cached_token(&cfg.did_key_id) {
+    // REST transport with a cached bearer token: short-circuit the handshake.
+    // Token caching stays caller-side — the SDK deliberately leaves it to us.
+    if creds.mediator_did.is_none()
+        && let Some(token) = config::load_cached_token(&cfg.did_key_id)
+    {
+        let client = VtaClient::new(&creds.vta_url);
         client.set_token(token);
         return Ok((client, creds));
     }
 
-    // Fall back to challenge-response auth with retry
-    let token_result = auth_with_retry(
-        &creds.vta_url,
-        &creds.credential_did,
-        &creds.private_key_multibase,
-        &creds.vta_did,
-    )
-    .await?;
+    // Let the SDK pick the transport and run the handshake. `connect_auto`
+    // encapsulates the DIDComm-vs-REST branch, the `rest_fallback` derivation,
+    // and the empty-URL rule we used to hand-roll here and in openvtc-core —
+    // that logic is SDK-level knowledge, so it lives there now (R22). We keep
+    // the transient-failure retry and (REST) token caching, both of which are
+    // application policy.
+    let connected = connect_with_retry(&creds).await?;
 
-    // Cache the token for future invocations
-    let _ = config::cache_token(
-        &cfg.did_key_id,
-        &token_result.access_token,
-        token_result.access_expires_at,
-    );
+    // DIDComm sessions carry no bearer token (`rest_token` is `None`); a REST
+    // handshake issues one, which we cache for the next invocation.
+    if let Some(token) = &connected.rest_token {
+        let _ = config::cache_token(
+            &cfg.did_key_id,
+            &token.access_token,
+            token.access_expires_at,
+        );
+    }
 
-    client.set_token(token_result.access_token);
-    Ok((client, creds))
+    Ok((connected.client, creds))
 }
 
 /// Validate VTA credentials before use.
@@ -118,27 +95,38 @@ fn validate_credentials(creds: &VtaCredentials) -> Result<()> {
     Ok(())
 }
 
-/// Perform challenge-response authentication with retry on transient failures.
-async fn auth_with_retry(
-    vta_url: &str,
-    credential_did: &str,
-    private_key_multibase: &str,
-    vta_did: &str,
-) -> Result<TokenResult> {
+/// Connect via [`VtaClient::connect_auto`] with retry on transient failures.
+///
+/// The transport (DIDComm vs REST) is chosen by the SDK from `creds`. Retry
+/// covers both paths uniformly — a transient mediator or network hiccup is
+/// worth a second attempt regardless of transport.
+async fn connect_with_retry(creds: &VtaCredentials) -> Result<ConnectedVta> {
     let mut last_err = None;
     for attempt in 1..=MAX_AUTH_RETRIES {
-        match challenge_response(vta_url, credential_did, private_key_multibase, vta_did).await {
-            Ok(result) => {
-                if result.access_token.is_empty() {
+        let result = VtaClient::connect_auto(AutoConnect {
+            vta_url: &creds.vta_url,
+            vta_did: &creds.vta_did,
+            credential_did: &creds.credential_did,
+            private_key_multibase: &creds.private_key_multibase,
+            mediator_did: creds.mediator_did.as_deref(),
+        })
+        .await;
+        match result {
+            Ok(connected) => {
+                // A REST handshake must yield a non-empty bearer token; DIDComm
+                // carries none (`rest_token` is `None`), so this skips it.
+                if let Some(token) = &connected.rest_token
+                    && token.access_token.is_empty()
+                {
                     bail!("VTA returned an empty access token");
                 }
-                return Ok(result);
+                return Ok(connected);
             }
             Err(e) => {
                 let err_msg = format!("{e}");
                 if attempt < MAX_AUTH_RETRIES {
                     eprintln!(
-                        "VTA auth attempt {attempt}/{MAX_AUTH_RETRIES} failed: {err_msg}, retrying..."
+                        "VTA connect attempt {attempt}/{MAX_AUTH_RETRIES} failed: {err_msg}, retrying..."
                     );
                 }
                 last_err = Some(err_msg);
@@ -146,7 +134,7 @@ async fn auth_with_retry(
         }
     }
     bail!(
-        "VTA authentication failed after {MAX_AUTH_RETRIES} attempts: {}",
+        "VTA connection failed after {MAX_AUTH_RETRIES} attempts: {}",
         last_err.unwrap_or_else(|| "unknown error".to_string())
     )
 }

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -462,43 +462,36 @@ pub async fn build_runtime_vta_client(
         ));
     };
 
-    if let Some(mediator) = mediator_did {
-        // DIDComm transport: the rotated admin credential opens a fresh
-        // session against the advertised mediator. `vta_url` is passed
-        // through as a fallback for REST-only operations like /health,
-        // and is allowed to be empty for fully-DIDComm VTAs.
-        let rest_fallback = if vta_url.is_empty() {
-            None
-        } else {
-            Some(vta_url.clone())
-        };
-        vta_sdk::client::VtaClient::connect_didcomm(
-            credential_did,
-            credential_private_key.expose_secret(),
-            vta_did,
-            mediator,
-            rest_fallback,
-        )
-        .await
-        .map_err(|e| OpenVTCError::Vta(format!("DIDComm session open failed: {e}")))
-    } else {
-        // REST transport: legacy challenge-response + bearer token.
-        if vta_url.is_empty() {
-            return Err(OpenVTCError::Config(
-                "REST transport selected but vta_url is empty".to_string(),
-            ));
-        }
-        let token = vta_sdk::session::challenge_response(
-            vta_url,
-            credential_did,
-            credential_private_key.expose_secret(),
-            vta_did,
-        )
-        .await
-        .map_err(|e| OpenVTCError::Auth(format!("VTA authentication failed: {e}")))?;
-        let client = vta_sdk::client::VtaClient::new(vta_url);
-        client.set_token(token.access_token);
-        Ok(client)
+    // The transport choice (DIDComm vs REST), the `rest_fallback` derivation,
+    // and the empty-URL rule are SDK-level knowledge — `connect_auto`
+    // encapsulates them so this no longer hand-rolls the branch (R22). The
+    // issued REST token is dropped: runtime clients re-auth per process and
+    // never cached it here.
+    vta_sdk::client::VtaClient::connect_auto(vta_sdk::client::AutoConnect {
+        vta_url,
+        vta_did,
+        credential_did,
+        private_key_multibase: credential_private_key.expose_secret(),
+        mediator_did: mediator_did.as_deref(),
+    })
+    .await
+    .map(|connected| connected.client)
+    .map_err(map_connect_error)
+}
+
+/// Map a `vta_sdk` connect error onto the typed [`OpenVTCError`] taxonomy so
+/// callers can keep distinguishing retryable transport/auth failures from
+/// genuine config corruption (R18). An empty `vta_url` on the REST path comes
+/// back as [`vta_sdk::error::VtaError::Validation`] — that is a bad on-disk
+/// config, so it maps to [`OpenVTCError::Config`]; auth rejection maps to
+/// [`OpenVTCError::Auth`]; everything else (network, DIDComm session open) is a
+/// live-VTA reachability problem, [`OpenVTCError::Vta`].
+fn map_connect_error(e: vta_sdk::error::VtaError) -> OpenVTCError {
+    use vta_sdk::error::VtaError;
+    match e {
+        VtaError::Validation(msg) => OpenVTCError::Config(msg),
+        VtaError::Auth(msg) => OpenVTCError::Auth(format!("VTA authentication failed: {msg}")),
+        other => OpenVTCError::Vta(format!("VTA connection failed: {other}")),
     }
 }
 


### PR DESCRIPTION
## Problem

The DIDComm-vs-REST VTA connect branch — transport selection, the
`rest_fallback` derivation, and the empty-`vta_url` rule — was hand-rolled
**identically** in two places:

- `did-git-sign/src/vta.rs::authenticate`
- `openvtc-core/src/config/mod.rs::build_runtime_vta_client`

That logic is SDK-level knowledge. The upstream issue
(OpenVTC/verifiable-trust-infrastructure#366) proposed `VtaClient::connect_auto`,
which shipped in **vta-sdk 0.11** as `connect_auto(AutoConnect) -> ConnectedVta`.

## Fix

- Bump `vta-sdk` `0.10` → `0.11`.
- `build_runtime_vta_client` delegates to `connect_auto`. A small
  `map_connect_error` preserves the R18 error taxonomy:
  `VtaError::Validation` → `OpenVTCError::Config` (bad on-disk config, e.g.
  empty REST url), `VtaError::Auth` → `OpenVTCError::Auth`, everything else
  (network / DIDComm session open) → `OpenVTCError::Vta`.
- `did-git-sign` keeps its **application-level** policy — caller-side REST
  token cache + transient-failure retry — but routes the actual connect
  through `connect_auto` via a new `connect_with_retry`. The cached-token
  short-circuit is now explicitly gated on the REST transport
  (`mediator_did.is_none()`), matching the prior implicit gating; the
  empty-access-token guard is preserved on the REST path.

### Behavior notes
- Identical for DIDComm-capable and REST-only VTAs.
- One intentional, benign change: retry now covers the DIDComm path too (it
  previously wrapped only the REST challenge-response). A transient mediator
  hiccup is worth a second attempt on either transport; bounded by
  `MAX_AUTH_RETRIES = 2`.

## Tests / gate
- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo test --workspace` — all green.
- Existing `validate_credentials` unit tests in `did-git-sign` unchanged and
  passing.
- Reviewed the diff against the published `connect_auto` semantics for
  error-mapping fidelity, cache gating, and the empty-token guard — no
  correctness regressions.

## Follow-up (pre-existing, out of scope)
`did-git-sign::authenticate` returns the `VtaClient` to callers that never call
`shutdown()`, leaking the DIDComm session per `git commit`. This is **identical
in the deleted code** (not a regression). Worth a separate fix giving
did-git-sign a `with_didcomm`-style scoped shutdown, mirroring
`openvtc-core::with_runtime_vta_client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)