### PR TITLE
feat(state): supervised multi-session manager wrapping DIDCommService (T1, part 2)

### DIFF
--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -16,7 +16,7 @@ use tokio::sync::{
     broadcast,
     mpsc::{self, UnboundedReceiver},
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Tail-truncate a DID for log-message display, fixed at 30 chars.
 pub(crate) fn log_did(did: &str) -> std::borrow::Cow<'_, str> {
@@ -59,6 +59,7 @@ pub mod main_page;
 mod message_dispatch;
 mod relationship_actions;
 mod save_coalesce;
+mod session_manager;
 mod settings_actions;
 mod setup_did_actions;
 mod setup_did_git_sign_actions;
@@ -568,14 +569,50 @@ impl StateHandler {
         // moment a `ListenerEvent::Connected` arrives — and back to Connecting on
         // a disconnect. Subscribe to typed lifecycle events for that.
         let mut listener_events = didcomm_service.subscribe();
-        // The persona listener ids (one per resolved identity, derived from each
-        // DID) are stable for the life of this loop — compute them once for event
-        // matching. A single-persona account yields a one-element set.
-        let persona_lids: std::collections::HashSet<String> = config
-            .identities
-            .values()
-            .map(|i| didcomm::persona_listener_id(&i.did))
-            .collect();
+
+        // Supervised multi-session manager (D11/D15): one persona-session per
+        // active community (a reused persona shares one), tracking per-session
+        // connection status over the listeners `start_service` already launched.
+        // Messaging runs through it from here on; at N=1 it holds one session and
+        // behaves identically to the previous single global flag.
+        let mut session_manager = session_manager::SessionManager::default();
+        {
+            use session_manager::RegisterOutcome;
+            // NOTE: a mid-session leave/reject/expire does NOT yet deregister its
+            // session (that is T6/T7), so until then `any_connected()` can read
+            // live for a persona whose communities have all gone inactive. Startup
+            // registers exactly the communities that require a live session at load
+            // time (`IdentityRegistry::sessions`).
+            let registry = openvtc_core::identity::IdentityRegistry::new(&config.account);
+            let mut at_capacity = 0usize;
+            for (persona_id, vtcs) in registry.sessions() {
+                let Some(ctx) = config.identities.get(&persona_id) else {
+                    // A live community whose persona didn't resolve to an identity
+                    // has no listener either — surfaced here for parity, not silent.
+                    debug!(%persona_id, "live-community persona missing from resolved identities — not tracked");
+                    continue;
+                };
+                let lid = didcomm::persona_listener_id(&ctx.did);
+                for vtc in vtcs {
+                    if matches!(
+                        session_manager.register(persona_id, &lid, vtc.clone()),
+                        RegisterOutcome::AtCapacity
+                    ) {
+                        at_capacity += 1;
+                        warn!(%persona_id, vtc = %vtc, "session manager at capacity — community not tracked");
+                    }
+                }
+            }
+            // No silent caps (D15): tell the user if any community exceeded the bound.
+            if at_capacity > 0 {
+                state.main_page.log(format!(
+                    "Warning: {at_capacity} communit{} exceeded the session limit ({}) and are not actively connected.",
+                    if at_capacity == 1 { "y" } else { "ies" },
+                    session_manager.max_sessions(),
+                ));
+            }
+        }
+
         state.connection.status = state::MediatorStatus::Connecting;
         state.main_page.log("Connecting to the mediator…");
         let _ = self.state_tx.send(state.clone());
@@ -629,21 +666,24 @@ impl StateHandler {
                         break interrupted;
                     },
                     Action::DeleteCommunity(i) => {
-                        // Identify the deleted community's persona BEFORE the
-                        // delete so we can tear down *its* listener (not the
-                        // active one) if it ends up with no live community.
-                        let target_persona = config
+                        // Capture the deleted community + its persona BEFORE the
+                        // delete so we can deregister its session and tear down
+                        // *its* listener (not the active one) if its persona ends
+                        // up with no live community.
+                        let target = config
                             .account
                             .communities_for_display(false)
                             .get(i)
-                            .map(|c| c.persona_ref);
+                            .map(|c| (c.vtc_did.clone(), c.persona_ref));
                         self.remove_community(&mut state, &mut config, &mut save, i);
-                        // A deleted community must not leave its persona's
-                        // mediator connection running. If that persona no longer
-                        // has any live community, stop and remove its listener so
-                        // the connection is torn down with the community (not left
-                        // dangling).
-                        if let Some(pid) = target_persona {
+                        // A deleted community must not leave its persona's mediator
+                        // connection running. Deregister it from the session
+                        // manager (D15/R-S-3); if that persona no longer has any
+                        // live community, stop and remove its listener so the
+                        // connection is torn down with the community, not left
+                        // dangling.
+                        if let Some((vtc, pid)) = target {
+                            let removed = session_manager.deregister(&vtc);
                             let still_live = config
                                 .account
                                 .communities
@@ -653,7 +693,11 @@ impl StateHandler {
                                 && let Some(did) =
                                     config.identities.get(&pid).map(|id| id.did.clone())
                             {
-                                let listener_id = didcomm::persona_listener_id(&did);
+                                // Prefer the listener id the manager recorded for
+                                // the torn-down session; fall back to deriving it.
+                                let listener_id = removed
+                                    .map(|s| s.listener_id)
+                                    .unwrap_or_else(|| didcomm::persona_listener_id(&did));
                                 if let Err(e) =
                                     didcomm_service.remove_listener(&listener_id).await
                                 {
@@ -1136,22 +1180,39 @@ impl StateHandler {
                 ev = listener_events.recv() => {
                     use affinidi_messaging_didcomm_service::ListenerEvent;
                     if let Ok(ev) = ev {
-                        match ev {
-                            // Any persona listener connecting marks messaging
-                            // live; a per-persona status panel is future work.
-                            ListenerEvent::Connected { listener_id }
-                                if persona_lids.contains(&listener_id) =>
-                            {
+                        // Route persona-listener lifecycle through the session
+                        // manager (D11/D15), which holds per-session status; a
+                        // disconnect carrying an error is recorded as that one
+                        // session failing (isolated — others are untouched). The
+                        // SDK keeps retrying per its restart policy, so a restart
+                        // or clean drop is "not connected" until the next connect.
+                        // Events for R-DID listeners (not persona sessions) match
+                        // nothing and are ignored.
+                        let changed = match ev {
+                            ListenerEvent::Connected { listener_id } => {
+                                session_manager.mark_connected(&listener_id)
+                            }
+                            ListenerEvent::Disconnected { listener_id, error } => match error {
+                                Some(e) => session_manager.mark_failed(&listener_id, e),
+                                None => session_manager.mark_disconnected(&listener_id),
+                            },
+                            ListenerEvent::Restarting { listener_id, .. } => {
+                                session_manager.mark_disconnected(&listener_id)
+                            }
+                        };
+                        // Derive the global connection indicator from the
+                        // aggregate of all persona-sessions (a per-community
+                        // status panel is future UI work). Leave a
+                        // `NoActiveCommunity` state untouched when no session
+                        // exists.
+                        if changed {
+                            if session_manager.any_connected() {
                                 state.connection.status = state::MediatorStatus::Connected;
                                 state.connection.messaging_active = true;
-                            }
-                            ListenerEvent::Disconnected { listener_id, .. }
-                                if persona_lids.contains(&listener_id) =>
-                            {
+                            } else if session_manager.session_count() > 0 {
                                 state.connection.status = state::MediatorStatus::Connecting;
                                 state.connection.messaging_active = false;
                             }
-                            _ => {}
                         }
                     }
                 },

--- a/openvtc/src/state_handler/session_manager.rs
+++ b/openvtc/src/state_handler/session_manager.rs
@@ -1,0 +1,327 @@
+//! Supervised multi-session manager (D11/D15).
+//!
+//! Each Active/Pending community needs a live DIDComm session so it can send and
+//! receive. A community presents a *persona*, and because the DIDComm layer keys
+//! connections by DID, a **reused** persona (D1) serves several communities over
+//! **one shared connection** — so the unit of a "session" is the persona, not the
+//! community (mirrors [`openvtc_core::identity::IdentityRegistry::sessions`]).
+//!
+//! This manager is the app-level **coordinator** over the messaging layer: it owns
+//! the registry of live persona-sessions, their per-session connection status, a
+//! bounded maximum number of concurrent sessions, and the register/deregister
+//! bookkeeping for join/leave. The actual connect / restart / recovery I/O stays
+//! in the SDK `DIDCommService`, which already supervises each listener
+//! independently (per-listener restart policy) — a mediator outage on one session
+//! is contained by the SDK and reflected here as that session's status, never
+//! affecting the others.
+//!
+//! It is **pure bookkeeping** (no I/O, no SDK types) so it is unit-testable with
+//! simulated sessions without a live mediator. The runtime loop turns its
+//! decisions into `DIDCommService` `add_listener`/`remove_listener` calls and
+//! feeds `ListenerEvent`s back into [`SessionManager::mark_connected`] etc.
+
+use std::collections::{BTreeSet, HashMap};
+
+use openvtc_core::config::account::{PersonaId, VtcDid};
+
+/// Default bound on concurrently live persona-sessions — a backstop against
+/// unbounded fan-out (D15). Generous relative to any realistic number of joined
+/// communities; the cap exists so a runaway never opens an unbounded number of
+/// mediator connections at once.
+pub const DEFAULT_MAX_SESSIONS: usize = 32;
+
+/// Connection status of a single persona-session, driven by `ListenerEvent`s.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub enum SessionStatus {
+    /// Registered; the listener is being brought up (or retrying after a drop).
+    #[default]
+    Connecting,
+    /// The listener is connected to its mediator — the session is live.
+    Connected,
+    /// The listener reported a failure. The SDK keeps retrying per its restart
+    /// policy; this records the last reason for display. Recovery flips it back
+    /// to `Connecting` then `Connected` on the next attempt.
+    Failed(String),
+    /// The listener cleanly disconnected (e.g. teardown in progress).
+    Disconnected,
+}
+
+impl SessionStatus {
+    /// Whether this session is currently live.
+    pub fn is_connected(&self) -> bool {
+        matches!(self, SessionStatus::Connected)
+    }
+}
+
+/// One supervised persona-session: a single DIDComm listener serving every
+/// community that presents this persona. Keyed by [`PersonaId`] in the manager.
+#[derive(Clone, Debug)]
+pub struct Session {
+    /// The DIDComm listener id this session owns (opaque; derived by the caller).
+    /// Returned by [`SessionManager::deregister`] so the caller can tear it down.
+    pub listener_id: String,
+    /// The communities this one session serves (≥1 while registered).
+    pub communities: BTreeSet<VtcDid>,
+    /// Current connection status, driven by `ListenerEvent`s.
+    pub status: SessionStatus,
+}
+
+/// Outcome of [`SessionManager::register`], telling the caller what I/O to do.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RegisterOutcome {
+    /// A new session was created — the caller must `add_listener` for it.
+    Created,
+    /// The persona already had a session (reused persona, D1); the community was
+    /// attached to it. No new listener — the existing connection is shared.
+    JoinedExisting,
+    /// The bounded-concurrency cap is reached and this persona had no session;
+    /// nothing was registered. The caller surfaces this rather than opening an
+    /// unbounded number of connections (D15).
+    AtCapacity,
+}
+
+/// The app-level registry of live persona-sessions (D11/D15). See module docs.
+#[derive(Clone, Debug)]
+pub struct SessionManager {
+    sessions: HashMap<PersonaId, Session>,
+    max_sessions: usize,
+}
+
+impl Default for SessionManager {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_SESSIONS)
+    }
+}
+
+impl SessionManager {
+    /// A manager bounded to at most `max_sessions` concurrent persona-sessions.
+    pub fn new(max_sessions: usize) -> Self {
+        SessionManager {
+            sessions: HashMap::new(),
+            max_sessions: max_sessions.max(1),
+        }
+    }
+
+    /// Register that `vtc` (a community) needs `persona`'s live session.
+    ///
+    /// If the persona already has a session (a reused persona serving multiple
+    /// communities, D1), `vtc` is attached to it and [`RegisterOutcome::JoinedExisting`]
+    /// is returned — no new listener. Otherwise a fresh `Connecting` session is
+    /// created ([`RegisterOutcome::Created`]) unless the bounded-concurrency cap
+    /// is hit ([`RegisterOutcome::AtCapacity`]). Partial-failure-tolerant: each
+    /// call is independent, so a launch loop registering many communities tolerates
+    /// any single one being at capacity without aborting the rest.
+    pub fn register(
+        &mut self,
+        persona: PersonaId,
+        listener_id: &str,
+        vtc: VtcDid,
+    ) -> RegisterOutcome {
+        if let Some(session) = self.sessions.get_mut(&persona) {
+            session.communities.insert(vtc);
+            return RegisterOutcome::JoinedExisting;
+        }
+        if self.sessions.len() >= self.max_sessions {
+            return RegisterOutcome::AtCapacity;
+        }
+        let mut communities = BTreeSet::new();
+        communities.insert(vtc);
+        self.sessions.insert(
+            persona,
+            Session {
+                listener_id: listener_id.to_string(),
+                communities,
+                status: SessionStatus::Connecting,
+            },
+        );
+        RegisterOutcome::Created
+    }
+
+    /// Deregister `vtc` from its persona's session.
+    ///
+    /// Removes `vtc` from whichever session serves it. If that session now serves
+    /// no communities, it is removed and returned so the caller can tear down its
+    /// listener; otherwise (the persona still serves other communities) `None` is
+    /// returned and the shared connection stays up. Isolation: only the affected
+    /// session is touched.
+    pub fn deregister(&mut self, vtc: &str) -> Option<Session> {
+        let persona = self
+            .sessions
+            .iter()
+            .find_map(|(pid, s)| s.communities.iter().any(|c| c == vtc).then_some(*pid))?;
+        let session = self.sessions.get_mut(&persona)?;
+        session.communities.remove(vtc);
+        if session.communities.is_empty() {
+            self.sessions.remove(&persona)
+        } else {
+            None
+        }
+    }
+
+    /// Mark the session owning `listener_id` Connected. Returns `true` if a
+    /// session matched and its status changed.
+    pub fn mark_connected(&mut self, listener_id: &str) -> bool {
+        self.set_status(listener_id, SessionStatus::Connected)
+    }
+
+    /// Mark the session owning `listener_id` Disconnected (clean teardown / drop;
+    /// the SDK will retry per its restart policy). Returns `true` on a change.
+    pub fn mark_disconnected(&mut self, listener_id: &str) -> bool {
+        self.set_status(listener_id, SessionStatus::Disconnected)
+    }
+
+    /// Mark the session owning `listener_id` Failed with `reason`. The SDK keeps
+    /// retrying; this records the reason for display. Returns `true` on a change.
+    pub fn mark_failed(&mut self, listener_id: &str, reason: impl Into<String>) -> bool {
+        self.set_status(listener_id, SessionStatus::Failed(reason.into()))
+    }
+
+    fn set_status(&mut self, listener_id: &str, status: SessionStatus) -> bool {
+        if let Some(session) = self
+            .sessions
+            .values_mut()
+            .find(|s| s.listener_id == listener_id)
+            && session.status != status
+        {
+            session.status = status;
+            return true;
+        }
+        false
+    }
+
+    /// Whether any session is currently connected — the aggregate that drives the
+    /// global "messaging active" indicator while per-session status exists too.
+    pub fn any_connected(&self) -> bool {
+        self.sessions.values().any(|s| s.status.is_connected())
+    }
+
+    /// Number of live persona-sessions (≤ the bound).
+    pub fn session_count(&self) -> usize {
+        self.sessions.len()
+    }
+
+    /// The bounded maximum number of concurrent sessions (D15).
+    pub fn max_sessions(&self) -> usize {
+        self.max_sessions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pid() -> PersonaId {
+        PersonaId::new()
+    }
+
+    // Tests access the private `sessions` map directly (same module) to inspect
+    // per-session status without a public accessor.
+    #[test]
+    fn register_creates_one_session_per_persona_and_shares_reused_personas() {
+        let mut mgr = SessionManager::new(8);
+        let a = pid();
+        let b = pid();
+
+        // Two distinct personas → two sessions, each needing its own listener.
+        assert_eq!(
+            mgr.register(a, "lid-a", "vtc-1".into()),
+            RegisterOutcome::Created
+        );
+        assert_eq!(
+            mgr.register(b, "lid-b", "vtc-2".into()),
+            RegisterOutcome::Created
+        );
+        assert_eq!(mgr.session_count(), 2);
+
+        // A third community presenting persona A reuses A's session (D1) — no new
+        // listener, still two sessions.
+        assert_eq!(
+            mgr.register(a, "lid-a", "vtc-3".into()),
+            RegisterOutcome::JoinedExisting
+        );
+        assert_eq!(mgr.session_count(), 2);
+        assert_eq!(mgr.sessions[&a].communities.len(), 2);
+    }
+
+    #[test]
+    fn bounded_concurrency_rejects_beyond_the_cap() {
+        let mut mgr = SessionManager::new(2);
+        assert_eq!(
+            mgr.register(pid(), "lid-a", "vtc-1".into()),
+            RegisterOutcome::Created
+        );
+        assert_eq!(
+            mgr.register(pid(), "lid-b", "vtc-2".into()),
+            RegisterOutcome::Created
+        );
+        // A third *distinct* persona exceeds the bound and is rejected.
+        assert_eq!(
+            mgr.register(pid(), "lid-c", "vtc-3".into()),
+            RegisterOutcome::AtCapacity
+        );
+        assert_eq!(mgr.session_count(), 2);
+    }
+
+    #[test]
+    fn status_is_isolated_per_session_recovery_and_failure_dont_cross() {
+        let mut mgr = SessionManager::new(8);
+        let a = pid();
+        let b = pid();
+        mgr.register(a, "lid-a", "vtc-1".into());
+        mgr.register(b, "lid-b", "vtc-2".into());
+
+        // Both start Connecting; nothing is connected yet.
+        assert!(!mgr.any_connected());
+
+        // A connects; B is untouched (isolation).
+        assert!(mgr.mark_connected("lid-a"));
+        assert!(mgr.sessions[&a].status.is_connected());
+        assert_eq!(mgr.sessions[&b].status, SessionStatus::Connecting);
+        assert!(mgr.any_connected());
+
+        // B fails (its mediator is down); A stays connected — one failing session
+        // does not affect another (D15).
+        assert!(mgr.mark_failed("lid-b", "mediator down"));
+        assert_eq!(
+            mgr.sessions[&b].status,
+            SessionStatus::Failed("mediator down".to_string())
+        );
+        assert!(mgr.sessions[&a].status.is_connected());
+        assert!(mgr.any_connected());
+
+        // B recovers on the SDK's next retry: drop → reconnect.
+        assert!(mgr.mark_disconnected("lid-b"));
+        assert!(mgr.mark_connected("lid-b"));
+        assert!(mgr.sessions[&b].status.is_connected());
+        // Idempotent: marking the same status again is not a change.
+        assert!(!mgr.mark_connected("lid-b"));
+
+        // An event for an unknown listener matches nothing.
+        assert!(!mgr.mark_connected("lid-unknown"));
+    }
+
+    #[test]
+    fn deregister_drops_listener_only_when_no_community_remains() {
+        let mut mgr = SessionManager::new(8);
+        let a = pid();
+        // Persona A serves two communities over one shared session.
+        mgr.register(a, "lid-a", "vtc-1".into());
+        mgr.register(a, "lid-a", "vtc-2".into());
+        mgr.mark_connected("lid-a");
+
+        // Leaving the first community keeps the session up (still serves vtc-2).
+        assert!(mgr.deregister("vtc-1").is_none());
+        assert_eq!(mgr.session_count(), 1);
+        assert!(mgr.sessions[&a].status.is_connected());
+
+        // Leaving the last one tears the session down — returned for listener
+        // teardown by the caller.
+        let removed = mgr.deregister("vtc-2").expect("session removed");
+        assert_eq!(removed.listener_id, "lid-a");
+        assert_eq!(mgr.session_count(), 0);
+        assert!(!mgr.any_connected());
+
+        // Deregistering something unknown is a harmless no-op.
+        assert!(mgr.deregister("vtc-unknown").is_none());
+    }
+}


### PR DESCRIPTION
## What & why

Second and final PR completing **T1**. Closes the last remaining T1 gap —
**D11/D15, the supervised multi-session manager**. (PR-1 #110 closed D10 +
R-C-6.) Independent of #110; both branch off `main`.

A community presents a *persona*; the DIDComm layer keys connections by DID, so a
**reused** persona (D1) serves several communities over **one shared listener** —
the unit of a "session" is the persona. The SDK `DIDCommService` already
supervises each listener independently (per-listener restart policy with backoff),
so a mediator outage on one session is contained by the SDK. This PR adds the
**app-level coordinator** over that supervision (per your "wrap the existing
`DIDCommService`" decision), rather than reimplementing per-session tasks.

## How

- **`SessionManager`** (new `state_handler/session_manager.rs`) — pure
  bookkeeping (no I/O, no SDK types), so it is unit-testable with simulated
  sessions without a live mediator:
  - `register(persona, listener_id, vtc) → Created | JoinedExisting | AtCapacity`
    — a reused persona shares one session (`JoinedExisting`); a bounded
    `max_sessions` cap prevents unbounded fan-out (D15).
  - `deregister(vtc) → Option<Session>` — returns the session for listener
    teardown only when its **last** community leaves (a shared connection stays up
    while any community still needs it).
  - `mark_connected/disconnected/failed(listener_id)` — per-session status;
    `any_connected()` / `session_count()` derive the global indicator.
- **Wired into the runtime loop**:
  - Built at startup from `IdentityRegistry::sessions()` (persona → live
    communities). Over-cap communities are **logged, not silently dropped** (D15).
  - The `ListenerEvent` arm routes `Connected` / `Disconnected{error}` /
    `Restarting` through the manager and derives `connection.status` +
    `messaging_active` from `any_connected()` — replacing the single global
    `persona_lids` flag. **Identical behaviour at N=1.**
  - `DeleteCommunity` deregisters and tears down the shared listener only when the
    persona has no live community left (the `still_live` guard preserves the
    shared-connection invariant).

## Isolation & recovery (D15)

One session failing (`mark_failed`) never touches another; the SDK retries per its
restart policy and the next `Connected` flips it back. Mid-session leave/reject
does not yet deregister — that's T6/T7, noted at the registration site (until then
`any_connected()` can read live for a persona whose communities all went inactive).

## Tests / gate

- **≥2 simulated sessions**: one-session-per-persona + reused-persona sharing;
  bounded-concurrency rejection; per-session **isolation** + **failure/recovery**;
  last-community teardown.
- `cargo fmt` ✓ · `clippy --workspace --all-targets -D warnings` ✓ ·
  `test --workspace` ✓ · `cargo doc` at parity with `main` · no dependency changes.
- **Code-reviewed** (concurrency/messaging): N=1 equivalence, shared-persona
  teardown guard, listener-id matching, exhaustive `ListenerEvent` match, and the
  degraded→active handoff all confirmed; the flagged must-fix (silently-dropped
  `AtCapacity`) is fixed (now logged + surfaced to the user).