### PR TITLE
feat(lifecycle): pending resolution, 7-day timeout, acknowledge + session deregistration (T6)

### DIFF
--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -13,9 +13,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use affinidi_tdk::{TDK, didcomm::Message};
 use dtg_credentials::DTGCredential;
 use serde_json::{Value, json};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
-use vta_sdk::protocols::join_requests::JoinRequestSubmitReceiptBody;
+use vta_sdk::protocols::join_requests::{
+    JoinRequestStatusResponseBody, JoinRequestSubmitReceiptBody,
+};
 
 use crate::config::Config;
 use crate::config::account::{Account, CommunityStatus};
@@ -217,6 +219,95 @@ pub fn handle_join_submit_receipt(
             "join submit-receipt did not match a pending join with that id — ignoring",
         );
         false
+    }
+}
+
+/// Outcome of applying a VTC `join-requests/status-response` to a community.
+pub struct StatusOutcome {
+    /// The community record changed and the config needs saving.
+    pub changed: bool,
+    /// The community transitioned to an inactive (read-only) status, so the
+    /// runtime must deregister its live session (R-S-3 / D15).
+    pub inactivated: bool,
+}
+
+impl StatusOutcome {
+    const NONE: StatusOutcome = StatusOutcome {
+        changed: false,
+        inactivated: false,
+    };
+}
+
+/// Apply a VTC `join-requests/status-response` to the matching Pending community
+/// (R-B-8). Correlated by the body's `request_id` against the Pending record's
+/// stored id, and gated on the sender being the community's own VTC (anti-spoof).
+/// Maps the protocol status onto the membership lifecycle:
+///
+/// - `approved` → `Active` (also reached via the issued VMC in
+///   [`handle_credential_issue`]; idempotent here).
+/// - `rejected` → `Rejected` (inactive — the caller deregisters the session).
+/// - `deferred` → stays `Pending` ("more info required"); the content handling
+///   (evaluating `needs` / presenting the DCQL) is a **D4 stub**, and a Pending
+///   record already raises actions-required (R-S-2).
+/// - `pending` / `withdrawn` / unknown → no transition (withdrawal is the
+///   member-initiated leave, owned by T7).
+pub fn handle_join_status_response(
+    account: &mut Account,
+    message: &Message,
+    from_did: &str,
+) -> StatusOutcome {
+    let body: JoinRequestStatusResponseBody = match serde_json::from_value(message.body.clone()) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "malformed join status-response body — ignoring");
+            return StatusOutcome::NONE;
+        }
+    };
+    let Some(record) = account.communities.get_mut(from_did) else {
+        warn!(vtc = %from_did, "status-response from an unknown community — ignoring");
+        return StatusOutcome::NONE;
+    };
+    // Correlate: only resolve a Pending record whose request id matches the reply.
+    let matches = matches!(
+        &record.status,
+        CommunityStatus::Pending { request_id } if *request_id == body.request_id
+    );
+    if !matches {
+        warn!(vtc = %from_did, "status-response did not match a pending request id — ignoring");
+        return StatusOutcome::NONE;
+    }
+
+    match body.status.as_str() {
+        "approved" => {
+            record.activate(chrono::Utc::now());
+            info!(vtc = %from_did, "join approved by VTC — now Active");
+            StatusOutcome {
+                changed: true,
+                inactivated: false,
+            }
+        }
+        "rejected" => {
+            record.reject();
+            info!(vtc = %from_did, "join rejected by VTC");
+            StatusOutcome {
+                changed: true,
+                inactivated: true,
+            }
+        }
+        "deferred" => {
+            // "More info required" — stays Pending (still raises actions-required);
+            // evaluating `needs` / presenting the DCQL is deferred to D4.
+            info!(
+                vtc = %from_did,
+                needs = ?body.needs,
+                "join deferred — more information required (handling deferred to D4)"
+            );
+            StatusOutcome::NONE
+        }
+        other => {
+            debug!(vtc = %from_did, status = %other, "status-response: no transition");
+            StatusOutcome::NONE
+        }
     }
 }
 
@@ -542,7 +633,9 @@ mod tests {
     use crate::config::account::{Account, CommunityRecord, PersonaId, PersonaRecord};
     use chrono::Utc;
     use vta_sdk::protocols::credential_exchange::ISSUE as CREDENTIAL_ISSUE_TYPE;
-    use vta_sdk::protocols::join_requests::JOIN_REQUEST_SUBMIT_RECEIPT_TYPE;
+    use vta_sdk::protocols::join_requests::{
+        JOIN_REQUEST_STATUS_RESPONSE_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
+    };
 
     fn pending_account(vtc: &str, placeholder: Uuid) -> Account {
         let mut acct = Account::default();
@@ -620,6 +713,106 @@ mod tests {
             CommunityStatus::Pending { request_id } => assert_eq!(*request_id, placeholder),
             other => panic!("expected unchanged Pending, got {other:?}"),
         }
+    }
+
+    // --- status-response lifecycle resolution (R-B-8) ---
+
+    fn status_response(from: &str, request_id: Uuid, status: &str) -> Message {
+        Message::build(
+            Uuid::new_v4().to_string(),
+            JOIN_REQUEST_STATUS_RESPONSE_TYPE.to_string(),
+            serde_json::json!({ "requestId": request_id, "status": status }),
+        )
+        .from(from.to_string())
+        .finalize()
+    }
+
+    #[test]
+    fn status_response_approved_activates() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out =
+            handle_join_status_response(&mut acct, &status_response(vtc, rid, "approved"), vtc);
+        assert!(out.changed);
+        assert!(!out.inactivated, "approval keeps the live session");
+        let rec = acct.communities.get(vtc).unwrap();
+        assert!(rec.status.is_active());
+        assert!(
+            rec.member_since.is_some(),
+            "member_since stamped on activate"
+        );
+    }
+
+    #[test]
+    fn status_response_rejected_inactivates_and_raises_badge() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out =
+            handle_join_status_response(&mut acct, &status_response(vtc, rid, "rejected"), vtc);
+        assert!(out.changed);
+        assert!(
+            out.inactivated,
+            "a rejection must deregister the session (R-S-3)"
+        );
+        let rec = acct.communities.get(vtc).unwrap();
+        assert!(matches!(rec.status, CommunityStatus::Rejected));
+        assert!(
+            rec.needs_attention(),
+            "an unacknowledged rejection nags (R-S-2)"
+        );
+    }
+
+    #[test]
+    fn status_response_deferred_stays_pending() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out =
+            handle_join_status_response(&mut acct, &status_response(vtc, rid, "deferred"), vtc);
+        assert!(
+            !out.changed,
+            "more-info handling is a D4 stub — stays Pending"
+        );
+        assert!(!out.inactivated);
+        assert!(matches!(
+            acct.communities.get(vtc).unwrap().status,
+            CommunityStatus::Pending { .. }
+        ));
+    }
+
+    #[test]
+    fn status_response_with_mismatched_request_id_is_ignored() {
+        let vtc = "did:webvh:example:vtc";
+        let mut acct = pending_account(vtc, Uuid::new_v4());
+
+        // A reply correlated to a different request id must not transition us.
+        let out = handle_join_status_response(
+            &mut acct,
+            &status_response(vtc, Uuid::new_v4(), "rejected"),
+            vtc,
+        );
+        assert!(!out.changed);
+        assert!(!out.inactivated);
+        assert!(matches!(
+            acct.communities.get(vtc).unwrap().status,
+            CommunityStatus::Pending { .. }
+        ));
+    }
+
+    #[test]
+    fn status_response_from_unknown_community_is_ignored() {
+        let mut acct = pending_account("did:webvh:example:vtc", Uuid::new_v4());
+        let out = handle_join_status_response(
+            &mut acct,
+            &status_response("did:webvh:example:other", Uuid::new_v4(), "approved"),
+            "did:webvh:example:other",
+        );
+        assert!(!out.changed);
     }
 
     // --- credential-issue outcome handling ---

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -276,6 +276,10 @@ pub enum Action {
     /// display index (R-C-4). Favourites sort to the top and the flag persists.
     ToggleFavourite(usize),
 
+    /// Acknowledge a terminal-outcome community (Rejected / Removed / Expired) at
+    /// this display index, clearing its actions-required badge (R-S-2).
+    AcknowledgeCommunity(usize),
+
     /// Open the quick community switcher overlay (R-C-7): a Ctrl+K popup listing
     /// the Active communities, reachable from anywhere on the main page.
     OpenCommunitySwitcher,

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -16,12 +16,12 @@ use affinidi_tdk::{TDK, didcomm::Message};
 use dtg_credentials::DTGCredential;
 use openvtc_core::messaging::{
     SeenMessages, check_message_age, check_task_capacity, create_finalize_message,
-    handle_credential_issue, handle_join_submit_receipt, require_thid, validate_did,
-    verify_vrc_proof, vet_vrc_issued,
+    handle_credential_issue, handle_join_status_response, handle_join_submit_receipt, require_thid,
+    validate_did, verify_vrc_proof, vet_vrc_issued,
 };
 use openvtc_core::{
     MessageType,
-    config::Config,
+    config::{Config, account::VtcDid},
     logs::LogFamily,
     relationships::{RelationshipAcceptBody, RelationshipRejectBody, RelationshipState},
     tasks::TaskType,
@@ -29,7 +29,9 @@ use openvtc_core::{
 };
 use tracing::{debug, info, warn};
 use vta_sdk::protocols::credential_exchange::ISSUE as CREDENTIAL_ISSUE_TYPE;
-use vta_sdk::protocols::join_requests::JOIN_REQUEST_SUBMIT_RECEIPT_TYPE;
+use vta_sdk::protocols::join_requests::{
+    JOIN_REQUEST_STATUS_RESPONSE_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
+};
 
 /// Maximum allowed message body size in bytes (1 MB).
 const MAX_MESSAGE_BODY_SIZE: usize = 1_048_576;
@@ -49,6 +51,7 @@ pub async fn process_inbound_message(
     service: &DIDCommService,
     seen: &mut SeenMessages,
     message: &Message,
+    inactivated: &mut Vec<VtcDid>,
 ) -> Result<bool, anyhow::Error> {
     // Drop messages outside the replay / freshness window before doing
     // any state-mutating work. Saves us from acting on stale captures
@@ -143,6 +146,18 @@ pub async fn process_inbound_message(
             message,
             &from_did,
         ));
+    }
+
+    // VTC join-requests status-response: the authoritative lifecycle resolution
+    // (approved / rejected / deferred) for a Pending join, correlated by
+    // `requestId` (R-B-8). A rejection inactivates the community, so report its
+    // VTC DID up so the loop deregisters the session (R-S-3).
+    if message.typ == JOIN_REQUEST_STATUS_RESPONSE_TYPE {
+        let outcome = handle_join_status_response(&mut config.account, message, &from_did);
+        if outcome.inactivated {
+            inactivated.push(from_did.to_string());
+        }
+        return Ok(outcome.changed);
     }
 
     let msg_type = match MessageType::try_from(message) {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -644,6 +644,11 @@ impl StateHandler {
         // matching the pre-R11 inline `save_config` failure handling.
         let (save_done_tx, mut save_done_rx) = mpsc::unbounded_channel::<Result<(), String>>();
 
+        // 7-day Pending timeout sweep (R-B-7 / D16). `interval`'s first tick fires
+        // immediately, so a Pending that aged out while the app was closed expires
+        // on launch; thereafter it sweeps hourly.
+        let mut pending_expiry_tick = tokio::time::interval(std::time::Duration::from_secs(3600));
+
         let result = loop {
             tokio::select! {
                 Some(action) = action_rx.recv() => match action {
@@ -759,6 +764,22 @@ impl StateHandler {
                                 state.main_page.content_panel.communities.selected_index =
                                     new_idx;
                             }
+                        }
+                    },
+                    Action::AcknowledgeCommunity(i) => {
+                        // R-S-2: clear the actions-required badge on a terminal
+                        // outcome (Rejected / Expired) the user has now seen.
+                        let vtc = config
+                            .account
+                            .communities_for_display(false)
+                            .get(i)
+                            .map(|c| c.vtc_did.clone());
+                        if let Some(vtc) = vtc
+                            && let Some(c) = config.account.community_mut(&vtc)
+                        {
+                            c.acknowledge();
+                            save.mark_dirty();
+                            state.main_page.sync_from_config(&config);
                         }
                     },
                     Action::OpenCommunitySwitcher => {
@@ -1094,12 +1115,14 @@ impl StateHandler {
                             let msg_to = message.to.as_ref().and_then(|v| v.first()).cloned().unwrap_or_default();
                             let msg_thid = message.thid.clone().unwrap_or_else(|| "none".into());
 
+                            let mut inactivated = Vec::new();
                             match message_dispatch::process_inbound_message(
                                 &mut config,
                                 &tdk,
                                 &didcomm_service,
                                 &mut seen_messages,
                                 &message,
+                                &mut inactivated,
                             )
                             .await
                             {
@@ -1111,6 +1134,20 @@ impl StateHandler {
                                     // mark dirty (coalesced + offloaded); the UI
                                     // sync stays immediate.
                                     save.mark_dirty();
+                                    // R-S-3: a community resolved to an inactive
+                                    // status (e.g. a rejection) — tear down its
+                                    // live session so a dead community stops
+                                    // holding a mediator connection.
+                                    for vtc in &inactivated {
+                                        deregister_inactive_community(
+                                            &mut session_manager,
+                                            &didcomm_service,
+                                            &config,
+                                            &mut state,
+                                            vtc,
+                                        )
+                                        .await;
+                                    }
                                     state.main_page.sync_from_config(&config);
                                     // Extract short type name for summary
                                     let short_type = msg_type.rsplit('/').next().unwrap_or(&msg_type);
@@ -1314,6 +1351,32 @@ impl StateHandler {
                 // loop stays responsive. At most one save is in flight; a mark
                 // that lands while a save runs is re-scheduled on completion.
                 // When nothing is scheduled the arm parks forever (no busy-wait).
+                _ = pending_expiry_tick.tick() => {
+                    // R-B-7: expire Pending joins unanswered for 7 days, raising
+                    // actions-required, and tear down each one's now-dead session
+                    // (R-S-3). Records are retained read-only (R-S-1).
+                    let expired = config.account.expire_stale_pending(chrono::Utc::now());
+                    if !expired.is_empty() {
+                        save.mark_dirty();
+                        for vtc in &expired {
+                            deregister_inactive_community(
+                                &mut session_manager,
+                                &didcomm_service,
+                                &config,
+                                &mut state,
+                                vtc,
+                            )
+                            .await;
+                        }
+                        state.main_page.sync_from_config(&config);
+                        state.main_page.log(format!(
+                            "{} pending join{} expired (no response within 7 days).",
+                            expired.len(),
+                            if expired.len() == 1 { "" } else { "s" },
+                        ));
+                        let _ = self.state_tx.send(state.clone());
+                    }
+                },
                 _ = save.wait_deadline() => {
                     match save.take_for_save(|| config.clone_for_save()) {
                         Ok(Ok(pending)) => {
@@ -1810,6 +1873,50 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
 /// proceeds under the listener's restart policy, and the `ListenerEvent::Connected`
 /// handler flips the session to `Connected`. Failures are non-fatal (a restart
 /// recovers the session) and surfaced to the activity log.
+/// Tear down a community's live session after it transitioned to an inactive
+/// status (rejected, expired) — the lifecycle twin of [`register_joined_session`]
+/// (R-S-3 / D15). Deregisters the session and, if its persona now serves no live
+/// community, stops + removes the persona's listener so a dead community stops
+/// holding a mediator connection. The community **record is retained** (R-S-1);
+/// only the live session is dropped. Also drops the global messaging indicator to
+/// `NoActiveCommunity` when the account has no live community left.
+async fn deregister_inactive_community(
+    session_manager: &mut session_manager::SessionManager,
+    service: &affinidi_messaging_didcomm_service::DIDCommService,
+    config: &Config,
+    state: &mut State,
+    vtc: &openvtc_core::config::account::VtcDid,
+) {
+    // The persona that served this (now-inactive but retained) community.
+    let Some(pid) = config.account.community(vtc).map(|c| c.persona_ref) else {
+        session_manager.deregister(vtc);
+        return;
+    };
+    let removed = session_manager.deregister(vtc);
+    let still_live = config
+        .account
+        .communities
+        .values()
+        .any(|c| c.persona_ref == pid && c.is_live());
+    if !still_live && let Some(did) = config.identities.get(&pid).map(|id| id.did.clone()) {
+        // Prefer the listener id the manager recorded; fall back to deriving it.
+        let listener_id = removed
+            .map(|s| s.listener_id)
+            .unwrap_or_else(|| didcomm::persona_listener_id(&did));
+        if let Err(e) = service.remove_listener(&listener_id).await {
+            debug!("remove_listener after community inactivation: {e}");
+        }
+        state
+            .main_page
+            .log("Community inactive — persona listener stopped.");
+    }
+    // Drop the global messaging indicator when no persona has a live community.
+    if !config.account.communities.values().any(|c| c.is_live()) {
+        state.connection.status = state::MediatorStatus::NoActiveCommunity;
+        state.connection.messaging_active = false;
+    }
+}
+
 async fn register_joined_session(
     session_manager: &mut session_manager::SessionManager,
     service: &affinidi_messaging_didcomm_service::DIDCommService,

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -146,8 +146,11 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         );
     } else {
         lines.push(
-            Line::from("↑/↓ navigate   j: join a community   d: remove selected")
-                .fg(COLOR_DARK_GRAY),
+            Line::from(
+                "↑/↓ navigate   ⏎ open   f: ★ favourite   a: acknowledge   \
+                 j: join a community   d: remove selected",
+            )
+            .fg(COLOR_DARK_GRAY),
         );
     }
 

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -436,6 +436,11 @@ impl MainPage {
                 let _ = self.action_tx.send(Action::ToggleFavourite(selected));
                 true
             }
+            KeyCode::Char('a') if selected < count => {
+                // Acknowledge a terminal outcome, clearing its badge (R-S-2).
+                let _ = self.action_tx.send(Action::AcknowledgeCommunity(selected));
+                true
+            }
             KeyCode::Char('d') | KeyCode::Delete if selected < count => {
                 let _ = self
                     .action_tx
@@ -2033,6 +2038,21 @@ mod key_handler_tests {
         match rx.try_recv() {
             Ok(Action::ToggleFavourite(1)) => {}
             _ => panic!("expected ToggleFavourite(1)"),
+        }
+    }
+
+    #[test]
+    fn communities_a_acknowledges_at_selection() {
+        // R-S-2: `a` on the Communities panel acknowledges the highlighted row.
+        let (mut page, mut rx) = page_for(MainMenu::Communities, |s| {
+            s.main_page.content_panel.communities.items =
+                vec![community_summary("a"), community_summary("b")].into();
+            s.main_page.content_panel.communities.selected_index = 1;
+        });
+        page.handle_key_event(press(KeyCode::Char('a')));
+        match rx.try_recv() {
+            Ok(Action::AcknowledgeCommunity(1)) => {}
+            _ => panic!("expected AcknowledgeCommunity(1)"),
         }
     }
 


### PR DESCRIPTION
## T6 — Community lifecycle: pending resolution, 7-day timeout, acknowledge, session deregistration

Wires up the community lifecycle state machine (R-B-7/8, R-S-1/2/3, D16). The
transition methods (`activate`/`reject`/`expire_if_stale`/`acknowledge`),
`expire_stale_pending`/`needs_attention`, and `SessionManager::deregister` all
existed and were tested, but were **unwired** — this connects them.

### Inbound resolution (R-B-8)
New core handler `handle_join_status_response`, routed on
`JOIN_REQUEST_STATUS_RESPONSE_TYPE` in `process_inbound_message`. Correlated by
`requestId`, anti-spoofed on the sender being the community's own VTC:

| status | transition |
|---|---|
| `approved` | → **Active** (stamps `member_since`; also reached via the VMC issue) |
| `rejected` | → **Rejected** (+ actions-required badge; inactivates the session) |
| `deferred` | stays **Pending** — "more info required"; the `needs`/DCQL content handling is a **D4 stub**, and a Pending record already nags |
| `pending` / `withdrawn` / unknown | no transition |

**Active→Removed is deferred:** vta-sdk 0.11 defines no VTC→client removal push
(only member-initiated `MEMBER_SELF_REMOVE`). `CommunityRecord::remove()` is kept
for when a protocol type lands.

### 7-day timeout (R-B-7)
An hourly `tokio::time::interval` arm in the runtime loop sweeps
`expire_stale_pending`. `interval`'s first tick is immediate, so a Pending that
aged out while the app was closed expires on launch. Expired raises the badge.

### Session deregistration on inactivation (R-S-3 / D15)
T1 explicitly deferred this. `process_inbound_message` now threads an
`inactivated: &mut Vec<VtcDid>`; the loop runs the new
`deregister_inactive_community` helper for each — it deregisters the session and
tears the persona's listener down when its last live community goes inactive (the
**record is retained**, R-S-1) and drops the global indicator to
`NoActiveCommunity` when nothing is live. The timeout sweep reuses it. The
user-delete path keeps its own inline teardown (it removes the record first, so
it can't resolve the persona afterwards).

### Acknowledge (R-S-2)
`Action::AcknowledgeCommunity` + an `a` key on the Communities panel + a loop
handler that calls `acknowledge()` and persists; the panel footer hint now lists
`f: ★ favourite` and `a: acknowledge`.

### Testing
- 5 `handle_join_status_response` tests: approved / rejected / deferred /
  mismatched request id / unknown community.
- `a`-key routing test (`AcknowledgeCommunity`).
- Transition / timeout / badge mechanics already covered in `account.rs`; session
  semantics (one-per-persona, shared reuse, bounded cap, isolation, deregister) in
  `session_manager` tests.
- `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ and `--no-default-features` ✓ (0 failed suites).
- No dependency change (`Cargo.lock` untouched).

The loop wiring (interval sweep + deregistration plumbing) is integration-level
and remains covered by manual verification; this PR unit-tests the pure handler +
the key routing.
