### PR TITLE
feat(did-git-sign): select the signing community persona via env var / git config (T8)

### DIFF
--- a/did-git-sign/README.md
+++ b/did-git-sign/README.md
@@ -108,6 +108,27 @@ Check your configuration:
 did-git-sign status
 ```
 
+### Selecting which community persona signs
+
+With more than one provisioned persona, you can choose which one signs without
+re-running `init`. At sign time the signing key is resolved in this order:
+
+1. The `DID_GIT_SIGN_KEY` environment variable (per-invocation override).
+2. The `did-git-sign.key` per-repo git config setting.
+3. The `did_key_id` in the config file git points at (the `init` default).
+
+The value is the persona's `did:webvh:…#key-N`. It must have credentials stored
+in the keyring (i.e. you ran `init` for that persona); otherwise signing fails
+with a clear message rather than silently signing as a different persona.
+
+```bash
+# One commit as a specific persona:
+DID_GIT_SIGN_KEY=did:webvh:abc:example.com#key-1 git commit -m "…"
+
+# Pin a persona for this repository:
+git config did-git-sign.key did:webvh:abc:example.com#key-1
+```
+
 ## Security Model
 
 - **No key material on disk** — the VTA credential private key is stored in the

--- a/did-git-sign/src/sign.rs
+++ b/did-git-sign/src/sign.rs
@@ -4,9 +4,84 @@ use sha2::{Digest, Sha512};
 use std::io::Read;
 use std::path::Path;
 
-use crate::config::SigningConfig;
+use crate::config::{self, SigningConfig};
 use crate::policy;
 use crate::vta;
+
+/// Environment variable that selects which persona signs (R-G-1), as a
+/// per-invocation override. Its value is the persona's `did:webvh:…#key-N`.
+pub const SIGNING_KEY_ENV: &str = "DID_GIT_SIGN_KEY";
+
+/// Per-repo git config key that selects which persona signs (R-G-1):
+/// `git config did-git-sign.key did:webvh:…#key-N`.
+pub const SIGNING_KEY_GIT_CONFIG: &str = "did-git-sign.key";
+
+/// Where the effective signing-key selection came from (for clear diagnostics).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeySource {
+    /// The [`SIGNING_KEY_ENV`] environment variable.
+    Env,
+    /// The [`SIGNING_KEY_GIT_CONFIG`] per-repo git config setting.
+    GitConfig,
+    /// The `did_key_id` from the config file git passed via `-f`.
+    ConfigFile,
+}
+
+impl std::fmt::Display for KeySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            KeySource::Env => "the DID_GIT_SIGN_KEY environment variable",
+            KeySource::GitConfig => "git config did-git-sign.key",
+            KeySource::ConfigFile => "the did-git-sign config file",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Pure selection precedence (R-G-1): env var > per-repo git config > the config
+/// file's own `did_key_id`. Whitespace is trimmed and an empty value is treated
+/// as unset, so an exported-but-empty variable doesn't shadow the others.
+fn select_signing_key(
+    config_did: &str,
+    env: Option<&str>,
+    git: Option<&str>,
+) -> (String, KeySource) {
+    let clean = |v: Option<&str>| {
+        v.map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    if let Some(v) = clean(env) {
+        return (v, KeySource::Env);
+    }
+    if let Some(v) = clean(git) {
+        return (v, KeySource::GitConfig);
+    }
+    (config_did.to_string(), KeySource::ConfigFile)
+}
+
+/// Read the per-repo git config selector (`did-git-sign.key`), if set. Runs in
+/// the current directory — git sets the signer's cwd to the repo.
+fn git_config_signing_key() -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["config", "--get", SIGNING_KEY_GIT_CONFIG])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!v.is_empty()).then_some(v)
+}
+
+/// Resolve the effective signing `did_key_id` and where it came from (R-G-1),
+/// reading the env var and the per-repo git config around the pure
+/// [`select_signing_key`].
+fn resolve_signing_key(config_did: &str) -> (String, KeySource) {
+    let env = std::env::var(SIGNING_KEY_ENV).ok();
+    let git = git_config_signing_key();
+    select_signing_key(config_did, env.as_deref(), git.as_deref())
+}
 
 /// Magic preamble for SSH signatures (PROTOCOL.sshsig)
 const SSHSIG_MAGIC: &[u8; 6] = b"SSHSIG";
@@ -52,8 +127,27 @@ pub async fn handle_sign(
         );
     }
 
-    // Load config
+    // Load the config git pointed us at (`-f`).
     let cfg = SigningConfig::load(config_path)?;
+
+    // R-G-1: resolve which community persona signs — an env var or a per-repo
+    // git-config setting may override the config file's persona. R-G-2: when an
+    // override names a persona with no stored credentials, fail clearly rather
+    // than silently signing as an arbitrary (the config file's) persona.
+    let (did_key_id, source) = resolve_signing_key(&cfg.did_key_id);
+    if did_key_id != cfg.did_key_id && config::load_vta_credentials(&did_key_id).is_err() {
+        anyhow::bail!(
+            "did-git-sign: the signing persona '{did_key_id}' selected via {source} has no \
+             stored credentials. Run `did-git-sign init` for that persona, or clear the \
+             override ({} / `git config --unset {}`).",
+            SIGNING_KEY_ENV,
+            SIGNING_KEY_GIT_CONFIG,
+        );
+    }
+    let cfg = SigningConfig {
+        did_key_id,
+        user_name: cfg.user_name,
+    };
 
     // Authenticate with VTA and fetch signing key
     let (client, creds) = vta::authenticate(&cfg).await?;
@@ -206,6 +300,50 @@ fn base64_encode(data: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn signing_key_selection_precedence() {
+        // env wins over git config and the config file (R-G-1).
+        let (key, src) = select_signing_key("cfg#k", Some("env#k"), Some("git#k"));
+        assert_eq!(key, "env#k");
+        assert_eq!(src, KeySource::Env);
+
+        // git config wins over the config file when no env override.
+        let (key, src) = select_signing_key("cfg#k", None, Some("git#k"));
+        assert_eq!(key, "git#k");
+        assert_eq!(src, KeySource::GitConfig);
+
+        // Falls back to the config file's own did_key_id (back-compat).
+        let (key, src) = select_signing_key("cfg#k", None, None);
+        assert_eq!(key, "cfg#k");
+        assert_eq!(src, KeySource::ConfigFile);
+    }
+
+    #[test]
+    fn signing_key_selection_ignores_blank_overrides() {
+        // An exported-but-empty / whitespace var must not shadow lower precedence.
+        let (key, src) = select_signing_key("cfg#k", Some("   "), Some("git#k"));
+        assert_eq!(key, "git#k");
+        assert_eq!(src, KeySource::GitConfig);
+
+        let (key, src) = select_signing_key("cfg#k", Some(""), None);
+        assert_eq!(key, "cfg#k");
+        assert_eq!(src, KeySource::ConfigFile);
+
+        // A value is trimmed.
+        let (key, _) = select_signing_key("cfg#k", Some("  env#k \n"), None);
+        assert_eq!(key, "env#k");
+    }
+
+    #[test]
+    fn key_source_messages_name_the_origin() {
+        assert!(KeySource::Env.to_string().contains("DID_GIT_SIGN_KEY"));
+        assert!(
+            KeySource::GitConfig
+                .to_string()
+                .contains("did-git-sign.key")
+        );
+    }
 
     #[test]
     fn test_ssh_string_encoding() {


### PR DESCRIPTION
## T8 — did-git-sign: select the signing community persona (R-G-1, R-G-2, D17)

`did-git-sign` assumed a single persona — git invokes it with one fixed
`-f <config>` path written at `init`. This lets the user choose which provisioned
persona signs, without re-running `init`.

### Audit
`did-git-sign` is **standalone**: its own `SigningConfig { did_key_id }` plus
per-persona VTA credentials in the OS keyring (keyed by `did:webvh:…#key-N`). It
does **not** read the OpenVTC account, so "resolved against the account's
personas" means resolved against those keyring entries — no `openvtc-core`
dependency. Per the selector-form decision, selection is by `did:webvh:…#key-N`
(not a label registry).

### What this PR adds
At sign time the effective signing key is resolved with precedence:

1. `DID_GIT_SIGN_KEY` environment variable (per-invocation override)
2. `did-git-sign.key` per-repo git config setting
3. the `did_key_id` from the config file git passed via `-f` (unchanged default)

```bash
DID_GIT_SIGN_KEY=did:webvh:abc:example.com#key-1 git commit -m "…"
git config did-git-sign.key did:webvh:abc:example.com#key-1   # pin per-repo
```

**R-G-2:** when an override names a persona with no stored credentials, signing
**fails with a clear message** naming the persona and where the selection came
from, rather than silently signing as the config-file persona. With no override,
behaviour is unchanged (back-compatible).

The selection is a pure `select_signing_key` (env > git > config-file) with a
`KeySource` for diagnostics; the env + git-config reads wrap it. The README
documents the selector.

### Testing
- `select_signing_key` precedence; blank/whitespace overrides ignored; value
  trimmed; `KeySource` messages name their origin.
- The git-config read + keyring lookup are I/O, covered by manual verification.
- `cargo fmt --all --check` ✓, `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` ✓ and `--no-default-features` ✓ (0 failed suites).
- No dependency change (`Cargo.lock` untouched).
