### PR TITLE
feat(state): community-scoped main page — selected working community + persona attribution (T1, part 1)

### DIFF
--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -18,6 +18,7 @@ use crate::CredentialKind;
 use crate::config::KeyTypes;
 use crate::errors::OpenVTCError;
 use crate::relationships::Relationships;
+use crate::tasks::Tasks;
 use crate::vrc::Vrcs;
 use chrono::{DateTime, TimeDelta, Utc};
 use serde::{Deserialize, Serialize};
@@ -201,6 +202,14 @@ pub struct CommunityRecord {
     /// DIDComm relationships scoped to this community.
     #[serde(default)]
     pub relationships: Relationships,
+    /// Reserved per-community inbox (protocol-workflow tasks). The eventual home
+    /// for a physically per-community inbox; **not yet populated** — PR-1 scopes
+    /// the main page by attribution (relationships/tasks carry an owning-persona
+    /// tag and are filtered to the working community) while the collections stay
+    /// in the global [`ProtectedConfig`] tier. Additive + serde(default)-tolerant
+    /// so older configs load and a later physical-move migration can fill it.
+    #[serde(default)]
+    pub tasks: Tasks,
     /// VRCs we have issued within this community.
     #[serde(default)]
     pub vrcs_issued: Vrcs,
@@ -245,6 +254,8 @@ struct CommunityRecordShadow {
     requested_at: Option<DateTime<Utc>>,
     #[serde(default)]
     relationships: Relationships,
+    #[serde(default)]
+    tasks: Tasks,
     #[serde(default)]
     vrcs_issued: Vrcs,
     #[serde(default)]
@@ -297,6 +308,7 @@ impl From<CommunityRecordShadow> for CommunityRecord {
             member_since: shadow.member_since,
             requested_at: shadow.requested_at,
             relationships: shadow.relationships,
+            tasks: shadow.tasks,
             vrcs_issued: shadow.vrcs_issued,
             vrcs_received: shadow.vrcs_received,
             credentials,
@@ -335,6 +347,7 @@ impl CommunityRecord {
             member_since: None,
             requested_at: Some(now),
             relationships: Relationships::default(),
+            tasks: Tasks::default(),
             vrcs_issued: Vrcs::default(),
             vrcs_received: Vrcs::default(),
             credentials: BTreeMap::new(),
@@ -564,6 +577,18 @@ impl Account {
         list
     }
 
+    /// The community to use as the default working context (D10 / R-C-6/7) when
+    /// the user hasn't explicitly selected one: the first **Active** community in
+    /// display order (favourites first, then by name, then VTC DID). Returns
+    /// `None` when there is no active community (the "no active community" state).
+    /// Deterministic so the working context is stable across launches.
+    pub fn default_working_community(&self) -> Option<VtcDid> {
+        self.communities_for_display(false)
+            .into_iter()
+            .find(|c| c.status.is_active())
+            .map(|c| c.vtc_did.clone())
+    }
+
     /// Archive an inactive community (R-C-8): retain its data but hide it from
     /// the default list. Errors if the community is unknown or still
     /// active/pending (it must be left first).
@@ -633,10 +658,63 @@ mod tests {
             member_since: None,
             requested_at: None,
             relationships: Relationships::default(),
+            tasks: Tasks::default(),
             vrcs_issued: Vrcs::default(),
             vrcs_received: Vrcs::default(),
             credentials: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn default_working_community_prefers_favourite_active_and_skips_inactive() {
+        let p = persona("p");
+        let mut acct = Account::default();
+        // No communities → no working context.
+        assert_eq!(acct.default_working_community(), None);
+
+        // An inactive (Left) community is never the working context.
+        let left = community("did:web:left", p.persona_id, CommunityStatus::Left);
+        acct.communities.insert(left.vtc_did.clone(), left);
+        assert_eq!(acct.default_working_community(), None);
+
+        // A plain active community becomes the default.
+        let act = community("did:web:active", p.persona_id, CommunityStatus::Active);
+        acct.communities.insert(act.vtc_did.clone(), act);
+        assert_eq!(
+            acct.default_working_community().as_deref(),
+            Some("did:web:active")
+        );
+
+        // A favourited active community wins (sorts first in display order).
+        let mut fav = community("did:web:fav", p.persona_id, CommunityStatus::Active);
+        fav.favourite = true;
+        acct.communities.insert(fav.vtc_did.clone(), fav);
+        acct.personas.insert(p.persona_id, p);
+        assert_eq!(
+            acct.default_working_community().as_deref(),
+            Some("did:web:fav")
+        );
+    }
+
+    #[test]
+    fn community_record_tasks_survive_json_round_trip() {
+        use crate::tasks::TaskType;
+        use std::sync::Arc;
+
+        let pid = PersonaId::new();
+        let mut comm = community("did:web:vtc-rt", pid, CommunityStatus::Active);
+        comm.tasks.new_task(
+            &Arc::new("task-rt".to_string()),
+            TaskType::RelationshipRequestRejected,
+        );
+        let json = serde_json::to_string(&comm).expect("serialize");
+        let back: CommunityRecord = serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            back.tasks
+                .get_by_id(&Arc::new("task-rt".to_string()))
+                .is_some(),
+            "per-community task should survive the round trip"
+        );
     }
 
     /// Pre-R19 configs stored credentials as flat `membership_credential` /

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -206,7 +206,7 @@ pub struct CommunityRecord {
     /// for a physically per-community inbox; **not yet populated** — PR-1 scopes
     /// the main page by attribution (relationships/tasks carry an owning-persona
     /// tag and are filtered to the working community) while the collections stay
-    /// in the global [`ProtectedConfig`] tier. Additive + serde(default)-tolerant
+    /// in the global `ProtectedConfig` tier. Additive + serde(default)-tolerant
     /// so older configs load and a later physical-move migration can fill it.
     #[serde(default)]
     pub tasks: Tasks,
@@ -481,6 +481,16 @@ impl Account {
         self.personas.get(&community.persona_ref)
     }
 
+    /// The id of the account persona whose `did` equals `did`, if any. Maps an
+    /// addressed persona DID (e.g. an inbound message's recipient) back to its
+    /// [`PersonaId`] for D10 attribution tagging.
+    pub fn persona_id_for_did(&self, did: &str) -> Option<PersonaId> {
+        self.personas
+            .iter()
+            .find(|(_, p)| p.did == did)
+            .map(|(id, _)| *id)
+    }
+
     /// True if any community references this persona.
     pub fn persona_referenced(&self, id: &PersonaId) -> bool {
         self.communities.values().any(|c| &c.persona_ref == id)
@@ -663,6 +673,18 @@ mod tests {
             vrcs_received: Vrcs::default(),
             credentials: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn persona_id_for_did_maps_addressed_did_to_persona() {
+        let pa = persona("alice");
+        let pb = persona("bob");
+        let (pid_a, did_a) = (pa.persona_id, pa.did.clone());
+        let mut acct = Account::default();
+        acct.personas.insert(pa.persona_id, pa);
+        acct.personas.insert(pb.persona_id, pb);
+        assert_eq!(acct.persona_id_for_did(&did_a), Some(pid_a));
+        assert_eq!(acct.persona_id_for_did("did:web:nobody"), None);
     }
 
     #[test]

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -427,6 +427,7 @@ impl Config {
             Config {
                 account,
                 identities,
+                active_persona: None,
                 key_backend,
                 public: public_config,
                 private: private_cfg,
@@ -530,6 +531,7 @@ mod tests {
                 remote_p_did: did.clone(),
                 created: chrono::Utc::now(),
                 state: RelationshipState::Established,
+                our_persona: None,
             },
         );
 

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -319,6 +319,13 @@ pub struct Config {
     /// therefore [`Config::active_identity`] — is deterministic across process
     /// runs and insertion orders.
     pub identities: BTreeMap<account::PersonaId, crate::identity::IdentityContext>,
+
+    /// The persona the user's selected working community resolves to (D10) — the
+    /// runtime "active identity". Set by the StateHandler loop from
+    /// `State.selected_community`; `None` falls back to the first persona so
+    /// startup/setup (which run before any selection) behave exactly as before.
+    /// Not persisted — a pure runtime selection pointer over `identities`.
+    pub active_persona: Option<account::PersonaId>,
 }
 
 /// Serializable bundle of public and secured config, used for import/export.
@@ -346,15 +353,28 @@ impl Config {
         }
     }
 
-    /// The currently-active runtime identity.
+    /// The currently-active runtime identity — the persona the selected working
+    /// community resolves to (D10 / R-C-6/7).
     ///
-    /// T1 migration: for the single-persona case this returns the one resolved
-    /// identity. With multiple personas the entry with the lowest
-    /// [`account::PersonaId`] wins — deterministic across runs because
-    /// `identities` is a `BTreeMap`. This is an interim heuristic until
-    /// explicit persona selection lands (T1 Stage 5).
+    /// Honours [`Config::active_persona`] (set by the loop from the selected
+    /// community) so all identity-derived reads — [`Config::persona_did`],
+    /// [`Config::mediator_did`], the main-page identity chrome, outbound actions —
+    /// scope to the working community without threading a selection through every
+    /// call site. Falls back to the first persona (lowest [`account::PersonaId`],
+    /// deterministic because `identities` is a `BTreeMap`) when no selection is
+    /// set — i.e. during startup/setup, or single-persona accounts — preserving
+    /// the prior behaviour.
     pub fn active_identity(&self) -> Option<&crate::identity::IdentityContext> {
-        self.identities.values().next()
+        self.active_persona
+            .and_then(|id| self.identities.get(&id))
+            .or_else(|| self.identities.values().next())
+    }
+
+    /// Point the runtime active identity at `persona` (the selected working
+    /// community's persona, D10), or clear it back to the first-persona default.
+    /// A no-op-safe setter the loop calls each iteration from the selection.
+    pub fn set_active_persona(&mut self, persona: Option<account::PersonaId>) {
+        self.active_persona = persona;
     }
 
     /// The active persona's `did:webvh` as a string slice.
@@ -696,6 +716,7 @@ mod tests {
             unlock_code: None,
             account: account::Account::default(),
             identities,
+            active_persona: None,
         }
     }
 

--- a/openvtc-core/src/config/saving.rs
+++ b/openvtc-core/src/config/saving.rs
@@ -120,6 +120,7 @@ impl Config {
             account: self.account.clone(),
             // Runtime-only; rebuilt at load and unused by `save`.
             identities: BTreeMap::new(),
+            active_persona: None,
         })
     }
 

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -185,6 +185,7 @@ mod tests {
             member_since: None,
             requested_at: None,
             relationships: Default::default(),
+            tasks: Default::default(),
             vrcs_issued: Default::default(),
             vrcs_received: Default::default(),
             credentials: Default::default(),

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -834,6 +834,7 @@ mod tests {
             remote_p_did: Arc::new(remote_p.to_string()),
             created: Utc::now(),
             state,
+            our_persona: None,
         }
     }
 

--- a/openvtc-core/src/relationships.rs
+++ b/openvtc-core/src/relationships.rs
@@ -9,6 +9,7 @@ use crate::{
     bip32::Bip32Extension,
     config::{
         KeyBackend, KeyTypes,
+        account::PersonaId,
         secured_config::{KeyInfoConfig, KeySourceMaterial},
     },
     errors::OpenVTCError,
@@ -106,6 +107,16 @@ pub struct Relationship {
 
     /// Current state of the relationship lifecycle.
     pub state: RelationshipState,
+
+    /// Which of our account personas owns this relationship (D10 attribution).
+    /// Set at creation to the working community's persona (outbound) or the
+    /// addressed persona (inbound); the community-scoped main page filters
+    /// relationships to the selected community's persona via this tag (R-C-6).
+    /// `None` on relationships created before this field (legacy/single-persona),
+    /// which are attributed to the sole persona at view time. Skipped when
+    /// `None` so older configs round-trip byte-identically (R20 invariant).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub our_persona: Option<PersonaId>,
 }
 
 impl From<RelationshipsShadow> for Relationships {
@@ -592,6 +603,7 @@ mod tests {
             remote_p_did: Arc::new(remote_p_did.to_string()),
             created: Utc::now(),
             state,
+            our_persona: None,
         }
     }
 

--- a/openvtc-core/src/tasks.rs
+++ b/openvtc-core/src/tasks.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use tracing::debug;
 
-use crate::{relationships::RelationshipRequestBody, vrc::VrcRequest};
+use crate::{config::account::PersonaId, relationships::RelationshipRequestBody, vrc::VrcRequest};
 
 /// Defined Task Types for OpenVTC.
 ///
@@ -118,14 +118,29 @@ impl Tasks {
         removed
     }
 
-    /// Creates a new task with the given ID and type, inserts it, and returns a
-    /// reference to it.
+    /// Creates a new untagged task (no owning persona) with the given ID and
+    /// type, inserts it, and returns a reference to it. Use [`Tasks::new_task_for`]
+    /// to attribute the task to a specific persona for community-scoping (D10).
     pub fn new_task(&mut self, id: &Arc<String>, type_: TaskType) -> &Task {
+        self.new_task_for(id, type_, None)
+    }
+
+    /// Like [`Tasks::new_task`] but tags the task with the persona that owns it
+    /// (D10 attribution): the working community's persona for an outbound task, or
+    /// the addressed persona for an inbound one. The community-scoped inbox filters
+    /// tasks to the selected community's persona via this tag (R-C-6).
+    pub fn new_task_for(
+        &mut self,
+        id: &Arc<String>,
+        type_: TaskType,
+        our_persona: Option<PersonaId>,
+    ) -> &Task {
         debug!("task created: type={:?}, id={}", type_, id);
         let task = Task {
             id: id.clone(),
             type_,
             created: Utc::now(),
+            our_persona,
         };
         self.tasks.entry(id.clone()).insert_entry(task).into_mut()
     }
@@ -161,6 +176,15 @@ pub struct Task {
 
     /// Timestamp when this task was created.
     pub created: DateTime<Utc>,
+
+    /// Which of our account personas owns this task (D10 attribution). Set to the
+    /// working community's persona (outbound) or the addressed persona (inbound);
+    /// the community-scoped inbox filters tasks to the selected community's
+    /// persona via this tag (R-C-6). `None` on legacy/single-persona tasks,
+    /// attributed to the sole persona at view time. Skipped when `None` so older
+    /// configs round-trip byte-identically.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub our_persona: Option<PersonaId>,
 }
 
 #[cfg(test)]

--- a/openvtc-core/tests/config_encryption.rs
+++ b/openvtc-core/tests/config_encryption.rs
@@ -394,6 +394,7 @@ mod export_import {
             // Type-inferred so this fixture is agnostic to the `identities`
             // map type (HashMap today, BTreeMap after the determinism fix).
             identities: Default::default(),
+            active_persona: None,
         }
     }
 

--- a/openvtc-core/tests/relationships.rs
+++ b/openvtc-core/tests/relationships.rs
@@ -17,6 +17,7 @@ fn make_relationship(
         remote_p_did: Arc::new(remote_p_did.to_string()),
         created: chrono::Utc::now(),
         state,
+        our_persona: None,
     }
 }
 

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -239,6 +239,11 @@ pub enum Action {
     /// Move the Communities-list selection to this index.
     CommunitySelect(usize),
 
+    /// Make the Active community at this index the working context (D10 / R-C-6):
+    /// the community-scoped main page (relationships/inbox/VRCs/identity) switches
+    /// to its persona. No-op for a non-Active (read-only) community.
+    SetActiveCommunity(usize),
+
     /// Arm a removal confirmation for the community at this index (the panel
     /// prompts for y/n before anything is deleted).
     CommunityConfirmDelete(usize),

--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -41,12 +41,14 @@ pub async fn send_vrc_request(
         .await
         .map_err(|e| anyhow::anyhow!("failed to send VRC request: {e}"))?;
 
-    // Create tracking task
-    config.private.tasks.new_task(
+    // Create tracking task, tagged with the working community's persona (D10).
+    let our_persona = config.active_persona;
+    config.private.tasks.new_task_for(
         &msg_id,
         TaskType::VRCRequestOutbound {
             remote_p_did: remote_key,
         },
+        our_persona,
     );
 
     config.public.logs.insert(

--- a/openvtc/src/state_handler/dispatch_util.rs
+++ b/openvtc/src/state_handler/dispatch_util.rs
@@ -127,5 +127,6 @@ pub(crate) fn test_config() -> Config {
         unlock_code: None,
         account: Account::default(),
         identities: std::collections::BTreeMap::new(),
+        active_persona: None,
     }
 }

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -415,6 +415,15 @@ impl InboxOutcome {
                                 our_did,
                                 created: Utc::now(),
                                 state: RelationshipState::RequestAccepted,
+                                // The accept is built and signed under
+                                // `persona_did_arc()` (the active/selected
+                                // persona), so the new relationship belongs to
+                                // that persona (D10). Invariant: the inbox is
+                                // filtered to the active persona (R-C-6), so a
+                                // selectable inbound-request task's addressed
+                                // persona (`task.our_persona`) always equals the
+                                // active persona — tag and signing persona agree.
+                                our_persona: config.active_persona,
                             },
                         );
                         config.private.tasks.remove(&task_id);

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -2,10 +2,27 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use openvtc_core::{
-    config::{Config, KeyBackend},
+    config::{Config, KeyBackend, account::PersonaId},
     display::truncate_did,
     tasks::TaskType,
 };
+
+/// Whether an item owned by `item_persona` is in scope for the working community
+/// whose persona is `active` (D10 / R-C-6). Tagged items match when their persona
+/// is the active one. Untagged items (legacy, pre-attribution) show only when the
+/// account has at most one persona, where there is no ambiguity; with multiple
+/// personas an untagged item is hidden until re-tagged. With no active selection
+/// (no working community), only the single/zero-persona case shows everything.
+fn persona_in_scope(
+    item_persona: Option<PersonaId>,
+    active: Option<PersonaId>,
+    persona_count: usize,
+) -> bool {
+    match active {
+        Some(p) => item_persona == Some(p) || (item_persona.is_none() && persona_count <= 1),
+        None => persona_count <= 1,
+    }
+}
 
 use crate::state_handler::main_page::{
     content::{
@@ -107,12 +124,19 @@ impl MainPageState {
         // Update header config
         self.config = MainMenuConfigState::from(config);
 
+        // The working community's persona scopes the relationship/inbox/VRC
+        // panels (D10 / R-C-6): only items owned by it (plus untagged legacy
+        // items in a single-persona account) are shown.
+        let active_persona = config.active_persona;
+        let persona_count = config.account.personas.len();
+
         // Sync inbox tasks
         let mut inbox_tasks: Vec<TaskSummary> = config
             .private
             .tasks
             .tasks
             .values()
+            .filter(|task| persona_in_scope(task.our_persona, active_persona, persona_count))
             .map(|task| {
                 let kind = match &task.type_ {
                     TaskType::RelationshipRequestInbound { from, request, .. } => {
@@ -184,12 +208,13 @@ impl MainPageState {
         inbox_tasks.sort_by(|a, b| b.created.cmp(&a.created));
         self.content_panel.inbox.tasks = inbox_tasks.into();
 
-        // Sync relationships
+        // Sync relationships (scoped to the working community's persona)
         self.content_panel.relationships.relationships = config
             .private
             .relationships
             .relationships
             .iter()
+            .filter(|(_, rel)| persona_in_scope(rel.our_persona, active_persona, persona_count))
             .map(|(remote_p_did, rel)| {
                 let alias = config
                     .private
@@ -253,11 +278,21 @@ impl MainPageState {
             })
             .collect();
 
-        // Sync credentials
-        self.content_panel.credentials.received =
-            collect_vrcs(&config.private.vrcs_received, config).into();
-        self.content_panel.credentials.issued =
-            collect_vrcs(&config.private.vrcs_issued, config).into();
+        // Sync credentials (scoped to the working community's persona)
+        self.content_panel.credentials.received = collect_vrcs(
+            &config.private.vrcs_received,
+            config,
+            active_persona,
+            persona_count,
+        )
+        .into();
+        self.content_panel.credentials.issued = collect_vrcs(
+            &config.private.vrcs_issued,
+            config,
+            active_persona,
+            persona_count,
+        )
+        .into();
         self.content_panel.credentials.membership = collect_membership_creds(config).into();
 
         // Sync settings
@@ -428,9 +463,24 @@ fn community_status_label(status: &openvtc_core::config::account::CommunityStatu
 
 /// Collect VRC summaries from a Vrcs collection.
 #[must_use]
-fn collect_vrcs(vrcs: &openvtc_core::vrc::Vrcs, config: &Config) -> Vec<VrcSummary> {
+fn collect_vrcs(
+    vrcs: &openvtc_core::vrc::Vrcs,
+    config: &Config,
+    active_persona: Option<PersonaId>,
+    persona_count: usize,
+) -> Vec<VrcSummary> {
     let mut result = Vec::new();
     for remote_p_did in vrcs.keys() {
+        // Scope to the working community: a VRC belongs to the community of the
+        // relationship with its remote party (D10 / R-C-6).
+        let rel_persona = config
+            .private
+            .relationships
+            .get(remote_p_did)
+            .and_then(|r| r.our_persona);
+        if !persona_in_scope(rel_persona, active_persona, persona_count) {
+            continue;
+        }
         let alias = config
             .private
             .contacts
@@ -679,6 +729,29 @@ impl MainPanel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- persona_in_scope (community-scoping filter, D10/R-C-6) ---
+
+    #[test]
+    fn persona_in_scope_filters_by_active_persona() {
+        let a = PersonaId::new();
+        let b = PersonaId::new();
+
+        // With a selection, only the active persona's items (and untagged items
+        // in a single-persona account) are in scope.
+        assert!(persona_in_scope(Some(a), Some(a), 2));
+        assert!(!persona_in_scope(Some(b), Some(a), 2));
+        // Untagged item: hidden when multiple personas (ambiguous)...
+        assert!(!persona_in_scope(None, Some(a), 2));
+        // ...but shown in a single-persona account (no ambiguity).
+        assert!(persona_in_scope(None, Some(a), 1));
+
+        // No active selection: only the single/zero-persona case shows items.
+        assert!(persona_in_scope(Some(a), None, 1));
+        assert!(persona_in_scope(None, None, 1));
+        assert!(!persona_in_scope(Some(a), None, 2));
+        assert!(!persona_in_scope(None, None, 2));
+    }
 
     // --- sanitize_display ---
 

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -103,6 +103,11 @@ pub async fn process_inbound_message(
         .cloned()
         .unwrap_or_else(|| config.persona_did().to_string());
 
+    // The persona this message was addressed to, for D10 attribution: inbox
+    // tasks created from this message are tagged with it so they scope to the
+    // right community on the main page (R-C-6).
+    let recipient_persona = config.account.persona_id_for_did(&recipient_did);
+
     // Validate message body size to prevent DoS via oversized payloads
     let body_size = serde_json::to_string(&message.body)
         .map(|s| s.len())
@@ -427,13 +432,14 @@ pub async fn process_inbound_message(
                 return Ok(false);
             }
 
-            config.private.tasks.new_task(
+            config.private.tasks.new_task_for(
                 &task_id,
                 TaskType::RelationshipRequestInbound {
                     from: from_did.clone(),
                     to: to_did,
                     request: body,
                 },
+                recipient_persona,
             );
 
             config.public.logs.insert(
@@ -467,12 +473,13 @@ pub async fn process_inbound_message(
                 return Ok(false);
             }
 
-            config.private.tasks.new_task(
+            config.private.tasks.new_task_for(
                 &task_id,
                 TaskType::VRCRequestInbound {
                     request: body,
                     remote_p_did,
                 },
+                recipient_persona,
             );
 
             config.public.logs.insert(
@@ -525,10 +532,11 @@ pub async fn process_inbound_message(
                 return Ok(false);
             }
 
-            config
-                .private
-                .tasks
-                .new_task(&task_id, TaskType::VRCIssued { vrc: Box::new(vrc) });
+            config.private.tasks.new_task_for(
+                &task_id,
+                TaskType::VRCIssued { vrc: Box::new(vrc) },
+                recipient_persona,
+            );
 
             config.public.logs.insert(
                 LogFamily::Task,
@@ -562,13 +570,14 @@ pub async fn process_inbound_message(
                 .find_by_remote_did(&from_did)
                 .map(|rel| Arc::clone(&rel.remote_p_did))
             {
-                config.private.tasks.new_task(
+                config.private.tasks.new_task_for(
                     &task_id,
                     TaskType::TrustPing {
                         from: from_did.clone(),
                         to: to_did,
                         remote_p_did,
                     },
+                    recipient_persona,
                 );
             }
             debug!(from = %from_did, "trust-ping task created");

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -483,6 +483,20 @@ impl StateHandler {
             (tdk, config, admin_vta)
         };
 
+        // Point the runtime active identity at the default working community and
+        // refilter the community-scoped panels before the first paint (D10 /
+        // R-C-6) — otherwise a multi-persona account renders empty panels until
+        // the first event re-syncs (the per-path syncs above run with no
+        // selection set yet).
+        state.reconcile_selected_community(&config.account);
+        let initial_active = state
+            .selected_community
+            .as_ref()
+            .and_then(|vtc| config.account.community(vtc))
+            .map(|c| c.persona_ref);
+        config.set_active_persona(initial_active);
+        state.main_page.sync_from_config(&config);
+
         // Send initial state immediately so the UI renders without blocking
         state.connection.status = state::MediatorStatus::Connecting;
         let _ = self.state_tx.send(state.clone());
@@ -655,6 +669,24 @@ impl StateHandler {
                         if !config.account.communities.values().any(|c| c.is_live()) {
                             state.connection.status = state::MediatorStatus::NoActiveCommunity;
                             state.connection.messaging_active = false;
+                        }
+                    },
+                    Action::SetActiveCommunity(i) => {
+                        // Switch the working context to the Active community at
+                        // display index `i` (R-C-6 / D10). Extract owned values to
+                        // end the immutable account borrow before mutating config.
+                        let target = config
+                            .account
+                            .communities_for_display(false)
+                            .get(i)
+                            .filter(|c| c.status.is_active())
+                            .map(|c| (c.vtc_did.clone(), c.persona_ref));
+                        if let Some((vtc, persona)) = target {
+                            state.selected_community = Some(vtc);
+                            config.set_active_persona(Some(persona));
+                            // Refilter the community-scoped panels immediately so
+                            // the switch is reflected this frame.
+                            state.main_page.sync_from_config(&config);
                         }
                     },
                     Action::DeleteDid(i) => {
@@ -1172,8 +1204,22 @@ impl StateHandler {
             }
             // Keep the working-context selection valid against any account change
             // this iteration applied (join/leave/status transition) before the UI
-            // re-renders from the broadcast (D10 / R-C-6).
+            // re-renders from the broadcast (D10 / R-C-6), then point the runtime
+            // active identity at the selected community's persona so all
+            // identity-derived reads scope to the working community. When the
+            // working persona actually changes (e.g. the active community left and
+            // the default shifted), refilter the community-scoped panels so the UI
+            // reflects the new context this frame.
             state.reconcile_selected_community(&config.account);
+            let active_persona = state
+                .selected_community
+                .as_ref()
+                .and_then(|vtc| config.account.community(vtc))
+                .map(|c| c.persona_ref);
+            if active_persona != config.active_persona {
+                config.set_active_persona(active_persona);
+                state.main_page.sync_from_config(&config);
+            }
             let _ = self.state_tx.send(state.clone());
         };
 

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1170,6 +1170,10 @@ impl StateHandler {
                     break interrupted;
                 }
             }
+            // Keep the working-context selection valid against any account change
+            // this iteration applied (join/leave/status transition) before the UI
+            // re-renders from the broadcast (D10 / R-C-6).
+            state.reconcile_selected_community(&config.account);
             let _ = self.state_tx.send(state.clone());
         };
 

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -724,12 +724,15 @@ impl RelationshipOutcome {
                         }
 
                         // No race: create the outbound task + log (post-send tail of
-                        // `send_relationship_request`).
-                        config.private.tasks.new_task(
+                        // `send_relationship_request`), tagged with the working
+                        // community's persona (D10).
+                        let our_persona = config.active_persona;
+                        config.private.tasks.new_task_for(
                             &msg_id,
                             TaskType::RelationshipRequestOutbound {
                                 to: Arc::clone(&respondent_did),
                             },
+                            our_persona,
                         );
                         config.public.logs.insert(
                         LogFamily::Relationship,
@@ -809,13 +812,15 @@ impl RelationshipOutcome {
                         LogFamily::Relationship,
                         format!("Sent ping to {remote_did} via {our_did}"),
                     );
-                    config.private.tasks.new_task(
+                    let our_persona = config.active_persona;
+                    config.private.tasks.new_task_for(
                         &msg_id,
                         TaskType::TrustPing {
                             from: Arc::clone(&our_did),
                             to: Arc::clone(&remote_did),
                             remote_p_did: Arc::new(remote_p_did.clone()),
                         },
+                        our_persona,
                     );
                     info!(to = %remote_p_did, "trust-ping sent");
 
@@ -868,11 +873,13 @@ impl RelationshipOutcome {
                 display_name,
             } => match self.result {
                 Ok(()) => {
-                    config.private.tasks.new_task(
+                    let our_persona = config.active_persona;
+                    config.private.tasks.new_task_for(
                         &msg_id,
                         TaskType::VRCRequestOutbound {
                             remote_p_did: Arc::new(remote_p_did.clone()),
                         },
+                        our_persona,
                     );
                     config.public.logs.insert(
                         LogFamily::Relationship,
@@ -1152,6 +1159,9 @@ async fn prepare_submit(
             remote_did: Arc::clone(&respondent_arc),
             created: Utc::now(),
             state: RelationshipState::RequestSent,
+            // Tag the relationship with the working community's persona (D10) so
+            // it scopes to the right community on the main page (R-C-6).
+            our_persona: config.active_persona,
         },
     );
 
@@ -1555,6 +1565,7 @@ mod tests {
             remote_did: Arc::clone(&key),
             created: Utc::now(),
             state: RelationshipState::Established,
+            our_persona: config.active_persona,
         };
         config.private.relationships.relationships.insert(key, rel);
     }
@@ -1657,6 +1668,7 @@ mod tests {
                 remote_did: Arc::clone(respondent),
                 created: Utc::now(),
                 state: RelationshipState::RequestSent,
+                our_persona: None,
             },
         );
     }

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -304,6 +304,7 @@ impl ConfigExtension for Config {
         let config = Config {
             account,
             identities: BTreeMap::new(),
+            active_persona: None,
             key_backend,
             public: PublicConfig {
                 config_version: openvtc_core::config::public_config::CONFIG_VERSION,

--- a/openvtc/src/state_handler/state.rs
+++ b/openvtc/src/state_handler/state.rs
@@ -16,6 +16,16 @@ pub struct State {
     pub join: JoinState,
     pub connection: ConnectionState,
 
+    /// The community the main page is currently scoped to (D10 / R-C-6/7) — the
+    /// "working context". The community-scoped panels (inbox / relationships /
+    /// VRCs) and outbound actions resolve through this rather than through a
+    /// single global persona. `None` means no active community (State-A, or every
+    /// membership inactive); the main page shows its "no active community" state.
+    ///
+    /// Runtime-only (not persisted): re-defaulted from the account on each launch
+    /// via [`State::reconcile_selected_community`].
+    pub selected_community: Option<openvtc_core::config::account::VtcDid>,
+
     /// Rotating-tip index for the startup loading screen, advanced as startup
     /// steps stream so the tip changes during the load/connect.
     pub tip_index: usize,
@@ -41,6 +51,29 @@ pub struct State {
     /// Not gated behind the openpgp-card feature so the StateHandler's
     /// select loop can update it unconditionally regardless of build config.
     pub token_touch_pending: bool,
+}
+
+impl State {
+    /// Keep [`State::selected_community`] valid against the current account
+    /// (D10): drop a selection that is no longer an Active membership (e.g. it
+    /// was left, rejected, or deleted), then default to the deterministic
+    /// working community when none is selected. Idempotent; called whenever the
+    /// account may have changed so the working context never dangles.
+    pub fn reconcile_selected_community(
+        &mut self,
+        account: &openvtc_core::config::account::Account,
+    ) {
+        if let Some(selected) = &self.selected_community
+            && !account
+                .community(selected)
+                .is_some_and(|c| c.status.is_active())
+        {
+            self.selected_community = None;
+        }
+        if self.selected_community.is_none() {
+            self.selected_community = account.default_working_community();
+        }
+    }
 }
 
 /// Lifecycle state of a single loading task or sub-step.
@@ -236,4 +269,45 @@ pub enum MediatorStatus {
     /// there is no DID to open a DIDComm session for. The app runs without
     /// messaging until the user joins a community.
     NoActiveCommunity,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use openvtc_core::config::account::{Account, CommunityRecord, PersonaId};
+    use uuid::Uuid;
+
+    #[test]
+    fn reconcile_defaults_to_active_then_clears_when_it_leaves() {
+        let mut account = Account::default();
+        let pid = PersonaId::new();
+        let now = Utc::now();
+        let mut active = CommunityRecord::new_pending(
+            "did:web:vtc-a".into(),
+            None,
+            "openvtc/a".into(),
+            pid,
+            Uuid::new_v4(),
+            now,
+        );
+        active.activate(now);
+        account.communities.insert(active.vtc_did.clone(), active);
+
+        let mut state = State::default();
+        assert_eq!(state.selected_community, None);
+
+        // With one active community and no selection, reconcile defaults to it.
+        state.reconcile_selected_community(&account);
+        assert_eq!(state.selected_community.as_deref(), Some("did:web:vtc-a"));
+
+        // Once it leaves (no longer active), the stale selection is dropped and
+        // there is nothing to default to → no active community.
+        account
+            .community_mut(&"did:web:vtc-a".to_string())
+            .unwrap()
+            .leave();
+        state.reconcile_selected_community(&account);
+        assert_eq!(state.selected_community, None);
+    }
 }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -415,6 +415,11 @@ impl MainPage {
                     .send(Action::CommunitySelect((selected + 1).min(count - 1)));
                 true
             }
+            KeyCode::Enter if selected < count => {
+                // Make the highlighted community the working context (R-C-6).
+                let _ = self.action_tx.send(Action::SetActiveCommunity(selected));
+                true
+            }
             KeyCode::Char('d') | KeyCode::Delete if selected < count => {
                 let _ = self
                     .action_tx


### PR DESCRIPTION
## What & why

First of two PRs completing **T1** (multi-community foundation). T1's config-v2
model, breaking reset, lifecycle states, and referential integrity already
landed earlier (#67–#80) and were hardened by the R0–R27 remediation; an audit
found the genuinely-remaining T1 work to be three runtime gaps. **This PR closes
two of them — D10 (active-identity selection) and R-C-6 (community-scoped main
page).** The third — D11/D15 supervised session manager — follows as PR-2.

The main page (relationships / inbox / VRCs / identity) now scopes to a
**selected working community** instead of an implicit "first persona".

## Design note — attribution-filter (not physical move)

The plan originally called for physically moving relationships/tasks/VRCs into
each `CommunityRecord`. Mid-implementation that surfaced a concrete
**key-collision hazard**: `path_pointer` (the BIP32 key-derivation counter) lives
inside `Relationships` and must stay globally unique — per-community counters
would derive colliding keys — and the move also forces a within-v2 data
migration. We instead **scope by attribution**: collections stay global (single
source of truth, no counter split, no migration), and items are tagged with their
owning persona and filtered to the working community. Same user-visible result.

## How

- **`Config.active_persona`** (runtime-only, never persisted): `active_identity()`
  honours it, falling back to the first persona when unset — so startup/setup and
  single-persona accounts are byte-for-byte unchanged. The loop points it at the
  selected community's persona, so `persona_did()`/`mediator_did()`/identity
  chrome and all outbound actions auto-scope **without** threading a selection
  through ~60 call sites.
- **`Relationship.our_persona` / `Task.our_persona`** (`Option<PersonaId>`, serde
  `default` + `skip_serializing_if`): tagged at creation — outbound = active
  persona; inbound = the addressed persona (`Account::persona_id_for_did`).
  `Tasks::new_task_for` adds the tag; `new_task` stays untagged for legacy callers.
- **`sync_from_config`** filters the panels via `persona_in_scope`: tagged items
  match the active persona; untagged legacy items show only in single-persona
  accounts; with no active community only the single/zero-persona case shows
  anything.
- **`Action::SetActiveCommunity`** + Enter-on-active-community sets the working
  context and refilters immediately; the loop also sets `active_persona` before
  the first paint and re-syncs when the working persona changes (so multi-persona
  accounts never render empty panels).
- **`State.selected_community`** + `reconcile_selected_community` keep the
  selection valid (dropped when it leaves; defaulted to the favourite-first
  Active community).

## Tests / gate

- New: `persona_in_scope` filter matrix, `persona_id_for_did`,
  `default_working_community`, `reconcile_selected_community`, per-community task
  round-trip.
- Existing relationship/inbox/credential + config round-trip suites pass
  unchanged (single-persona shows everything → no regression).
- `cargo fmt` ✓ · `clippy --workspace --all-targets -D warnings` ✓ ·
  `test --workspace` ✓ · `cargo doc` at parity with `main` · no dependency
  changes (`cargo deny` unaffected).
- **Code-reviewed** (trust/identity flow): confirmed encryption-seed
  independence, startup secret-loading safety, R20 byte-compat, borrow safety;
  fixed the flagged multi-persona empty-startup ordering bug.

## On-disk compatibility

New `Option<PersonaId>` fields skip-serialize when `None`, so existing configs
round-trip byte-identically (R20 invariant); `active_persona` is never persisted.

## Follow-up (PR-2)

Supervised multi-session manager (D11/D15) wrapping the existing `DIDCommService`
— register/deregister, bounded concurrency, ≥2-session isolation/recovery tests.