### PR TITLE
feat(community): leave (MEMBER_SELF_REMOVE), archive, inactive-only delete, read-only styling (T7)

### DIFF
--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -18,7 +18,9 @@ use affinidi_tdk::{
 use chrono::Utc;
 use serde_json::Value;
 use uuid::Uuid;
-use vta_sdk::protocols::join_requests::{JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitBody};
+use vta_sdk::protocols::join_requests::{
+    JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitBody, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
+};
 
 use crate::errors::OpenVTCError;
 
@@ -64,5 +66,42 @@ pub async fn submit_join_request(
     .finalize();
 
     crate::pack_and_send(atm, profile, &msg, persona_did, vtc_did, mediator_did).await?;
+    Ok(msg_id)
+}
+
+/// Send a member self-removal (`MEMBER_SELF_REMOVE`) to a VTC over DIDComm to
+/// leave the community (R-L-1). `member_did` is the persona presented to the
+/// community (the authcrypt sender authenticates it). `disposition` optionally
+/// requests how the VTC should treat the departing member's record (purge /
+/// tombstone / historical); `None` lets the VTC apply its default.
+///
+/// Returns the DIDComm message id — the thread root the VTC's
+/// `members/self-remove-receipt/1.0` reply references. The local membership is
+/// set to `Left` on send success; the receipt is advisory (logged if it
+/// arrives), so callers don't block on it.
+pub async fn submit_self_remove(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    member_did: &str,
+    vtc_did: &str,
+    mediator_did: &str,
+    disposition: Option<String>,
+) -> Result<Uuid, OpenVTCError> {
+    let body = serde_json::to_value(SelfRemoveBody { disposition })
+        .map_err(|e| OpenVTCError::Config(format!("self-remove body serialize: {e}")))?;
+
+    let msg_id = Uuid::new_v4();
+    let now = Utc::now().timestamp().max(0) as u64;
+    let msg = Message::build(
+        msg_id.to_string(),
+        MEMBER_SELF_REMOVE_TYPE.to_string(),
+        body,
+    )
+    .from(member_did.to_string())
+    .to(vtc_did.to_string())
+    .created_time(now)
+    .finalize();
+
+    crate::pack_and_send(atm, profile, &msg, member_did, vtc_did, mediator_did).await?;
     Ok(msg_id)
 }

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -280,6 +280,26 @@ pub enum Action {
     /// this display index, clearing its actions-required badge (R-S-2).
     AcknowledgeCommunity(usize),
 
+    /// Arm a leave confirmation for the Active community at this index (the panel
+    /// prompts y/n before sending the self-removal).
+    CommunityConfirmLeave(usize),
+
+    /// Dismiss a pending leave confirmation without leaving.
+    CommunityCancelLeave,
+
+    /// Leave the Active community at this index: send `MEMBER_SELF_REMOVE`, then
+    /// set it `Left` and deregister its session (R-L-1 / R-S-3). Only sent after
+    /// the user confirms.
+    LeaveCommunity(usize),
+
+    /// Archive the inactive community at this index (hide from the default list,
+    /// retain the record) (R-C-8).
+    ArchiveCommunity(usize),
+
+    /// Toggle whether archived communities are shown in the Communities list, so
+    /// archived records stay discoverable (R-C-8).
+    ToggleShowArchived,
+
     /// Open the quick community switcher overlay (R-C-7): a Ctrl+K popup listing
     /// the Active communities, reachable from anywhere on the main page.
     OpenCommunitySwitcher,

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -90,6 +90,12 @@ pub struct CommunitiesState {
     /// When `Some(index)`, a removal of that community is awaiting `y`/`n`
     /// confirmation (the panel shows a prompt and other keys are suppressed).
     pub confirm_delete: Option<usize>,
+    /// When `Some(index)`, leaving that community is awaiting `y`/`n`
+    /// confirmation (R-L-1).
+    pub confirm_leave: Option<usize>,
+    /// Whether archived communities are included in the list (R-C-8). Off by
+    /// default; toggled so archived records stay discoverable.
+    pub show_archived: bool,
 }
 
 /// Quick community-switcher overlay state (R-C-7). `Some` while the Ctrl+K popup
@@ -127,6 +133,15 @@ pub struct CommunitySummary {
     pub member_since: String,
     /// Whether the user has starred this community (R-C-4).
     pub favourite: bool,
+    /// Whether the membership is Active — the only state you can leave (R-L-1)
+    /// or set as the working context (R-C-6).
+    pub is_active: bool,
+    /// Whether the membership is inactive (Left/Rejected/Removed/Expired) — the
+    /// only states that can be archived or deleted, and rendered read-only (D14).
+    pub is_inactive: bool,
+    /// Whether this community is archived (R-C-8); only shown when "show archived"
+    /// is on, with a marker.
+    pub archived: bool,
     /// Whether this community raises the actions-required indicator (R-C-3).
     pub needs_attention: bool,
     /// Full persona `did:webvh` presented to this community (troubleshooting

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -406,7 +406,8 @@ impl MainPageState {
         // Sync the Communities overview (R-C-*): display order from the model,
         // archived excluded, with the actions-required count for the badge.
         let mut community_items = Vec::new();
-        for c in config.account.communities_for_display(false) {
+        let show_archived = self.content_panel.communities.show_archived;
+        for c in config.account.communities_for_display(show_archived) {
             let persona = config.account.personas.get(&c.persona_ref);
             let persona_label = persona
                 .and_then(|p| p.label.clone())
@@ -430,6 +431,9 @@ impl MainPageState {
                     .map(|d| d.format("%Y-%m-%d").to_string())
                     .unwrap_or_default(),
                 favourite: c.favourite,
+                is_active: c.status.is_active(),
+                is_inactive: c.status.is_inactive(),
+                archived: c.archived,
                 needs_attention: c.needs_attention(),
                 persona_did: persona.map(|p| p.did.clone()).unwrap_or_default(),
                 vtc_did: c.vtc_did.clone(),

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -679,7 +679,7 @@ impl StateHandler {
                         // up with no live community.
                         let target = config
                             .account
-                            .communities_for_display(false)
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .get(i)
                             .map(|c| (c.vtc_did.clone(), c.persona_ref));
                         self.remove_community(&mut state, &mut config, &mut save, i);
@@ -728,7 +728,7 @@ impl StateHandler {
                         // end the immutable account borrow before mutating config.
                         let target = config
                             .account
-                            .communities_for_display(false)
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .get(i)
                             .filter(|c| c.status.is_active())
                             .map(|c| (c.vtc_did.clone(), c.persona_ref));
@@ -746,7 +746,7 @@ impl StateHandler {
                         // as the list re-sorts (favourites float to the top).
                         let vtc = config
                             .account
-                            .communities_for_display(false)
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .get(i)
                             .map(|c| c.vtc_did.clone());
                         if let Some(vtc) = vtc {
@@ -757,7 +757,7 @@ impl StateHandler {
                             state.main_page.sync_from_config(&config);
                             if let Some(new_idx) = config
                                 .account
-                                .communities_for_display(false)
+                                .communities_for_display(state.main_page.content_panel.communities.show_archived)
                                 .iter()
                                 .position(|c| c.vtc_did == vtc)
                             {
@@ -771,7 +771,7 @@ impl StateHandler {
                         // outcome (Rejected / Expired) the user has now seen.
                         let vtc = config
                             .account
-                            .communities_for_display(false)
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .get(i)
                             .map(|c| c.vtc_did.clone());
                         if let Some(vtc) = vtc
@@ -782,13 +782,114 @@ impl StateHandler {
                             state.main_page.sync_from_config(&config);
                         }
                     },
+                    Action::LeaveCommunity(i) => {
+                        // R-L-1: send MEMBER_SELF_REMOVE, then set Left + deregister
+                        // the session on send success (the receipt is advisory).
+                        state.main_page.content_panel.communities.confirm_leave = None;
+                        let target = config
+                            .account
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
+                            .get(i)
+                            .filter(|c| c.status.is_active())
+                            .map(|c| (c.vtc_did.clone(), c.persona_ref));
+                        if let Some((vtc, persona_id)) = target {
+                            // Owned send inputs from the persona's runtime identity,
+                            // so no config borrow is held across the network await.
+                            let sender = config.identities.get(&persona_id).map(|id| {
+                                (
+                                    id.persona_did().to_string(),
+                                    id.profile().clone(),
+                                    id.mediator_did.clone().unwrap_or_default(),
+                                )
+                            });
+                            let send = match (sender, tdk.atm.as_ref()) {
+                                (Some((member_did, profile, mediator)), Some(atm)) => {
+                                    openvtc_core::join::submit_self_remove(
+                                        atm, &profile, &member_did, &vtc, &mediator, None,
+                                    )
+                                    .await
+                                }
+                                _ => Err(openvtc_core::errors::OpenVTCError::Config(
+                                    "Messaging unavailable — cannot leave right now.".into(),
+                                )),
+                            };
+                            match send {
+                                Ok(_) => {
+                                    if let Some(c) = config.account.community_mut(&vtc) {
+                                        c.leave();
+                                    }
+                                    save.mark_dirty();
+                                    deregister_inactive_community(
+                                        &mut session_manager,
+                                        &didcomm_service,
+                                        &config,
+                                        &mut state,
+                                        &vtc,
+                                    )
+                                    .await;
+                                    state.main_page.sync_from_config(&config);
+                                    state
+                                        .main_page
+                                        .content_panel
+                                        .communities
+                                        .status_message = Some("Left the community.".to_string());
+                                }
+                                Err(e) => {
+                                    state.main_page.log_error("Leave failed", &e);
+                                    state
+                                        .main_page
+                                        .content_panel
+                                        .communities
+                                        .status_message = Some(format!("Couldn't leave: {e}"));
+                                }
+                            }
+                        }
+                    },
+                    Action::ArchiveCommunity(i) => {
+                        // R-C-8: archive an inactive community (hide it, retain the
+                        // record). Guarded inactive-only by `archive_community`.
+                        let vtc = config
+                            .account
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
+                            .get(i)
+                            .map(|c| c.vtc_did.clone());
+                        if let Some(vtc) = vtc {
+                            match config.account.archive_community(&vtc) {
+                                Ok(()) => {
+                                    save.mark_dirty();
+                                    state.main_page.sync_from_config(&config);
+                                    state
+                                        .main_page
+                                        .content_panel
+                                        .communities
+                                        .status_message =
+                                        Some("Community archived.".to_string());
+                                }
+                                Err(e) => {
+                                    state
+                                        .main_page
+                                        .content_panel
+                                        .communities
+                                        .status_message =
+                                        Some(format!("Couldn't archive: {e}"));
+                                }
+                            }
+                        }
+                    },
+                    Action::ToggleShowArchived => {
+                        // R-C-8: flip archived visibility and rebuild the list so
+                        // archived records stay discoverable.
+                        let comms = &mut state.main_page.content_panel.communities;
+                        comms.show_archived = !comms.show_archived;
+                        state.main_page.sync_from_config(&config);
+                    },
                     Action::OpenCommunitySwitcher => {
                         // R-C-7: list the Active communities (the only switchable
                         // ones) in display order and preselect the current one.
                         let current = state.selected_community.clone();
                         let items: Vec<_> = config
                             .account
-                            .communities_for_display(false)
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .into_iter()
                             .filter(|c| c.status.is_active())
                             .map(|c| main_page::content::SwitcherItem {
@@ -1500,7 +1601,7 @@ impl StateHandler {
     ) {
         let Some(vtc) = config
             .account
-            .communities_for_display(false)
+            .communities_for_display(state.main_page.content_panel.communities.show_archived)
             .get(index)
             .map(|c| c.vtc_did.clone())
         else {
@@ -1508,11 +1609,10 @@ impl StateHandler {
         };
         // The confirmation is now resolved.
         state.main_page.content_panel.communities.confirm_delete = None;
-        if config.account.community(&vtc).is_some_and(|c| c.is_live())
-            && let Some(c) = config.account.community_mut(&vtc)
-        {
-            c.leave();
-        }
+        // Delete is inactive-only (R-C-8): an Active/Pending community must be
+        // left first (the `d` key is gated to inactive rows, and `delete_community`
+        // re-checks). We no longer silently `leave()` here — that conflated leave
+        // with delete and skipped the protocol self-removal.
         match config.account.delete_community(&vtc) {
             Ok(_) => {
                 // R11: coalesced save (was an inline `config.save`). The
@@ -1844,6 +1944,12 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
         Action::CommunityCancelDelete => {
             state.main_page.content_panel.communities.confirm_delete = None;
         }
+        Action::CommunityConfirmLeave(i) => {
+            state.main_page.content_panel.communities.confirm_leave = Some(*i);
+        }
+        Action::CommunityCancelLeave => {
+            state.main_page.content_panel.communities.confirm_leave = None;
+        }
         Action::CommunitySwitcherMove(i) => {
             if let Some(switcher) = state.main_page.switcher.as_mut() {
                 switcher.selected = (*i).min(switcher.items.len().saturating_sub(1));
@@ -2067,6 +2173,13 @@ mod tests {
                 },
             },
             Case {
+                name: "CommunityConfirmLeave arms the leave confirmation",
+                action: Action::CommunityConfirmLeave(1),
+                assert_fn: |s| {
+                    assert_eq!(s.main_page.content_panel.communities.confirm_leave, Some(1))
+                },
+            },
+            Case {
                 name: "DidConfirmDelete arms the VTA DID confirmation (degraded mode used to drop this)",
                 action: Action::DidConfirmDelete(1),
                 assert_fn: |s| {
@@ -2118,6 +2231,20 @@ mod tests {
         assert!(
             !handle_nav_action(&mut state, &Action::ToggleFavourite(0)),
             "ToggleFavourite mutates + persists config in the loop"
+        );
+        // T7 community-management arms also reach the loop (network send / config
+        // mutation / re-sync), not the pure reducer.
+        assert!(
+            !handle_nav_action(&mut state, &Action::LeaveCommunity(0)),
+            "LeaveCommunity sends MEMBER_SELF_REMOVE in the loop"
+        );
+        assert!(
+            !handle_nav_action(&mut state, &Action::ArchiveCommunity(0)),
+            "ArchiveCommunity mutates + persists config in the loop"
+        );
+        assert!(
+            !handle_nav_action(&mut state, &Action::ToggleShowArchived),
+            "ToggleShowArchived re-syncs from config in the loop"
         );
     }
 

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -68,6 +68,9 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         let prefix = if is_selected { "▸ " } else { "  " };
         let name_style = if is_selected {
             Style::new().fg(COLOR_SUCCESS).bold()
+        } else if c.is_inactive {
+            // Inactive communities are read-only (D14) — dimmed in the list.
+            Style::new().fg(COLOR_DARK_GRAY)
         } else {
             Style::new().fg(COLOR_TEXT_DEFAULT)
         };
@@ -89,6 +92,9 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         }
         if !c.member_since.is_empty() {
             detail.push_str(&format!("  ·  since {}", c.member_since));
+        }
+        if c.archived {
+            detail.push_str("  ·  archived");
         }
         let detail_style = if is_selected {
             Style::new().fg(COLOR_SOFT_PURPLE)
@@ -133,23 +139,42 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
     }
 
     lines.push(Line::from(""));
-    if let Some(idx) = state.confirm_delete {
-        let name = state
+    let confirm_name = |idx: usize| {
+        state
             .items
             .get(idx)
-            .map(|c| c.display_name.as_str())
-            .unwrap_or("this community");
+            .map(|c| c.display_name.clone())
+            .unwrap_or_else(|| "this community".to_string())
+    };
+    if let Some(idx) = state.confirm_delete {
         lines.push(
-            Line::from(format!("Remove “{name}”?   y: confirm    n: cancel"))
-                .fg(COLOR_ORANGE)
-                .bold(),
+            Line::from(format!(
+                "Delete “{}”?   y: confirm    n: cancel",
+                confirm_name(idx)
+            ))
+            .fg(COLOR_ORANGE)
+            .bold(),
+        );
+    } else if let Some(idx) = state.confirm_leave {
+        lines.push(
+            Line::from(format!(
+                "Leave “{}”? This sends a self-removal to the community.   y: confirm    n: cancel",
+                confirm_name(idx)
+            ))
+            .fg(COLOR_ORANGE)
+            .bold(),
         );
     } else {
+        let archived_hint = if state.show_archived {
+            "v: hide archived"
+        } else {
+            "v: show archived"
+        };
         lines.push(
-            Line::from(
-                "↑/↓ navigate   ⏎ open   f: ★ favourite   a: acknowledge   \
-                 j: join a community   d: remove selected",
-            )
+            Line::from(format!(
+                "↑/↓ navigate   ⏎ open   f: ★   a: acknowledge   l: leave   \
+                 x: archive   d: delete   j: join   {archived_hint}"
+            ))
             .fg(COLOR_DARK_GRAY),
         );
     }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -408,6 +408,22 @@ impl MainPage {
             }
             return true;
         }
+        // A leave confirmation is pending (R-L-1): same y/n gate.
+        if let Some(idx) = comms.confirm_leave {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    let _ = self.action_tx.send(Action::LeaveCommunity(idx));
+                }
+                _ => {
+                    let _ = self.action_tx.send(Action::CommunityCancelLeave);
+                }
+            }
+            return true;
+        }
+
+        // Status of the highlighted row gates which management keys apply.
+        let sel_active = comms.items.get(selected).is_some_and(|c| c.is_active);
+        let sel_inactive = comms.items.get(selected).is_some_and(|c| c.is_inactive);
 
         match key.code {
             KeyCode::Char('j') => {
@@ -441,7 +457,24 @@ impl MainPage {
                 let _ = self.action_tx.send(Action::AcknowledgeCommunity(selected));
                 true
             }
-            KeyCode::Char('d') | KeyCode::Delete if selected < count => {
+            KeyCode::Char('l') if sel_active => {
+                // Leave an Active community (R-L-1) — arm the y/n confirmation.
+                let _ = self.action_tx.send(Action::CommunityConfirmLeave(selected));
+                true
+            }
+            KeyCode::Char('x') if sel_inactive => {
+                // Archive an inactive community (R-C-8).
+                let _ = self.action_tx.send(Action::ArchiveCommunity(selected));
+                true
+            }
+            KeyCode::Char('v') => {
+                // Toggle whether archived communities are listed (R-C-8).
+                let _ = self.action_tx.send(Action::ToggleShowArchived);
+                true
+            }
+            // Delete is inactive-only (R-C-8): an Active community must be left
+            // first. Arming on Active would only fail downstream, so it's gated.
+            KeyCode::Char('d') | KeyCode::Delete if sel_inactive => {
                 let _ = self
                     .action_tx
                     .send(Action::CommunityConfirmDelete(selected));
@@ -1937,12 +1970,21 @@ mod key_handler_tests {
 
     /// A minimal Communities-panel summary row for key-routing tests.
     fn community_summary(name: &str) -> CommunitySummary {
+        community_summary_with(name, true, false)
+    }
+
+    /// A summary with explicit active/inactive status, for the leave/archive/
+    /// delete key-gating tests.
+    fn community_summary_with(name: &str, is_active: bool, is_inactive: bool) -> CommunitySummary {
         CommunitySummary {
             display_name: name.to_string(),
-            status_label: "Active".to_string(),
+            status_label: if is_active { "Active" } else { "Left" }.to_string(),
             persona_label: "persona".to_string(),
             member_since: String::new(),
             favourite: false,
+            is_active,
+            is_inactive,
+            archived: false,
             needs_attention: false,
             persona_did: "did:example:persona".to_string(),
             vtc_did: format!("did:example:{name}"),
@@ -2053,6 +2095,92 @@ mod key_handler_tests {
         match rx.try_recv() {
             Ok(Action::AcknowledgeCommunity(1)) => {}
             _ => panic!("expected AcknowledgeCommunity(1)"),
+        }
+    }
+
+    #[test]
+    fn communities_leave_archive_delete_are_status_gated() {
+        // Active row: `l` arms a leave; `d`/`x` do nothing (must leave first).
+        let active = || {
+            page_for(MainMenu::Communities, |s| {
+                s.main_page.content_panel.communities.items =
+                    vec![community_summary_with("a", true, false)].into();
+            })
+        };
+        let (mut page, mut rx) = active();
+        page.handle_key_event(press(KeyCode::Char('l')));
+        match rx.try_recv() {
+            Ok(Action::CommunityConfirmLeave(0)) => {}
+            _ => panic!("expected CommunityConfirmLeave(0)"),
+        }
+        let (mut page, mut rx) = active();
+        page.handle_key_event(press(KeyCode::Char('d')));
+        assert!(
+            rx.try_recv().is_err(),
+            "delete is gated off for Active rows"
+        );
+        let (mut page, mut rx) = active();
+        page.handle_key_event(press(KeyCode::Char('x')));
+        assert!(
+            rx.try_recv().is_err(),
+            "archive is gated off for Active rows"
+        );
+
+        // Inactive row: `x` archives, `d` arms delete; `l` does nothing.
+        let inactive = || {
+            page_for(MainMenu::Communities, |s| {
+                s.main_page.content_panel.communities.items =
+                    vec![community_summary_with("a", false, true)].into();
+            })
+        };
+        let (mut page, mut rx) = inactive();
+        page.handle_key_event(press(KeyCode::Char('x')));
+        match rx.try_recv() {
+            Ok(Action::ArchiveCommunity(0)) => {}
+            _ => panic!("expected ArchiveCommunity(0)"),
+        }
+        let (mut page, mut rx) = inactive();
+        page.handle_key_event(press(KeyCode::Char('d')));
+        match rx.try_recv() {
+            Ok(Action::CommunityConfirmDelete(0)) => {}
+            _ => panic!("expected CommunityConfirmDelete(0)"),
+        }
+        let (mut page, mut rx) = inactive();
+        page.handle_key_event(press(KeyCode::Char('l')));
+        assert!(
+            rx.try_recv().is_err(),
+            "leave is gated off for inactive rows"
+        );
+    }
+
+    #[test]
+    fn communities_leave_confirm_commits_and_cancels() {
+        let (mut page, mut rx) = page_for(MainMenu::Communities, |s| {
+            s.main_page.content_panel.communities.confirm_leave = Some(0);
+        });
+        page.handle_key_event(press(KeyCode::Char('y')));
+        match rx.try_recv() {
+            Ok(Action::LeaveCommunity(0)) => {}
+            _ => panic!("expected LeaveCommunity(0)"),
+        }
+
+        let (mut page, mut rx) = page_for(MainMenu::Communities, |s| {
+            s.main_page.content_panel.communities.confirm_leave = Some(0);
+        });
+        page.handle_key_event(press(KeyCode::Char('n')));
+        match rx.try_recv() {
+            Ok(Action::CommunityCancelLeave) => {}
+            _ => panic!("expected CommunityCancelLeave"),
+        }
+    }
+
+    #[test]
+    fn communities_v_toggles_show_archived() {
+        let (mut page, mut rx) = page_for(MainMenu::Communities, |_| {});
+        page.handle_key_event(press(KeyCode::Char('v')));
+        match rx.try_recv() {
+            Ok(Action::ToggleShowArchived) => {}
+            _ => panic!("expected ToggleShowArchived"),
         }
     }
 


### PR DESCRIPTION
## T7 — Leave / read-only / archive / delete

Community management for inactive memberships (R-L-1, R-C-8, R-S-1/3, D14). Single PR.

### Audit
Leave was **missing** (no `MEMBER_SELF_REMOVE` send — `leave()` only set local
state, and `d` silently leave-then-deleted an Active community); Archive was
**missing UI** (`archive_community` existed); Delete was inactive-guarded but
reachable on Active via the silent leave; read-only (D14) was already implied
(the working community can only ever be Active).

### Leave (R-L-1)
- New `openvtc_core::join::submit_self_remove` sends `MEMBER_SELF_REMOVE` (mirrors
  `submit_join_request`).
- `Action::LeaveCommunity` with a y/n confirmation + `l` key, **gated to Active
  rows**. The handler sends the self-removal via the persona's ATM profile/mediator
  and, **on send success**, sets the membership `Left` + deregisters its session
  (reusing T6's `deregister_inactive_community`) + saves. The VTC's
  `self-remove-receipt` is advisory (logged if it arrives) so leaving never stalls.
  The record is retained read-only (R-S-1).

### Delete fix (R-C-8)
`remove_community` no longer silently `leave()`s an Active community before
deleting. Delete is now genuinely **inactive-only**: `d` is gated to inactive rows
and `Account::delete_community` re-checks. Active communities must be left first.
The presented persona is retained even if orphaned (R-P-2).

### Archive (R-C-8)
- `Action::ArchiveCommunity` + `x` key (inactive rows) → `Account::archive_community`.
- `Action::ToggleShowArchived` + `v` key flips archived visibility and re-syncs,
  so archived records stay **discoverable** (else they'd be invisible and
  undeletable).
- Index→vtc mapping now uses `communities_for_display(show_archived)` everywhere,
  so the panel and the action handlers share one ordering basis when archived rows
  are shown.

### Read-only (D14)
Inactive rows are dimmed and archived rows marked in the panel. The working
community can only ever be Active (`SetActiveCommunity` + `reconcile_selected_community`
filter `is_active`), so an inactive community can never be the working context —
**read-only by construction**.

### Testing
- 6 panel key-routing tests: leave/archive/delete **status-gating** (Active → `l`
  only; inactive → `x`/`d` only), leave-confirm commit+cancel, show-archived toggle.
- Nav-reducer tests: confirm-leave arms the prompt; `Leave`/`Archive`/`ToggleShowArchived`
  are deferred to the loop (network / config mutation / re-sync).
- Archive/delete guards and `leave()` already covered in `account.rs`.
- `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ and `--no-default-features` ✓ (0 failed suites).
- No dependency change (`Cargo.lock` untouched).

The full send→Left→deregister path and the receipt are integration-level and
remain covered by manual verification; this PR unit-tests the key routing + the
pure reducer arms.
