### PR TITLE
feat(ui): community favourite toggle + active-community chrome & Ctrl+K switcher (T4)

### DIFF
--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -256,6 +256,24 @@ pub enum Action {
     /// user confirms.
     DeleteCommunity(usize),
 
+    /// Toggle the favourite (★) flag on the community at this Communities-list
+    /// display index (R-C-4). Favourites sort to the top and the flag persists.
+    ToggleFavourite(usize),
+
+    /// Open the quick community switcher overlay (R-C-7): a Ctrl+K popup listing
+    /// the Active communities, reachable from anywhere on the main page.
+    OpenCommunitySwitcher,
+
+    /// Move the switcher overlay's highlighted entry to this index.
+    CommunitySwitcherMove(usize),
+
+    /// Switch the working context to the switcher's highlighted Active community
+    /// and close the overlay (R-C-6 / R-C-7).
+    CommunitySwitcherSelect,
+
+    /// Dismiss the switcher overlay without changing the working community.
+    CloseCommunitySwitcher,
+
     /// Move the Context-Identities (VTA DID manager) selection to this index.
     DidSelect(usize),
 

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -92,6 +92,28 @@ pub struct CommunitiesState {
     pub confirm_delete: Option<usize>,
 }
 
+/// Quick community-switcher overlay state (R-C-7). `Some` while the Ctrl+K popup
+/// is open; it lists the **Active** communities (the only switchable ones) and
+/// owns all key input until dismissed.
+#[derive(Clone, Debug, Default)]
+pub struct CommunitySwitcherState {
+    /// Active communities, in display order (favourites first).
+    pub items: Vec<SwitcherItem>,
+    /// Highlighted entry.
+    pub selected: usize,
+}
+
+/// One entry in the community switcher overlay.
+#[derive(Clone, Debug)]
+pub struct SwitcherItem {
+    /// The community's VTC DID — the switch target.
+    pub vtc_did: openvtc_core::config::account::VtcDid,
+    /// Display name (resolved name, or the shortened VTC DID when unnamed).
+    pub display_name: String,
+    /// Whether this is the current working community.
+    pub is_current: bool,
+}
+
 /// Lightweight display summary of a community membership (no Arc/Mutex).
 #[derive(Clone, Debug)]
 pub struct CommunitySummary {

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -57,6 +57,11 @@ pub struct MainPageState {
 
     pub config: MainMenuConfigState,
 
+    /// Quick community-switcher overlay (R-C-7). `Some` while the Ctrl+K popup is
+    /// open; `None` (the default) when closed. Lives at the page level rather
+    /// than in a content panel because it floats over whichever panel is focused.
+    pub switcher: Option<content::CommunitySwitcherState>,
+
     /// Activity log entries shown in the bottom panel (newest last).
     ///
     /// Entries are wrapped in `Arc` so cloning `MainPageState` (which happens
@@ -664,7 +669,7 @@ fn detect_did_git_sign_info(persona_did: &str) -> Option<DidGitSignInfo> {
 /// Sanitises first to drop ANSI / control bytes from untrusted input,
 /// then delegates to the canonical tail-truncate helper.
 #[must_use]
-fn shorten_did(did: &str, max_width: usize) -> String {
+pub(crate) fn shorten_did(did: &str, max_width: usize) -> String {
     let sanitized = sanitize_display(did, 256);
     truncate_did(&sanitized, max_width).into_owned()
 }
@@ -674,6 +679,9 @@ fn shorten_did(did: &str, max_width: usize) -> String {
 pub struct MainMenuConfigState {
     pub name: String,
     pub did: Arc<String>,
+    /// Display name of the working (active) community, shown top-left (R-C-7a).
+    /// Empty when there is no active community.
+    pub community: String,
 }
 
 impl From<&Box<Config>> for MainMenuConfigState {
@@ -693,6 +701,27 @@ impl From<&Config> for MainMenuConfigState {
             .communities
             .values()
             .any(|c| c.status.is_active());
+        // The working community (R-C-7a): the Active community whose persona is
+        // the active one. `active_persona` is kept in lockstep with the selected
+        // working community (set at launch, on reconcile, and on switch), so the
+        // header name matches the persona that scopes the panels. In the rare
+        // persona-reuse case (one persona across several Active communities) the
+        // first in display order is shown — those communities share a context.
+        let community = config
+            .active_persona
+            .and_then(|persona| {
+                config
+                    .account
+                    .communities_for_display(false)
+                    .into_iter()
+                    .find(|c| c.status.is_active() && c.persona_ref == persona)
+                    .map(|c| {
+                        c.display_name
+                            .clone()
+                            .unwrap_or_else(|| shorten_did(&c.vtc_did, 40))
+                    })
+            })
+            .unwrap_or_default();
         MainMenuConfigState {
             name: if in_community {
                 config.public.friendly_name.clone()
@@ -704,6 +733,7 @@ impl From<&Config> for MainMenuConfigState {
             } else {
                 Arc::new(String::new())
             },
+            community,
         }
     }
 }

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -202,9 +202,11 @@ impl StateHandler {
                 state.main_page.config = main_page::MainMenuConfigState {
                     name: deferred.public_config.friendly_name.clone(),
                     // The persona DID now lives in the encrypted account, which
-                    // isn't decrypted yet at this pre-load render. It populates
-                    // from the full Config once load_step2 completes.
+                    // isn't decrypted yet at this pre-load render. It (and the
+                    // working community name) populate from the full Config once
+                    // load_step2 completes.
                     did: std::sync::Arc::new(String::new()),
+                    community: String::new(),
                 };
                 state.connection.status = state::MediatorStatus::Initializing("Starting...".into());
                 let _ = self.state_tx.send(state.clone());
@@ -732,6 +734,81 @@ impl StateHandler {
                             // the switch is reflected this frame.
                             state.main_page.sync_from_config(&config);
                         }
+                    },
+                    Action::ToggleFavourite(i) => {
+                        // R-C-4: flip the star on the community at display index
+                        // `i`, persist (coalesced), then keep the highlight on it
+                        // as the list re-sorts (favourites float to the top).
+                        let vtc = config
+                            .account
+                            .communities_for_display(false)
+                            .get(i)
+                            .map(|c| c.vtc_did.clone());
+                        if let Some(vtc) = vtc {
+                            if let Some(c) = config.account.community_mut(&vtc) {
+                                c.toggle_favourite();
+                            }
+                            save.mark_dirty();
+                            state.main_page.sync_from_config(&config);
+                            if let Some(new_idx) = config
+                                .account
+                                .communities_for_display(false)
+                                .iter()
+                                .position(|c| c.vtc_did == vtc)
+                            {
+                                state.main_page.content_panel.communities.selected_index =
+                                    new_idx;
+                            }
+                        }
+                    },
+                    Action::OpenCommunitySwitcher => {
+                        // R-C-7: list the Active communities (the only switchable
+                        // ones) in display order and preselect the current one.
+                        let current = state.selected_community.clone();
+                        let items: Vec<_> = config
+                            .account
+                            .communities_for_display(false)
+                            .into_iter()
+                            .filter(|c| c.status.is_active())
+                            .map(|c| main_page::content::SwitcherItem {
+                                vtc_did: c.vtc_did.clone(),
+                                display_name: c
+                                    .display_name
+                                    .clone()
+                                    .unwrap_or_else(|| main_page::shorten_did(&c.vtc_did, 40)),
+                                is_current: Some(&c.vtc_did) == current.as_ref(),
+                            })
+                            .collect();
+                        // Don't pop an empty overlay when there's nothing to switch.
+                        if !items.is_empty() {
+                            let selected =
+                                items.iter().position(|it| it.is_current).unwrap_or(0);
+                            state.main_page.switcher =
+                                Some(main_page::content::CommunitySwitcherState {
+                                    items,
+                                    selected,
+                                });
+                        }
+                    },
+                    Action::CommunitySwitcherSelect => {
+                        // Switch the working context to the highlighted Active
+                        // community, then close the overlay (R-C-6 / R-C-7).
+                        let target = state.main_page.switcher.as_ref().and_then(|sw| {
+                            sw.items.get(sw.selected).map(|it| it.vtc_did.clone())
+                        });
+                        if let Some(vtc) = target {
+                            let persona = config
+                                .account
+                                .community(&vtc)
+                                .filter(|c| c.status.is_active())
+                                .map(|c| c.persona_ref);
+                            if let Some(persona) = persona {
+                                state.selected_community = Some(vtc);
+                                config.set_active_persona(Some(persona));
+                                state.main_page.sync_from_config(&config);
+                            }
+                        }
+                        state.main_page.switcher = None;
                     },
                     Action::DeleteDid(i) => {
                         // Identity deletion does a VTA `delete_did_webvh` + listener
@@ -1684,6 +1761,14 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
         Action::CommunityCancelDelete => {
             state.main_page.content_panel.communities.confirm_delete = None;
         }
+        Action::CommunitySwitcherMove(i) => {
+            if let Some(switcher) = state.main_page.switcher.as_mut() {
+                switcher.selected = (*i).min(switcher.items.len().saturating_sub(1));
+            }
+        }
+        Action::CloseCommunitySwitcher => {
+            state.main_page.switcher = None;
+        }
         Action::DidSelect(i) => {
             state.main_page.content_panel.vta.did_selected_index = *i;
         }
@@ -1833,5 +1918,56 @@ mod tests {
             !handle_nav_action(&mut state, &Action::StartJoin),
             "StartJoin is async/loop-local"
         );
+        // The switcher's config-mutating arms resolve a community + persona and
+        // must reach the loop, not the pure reducer (R-C-7).
+        assert!(
+            !handle_nav_action(&mut state, &Action::OpenCommunitySwitcher),
+            "OpenCommunitySwitcher reads config in the loop"
+        );
+        assert!(
+            !handle_nav_action(&mut state, &Action::CommunitySwitcherSelect),
+            "CommunitySwitcherSelect mutates config in the loop"
+        );
+        assert!(
+            !handle_nav_action(&mut state, &Action::ToggleFavourite(0)),
+            "ToggleFavourite mutates + persists config in the loop"
+        );
+    }
+
+    /// The switcher's UI-only arms (move highlight / close) are handled by the
+    /// pure reducer so both loops share them (R-C-7).
+    #[test]
+    fn nav_reducer_handles_switcher_navigation() {
+        use crate::state_handler::main_page::content::{CommunitySwitcherState, SwitcherItem};
+
+        let item = |n: &str| SwitcherItem {
+            vtc_did: format!("did:example:{n}"),
+            display_name: n.to_string(),
+            is_current: false,
+        };
+        let mut state = State::default();
+        state.main_page.switcher = Some(CommunitySwitcherState {
+            items: vec![item("a"), item("b"), item("c")],
+            selected: 0,
+        });
+
+        assert!(handle_nav_action(
+            &mut state,
+            &Action::CommunitySwitcherMove(2)
+        ));
+        assert_eq!(state.main_page.switcher.as_ref().unwrap().selected, 2);
+
+        // Out-of-range moves clamp to the last entry rather than panicking.
+        assert!(handle_nav_action(
+            &mut state,
+            &Action::CommunitySwitcherMove(99)
+        ));
+        assert_eq!(state.main_page.switcher.as_ref().unwrap().selected, 2);
+
+        assert!(handle_nav_action(
+            &mut state,
+            &Action::CloseCommunitySwitcher
+        ));
+        assert!(state.main_page.switcher.is_none());
     }
 }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     ui::component::{Component, ComponentRender},
 };
-use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use openvtc_core::display::truncate_did_centered;
 use ratatui::{
     Frame,
@@ -113,6 +113,17 @@ impl Component for MainPage {
 
     fn handle_key_event(&mut self, key: KeyEvent) {
         if key.kind != KeyEventKind::Press {
+            return;
+        }
+
+        // Community switcher overlay (R-C-7): while open it owns all input; while
+        // closed, Ctrl+K opens it from anywhere on the main page.
+        if self.props.main_page.switcher.is_some() {
+            self.handle_switcher_key(key);
+            return;
+        }
+        if key.code == KeyCode::Char('k') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            let _ = self.action_tx.send(Action::OpenCommunitySwitcher);
             return;
         }
 
@@ -420,6 +431,11 @@ impl MainPage {
                 let _ = self.action_tx.send(Action::SetActiveCommunity(selected));
                 true
             }
+            KeyCode::Char('f') if selected < count => {
+                // Toggle the favourite star (R-C-4); the row re-sorts to the top.
+                let _ = self.action_tx.send(Action::ToggleFavourite(selected));
+                true
+            }
             KeyCode::Char('d') | KeyCode::Delete if selected < count => {
                 let _ = self
                     .action_tx
@@ -433,6 +449,39 @@ impl MainPage {
                 true
             }
             _ => false,
+        }
+    }
+
+    /// Community switcher overlay keys (R-C-7): ↑/↓ move the highlight, Enter
+    /// switches the working community, Esc (or Ctrl+K again) dismisses. Called
+    /// only while the overlay is open, where it owns all input.
+    fn handle_switcher_key(&mut self, key: KeyEvent) {
+        let Some(switcher) = self.props.main_page.switcher.as_ref() else {
+            return;
+        };
+        let count = switcher.items.len();
+        let selected = switcher.selected;
+        match key.code {
+            KeyCode::Up if count > 0 => {
+                let _ = self
+                    .action_tx
+                    .send(Action::CommunitySwitcherMove(selected.saturating_sub(1)));
+            }
+            KeyCode::Down if count > 0 => {
+                let _ = self
+                    .action_tx
+                    .send(Action::CommunitySwitcherMove((selected + 1).min(count - 1)));
+            }
+            KeyCode::Enter if selected < count => {
+                let _ = self.action_tx.send(Action::CommunitySwitcherSelect);
+            }
+            KeyCode::Esc => {
+                let _ = self.action_tx.send(Action::CloseCommunitySwitcher);
+            }
+            KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let _ = self.action_tx.send(Action::CloseCommunitySwitcher);
+            }
+            _ => {}
         }
     }
 
@@ -1636,12 +1685,21 @@ impl ComponentRender<()> for MainPage {
             Layout::horizontal([Percentage(35), Percentage(30), Percentage(35)]).split(main_top);
         let middle = Layout::horizontal([Percentage(20), Min(0)]).split(main_middle);
 
-        frame.render_widget(
-            Paragraph::new(" OpenVTC Dashboard")
-                .fg(COLOR_SUCCESS)
-                .alignment(Alignment::Left),
-            top[0],
-        );
+        // Top-left: the working community name with a ▾ switcher affordance
+        // (R-C-7a), or the dashboard title when there's no active community.
+        let community = &self.props.main_page.config.community;
+        let top_left = if community.is_empty() {
+            Line::from(" OpenVTC Dashboard").fg(COLOR_SUCCESS)
+        } else {
+            Line::from(vec![
+                Span::styled(
+                    format!(" {community} "),
+                    ratatui::style::Style::default().fg(COLOR_SUCCESS),
+                ),
+                Span::styled("▾", ratatui::style::Style::default().fg(COLOR_ORANGE)),
+            ])
+        };
+        frame.render_widget(Paragraph::new(top_left).alignment(Alignment::Left), top[0]);
 
         // Connection status indicator
         let connection_line = match &self.props.connection.status {
@@ -1746,11 +1804,83 @@ impl ComponentRender<()> for MainPage {
 
         // Bottom key hints (single line)
         frame.render_widget(
-            Paragraph::new(" <TAB> switch panels  <PgUp/PgDn/Home/End> scroll  <F10> quit")
-                .dark_gray()
-                .alignment(Alignment::Left),
+            Paragraph::new(
+                " <TAB> switch panels  <Ctrl+K> switch community  <PgUp/PgDn/Home/End> scroll  <F10> quit",
+            )
+            .dark_gray()
+            .alignment(Alignment::Left),
             main_bottom,
         );
+
+        // Community switcher overlay (R-C-7) floats over everything when open.
+        if let Some(switcher) = self.props.main_page.switcher.as_ref() {
+            self.render_switcher_overlay(frame, switcher);
+        }
+    }
+}
+
+impl MainPage {
+    /// Render the quick community-switcher popup (R-C-7): a centered overlay
+    /// listing the Active communities, the current one marked, the highlighted
+    /// one styled. Mirrors the hardware-token overlay's centering pattern.
+    fn render_switcher_overlay(
+        &self,
+        frame: &mut Frame,
+        switcher: &crate::state_handler::main_page::content::CommunitySwitcherState,
+    ) {
+        use ratatui::{
+            layout::{Constraint, Flex},
+            style::Style,
+            widgets::{Block, Clear, Padding},
+        };
+
+        let area = frame.area();
+        // Header + footer (3 lines) plus one line per entry, within bounds.
+        let rows = switcher.items.len() as u16;
+        // rows + border(2) + padding(2) + blank line + footer line.
+        let popup_height = (rows + 6).min(area.height.saturating_sub(2)).max(6);
+        let popup_width = 52u16.min(area.width.saturating_sub(4));
+
+        let [popup_area] = Layout::vertical([Constraint::Length(popup_height)])
+            .flex(Flex::Center)
+            .areas(area);
+        let [popup_area] = Layout::horizontal([Constraint::Length(popup_width)])
+            .flex(Flex::Center)
+            .areas(popup_area);
+
+        frame.render_widget(Clear, popup_area);
+
+        let block = Block::bordered()
+            .title(" Switch community ")
+            .title_style(Style::new().fg(COLOR_ORANGE).bold())
+            .border_style(Style::new().fg(COLOR_ORANGE))
+            .padding(Padding::uniform(1));
+
+        let mut lines: Vec<Line> = switcher
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| {
+                let marker = if i == switcher.selected { "▸ " } else { "  " };
+                let current = if item.is_current { "  (active)" } else { "" };
+                let style = if i == switcher.selected {
+                    Style::new().fg(COLOR_SUCCESS).bold()
+                } else {
+                    Style::new().fg(COLOR_TEXT_DEFAULT)
+                };
+                Line::from(Span::styled(
+                    format!("{marker}{}{current}", item.display_name),
+                    style,
+                ))
+            })
+            .collect();
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled(
+            "↑/↓ select   ⏎ switch   esc close",
+            Style::new().fg(COLOR_BORDER),
+        )));
+
+        frame.render_widget(Paragraph::new(lines).block(block), popup_area);
     }
 }
 
@@ -1766,8 +1896,9 @@ mod key_handler_tests {
     //! assertions pattern-match the expected variant rather than `assert_eq!`.
     use super::*;
     use crate::state_handler::main_page::content::{
-        CredentialTab, CredentialsMode, InboxConfirm, RawCredential, RelationshipSummary,
-        RelationshipsMode, TaskKind, TaskSummary, VrcSummary,
+        CommunitySummary, CommunitySwitcherState, CredentialTab, CredentialsMode, InboxConfirm,
+        RawCredential, RelationshipSummary, RelationshipsMode, SwitcherItem, TaskKind, TaskSummary,
+        VrcSummary,
     };
     use crossterm::event::KeyModifiers;
     use std::sync::Arc;
@@ -1792,6 +1923,37 @@ mod key_handler_tests {
     /// A `Press` key event (the only kind `handle_key_event` acts on).
     fn press(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    /// A Ctrl-modified `Press` key event.
+    fn ctrl(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
+
+    /// A minimal Communities-panel summary row for key-routing tests.
+    fn community_summary(name: &str) -> CommunitySummary {
+        CommunitySummary {
+            display_name: name.to_string(),
+            status_label: "Active".to_string(),
+            persona_label: "persona".to_string(),
+            member_since: String::new(),
+            favourite: false,
+            needs_attention: false,
+            persona_did: "did:example:persona".to_string(),
+            vtc_did: format!("did:example:{name}"),
+            sub_context_id: format!("top/{name}"),
+            request_id: String::new(),
+            has_membership_credential: false,
+            has_role_credential: false,
+        }
+    }
+
+    fn switcher_item(name: &str, is_current: bool) -> SwitcherItem {
+        SwitcherItem {
+            vtc_did: format!("did:example:{name}"),
+            display_name: name.to_string(),
+            is_current,
+        }
     }
 
     fn rel_summary(remote_p_did: &str) -> RelationshipSummary {
@@ -1852,6 +2014,80 @@ mod key_handler_tests {
         match rx.try_recv() {
             Ok(Action::CommunityCancelDelete) => {}
             _ => panic!("expected CommunityCancelDelete"),
+        }
+    }
+
+    #[test]
+    fn communities_f_toggles_favourite_at_selection() {
+        // R-C-4: `f` on the Communities panel stars the highlighted row.
+        let (mut page, mut rx) = page_for(MainMenu::Communities, |s| {
+            s.main_page.content_panel.communities.items = vec![
+                community_summary("a"),
+                community_summary("b"),
+                community_summary("c"),
+            ]
+            .into();
+            s.main_page.content_panel.communities.selected_index = 1;
+        });
+        page.handle_key_event(press(KeyCode::Char('f')));
+        match rx.try_recv() {
+            Ok(Action::ToggleFavourite(1)) => {}
+            _ => panic!("expected ToggleFavourite(1)"),
+        }
+    }
+
+    // ----- Community switcher overlay (R-C-7) --------------------------------
+
+    #[test]
+    fn ctrl_k_opens_switcher() {
+        // Ctrl+K opens the quick switcher from the main page (here, no overlay yet).
+        let (mut page, mut rx) = page_for(MainMenu::Communities, |_| {});
+        page.handle_key_event(ctrl(KeyCode::Char('k')));
+        match rx.try_recv() {
+            Ok(Action::OpenCommunitySwitcher) => {}
+            _ => panic!("expected OpenCommunitySwitcher"),
+        }
+    }
+
+    #[test]
+    fn open_switcher_owns_input_and_navigates() {
+        // While the overlay is open it owns all input: ↑/↓ move, Enter switches,
+        // Esc and Ctrl+K both close.
+        let build = || {
+            page_for(MainMenu::Communities, |s| {
+                s.main_page.switcher = Some(CommunitySwitcherState {
+                    items: vec![switcher_item("a", true), switcher_item("b", false)],
+                    selected: 0,
+                });
+            })
+        };
+
+        let (mut page, mut rx) = build();
+        page.handle_key_event(press(KeyCode::Down));
+        match rx.try_recv() {
+            Ok(Action::CommunitySwitcherMove(1)) => {}
+            _ => panic!("expected CommunitySwitcherMove(1)"),
+        }
+
+        let (mut page, mut rx) = build();
+        page.handle_key_event(press(KeyCode::Enter));
+        match rx.try_recv() {
+            Ok(Action::CommunitySwitcherSelect) => {}
+            _ => panic!("expected CommunitySwitcherSelect"),
+        }
+
+        let (mut page, mut rx) = build();
+        page.handle_key_event(press(KeyCode::Esc));
+        match rx.try_recv() {
+            Ok(Action::CloseCommunitySwitcher) => {}
+            _ => panic!("expected CloseCommunitySwitcher on Esc"),
+        }
+
+        let (mut page, mut rx) = build();
+        page.handle_key_event(ctrl(KeyCode::Char('k')));
+        match rx.try_recv() {
+            Ok(Action::CloseCommunitySwitcher) => {}
+            _ => panic!("expected CloseCommunitySwitcher on Ctrl+K"),
         }
     }
 


### PR DESCRIPTION
## T4 — Communities overview page + active-community switcher

Closes **T4** (R-C-1..7, R-S-2). Audit-first, same "done ahead" pattern as T1–T3.

### Audit: most of T4 already shipped in T1 (#110/#111)
The Communities panel already lists rows with status / member-since / persona /
★ / actions-required badge (R-C-1/2/3), the playful empty state + join entry
(R-C-5), navigation, `SetActiveCommunity` Enter-to-switch (R-C-6), favourites-first
sort (`communities_for_display`), the `favourite`/`archived` model fields +
`toggle_favourite()`, and the `NoActiveCommunity` chrome. R-S-2's *display* side
(the `needs_attention` predicate + badge) is also done — the lifecycle
transitions that raise it are **T6**, and archive/delete/leave are **T7**.

### Gaps this PR closes

**R-C-4 — favourite toggle.** The field, sort, and ★ render existed but nothing
flipped it. Added `Action::ToggleFavourite(usize)` + `f` on the Communities
panel + a config-mutating loop handler: `toggle_favourite()` → coalesced
`mark_dirty` (persists across restarts) → resync, keeping the highlight on the
row as it re-sorts to the top.

**R-C-7a — active community name.** New `MainMenuConfigState.community`, resolved
in `From<&Config>` from `active_persona` (kept in lockstep with the selected
working community at launch / reconcile / switch), rendered top-left with a ▾
affordance; falls back to the dashboard title when there's no active community.

**R-C-7b — quick switcher (Ctrl+K).** Chosen UX: a global-hotkey **centered
popup** listing the Active communities.

```
┌─ Switch community ───────────┐
│  ▸ Acme Corp        (active) │
│    Beta Collective           │
│  ↑/↓ select  ⏎ switch  esc   │
└──────────────────────────────┘
```

- New `CommunitySwitcherState` on `MainPageState`.
- Actions: `OpenCommunitySwitcher` / `CommunitySwitcherMove` /
  `CommunitySwitcherSelect` / `CloseCommunitySwitcher`.
- The overlay owns all input while open, and Ctrl+K opens it from anywhere —
  both intercepted at the top of `handle_key_event`.
- Pure move/close go through the shared `handle_nav_action` reducer (so both
  loops share them); the config-reading open and config-mutating select run in
  the runtime loop.
- Overlay render mirrors the existing hardware-token popup centering.

### Testing
- 4 key-handler tests: favourite `f` → `ToggleFavourite`; Ctrl+K → open; while
  open, ↑/↓ → move, Enter → select, Esc & Ctrl+K → close.
- Nav-reducer tests: switcher move clamps out-of-range, close clears, and the
  config-mutating arms (`Open`/`Select`/`ToggleFavourite`) are deferred to the loop.
- `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ and `--no-default-features` ✓ (0 failed suites)
- No dependency change (`Cargo.lock` untouched) → `cargo deny` unaffected.

The header name resolution is a thin `.find()` map left to model-level + manual
coverage (`Config` has no `Default`; the sort/filter is already unit-tested in
`account.rs`).
