### PR TITLE
feat(join): register the joined community's live session without a restart (T5 PR-B, R-B-5)

### DIFF
--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -518,6 +518,32 @@ pub async fn persona_listener_config(config: &Config, tdk: &affinidi_tdk::TDK) -
     }
 }
 
+/// Build the persona listener config for a **specific** persona (not necessarily
+/// the active one), mirroring one iteration of [`build_listener_configs`]. Used
+/// to bring a freshly-joined community's session live at runtime (R-B-5) without
+/// a restart. Returns `None` if `persona_id` does not resolve to an identity.
+pub async fn persona_listener_config_for(
+    config: &Config,
+    tdk: &affinidi_tdk::TDK,
+    persona_id: openvtc_core::config::account::PersonaId,
+) -> Option<ListenerConfig> {
+    let ident = config.identities.get(&persona_id)?;
+    let did = ident.did.as_str();
+    let secrets = get_secrets_for_did(tdk, config, did).await;
+    let mediator = ident
+        .mediator_did
+        .as_deref()
+        .unwrap_or(config.mediator_did());
+    let label = config.persona_profile_label_for(persona_id);
+    Some(ListenerConfig {
+        id: persona_listener_id(did),
+        profile: make_profile(did, mediator, &label, secrets),
+        restart_policy: default_listener_restart_policy(),
+        auto_delete: true,
+        ..Default::default()
+    })
+}
+
 /// Start the DIDComm service with the given config.
 pub async fn start_service(
     config: &Config,

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -17,7 +17,7 @@ use anyhow::Result;
 use chrono::Utc;
 use openvtc_core::config::{
     Config,
-    account::{CommunityRecord, PersonaId},
+    account::{CommunityRecord, PersonaId, VtcDid},
     context_path::build_sub_context_id,
 };
 use tokio::sync::{broadcast, mpsc::UnboundedReceiver};
@@ -29,7 +29,7 @@ use crate::{
     state_handler::{
         StateHandler,
         actions::Action,
-        join::{JoinPage, PersonaOption},
+        join::{JoinPage, JoinState, PersonaOption},
         main_page::shorten_did,
         setup_sequence::{Completion, config::ConfigExtension, vta},
         state::{ActivePage, State},
@@ -43,6 +43,26 @@ enum JoinIdentityChoice {
     Mint,
     /// Reuse an existing account persona (links the user across communities).
     Reuse(PersonaId),
+}
+
+/// The persona + community of a just-completed join, handed back to the runtime
+/// loop so it can bring a live session up immediately (R-B-5 / D11) rather than
+/// only on the next launch.
+pub(crate) struct JoinedSession {
+    pub persona_id: PersonaId,
+    pub persona_did: String,
+    pub vtc_did: VtcDid,
+}
+
+/// Extract the [`JoinedSession`] from a finished join's state — `Some` only when
+/// the sequence persisted a community (i.e. the join succeeded).
+fn joined_session(js: &JoinState) -> Option<JoinedSession> {
+    let record = js.created_community.as_ref()?;
+    Some(JoinedSession {
+        persona_id: record.persona_ref,
+        persona_did: js.created_persona_did.clone().unwrap_or_default(),
+        vtc_did: record.vtc_did.clone(),
+    })
 }
 
 impl StateHandler {
@@ -81,8 +101,10 @@ impl StateHandler {
                         }
                         Action::JoinCancel => {
                             // Leave the flow; the caller restores the main page.
+                            // Hand back the joined session (if any) so the runtime
+                            // loop can bring its live session up (R-B-5).
                             state.active_page = ActivePage::Main;
-                            return Ok(JoinExit::Returned);
+                            return Ok(JoinExit::Returned(joined_session(&state.join)));
                         }
                         Action::JoinSubmitVtc(vtc_did) => {
                             let Some(vtc_did) = validate_join_input(&vtc_did) else {
@@ -306,8 +328,9 @@ fn build_persona_options(config: &Config) -> Vec<PersonaOption> {
 /// Outcome of a `join_flow` invocation.
 pub(crate) enum JoinExit {
     /// User cancelled / finished — return to the main page and resume the
-    /// caller's loop.
-    Returned,
+    /// caller's loop. Carries the just-joined session when a join succeeded, so
+    /// the runtime loop can register it + start its listener live (R-B-5).
+    Returned(Option<JoinedSession>),
     /// Application is exiting (Exit / UXError / interrupt).
     Exit(Interrupted),
 }
@@ -751,9 +774,12 @@ mod tests {
     //! (`join_flow` → `rollback_minted_persona` when `!persona_referenced`).
 
     use super::race_against_interrupt;
-    use super::{build_pending_record, is_duplicate_membership, validate_join_input};
+    use super::{
+        build_pending_record, is_duplicate_membership, joined_session, validate_join_input,
+    };
     use crate::Interrupted;
     use crate::state_handler::dispatch_util::test_config;
+    use crate::state_handler::join::JoinState;
     use openvtc_core::config::account::{CommunityRecord, CommunityStatus, PersonaId};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -857,6 +883,31 @@ mod tests {
             }
             other => panic!("expected Pending status, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn joined_session_extracted_only_on_success() {
+        // No persisted community → nothing for the runtime loop to register (R-B-5).
+        let mut js = JoinState::default();
+        assert!(joined_session(&js).is_none());
+
+        // A successful sequence leaves the record + persona did → a session.
+        let persona = PersonaId::new();
+        let rec = build_pending_record(
+            "did:vtc:c".to_string(),
+            None,
+            "top/slug".to_string(),
+            persona,
+            uuid::Uuid::new_v4(),
+            chrono::Utc::now(),
+        );
+        js.created_community = Some(rec);
+        js.created_persona_did = Some("did:webvh:persona".to_string());
+
+        let joined = joined_session(&js).expect("a persisted community yields a session");
+        assert_eq!(joined.persona_id, persona);
+        assert_eq!(joined.persona_did, "did:webvh:persona");
+        assert_eq!(joined.vtc_did, "did:vtc:c");
     }
 
     #[tokio::test]

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -858,8 +858,22 @@ impl StateHandler {
                             )
                             .await
                         {
-                            Ok(join_flow::JoinExit::Returned) => {
+                            Ok(join_flow::JoinExit::Returned(joined)) => {
                                 state.active_page = state::ActivePage::Main;
+                                // R-B-5 / D11: bring the new community's session up
+                                // live so the VTC's async receipt is received now,
+                                // not only after a restart.
+                                if let Some(joined) = joined {
+                                    register_joined_session(
+                                        &mut session_manager,
+                                        &didcomm_service,
+                                        &tdk,
+                                        &config,
+                                        joined,
+                                        &mut state,
+                                    )
+                                    .await;
+                                }
                             }
                             Ok(join_flow::JoinExit::Exit(interrupted)) => {
                                 break interrupted;
@@ -1599,7 +1613,13 @@ impl StateHandler {
                                 )
                                 .await
                             {
-                                Ok(join_flow::JoinExit::Returned) => {
+                                // The joined session is ignored here: a first join
+                                // from State A flips `joined_with_identity`, breaking
+                                // `Joined` so `run()` restarts into the full pipeline,
+                                // whose startup registration (`IdentityRegistry`)
+                                // brings the new session up (R-B-5). Live in-loop
+                                // registration is only needed in the runtime loop.
+                                Ok(join_flow::JoinExit::Returned(_)) => {
                                     // Back on the main page; resume the degraded loop.
                                     state.active_page = state::ActivePage::Main;
                                     joined_with_identity =
@@ -1781,6 +1801,66 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
         _ => return false,
     }
     true
+}
+
+/// Bring a just-joined community's session live (R-B-5 / D11): register it with
+/// the multi-session manager and, when that creates a fresh session, start the
+/// persona's DIDComm listener now so the VTC's asynchronous receipt arrives
+/// without a restart. `add_listener` returns promptly — the mediator connect
+/// proceeds under the listener's restart policy, and the `ListenerEvent::Connected`
+/// handler flips the session to `Connected`. Failures are non-fatal (a restart
+/// recovers the session) and surfaced to the activity log.
+async fn register_joined_session(
+    session_manager: &mut session_manager::SessionManager,
+    service: &affinidi_messaging_didcomm_service::DIDCommService,
+    tdk: &TDK,
+    config: &Config,
+    joined: join_flow::JoinedSession,
+    state: &mut State,
+) {
+    use session_manager::RegisterOutcome;
+
+    let lid = didcomm::persona_listener_id(&joined.persona_did);
+    match session_manager.register(joined.persona_id, &lid, joined.vtc_did.clone()) {
+        RegisterOutcome::JoinedExisting => {
+            // A reused persona that is already live — the new community shares its
+            // session; no new listener (D1/D11).
+            state
+                .main_page
+                .log("New community attached to an existing live session.");
+        }
+        RegisterOutcome::AtCapacity => {
+            // No silent caps (D15): the join succeeded but the bound is reached.
+            state.main_page.log(format!(
+                "Joined, but its live session is not active yet: the session limit ({}) is \
+                 reached. It will connect when one frees up or on next launch.",
+                session_manager.max_sessions(),
+            ));
+        }
+        RegisterOutcome::Created => {
+            match didcomm::persona_listener_config_for(config, tdk, joined.persona_id).await {
+                Some(cfg) => {
+                    if let Err(e) = service.add_listener(cfg).await {
+                        session_manager.mark_failed(&lid, format!("{e:#}"));
+                        state.main_page.log(format!(
+                            "Joined, but couldn't start its live session now (it will connect \
+                             on next launch): {e}"
+                        ));
+                    } else {
+                        state.main_page.log("New community session connecting…");
+                    }
+                }
+                None => {
+                    // The join just wrote this identity, so this is unexpected — but
+                    // never leave a registered session with no listener behind it.
+                    session_manager.deregister(&joined.vtc_did);
+                    state.main_page.log(
+                        "Joined, but its identity could not be resolved to start a live session.",
+                    );
+                }
+            }
+        }
+    }
 }
 
 // Per-domain action dispatch lives in the corresponding sub-module:


### PR DESCRIPTION
## T5 PR-B — Register the joined community's live session without a restart (R-B-5)

Second of two PRs for **T5 — State B (join a community)**; completes T5 alongside
PR-A (#115, identity choice). This is **R-B-5 / D11**.

### Problem
A join from the live runtime created a `Pending` community but did **not**
register its session or start a DIDComm listener for it. The VTC's asynchronous
`join-requests/submit-receipt` therefore only arrived after the next app launch
(startup registration). The success message even implied otherwise.

### Fix
- `join_flow` now returns `JoinExit::Returned(Option<JoinedSession>)` — the joined
  `{persona_id, persona_did, vtc_did}` on success, `None` on cancel/failure.
- The **runtime-loop** `StartJoin` handler calls a new `register_joined_session`:
  - `SessionManager::register` → **`Created`**: build the persona's listener config
    via the new `didcomm::persona_listener_config_for` (works for a specific,
    possibly non-active persona — the joined community is `Pending`, not the
    working community) and `service.add_listener(...)`. `add_listener` returns
    promptly; the mediator connect proceeds under the restart policy and the
    **existing `ListenerEvent::Connected` handler** flips the session to
    `Connected`. The loop is never parked (deliberately *not* the 30s
    `wait_connected` reconnect path).
  - **`JoinedExisting`**: a reused persona that is already live shares its session
    (D1) — no new listener.
  - **`AtCapacity`**: logged, not silent (D15).
- The **degraded (State-A first-join) loop is unchanged**: a first join flips
  `joined_with_identity` and breaks `Joined`, so `run()` restarts into the full
  pipeline whose startup `IdentityRegistry` registration brings the new session
  up. In-loop registration is only needed in the runtime loop, so PR-B touches
  only that path.

### Testing
- The concurrent-session semantics this enables — one session per persona, reused
  personas share one, bounded cap, per-session failure isolation — are already
  covered by the `session_manager` unit tests (incl.
  `register_creates_one_session_per_persona_and_shares_reused_personas`).
- Adds a `joined_session` extraction test: a `JoinedSession` is produced only when
  the sequence persisted a community (so a cancel/failure never triggers a
  spurious registration).
- `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ and `--no-default-features` ✓ (0 failed suites).
- No dependency change (`Cargo.lock` untouched).

The full join → register → live-receipt path is network/integration and remains
covered by manual verification (consistent with the existing join tests).

Completes **T5** (PR-A #115 + this).
