### PR TITLE
feat(ui): consistent y/Enter confirmation for destructive actions (R25)

### DIFF
--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -47,6 +47,14 @@ pub enum InboxAction {
         task_id: String,
     },
     ClearAll,
+    /// Arm the confirmation for dismissing a single task (R25).
+    ConfirmDismiss {
+        task_id: String,
+    },
+    /// Arm the confirmation for clearing all tasks (R25).
+    ConfirmClearAll,
+    /// Cancel a pending dismiss/clear-all confirmation (R25).
+    CancelConfirm,
     Back,
 }
 
@@ -67,6 +75,12 @@ pub enum RelationshipAction {
     Remove {
         remote_p_did: String,
     },
+    /// Arm the confirmation for removing a relationship (R25).
+    ConfirmRemove {
+        remote_p_did: String,
+    },
+    /// Cancel a pending relationship-removal confirmation (R25).
+    CancelRemove,
     Back,
     InputUpdate {
         field: usize,
@@ -113,6 +127,12 @@ pub enum CredentialAction {
     Remove {
         vrc_id: String,
     },
+    /// Arm the confirmation for removing a credential (R25).
+    ConfirmRemove {
+        vrc_id: String,
+    },
+    /// Cancel a pending credential-removal confirmation (R25).
+    CancelRemove,
 }
 
 pub enum SettingsAction {

--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -184,6 +184,8 @@ fn handle_remove(
     save: &mut SaveScheduler,
     vrc_id: &str,
 ) {
+    // The confirmation is now resolved.
+    state.main_page.content_panel.credentials.confirm_delete = None;
     if let Err(e) = remove_vrc(config, vrc_id) {
         state.main_page.log_error("Failed to remove VRC", &e);
         return;
@@ -236,6 +238,13 @@ pub(crate) async fn dispatch(
             .await
         }
         CredentialAction::Remove { vrc_id } => handle_remove(config, state, save, &vrc_id),
+        // R25 confirmation arming/cancel — pure state mutations.
+        CredentialAction::ConfirmRemove { vrc_id } => {
+            state.main_page.content_panel.credentials.confirm_delete = Some(vrc_id);
+        }
+        CredentialAction::CancelRemove => {
+            state.main_page.content_panel.credentials.confirm_delete = None;
+        }
     }
 }
 

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -126,7 +126,7 @@ fn build_reject_message(from: &str, to: &str, reason: Option<&str>, thid: &str) 
 use crate::state_handler::{
     actions::InboxAction,
     dispatch_util,
-    main_page::content::{ActiveTaskView, TaskKind},
+    main_page::content::{ActiveTaskView, InboxConfirm, TaskKind},
     save_coalesce::SaveScheduler,
     state::State,
 };
@@ -797,6 +797,8 @@ fn handle_dismiss_task(
     save: &mut SaveScheduler,
     task_id: &str,
 ) {
+    // The confirmation (if any) is now resolved.
+    state.main_page.content_panel.inbox.confirm = None;
     if let Err(e) = dismiss_task(config, task_id) {
         state.main_page.log_error("Failed to dismiss task", &e);
         return;
@@ -809,6 +811,8 @@ fn handle_dismiss_task(
 }
 
 fn handle_clear_all(config: &mut Box<Config>, state: &mut State, save: &mut SaveScheduler) {
+    // The confirmation (if any) is now resolved.
+    state.main_page.content_panel.inbox.confirm = None;
     if let Err(e) = clear_all_tasks(config) {
         state.main_page.log_error("Failed to clear inbox", &e);
         return;
@@ -903,6 +907,16 @@ pub(crate) async fn dispatch(
         }
         InboxAction::DismissTask { task_id } => handle_dismiss_task(config, state, save, &task_id),
         InboxAction::ClearAll => handle_clear_all(config, state, save),
+        // R25 confirmation arming/cancel — pure state mutations, never network.
+        InboxAction::ConfirmDismiss { task_id } => {
+            state.main_page.content_panel.inbox.confirm = Some(InboxConfirm::Dismiss { task_id });
+        }
+        InboxAction::ConfirmClearAll => {
+            state.main_page.content_panel.inbox.confirm = Some(InboxConfirm::ClearAll);
+        }
+        InboxAction::CancelConfirm => {
+            state.main_page.content_panel.inbox.confirm = None;
+        }
     }
     InboxDispatch::Handled
 }

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -204,6 +204,19 @@ pub struct InboxState {
     pub active_task: Option<ActiveTaskView>,
     /// Transient status message (e.g., "Task accepted", "Error: ...")
     pub status_message: Option<String>,
+    /// When `Some`, a destructive inbox action (dismiss one task, or clear all)
+    /// is awaiting `y`/`n` confirmation; the panel shows a prompt and other keys
+    /// are suppressed. Mirrors the Communities/VTA-DID confirm pattern (R25).
+    pub confirm: Option<InboxConfirm>,
+}
+
+/// A pending destructive inbox action awaiting `y`/`n` confirmation (R25).
+#[derive(Clone, Debug)]
+pub enum InboxConfirm {
+    /// Dismiss a single task (by id) — armed from the list or a task detail.
+    Dismiss { task_id: String },
+    /// Clear every pending task.
+    ClearAll,
 }
 
 /// Lightweight display summary of a task (no Arc/Mutex).
@@ -304,6 +317,10 @@ pub struct RelationshipsState {
     pub mode: RelationshipsMode,
     /// Transient status message
     pub status_message: Option<String>,
+    /// When `Some(remote_p_did)`, removal of that relationship is awaiting
+    /// `y`/`n` confirmation (armed from the detail view). Mirrors the
+    /// Communities/VTA-DID confirm pattern (R25).
+    pub confirm_delete: Option<String>,
 }
 
 /// Display modes for the relationships panel.
@@ -395,6 +412,10 @@ pub struct CredentialsState {
     pub mode: CredentialsMode,
     /// Transient status message
     pub status_message: Option<String>,
+    /// When `Some(vrc_id)`, removal of that credential is awaiting `y`/`n`
+    /// confirmation (armed from the detail view). Mirrors the Communities/
+    /// VTA-DID confirm pattern (R25).
+    pub confirm_delete: Option<String>,
 }
 
 /// Which credential tab is active.

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -1245,6 +1245,8 @@ fn prepare_remove(
         .map(|rel| Arc::clone(&rel.our_did))
         .filter(|our_did| !config.is_persona_did(our_did.as_str()));
     let listener_id = our_did.map(|our_did| super::didcomm::listener_id_for_did(&our_did, config));
+    // The confirmation is now resolved.
+    state.main_page.content_panel.relationships.confirm_delete = None;
     state.main_page.content_panel.relationships.status_message =
         Some("Removing relationship...".to_string());
     RelationshipJob::Remove {
@@ -1479,6 +1481,13 @@ pub(crate) async fn dispatch(
                 job: prepare_remove(config, service, state, &remote_p_did),
                 is_ping: false,
             };
+        }
+        // R25 confirmation arming/cancel — pure state mutations, never network.
+        RelationshipAction::ConfirmRemove { remote_p_did } => {
+            state.main_page.content_panel.relationships.confirm_delete = Some(remote_p_did);
+        }
+        RelationshipAction::CancelRemove => {
+            state.main_page.content_panel.relationships.confirm_delete = None;
         }
         RelationshipAction::StartEditAlias {
             index,

--- a/openvtc/src/ui/pages/main/components/credentials_panel.rs
+++ b/openvtc/src/ui/pages/main/components/credentials_panel.rs
@@ -1,6 +1,6 @@
 use super::panel::Panel;
 use crate::colors::{
-    COLOR_DARK_GRAY, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+    COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
     COLOR_WARNING_ACCESSIBLE_RED,
 };
 use crate::state_handler::{
@@ -186,7 +186,16 @@ fn render_detail(state: &CredentialsState, index: usize) -> Vec<Line<'static>> {
     }
 
     lines.push(Line::from(""));
-    lines.push(Line::from("d: remove  c: copy JSON  Esc: back").fg(COLOR_DARK_GRAY));
+    // A pending removal confirmation replaces the footer hint (R25).
+    if state.confirm_delete.is_some() {
+        lines.push(
+            Line::from("Remove this credential?   y: confirm    n: cancel")
+                .fg(COLOR_ORANGE)
+                .bold(),
+        );
+    } else {
+        lines.push(Line::from("d: remove  c: copy JSON  Esc: back").fg(COLOR_DARK_GRAY));
+    }
 
     lines
 }

--- a/openvtc/src/ui/pages/main/components/inbox_panel.rs
+++ b/openvtc/src/ui/pages/main/components/inbox_panel.rs
@@ -4,7 +4,7 @@ use crate::colors::{
     COLOR_WARNING_ACCESSIBLE_RED,
 };
 use crate::state_handler::{
-    main_page::content::{ActiveTaskView, ContentPanelState, InboxState, TaskKind},
+    main_page::content::{ActiveTaskView, ContentPanelState, InboxConfirm, InboxState, TaskKind},
     state::{ConnectionState, MediatorStatus},
 };
 use ratatui::{
@@ -29,7 +29,13 @@ impl Panel for InboxPanel {
 pub fn render(state: &InboxState, connection: &ConnectionState) -> Vec<Line<'static>> {
     // If viewing a specific task detail
     if let Some(active_task) = &state.active_task {
-        return render_task_detail(active_task);
+        let mut lines = render_task_detail(active_task);
+        // A pending dismiss confirmation overrides the detail footer hint (R25).
+        if let Some(confirm) = &state.confirm {
+            lines.push(Line::from(""));
+            lines.push(confirm_prompt_line(confirm));
+        }
+        return lines;
     }
 
     let mut lines = vec![Line::from("")];
@@ -113,12 +119,27 @@ pub fn render(state: &InboxState, connection: &ConnectionState) -> Vec<Line<'sta
         }
 
         lines.push(Line::from(""));
-        lines.push(
-            Line::from("↑/↓ navigate  Enter: view  d: dismiss  c: clear all").fg(COLOR_DARK_GRAY),
-        );
+        // A pending dismiss/clear-all confirmation replaces the footer hint (R25).
+        if let Some(confirm) = &state.confirm {
+            lines.push(confirm_prompt_line(confirm));
+        } else {
+            lines.push(
+                Line::from("↑/↓ navigate  Enter: view  d: dismiss  c: clear all")
+                    .fg(COLOR_DARK_GRAY),
+            );
+        }
     }
 
     lines
+}
+
+/// Footer prompt shown while a destructive inbox action awaits `y`/`n` (R25).
+fn confirm_prompt_line(confirm: &InboxConfirm) -> Line<'static> {
+    let text = match confirm {
+        InboxConfirm::Dismiss { .. } => "Dismiss this task?   y: confirm    n: cancel",
+        InboxConfirm::ClearAll => "Clear all tasks?   y: confirm    n: cancel",
+    };
+    Line::from(text).fg(COLOR_ORANGE).bold()
 }
 
 /// Render detail view for a selected inbox task.

--- a/openvtc/src/ui/pages/main/components/relationships_panel.rs
+++ b/openvtc/src/ui/pages/main/components/relationships_panel.rs
@@ -318,12 +318,21 @@ fn render_detail(
     }
 
     lines.push(Line::from(""));
-    lines.push(
-        Line::from(
-            "e: edit alias  p: ping  v: request VRC  d: remove  \u{2191}/\u{2193}: browse VRCs  Esc: back",
-        )
-        .fg(COLOR_DARK_GRAY),
-    );
+    // A pending removal confirmation replaces the footer hint (R25).
+    if state.confirm_delete.is_some() {
+        lines.push(
+            Line::from("Remove this relationship?   y: confirm    n: cancel")
+                .fg(COLOR_ORANGE)
+                .bold(),
+        );
+    } else {
+        lines.push(
+            Line::from(
+                "e: edit alias  p: ping  v: request VRC  d: remove  \u{2191}/\u{2193}: browse VRCs  Esc: back",
+            )
+            .fg(COLOR_DARK_GRAY),
+        );
+    }
 
     lines
 }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -4,7 +4,11 @@ use crate::colors::{
 use crate::{
     state_handler::{
         actions::{Action, CredentialAction, InboxAction, RelationshipAction, SettingsAction},
-        main_page::{MainPageState, MainPanel, content::ActiveTaskView, menu::MainMenu},
+        main_page::{
+            MainPageState, MainPanel,
+            content::{ActiveTaskView, InboxConfirm},
+            menu::MainMenu,
+        },
         state::{ConnectionState, MediatorStatus, State},
     },
     ui::component::{Component, ComponentRender},
@@ -430,6 +434,26 @@ impl MainPage {
     fn handle_inbox_key(&mut self, key: KeyEvent) -> bool {
         let inbox = &self.props.main_page.content_panel.inbox;
 
+        // A destructive-action confirmation is pending: only y/Enter commits;
+        // anything else cancels. Mirrors the Communities/VTA-DID pattern (R25).
+        if let Some(confirm) = inbox.confirm.clone() {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    let commit = match confirm {
+                        InboxConfirm::Dismiss { task_id } => InboxAction::DismissTask { task_id },
+                        InboxConfirm::ClearAll => InboxAction::ClearAll,
+                    };
+                    let _ = self.action_tx.send(Action::Inbox(commit));
+                }
+                _ => {
+                    let _ = self
+                        .action_tx
+                        .send(Action::Inbox(InboxAction::CancelConfirm));
+                }
+            }
+            return true;
+        }
+
         // If viewing a task detail, handle detail keys
         if let Some(active_task) = &inbox.active_task {
             // Extract what we need before borrowing self mutably
@@ -503,7 +527,7 @@ impl MainPage {
                 KeyCode::Char('d') => {
                     let _ = self
                         .action_tx
-                        .send(Action::Inbox(InboxAction::DismissTask { task_id }));
+                        .send(Action::Inbox(InboxAction::ConfirmDismiss { task_id }));
                     true
                 }
                 _ => false,
@@ -538,11 +562,13 @@ impl MainPage {
                 let task_id = inbox.tasks[selected].id.clone();
                 let _ = self
                     .action_tx
-                    .send(Action::Inbox(InboxAction::DismissTask { task_id }));
+                    .send(Action::Inbox(InboxAction::ConfirmDismiss { task_id }));
                 true
             }
             KeyCode::Char('c') if task_count > 0 => {
-                let _ = self.action_tx.send(Action::Inbox(InboxAction::ClearAll));
+                let _ = self
+                    .action_tx
+                    .send(Action::Inbox(InboxAction::ConfirmClearAll));
                 true
             }
             KeyCode::Esc => {
@@ -652,6 +678,25 @@ impl MainPage {
             } => {
                 let index = *index;
                 let current_vrc = *selected_vrc;
+
+                // A removal confirmation is pending: y/Enter commits, anything
+                // else cancels. Mirrors the Communities/VTA-DID pattern (R25).
+                if let Some(remote_p_did) = rels.confirm_delete.clone() {
+                    match key.code {
+                        KeyCode::Char('y') | KeyCode::Enter => {
+                            let _ = self.action_tx.send(Action::Relationship(
+                                RelationshipAction::Remove { remote_p_did },
+                            ));
+                        }
+                        _ => {
+                            let _ = self
+                                .action_tx
+                                .send(Action::Relationship(RelationshipAction::CancelRemove));
+                        }
+                    }
+                    return true;
+                }
+
                 match key.code {
                     KeyCode::Down => {
                         if let Some(rel) = rels.relationships.get(index) {
@@ -719,7 +764,7 @@ impl MainPage {
                     KeyCode::Char('d') => {
                         if let Some(rel) = rels.relationships.get(index) {
                             let _ = self.action_tx.send(Action::Relationship(
-                                RelationshipAction::Remove {
+                                RelationshipAction::ConfirmRemove {
                                     remote_p_did: rel.remote_p_did.clone(),
                                 },
                             ));
@@ -884,6 +929,25 @@ impl MainPage {
             }
             CredentialsMode::Detail { index } => {
                 let detail_index = *index;
+
+                // A removal confirmation is pending: y/Enter commits, anything
+                // else cancels. Mirrors the Communities/VTA-DID pattern (R25).
+                if let Some(vrc_id) = creds.confirm_delete.clone() {
+                    match key.code {
+                        KeyCode::Char('y') | KeyCode::Enter => {
+                            let _ = self
+                                .action_tx
+                                .send(Action::Credential(CredentialAction::Remove { vrc_id }));
+                        }
+                        _ => {
+                            let _ = self
+                                .action_tx
+                                .send(Action::Credential(CredentialAction::CancelRemove));
+                        }
+                    }
+                    return true;
+                }
+
                 match key.code {
                     KeyCode::Esc => {
                         let _ = self
@@ -903,11 +967,11 @@ impl MainPage {
                         if creds.selected_tab != CredentialTab::Membership
                             && let Some(vrc) = active_list.get(detail_index)
                         {
-                            let _ =
-                                self.action_tx
-                                    .send(Action::Credential(CredentialAction::Remove {
-                                        vrc_id: vrc.vrc_id.clone(),
-                                    }));
+                            let _ = self.action_tx.send(Action::Credential(
+                                CredentialAction::ConfirmRemove {
+                                    vrc_id: vrc.vrc_id.clone(),
+                                },
+                            ));
                         }
                         true
                     }


### PR DESCRIPTION
## Problem

Communities and VTA-DID deletes require a `y`/`Enter` confirmation
(`handle_communities_key`/`handle_vta_key`), but three destructive actions fire
instantly:

- `d` in **Relationship detail** → removes the relationship
- `d` in **Credential detail** → removes the VRC
- `d` (dismiss) and `c` (clear all) in the **Inbox**

## Fix

Apply the existing `confirm_delete: Option<…>` arm pattern to all three panels.

- **State** (`content.rs`): `RelationshipsState.confirm_delete: Option<String>`
  (remote_p_did), `CredentialsState.confirm_delete: Option<String>` (vrc_id),
  and `InboxState.confirm: Option<InboxConfirm>` where
  `InboxConfirm = Dismiss { task_id } | ClearAll`.
- **Actions**: pure arming/cancel variants — `RelationshipAction::{ConfirmRemove,
  CancelRemove}`, `CredentialAction::{ConfirmRemove, CancelRemove}`,
  `InboxAction::{ConfirmDismiss, ConfirmClearAll, CancelConfirm}`. Handled as
  pure state mutations in the `*_actions.rs` dispatchers (never network); the
  commit handlers clear the flag exactly as the community/VTA-DID commits do.
- **Key handlers** (`main/mod.rs`): the destructive keys arm the confirmation;
  while pending, `y`/`Enter` commits and any other key (incl. `Esc`) cancels.
- **Render**: each panel footer shows `… ?  y: confirm  n: cancel` (orange/bold)
  while a confirmation is pending, matching the Communities panel.

The confirm fields live on the panel state and survive `sync_from_config`
(which updates the inner data vectors, not the whole struct) — the same
mechanism the existing communities `confirm_delete` relies on.

## Tests

Per the task's verification note ("key-handler tests if R26 has landed"), the
key-handler test coverage lands in **R26 slice 2**, stacked immediately after
this PR, exercising the new confirm flow end-to-end (one test per panel).

## Gate
`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)