### PR TITLE
feat(join): identity choice — reuse an existing persona or mint a new one (T5 PR-A, R-B-3)

### DIFF
--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -229,9 +229,25 @@ pub enum Action {
     /// both the degraded loop (State-A first join) and the runtime select loop.
     StartJoin,
 
-    /// Submit the entered community VTC DID — kicks off the automated
-    /// persona-mint + sub-context + join-submit sequence.
+    /// Submit the entered community VTC DID. With existing personas this opens
+    /// the identity-choice page (R-B-3); with none it kicks off the mint+join
+    /// sequence directly.
     JoinSubmitVtc(String),
+
+    /// Move the identity-choice highlight to this row (reuse option, or the
+    /// trailing "mint new" row).
+    JoinIdentitySelect(usize),
+
+    /// Commit the highlighted identity choice: "mint new" launches the sequence;
+    /// a reuse option arms the cross-community linkage warning (R-B-3 / D1).
+    JoinIdentityChoose,
+
+    /// Confirm reusing the highlighted persona (after the linkage warning) and
+    /// launch the join sequence with it.
+    JoinReuseConfirm,
+
+    /// Dismiss the reuse linkage warning without choosing.
+    JoinReuseCancel,
 
     /// Cancel the join flow and return to the main page.
     JoinCancel,

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -7,7 +7,7 @@
 //! [`SetupState`](crate::state_handler::setup_sequence::SetupState) on
 //! `State.setup`; this struct only tracks the join-specific surface.
 
-use openvtc_core::config::account::CommunityRecord;
+use openvtc_core::config::account::{CommunityRecord, PersonaId};
 
 use crate::state_handler::setup_sequence::{Completion, MessageType};
 
@@ -17,8 +17,25 @@ pub enum JoinPage {
     /// Operator enters the community (VTC) DID.
     #[default]
     EnterDid,
+    /// Choose the identity to present (R-B-3 / D1): reuse an existing persona or
+    /// mint a fresh one. Skipped when the account has no personas yet.
+    IdentityChoice,
     /// Automated mint + join sequence progress / result.
     Progress,
+}
+
+/// One selectable existing persona on the identity-choice page (R-B-3).
+#[derive(Clone, Debug)]
+pub struct PersonaOption {
+    /// Stable persona id, the reuse target.
+    pub id: PersonaId,
+    /// Human label (the persona's label, or a shortened DID).
+    pub label: String,
+    /// The persona's `did:webvh` (shown as detail).
+    pub did: String,
+    /// Display names of communities this persona is *already* presented to —
+    /// drives the cross-community linkage warning (D1).
+    pub linked_communities: Vec<String>,
 }
 
 /// Transient state for the join flow.
@@ -28,6 +45,17 @@ pub struct JoinState {
     pub page: JoinPage,
     /// Display name resolved from the VTC DID document (best-effort).
     pub display_name: Option<String>,
+    /// The VTC DID awaiting an identity choice (set on `EnterDid` submit, read
+    /// when the chosen identity launches the sequence).
+    pub pending_vtc: Option<String>,
+    /// Existing personas offered for reuse on the identity-choice page (R-B-3).
+    pub persona_options: Vec<PersonaOption>,
+    /// Highlighted row on the identity-choice page. `0..persona_options.len()`
+    /// indexes a reuse option; `persona_options.len()` is the "mint new" row.
+    pub identity_selected: usize,
+    /// When `Some(id)`, the cross-community linkage warning for reusing that
+    /// persona is shown and awaiting `y`/`n` confirmation (D1).
+    pub reuse_confirm: Option<PersonaId>,
     /// True while the background mint+join sequence is running. Locks input.
     pub processing: bool,
     /// Progress / error log shown on the `JoinProgress` page.
@@ -36,7 +64,7 @@ pub struct JoinState {
     pub completed: Completion,
     /// The pending community record created on success (for the success page).
     pub created_community: Option<CommunityRecord>,
-    /// The DID of the persona minted for this community, shown on the success
+    /// The DID of the persona presented for this community, shown on the success
     /// page alongside the community DID.
     pub created_persona_did: Option<String>,
 }
@@ -45,6 +73,16 @@ impl JoinState {
     /// Reset to a fresh `EnterDid` page (called when the flow opens).
     pub fn reset(&mut self) {
         *self = JoinState::default();
+    }
+
+    /// The index of the "mint a new identity" row (one past the reuse options).
+    pub fn mint_row(&self) -> usize {
+        self.persona_options.len()
+    }
+
+    /// Whether the highlighted identity-choice row is the "mint new" row.
+    pub fn mint_row_selected(&self) -> bool {
+        self.identity_selected >= self.persona_options.len()
     }
 
     /// Append an info message to the progress log.
@@ -57,5 +95,36 @@ impl JoinState {
         self.messages.push(MessageType::Error(msg.into()));
         self.completed = Completion::CompletedFail;
         self.processing = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opt() -> PersonaOption {
+        PersonaOption {
+            id: PersonaId::new(),
+            label: "p".to_string(),
+            did: "did:webvh:x".to_string(),
+            linked_communities: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn mint_row_sits_past_the_reuse_options() {
+        let mut js = JoinState::default();
+        // No personas: the only row is "mint", at index 0.
+        assert_eq!(js.mint_row(), 0);
+        assert!(js.mint_row_selected());
+
+        js.persona_options = vec![opt(), opt()];
+        assert_eq!(js.mint_row(), 2);
+        js.identity_selected = 0;
+        assert!(!js.mint_row_selected());
+        js.identity_selected = 1;
+        assert!(!js.mint_row_selected());
+        js.identity_selected = 2;
+        assert!(js.mint_row_selected());
     }
 }

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -29,11 +29,21 @@ use crate::{
     state_handler::{
         StateHandler,
         actions::Action,
-        join::JoinPage,
+        join::{JoinPage, PersonaOption},
+        main_page::shorten_did,
         setup_sequence::{Completion, config::ConfigExtension, vta},
         state::{ActivePage, State},
     },
 };
+
+/// Which identity to present to the community being joined (R-B-3 / D1).
+#[derive(Clone, Debug)]
+enum JoinIdentityChoice {
+    /// Mint a fresh, self-contained `did:webvh` persona (D6).
+    Mint,
+    /// Reuse an existing account persona (links the user across communities).
+    Reuse(PersonaId),
+}
 
 impl StateHandler {
     /// Run the join flow until the user cancels or the sequence finishes.
@@ -78,71 +88,107 @@ impl StateHandler {
                             let Some(vtc_did) = validate_join_input(&vtc_did) else {
                                 continue;
                             };
-                            // Move to the progress page and lock input.
-                            state.join.page = JoinPage::Progress;
-                            state.join.processing = true;
-                            state.join.completed = Completion::NotFinished;
-                            state.join.messages.clear();
-                            state.join.info(format!("Joining {vtc_did}…"));
-                            let _ = self.state_tx.send(state.clone());
-
-                            // R15: race the multi-step VTA sequence against the
-                            // interrupt so Ctrl-C / Exit stay live for its whole
-                            // (potentially many-second, network-bound) duration.
-                            // When an interrupt fires, the sequence future is
-                            // DROPPED — cancelled at whatever `.await` it was
-                            // parked on — and we leave via `JoinExit::Exit`, the
-                            // existing path that restores the terminal.
-                            //
-                            // `minted_persona` is the only handle to mid-sequence
-                            // persisted state: `mint_persona_into` writes a
-                            // persona to disk before the join receipt, so a cancel
-                            // after that point must roll it back to honour the
-                            // "leaves no partial config" contract. It lives in the
-                            // outer scope (not borrowed by the future) so it is
-                            // readable after the future is dropped.
-                            let mut minted_persona: Option<PersonaId> = None;
-                            let sequence = run_join_sequence(
-                                self,
-                                state,
-                                tdk,
-                                config,
-                                admin_vta,
-                                profile,
-                                vtc_did,
-                                &mut minted_persona,
-                            );
-                            let interrupted =
-                                race_against_interrupt(sequence, interrupt_rx).await;
-
-                            if let Some(interrupted) = interrupted {
-                                // The sequence future has been dropped here, so
-                                // its `&mut config` / `&mut state` borrows are
-                                // released and we can clean up. If a persona was
-                                // minted (and persisted) but never bound to a
-                                // community, roll it back so the next load sees no
-                                // orphan identity — the same cleanup the failure
-                                // paths use. A persona already referenced by a
-                                // community means the join completed before the
-                                // interrupt landed; leave it.
-                                if let Some(persona_id) = minted_persona
-                                    && !config.account.persona_referenced(&persona_id)
-                                {
-                                    rollback_minted_persona(
-                                        config, persona_id, state, profile,
-                                    );
-                                }
-                                state.join.processing = false;
-                                state.join.completed = Completion::CompletedFail;
-                                state.join.info(
-                                    "Join cancelled. Any partially-minted persona was rolled back; a sub-context may remain at the VTA.",
+                            // Idempotency (R-B-9): refuse a duplicate live/pending
+                            // membership before bothering the user with an identity
+                            // choice.
+                            if is_duplicate_membership(config, &vtc_did) {
+                                state.join.page = JoinPage::Progress;
+                                state.join.fail(
+                                    "Already a member of (or have a pending request for) this community.",
                                 );
-                                state.main_page.log("Join cancelled by user.");
                                 let _ = self.state_tx.send(state.clone());
+                                continue;
+                            }
+                            // R-B-3 / D1: with existing personas, let the user choose
+                            // to reuse one or mint a fresh identity; with none (the
+                            // first join), there's nothing to reuse — mint directly.
+                            let options = build_persona_options(config);
+                            if options.is_empty() {
+                                if let Some(interrupted) = self
+                                    .launch_join_sequence(
+                                        JoinIdentityChoice::Mint,
+                                        vtc_did,
+                                        interrupt_rx,
+                                        state,
+                                        tdk,
+                                        config,
+                                        admin_vta,
+                                        profile,
+                                    )
+                                    .await
+                                {
+                                    return Ok(JoinExit::Exit(interrupted));
+                                }
+                            } else {
+                                state.join.pending_vtc = Some(vtc_did);
+                                state.join.persona_options = options;
+                                state.join.identity_selected = 0;
+                                state.join.reuse_confirm = None;
+                                state.join.page = JoinPage::IdentityChoice;
+                                let _ = self.state_tx.send(state.clone());
+                            }
+                        }
+                        Action::JoinIdentitySelect(i) => {
+                            // Clamp to the reuse rows plus the trailing "mint" row.
+                            state.join.identity_selected = i.min(state.join.mint_row());
+                            // Moving the highlight dismisses any armed warning.
+                            state.join.reuse_confirm = None;
+                            let _ = self.state_tx.send(state.clone());
+                        }
+                        Action::JoinIdentityChoose => {
+                            if state.join.mint_row_selected() {
+                                let Some(vtc_did) = state.join.pending_vtc.clone() else {
+                                    continue;
+                                };
+                                if let Some(interrupted) = self
+                                    .launch_join_sequence(
+                                        JoinIdentityChoice::Mint,
+                                        vtc_did,
+                                        interrupt_rx,
+                                        state,
+                                        tdk,
+                                        config,
+                                        admin_vta,
+                                        profile,
+                                    )
+                                    .await
+                                {
+                                    return Ok(JoinExit::Exit(interrupted));
+                                }
+                            } else if let Some(opt) =
+                                state.join.persona_options.get(state.join.identity_selected)
+                            {
+                                // Arm the cross-community linkage warning (D1).
+                                state.join.reuse_confirm = Some(opt.id);
+                                let _ = self.state_tx.send(state.clone());
+                            }
+                        }
+                        Action::JoinReuseConfirm => {
+                            let Some(persona_id) = state.join.reuse_confirm else {
+                                continue;
+                            };
+                            let Some(vtc_did) = state.join.pending_vtc.clone() else {
+                                continue;
+                            };
+                            state.join.reuse_confirm = None;
+                            if let Some(interrupted) = self
+                                .launch_join_sequence(
+                                    JoinIdentityChoice::Reuse(persona_id),
+                                    vtc_did,
+                                    interrupt_rx,
+                                    state,
+                                    tdk,
+                                    config,
+                                    admin_vta,
+                                    profile,
+                                )
+                                .await
+                            {
                                 return Ok(JoinExit::Exit(interrupted));
                             }
-
-                            state.join.processing = false;
+                        }
+                        Action::JoinReuseCancel => {
+                            state.join.reuse_confirm = None;
                             let _ = self.state_tx.send(state.clone());
                         }
                         _ => {}
@@ -155,6 +201,106 @@ impl StateHandler {
             let _ = self.state_tx.send(state.clone());
         }
     }
+
+    /// Move to the progress page and run [`run_join_sequence`] for the chosen
+    /// identity, raced against the interrupt (R15). Returns `Some(interrupted)`
+    /// when the user cancelled mid-sequence (the caller then exits the flow);
+    /// `None` when the sequence ran to its own success/failure terminal.
+    #[allow(clippy::too_many_arguments)]
+    async fn launch_join_sequence(
+        &self,
+        choice: JoinIdentityChoice,
+        vtc_did: String,
+        interrupt_rx: &mut broadcast::Receiver<Interrupted>,
+        state: &mut State,
+        tdk: &TDK,
+        config: &mut Config,
+        admin_vta: Option<&VtaClient>,
+        profile: &str,
+    ) -> Option<Interrupted> {
+        // Move to the progress page and lock input.
+        state.join.page = JoinPage::Progress;
+        state.join.processing = true;
+        state.join.completed = Completion::NotFinished;
+        state.join.messages.clear();
+        state.join.info(format!("Joining {vtc_did}…"));
+        let _ = self.state_tx.send(state.clone());
+
+        // R15: race the multi-step VTA sequence against the interrupt so Ctrl-C /
+        // Exit stay live for its whole (network-bound) duration. On interrupt the
+        // sequence future is DROPPED — cancelled at whatever `.await` it parked
+        // on. `minted_persona` is the only handle to mid-sequence persisted state
+        // (`mint_persona_into` writes a persona before the receipt), so a cancel
+        // after that point rolls it back. It lives outside the future so it stays
+        // readable after the drop. A *reused* persona is never set here, so it is
+        // never rolled back.
+        let mut minted_persona: Option<PersonaId> = None;
+        let sequence = run_join_sequence(
+            self,
+            state,
+            tdk,
+            config,
+            admin_vta,
+            profile,
+            vtc_did,
+            choice,
+            &mut minted_persona,
+        );
+        let interrupted = race_against_interrupt(sequence, interrupt_rx).await;
+
+        if let Some(interrupted) = interrupted {
+            if let Some(persona_id) = minted_persona
+                && !config.account.persona_referenced(&persona_id)
+            {
+                rollback_minted_persona(config, persona_id, state, profile);
+            }
+            state.join.processing = false;
+            state.join.completed = Completion::CompletedFail;
+            state.join.info(
+                "Join cancelled. Any partially-minted persona was rolled back; a sub-context may remain at the VTA.",
+            );
+            state.main_page.log("Join cancelled by user.");
+            let _ = self.state_tx.send(state.clone());
+            return Some(interrupted);
+        }
+
+        state.join.processing = false;
+        let _ = self.state_tx.send(state.clone());
+        None
+    }
+}
+
+/// Build the reuse options for the identity-choice page (R-B-3): every existing
+/// persona, labelled, with the communities it is already presented to (the
+/// linkage-warning detail). Sorted by label for a stable list.
+fn build_persona_options(config: &Config) -> Vec<PersonaOption> {
+    let mut options: Vec<PersonaOption> = config
+        .account
+        .personas
+        .values()
+        .map(|p| {
+            let mut linked_communities: Vec<String> = config
+                .account
+                .communities
+                .values()
+                .filter(|c| c.persona_ref == p.persona_id)
+                .map(|c| {
+                    c.display_name
+                        .clone()
+                        .unwrap_or_else(|| shorten_did(&c.vtc_did, 40))
+                })
+                .collect();
+            linked_communities.sort();
+            PersonaOption {
+                id: p.persona_id,
+                label: p.label.clone().unwrap_or_else(|| shorten_did(&p.did, 32)),
+                did: p.did.clone(),
+                linked_communities,
+            }
+        })
+        .collect();
+    options.sort_by(|a, b| a.label.cmp(&b.label).then_with(|| a.did.cmp(&b.did)));
+    options
 }
 
 /// Outcome of a `join_flow` invocation.
@@ -235,17 +381,13 @@ async fn run_join_sequence(
     admin_vta: Option<&VtaClient>,
     profile: &str,
     vtc_did: String,
+    choice: JoinIdentityChoice,
     minted_persona: &mut Option<PersonaId>,
 ) {
-    // 1. Idempotency (R-B-9): refuse a duplicate live/pending membership.
-    if is_duplicate_membership(config, &vtc_did) {
-        state
-            .join
-            .fail("Already a member of (or have a pending request for) this community.");
-        return;
-    }
+    // Idempotency (R-B-9) was already enforced at submit, before the identity
+    // choice — no re-check here.
 
-    // 3. The mint + join sequence needs the admin VTA session.
+    // The mint + join sequence needs the admin VTA session.
     let Some(admin_vta) = admin_vta else {
         state
             .join
@@ -265,114 +407,141 @@ async fn run_join_sequence(
 
     let top_context_id = config.account.top_context_id.clone();
 
-    // 4. Mint a fresh persona into `state.setup` (reusing the setup helpers).
-    // Persona signing/auth/encryption keys.
-    state
-        .join
-        .info("Creating persona keys (signing, authentication, encryption)…");
-    let _ = handler.state_tx.send(state.clone());
-    match vta::create_persona_keys(admin_vta, Some(&top_context_id)).await {
-        Ok(keys) => state.setup.did_keys = Some(keys),
-        Err(e) => {
-            state
-                .join
-                .fail(format!("Failed to create persona keys: {e}"));
-            return;
-        }
-    }
-    // WebVH update keys.
-    state.join.info("Creating DID update keys…");
-    let _ = handler.state_tx.send(state.clone());
-    match vta::create_update_keys(admin_vta, Some(&top_context_id)).await {
-        Ok((update, next_update)) => {
-            state.setup.vta.update_secret = Some(update);
-            state.setup.vta.next_update_secret = Some(next_update);
-        }
-        Err(e) => {
-            state
-                .join
-                .fail(format!("Failed to create update keys: {e}"));
-            return;
-        }
-    }
-
-    // Pick the first WebVH server. Serverless mint is a deliberate follow-up.
-    state.join.info("Finding a DID hosting server…");
-    let _ = handler.state_tx.send(state.clone());
-    let server_id = match vta::list_webvh_servers(admin_vta).await {
-        Ok(servers) => match servers.into_iter().next() {
-            Some(s) => s.id,
+    // Resolve the persona to present: reuse an existing account persona (R-B-3)
+    // or mint a fresh, self-contained one (D6). Only a *minted* persona is
+    // recorded in `minted_persona` for rollback — a reused persona pre-exists and
+    // must never be rolled back.
+    let (persona_id, persona_did) = match choice {
+        JoinIdentityChoice::Reuse(persona_id) => match config.identities.get(&persona_id) {
+            Some(ident) => {
+                let did = ident.persona_did().to_string();
+                state.join.info(format!("Reusing persona {did}…"));
+                let _ = handler.state_tx.send(state.clone());
+                (persona_id, did)
+            }
             None => {
-                state.join.fail(
-                    "No WebVH server available from the VTA (serverless mint not yet supported).",
-                );
+                state
+                    .join
+                    .fail("Selected persona is unavailable — cannot reuse it.");
                 return;
             }
         },
-        Err(e) => {
+        JoinIdentityChoice::Mint => {
+            // 4. Mint a fresh persona into `state.setup` (reusing the setup helpers).
+            // Persona signing/auth/encryption keys.
             state
                 .join
-                .fail(format!("Failed to list WebVH servers: {e}"));
-            return;
-        }
-    };
+                .info("Creating persona keys (signing, authentication, encryption)…");
+            let _ = handler.state_tx.send(state.clone());
+            match vta::create_persona_keys(admin_vta, Some(&top_context_id)).await {
+                Ok(keys) => state.setup.did_keys = Some(keys),
+                Err(e) => {
+                    state
+                        .join
+                        .fail(format!("Failed to create persona keys: {e}"));
+                    return;
+                }
+            }
+            // WebVH update keys.
+            state.join.info("Creating DID update keys…");
+            let _ = handler.state_tx.send(state.clone());
+            match vta::create_update_keys(admin_vta, Some(&top_context_id)).await {
+                Ok((update, next_update)) => {
+                    state.setup.vta.update_secret = Some(update);
+                    state.setup.vta.next_update_secret = Some(next_update);
+                }
+                Err(e) => {
+                    state
+                        .join
+                        .fail(format!("Failed to create update keys: {e}"));
+                    return;
+                }
+            }
 
-    // Create the persona did:webvh via the server (auto-assigned path).
-    state
-        .join
-        .info(format!("Creating persona DID via {server_id}…"));
-    let _ = handler.state_tx.send(state.clone());
-    match vta::create_did_via_server(
-        admin_vta,
-        tdk,
-        &top_context_id,
-        &server_id,
-        WebvhPathMode::AutoAssign,
-    )
-    .await
-    {
-        Ok((keys, did, document, _mnemonic)) => {
-            state.setup.did_keys = Some(keys);
-            state.setup.webvh_address.did = did;
-            state.setup.webvh_address.document = document;
-        }
-        Err(e) => {
+            // Pick the first WebVH server. Serverless mint is a deliberate follow-up.
+            state.join.info("Finding a DID hosting server…");
+            let _ = handler.state_tx.send(state.clone());
+            let server_id = match vta::list_webvh_servers(admin_vta).await {
+                Ok(servers) => match servers.into_iter().next() {
+                    Some(s) => s.id,
+                    None => {
+                        state.join.fail(
+                    "No WebVH server available from the VTA (serverless mint not yet supported).",
+                );
+                        return;
+                    }
+                },
+                Err(e) => {
+                    state
+                        .join
+                        .fail(format!("Failed to list WebVH servers: {e}"));
+                    return;
+                }
+            };
+
+            // Create the persona did:webvh via the server (auto-assigned path).
             state
                 .join
-                .fail(format!("Failed to create persona DID: {e}"));
-            return;
-        }
-    }
+                .info(format!("Creating persona DID via {server_id}…"));
+            let _ = handler.state_tx.send(state.clone());
+            match vta::create_did_via_server(
+                admin_vta,
+                tdk,
+                &top_context_id,
+                &server_id,
+                WebvhPathMode::AutoAssign,
+            )
+            .await
+            {
+                Ok((keys, did, document, _mnemonic)) => {
+                    state.setup.did_keys = Some(keys);
+                    state.setup.webvh_address.did = did;
+                    state.setup.webvh_address.document = document;
+                }
+                Err(e) => {
+                    state
+                        .join
+                        .fail(format!("Failed to create persona DID: {e}"));
+                    return;
+                }
+            }
 
-    // The persona's mediator is the account's VTA mediator: the DID minted via
-    // the VTA's webvh server advertises that mediator in its DIDComm service, so
-    // the persona listener must use the same one. Hardcoding `None` (the public
-    // default) left the persona with no usable mediator — the listener then
-    // failed with "No Mediator is configured" and retried forever.
-    state.setup.custom_mediator = match &config.key_backend {
-        openvtc_core::config::KeyBackend::Vta { mediator_did, .. } => mediator_did.clone(),
-        _ => None,
-    };
-    state.setup.username = display_name.clone().unwrap_or_else(|| {
-        openvtc_core::config::context_path::render_for_display(&vtc_did).to_string()
-    });
+            // The persona's mediator is the account's VTA mediator: the DID minted via
+            // the VTA's webvh server advertises that mediator in its DIDComm service, so
+            // the persona listener must use the same one. Hardcoding `None` (the public
+            // default) left the persona with no usable mediator — the listener then
+            // failed with "No Mediator is configured" and retried forever.
+            state.setup.custom_mediator = match &config.key_backend {
+                openvtc_core::config::KeyBackend::Vta { mediator_did, .. } => mediator_did.clone(),
+                _ => None,
+            };
+            state.setup.username = display_name.clone().unwrap_or_else(|| {
+                openvtc_core::config::context_path::render_for_display(&vtc_did).to_string()
+            });
 
-    // 5. Persist the persona into the account. `mint_persona_into` writes the
-    // persona record + runtime identity + key info to disk *immediately* (a
-    // synchronous `Config::save`), so from here until the community record is
-    // persisted (step 9) the on-disk config holds a persona with no community.
-    // Record its id so a cancel (R15) or later failure can roll it back.
-    let persona_id = match Config::mint_persona_into(config, &state.setup, tdk, profile).await {
-        Ok(id) => id,
-        Err(e) => {
-            state.join.fail(format!("Failed to save persona: {e}"));
-            return;
+            // 5. Persist the persona into the account. `mint_persona_into` writes the
+            // persona record + runtime identity + key info to disk *immediately* (a
+            // synchronous `Config::save`), so from here until the community record is
+            // persisted (step 9) the on-disk config holds a persona with no community.
+            // Record its id so a cancel (R15) or later failure can roll it back.
+            let persona_id =
+                match Config::mint_persona_into(config, &state.setup, tdk, profile).await {
+                    Ok(id) => id,
+                    Err(e) => {
+                        state.join.fail(format!("Failed to save persona: {e}"));
+                        return;
+                    }
+                };
+            *minted_persona = Some(persona_id);
+            let persona_did = state.setup.webvh_address.did.clone();
+            state.join.info(format!("Persona created: {persona_did}"));
+            let _ = handler.state_tx.send(state.clone());
+            (persona_id, persona_did)
         }
     };
-    *minted_persona = Some(persona_id);
-    let persona_did = state.setup.webvh_address.did.clone();
-    state.join.info(format!("Persona created: {persona_did}"));
-    let _ = handler.state_tx.send(state.clone());
+    // Only a freshly-minted persona is rolled back on a later failure; a reused
+    // persona pre-existed and is left intact.
+    let minted = minted_persona.is_some();
 
     // 6. Derive the per-community sub-context id (D9, collision-safe).
     let sub_context_id =
@@ -388,7 +557,9 @@ async fn run_join_sequence(
                 state
                     .join
                     .fail(format!("Failed to derive sub-context id: {e}"));
-                rollback_minted_persona(config, persona_id, state, profile);
+                if minted {
+                    rollback_minted_persona(config, persona_id, state, profile);
+                }
                 return;
             }
         };
@@ -402,7 +573,9 @@ async fn run_join_sequence(
         state
             .join
             .fail(format!("Failed to create sub-context: {e}"));
-        rollback_minted_persona(config, persona_id, state, profile);
+        if minted {
+            rollback_minted_persona(config, persona_id, state, profile);
+        }
         return;
     }
 
@@ -423,7 +596,9 @@ async fn run_join_sequence(
         state
             .join
             .fail("Messaging (ATM) unavailable — cannot submit the join request.");
-        rollback_minted_persona(config, persona_id, state, profile);
+        if minted {
+            rollback_minted_persona(config, persona_id, state, profile);
+        }
         return;
     };
     let (applicant_did, persona_profile, persona_mediator) =
@@ -437,7 +612,9 @@ async fn run_join_sequence(
                 state
                     .join
                     .fail("Persona identity unavailable after mint — cannot submit.");
-                rollback_minted_persona(config, persona_id, state, profile);
+                if minted {
+                    rollback_minted_persona(config, persona_id, state, profile);
+                }
                 return;
             }
         };

--- a/openvtc/src/ui/pages/join_flow/identity_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/identity_choice.rs
@@ -1,0 +1,320 @@
+//! Join flow — identity choice (R-B-3 / D1).
+//!
+//! After the VTC DID is entered, the operator chooses which identity to present:
+//! reuse one of the account's existing personas, or mint a fresh, self-contained
+//! one (D6). Reusing a persona links the user across those communities, so
+//! selecting a reuse option arms a clear linkage warning that must be confirmed
+//! before the join proceeds. Mirrors the other join pages' component shape.
+
+use crate::colors::{
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
+    COLOR_TEXT_DEFAULT,
+};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Layout, Margin,
+    },
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+
+use crate::{
+    state_handler::{actions::Action, join::JoinState},
+    ui::pages::join_flow::JoinFlow,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct IdentityChoice;
+
+impl IdentityChoice {
+    pub fn handle_key_event(state: &mut JoinFlow, key: KeyEvent) {
+        // Input is locked once a choice has launched the background sequence.
+        if state.props.state.processing {
+            return;
+        }
+        let js = &state.props.state;
+
+        // The linkage warning owns input while armed: only confirm / cancel apply.
+        if js.reuse_confirm.is_some() {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    let _ = state.action_tx.send(Action::JoinReuseConfirm);
+                }
+                KeyCode::F(10) => {
+                    let _ = state.action_tx.send(Action::Exit);
+                }
+                _ => {
+                    let _ = state.action_tx.send(Action::JoinReuseCancel);
+                }
+            }
+            return;
+        }
+
+        let selected = js.identity_selected;
+        let mint_row = js.mint_row();
+        match key.code {
+            KeyCode::F(10) => {
+                let _ = state.action_tx.send(Action::Exit);
+            }
+            KeyCode::Up => {
+                let _ = state
+                    .action_tx
+                    .send(Action::JoinIdentitySelect(selected.saturating_sub(1)));
+            }
+            KeyCode::Down => {
+                let _ = state
+                    .action_tx
+                    .send(Action::JoinIdentitySelect((selected + 1).min(mint_row)));
+            }
+            KeyCode::Enter => {
+                let _ = state.action_tx.send(Action::JoinIdentityChoose);
+            }
+            KeyCode::Esc => {
+                let _ = state.action_tx.send(Action::JoinCancel);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn render(&self, state: &JoinState, frame: &mut Frame<'_>) {
+        let [middle, bottom] = Layout::vertical([Min(0), Length(3)]).areas(frame.area());
+
+        frame.render_widget(
+            Block::bordered()
+                .fg(COLOR_BORDER)
+                .padding(Padding::proportional(1))
+                .title(" Choose an identity for this community "),
+            middle,
+        );
+        let inner = middle.inner(Margin::new(3, 2));
+
+        // When a reuse is armed, the body is the linkage warning + confirm prompt.
+        if let Some(persona_id) = state.reuse_confirm {
+            let opt = state.persona_options.iter().find(|o| o.id == persona_id);
+            let label = opt.map(|o| o.label.as_str()).unwrap_or("this persona");
+            let mut lines = vec![
+                Line::styled(
+                    "Reuse an existing identity?",
+                    Style::new().fg(COLOR_ORANGE).bold(),
+                ),
+                Line::default(),
+                Line::styled(
+                    format!(
+                        "Presenting \"{label}\" to this community links you across every \
+                         community that uses it."
+                    ),
+                    Style::new().fg(COLOR_TEXT_DEFAULT),
+                ),
+            ];
+            if let Some(opt) = opt {
+                if opt.linked_communities.is_empty() {
+                    lines.push(Line::styled(
+                        "It is not yet presented to any other community.",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    ));
+                } else {
+                    lines.push(Line::default());
+                    lines.push(Line::styled(
+                        "Already presented to:",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    ));
+                    for c in &opt.linked_communities {
+                        lines.push(Line::styled(
+                            format!("  • {c}"),
+                            Style::new().fg(COLOR_DARK_GRAY),
+                        ));
+                    }
+                }
+            }
+            lines.push(Line::default());
+            lines.push(Line::from(vec![
+                Span::styled("[Y]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(
+                    " reuse and continue   ",
+                    Style::new().fg(COLOR_TEXT_DEFAULT),
+                ),
+                Span::styled("[N/ESC]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(" go back", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            ]));
+            frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+            render_bottom(frame, bottom);
+            return;
+        }
+
+        // Otherwise the body is the selectable list: each persona, then "mint new".
+        let mut lines = vec![
+            Line::styled(
+                "Select the identity to present to this community:",
+                Style::new().fg(COLOR_BORDER).bold(),
+            ),
+            Line::default(),
+        ];
+        for (i, opt) in state.persona_options.iter().enumerate() {
+            let selected = i == state.identity_selected;
+            let marker = if selected { "▸ " } else { "  " };
+            let style = if selected {
+                Style::new().fg(COLOR_SUCCESS).bold()
+            } else {
+                Style::new().fg(COLOR_TEXT_DEFAULT)
+            };
+            lines.push(Line::from(Span::styled(
+                format!("{marker}{}", opt.label),
+                style,
+            )));
+            let detail = if opt.linked_communities.is_empty() {
+                format!("    {}", opt.did)
+            } else {
+                format!(
+                    "    {}  ·  used by {} communit{}",
+                    opt.did,
+                    opt.linked_communities.len(),
+                    if opt.linked_communities.len() == 1 {
+                        "y"
+                    } else {
+                        "ies"
+                    }
+                )
+            };
+            lines.push(Line::styled(detail, Style::new().fg(COLOR_DARK_GRAY)));
+        }
+        // The trailing "mint new" row.
+        let mint_selected = state.mint_row_selected();
+        let marker = if mint_selected { "▸ " } else { "  " };
+        let style = if mint_selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_SOFT_PURPLE)
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker}✦ Create a new identity for this community"),
+            style,
+        )));
+        lines.push(Line::styled(
+            "    A fresh did:webvh, unlinked from your other communities",
+            Style::new().fg(COLOR_DARK_GRAY),
+        ));
+        lines.push(Line::default());
+        lines.push(Line::from(vec![
+            Span::styled("[↑/↓]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" select   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" choose   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" cancel", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]));
+
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+        render_bottom(frame, bottom);
+    }
+}
+
+fn render_bottom(frame: &mut Frame, area: ratatui::layout::Rect) {
+    let bottom_line = Line::from(vec![
+        Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+        Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+    ]);
+    frame.render_widget(
+        Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
+        area,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    //! Key-routing tests for the identity-choice page (R-B-3). `Action` derives
+    //! neither `PartialEq` nor `Debug`, so assertions pattern-match the variant.
+    use super::*;
+    use crate::state_handler::{
+        join::{JoinPage, JoinState, PersonaOption},
+        state::State,
+    };
+    use crate::ui::component::Component;
+    use crossterm::event::KeyModifiers;
+    use openvtc_core::config::account::PersonaId;
+    use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+    fn flow_with(mutate: impl FnOnce(&mut JoinState)) -> (JoinFlow, UnboundedReceiver<Action>) {
+        let (tx, rx) = unbounded_channel();
+        let mut state = State::default();
+        state.join.page = JoinPage::IdentityChoice;
+        state.join.persona_options = vec![
+            PersonaOption {
+                id: PersonaId::new(),
+                label: "alice".to_string(),
+                did: "did:webvh:a".to_string(),
+                linked_communities: Vec::new(),
+            },
+            PersonaOption {
+                id: PersonaId::new(),
+                label: "bob".to_string(),
+                did: "did:webvh:b".to_string(),
+                linked_communities: Vec::new(),
+            },
+        ];
+        mutate(&mut state.join);
+        (JoinFlow::new(&state, tx), rx)
+    }
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn down_moves_selection_down() {
+        let (mut flow, mut rx) = flow_with(|_| {});
+        IdentityChoice::handle_key_event(&mut flow, press(KeyCode::Down));
+        match rx.try_recv() {
+            Ok(Action::JoinIdentitySelect(1)) => {}
+            _ => panic!("expected JoinIdentitySelect(1)"),
+        }
+    }
+
+    #[test]
+    fn enter_chooses_the_highlight() {
+        let (mut flow, mut rx) = flow_with(|_| {});
+        IdentityChoice::handle_key_event(&mut flow, press(KeyCode::Enter));
+        match rx.try_recv() {
+            Ok(Action::JoinIdentityChoose) => {}
+            _ => panic!("expected JoinIdentityChoose"),
+        }
+    }
+
+    #[test]
+    fn esc_cancels_the_flow() {
+        let (mut flow, mut rx) = flow_with(|_| {});
+        IdentityChoice::handle_key_event(&mut flow, press(KeyCode::Esc));
+        match rx.try_recv() {
+            Ok(Action::JoinCancel) => {}
+            _ => panic!("expected JoinCancel"),
+        }
+    }
+
+    #[test]
+    fn armed_warning_confirms_and_cancels() {
+        // y confirms the reuse.
+        let (mut flow, mut rx) = flow_with(|js| {
+            let pid = js.persona_options[0].id;
+            js.reuse_confirm = Some(pid);
+        });
+        IdentityChoice::handle_key_event(&mut flow, press(KeyCode::Char('y')));
+        match rx.try_recv() {
+            Ok(Action::JoinReuseConfirm) => {}
+            _ => panic!("expected JoinReuseConfirm"),
+        }
+
+        // Any other key (here Esc) backs out of the warning.
+        let (mut flow, mut rx) = flow_with(|js| {
+            let pid = js.persona_options[0].id;
+            js.reuse_confirm = Some(pid);
+        });
+        IdentityChoice::handle_key_event(&mut flow, press(KeyCode::Esc));
+        match rx.try_recv() {
+            Ok(Action::JoinReuseCancel) => {}
+            _ => panic!("expected JoinReuseCancel"),
+        }
+    }
+}

--- a/openvtc/src/ui/pages/join_flow/mod.rs
+++ b/openvtc/src/ui/pages/join_flow/mod.rs
@@ -15,7 +15,10 @@ use crate::{
     },
     ui::{
         component::{Component, ComponentRender},
-        pages::join_flow::{join_progress::JoinProgress, vtc_enter_did::VtcEnterDid},
+        pages::join_flow::{
+            identity_choice::IdentityChoice, join_progress::JoinProgress,
+            vtc_enter_did::VtcEnterDid,
+        },
     },
 };
 use crossterm::event::{KeyEvent, KeyEventKind};
@@ -23,6 +26,7 @@ use ratatui::Frame;
 use tokio::sync::mpsc::UnboundedSender;
 use tui_input::Input;
 
+pub mod identity_choice;
 pub mod join_progress;
 pub mod vtc_enter_did;
 
@@ -38,6 +42,7 @@ pub struct JoinFlow {
 
     // Page handlers (zero-sized — they read from `props.state`).
     pub vtc_enter_did: VtcEnterDid,
+    pub identity_choice: IdentityChoice,
     pub join_progress: JoinProgress,
 
     /// State-mapped join props.
@@ -66,6 +71,7 @@ impl Component for JoinFlow {
             action_tx,
             vtc_did: Input::default(),
             vtc_enter_did: VtcEnterDid,
+            identity_choice: IdentityChoice,
             join_progress: JoinProgress,
             props: Props::from(state),
         }
@@ -88,6 +94,7 @@ impl Component for JoinFlow {
         }
         match self.props.state.page {
             JoinPage::EnterDid => VtcEnterDid::handle_key_event(self, key),
+            JoinPage::IdentityChoice => IdentityChoice::handle_key_event(self, key),
             JoinPage::Progress => JoinProgress::handle_key_event(self, key),
         }
     }
@@ -107,6 +114,7 @@ impl ComponentRender<()> for JoinFlow {
                 self.vtc_enter_did
                     .render(&self.props.state, &self.vtc_did, frame)
             }
+            JoinPage::IdentityChoice => self.identity_choice.render(&self.props.state, frame),
             JoinPage::Progress => self.join_progress.render(&self.props.state, frame),
         }
     }


### PR DESCRIPTION
## T5 PR-A — Identity choice on join: reuse an existing persona or mint a new one (R-B-3)

First of two PRs for **T5 — State B (join a community)**, split per the plan
(mirrors T1's #110/#111). This PR is **R-B-3 / D1 / D6**; PR-B will add **R-B-5**
(register the new session with the multi-session manager).

### Audit
The join flow (`join_flow.rs`, `ActivePage::Join`) was already built in T1:
enter VTC DID → mint persona → sub-context (`build_sub_context_id`, T2) → submit
`join-requests/submit` with a **stub VP isolated to one call site** → persist
`Pending`. R-B-1 (entry), R-B-4 (sub-context / VP / mediator-default), R-B-6
(submit + receipt → status), and R-B-9 (duplicate / re-join) are all present and
tested. The flow, however, **always minted** a fresh persona — no reuse, no
linkage warning.

### What this PR adds
- **New `JoinPage::IdentityChoice`** between EnterDid and Progress. It lists the
  account's existing personas (each annotated with the communities it is already
  presented to) plus a **"Create a new identity"** row. With no personas yet (the
  very first join), there's nothing to reuse — the flow mints directly, skipping
  the page.
- **Cross-community linkage warning (D1):** choosing to reuse a persona arms a
  warning that names the communities the persona is already used by, and requires
  `y`/`n` confirmation before proceeding.
- **`run_join_sequence` now takes `JoinIdentityChoice { Mint | Reuse(PersonaId) }`:**
  the reuse branch skips the mint entirely and references the existing persona,
  inheriting its mediator. A **reused persona is never rolled back** on a later
  failure — only a freshly-minted one is (guarded by a `minted` flag).
- **Duplicate-membership check (R-B-9) moved to submit time**, before the identity
  choice, so an already-joined community is refused without prompting for an identity.
- New actions: `JoinIdentitySelect` / `JoinIdentityChoose` / `JoinReuseConfirm` /
  `JoinReuseCancel`.

### Deferred (not acceptance-criteria; spec marks optional / "if available")
- R-B-2 display-name capture from the VTC DID document (stays the current
  deterministic `None`).
- The R-B-4 optional "use a different mediator" override step (mint still defaults
  to the VTA mediator; reuse inherits the persona's).

### Testing
- Identity-page key routing: ↑/↓ move, Enter chooses, Esc cancels, and the armed
  linkage warning confirms (`y`) / backs out (any other key).
- `JoinState` mint-row helpers (`mint_row` / `mint_row_selected`).
- `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ and `--no-default-features` ✓ (0 failed suites).
- No dependency change (`Cargo.lock` untouched) → `cargo deny` unaffected.

The full mint → sub-context → submit sequence is network-bound and remains
covered by manual verification (consistent with the existing join tests); this PR
unit-tests the new UI routing + pure state helpers.

### Follow-up
PR-B (R-B-5): after a successful join, register the joined persona/community
session with the `SessionManager` and bring its listener up at runtime so the
VTC's async receipt arrives without a restart (D11).
