### PR TITLE
test(bootstrap): persona did:webvh mint e2e + adopt MockVta ACL helper (T9 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8931,7 +8931,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vta-cli-common"
 version = "0.9.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f#6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -8948,7 +8948,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
- "vta-sdk 0.12.0 (git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f)",
+ "vta-sdk 0.12.0 (git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c)",
  "x25519-dalek",
 ]
 
@@ -9023,7 +9023,7 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.12.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f#6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9058,8 +9058,8 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.2"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f#6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f"
+version = "0.9.4"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9122,7 +9122,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.12.0 (git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f)",
+ "vta-sdk 0.12.0 (git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c)",
  "vti-common",
  "vti-webauthn",
  "webauthn-rs",
@@ -9134,7 +9134,7 @@ dependencies = [
 [[package]]
 name = "vti-common"
 version = "0.10.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f#6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -9162,7 +9162,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "vta-sdk 0.12.0 (git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f)",
+ "vta-sdk 0.12.0 (git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c)",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "vti-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f#6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -76,7 +76,7 @@ affinidi-messaging-didcomm-service = { workspace = true }
 # consumed as a git dev-dependency (the VTI git source is allow-listed in
 # deny.toml). Pinned to a commit on `origin/main` carrying vta-sdk 0.12.0 +
 # `provision_admin_rotated_via_rest` + the `MockVta::start_provisionable` seams.
-vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "6a9d2e1a8fb86f928c2ee29920485ae2fde0c60f", version = "0.9", default-features = false, features = ["test-support", "rest", "didcomm"] }
+vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "82097382702a88cc86f2268a1a37068027d9831c", version = "0.9", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc-core/tests/mockvta_bootstrap_e2e.rs
+++ b/openvtc-core/tests/mockvta_bootstrap_e2e.rs
@@ -11,19 +11,20 @@
 //! Scenarios:
 //!
 //!   * `admin_rotation_provisions_against_mock_vta` — the State-A admin
-//!     rotation: an ephemeral setup `did:key` (authorized in the ACL, the
-//!     `pnm acl create` step) drives `provision_admin_rotated_via_rest`, which
-//!     returns a freshly-minted long-term admin DID + key (not the setup pair).
+//!     rotation: an ephemeral setup `did:key` (authorized in the ACL via
+//!     `grant_super_admin`, the `pnm acl create` step) drives
+//!     `provision_admin_rotated_via_rest`, which returns a freshly-minted
+//!     long-term admin DID + key (not the setup pair).
 //!   * `bootstrap_creates_top_context_and_lists_webvh_server` — the rest of the
 //!     State-A VTA surface: an authenticated client creates the account's
-//!     top-level context and sees a seeded webvh hosting server in the
-//!     catalogue (the prerequisite a later persona `did:webvh` mint resolves).
+//!     top-level context and sees a seeded webvh hosting server in the catalogue.
+//!   * `persona_did_webvh_mint_round_trips` — the State-B persona mint: against a
+//!     `MockVta::start_with_webvh_host` (an in-process stub webvh host + a
+//!     resolvable server DID), `create_did_webvh` mints a server-managed
+//!     `did:webvh` persona.
 //!
 //! The DIDComm join-request submission + lifecycle resolution that follow
-//! bootstrap are pure-mediator and covered in `join_lifecycle_e2e.rs`. The
-//! persona `did:webvh` mint itself (`create_key` → `create_did_webvh`) is not
-//! yet exercised here — `MockVta` has no webvh hosting backend, so the publish
-//! 500s; tracked as VTI#431 (and the ACL ergonomics as VTI#429).
+//! bootstrap are pure-mediator and covered in `join_lifecycle_e2e.rs`.
 //!
 //! All `#[ignore]`'d: spinning up the provisionable VTA + the provision
 //! round-trip is slow. CI's coverage job runs them via `--include-ignored`.
@@ -31,26 +32,12 @@
 //! NOTE: depends on the `vta-service` git dev-dependency (the VTA server crate
 //! is not on crates.io); its git source is allow-listed in `deny.toml`.
 
-use vta_sdk::client::{CreateContextRequest, VtaClient};
+use vta_sdk::client::{CreateContextRequest, CreateDidWebvhRequest, VtaClient};
+use vta_sdk::protocols::did_management::create::WebvhPathMode;
 use vta_sdk::provision_client::{
     EphemeralSetupKey, ProvisionAsk, provision_admin_rotated_via_rest,
 };
-use vta_service::acl::{AclEntry, Role};
 use vta_service::test_support::MockVta;
-
-/// Authorize `did` as super-admin in the mock's ACL — the `pnm acl create`
-/// step the real bootstrap performs before the setup DID can provision. (An
-/// ergonomic `MockVta` helper for this is requested in VTI#429; until then we
-/// seed the entry through the public keyspace API, mirroring vta-service's own
-/// `url_direct_admin_rotation_round_trips_against_rest_only_mock` test.)
-async fn authorize_super_admin(mock: &MockVta, did: &str) {
-    let entry = AclEntry::new(did, Role::Admin, "openvtc-e2e").with_contexts(vec![]);
-    mock.ctx
-        .acl_ks
-        .insert(format!("acl:{did}"), &entry)
-        .await
-        .expect("seed super-admin acl");
-}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "slow: spins up a provisionable VTA + URL-direct admin-rotation round-trip"]
@@ -62,7 +49,9 @@ async fn admin_rotation_provisions_against_mock_vta() {
     );
 
     let setup = EphemeralSetupKey::generate().expect("generate setup key");
-    authorize_super_admin(&mock, &setup.did).await;
+    // Authorize the ephemeral setup did:key as super-admin (the `pnm acl create`
+    // step) so the provision gate accepts it — VTI#429's ergonomic seam.
+    mock.grant_super_admin(&setup.did).await;
 
     // URL-direct: REST to base_url() with the configured vta_did, no DID→URL
     // resolution — the seam OpenVTC's bootstrap takes when OPENVTC_VTA_URL is set.
@@ -136,6 +125,62 @@ async fn bootstrap_creates_top_context_and_lists_webvh_server() {
         "seeded webvh server must appear in the catalogue, got {:?}",
         servers.servers
     );
+
+    mock.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "slow: spins up a provisionable VTA + an in-process stub webvh host"]
+async fn persona_did_webvh_mint_round_trips() {
+    // `start_with_webvh_host` stands up an in-process stub webvh host and
+    // registers a resolvable server DID under `WEBVH_SERVER_ID`, so a
+    // server-managed mint publishes and resolves entirely in-process (VTI#431).
+    let mock = MockVta::start_with_webvh_host().await;
+
+    let token = mock
+        .ctx
+        .mint_token("did:key:z6MkOpenVtcMintAdmin", "admin", vec![])
+        .await;
+    let client = VtaClient::new(mock.base_url());
+    client.set_token_async(token).await;
+
+    // State-B: mint the persona did:webvh against the hosting server.
+    let minted = client
+        .create_did_webvh(CreateDidWebvhRequest {
+            context_id: "ctx1".to_string(),
+            server_id: Some(MockVta::WEBVH_SERVER_ID.to_string()),
+            url: None,
+            path: None,
+            path_mode: Some(WebvhPathMode::AutoAssign),
+            domain: None,
+            label: None,
+            portable: false,
+            add_mediator_service: false,
+            additional_services: None,
+            pre_rotation_count: 0,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: Default::default(),
+        })
+        .await
+        .expect("create_did_webvh round-trips against the stub host");
+
+    assert!(
+        minted.did.starts_with("did:webvh:"),
+        "expected a minted did:webvh, got {}",
+        minted.did
+    );
+    assert_eq!(
+        minted.server_id.as_deref(),
+        Some(MockVta::WEBVH_SERVER_ID),
+        "result records the server the persona was minted against"
+    );
+    assert!(!minted.scid.is_empty(), "minted DID must carry an SCID");
 
     mock.shutdown().await;
 }


### PR DESCRIPTION
Follow-up to #120/#121 that closes the loop on T9 now that the two deferred VTI
issues landed: **VTI#429** (ergonomic `MockVta` ACL-authorize seam) and
**VTI#431** (`create_did_webvh` round-trip via an in-process stub webvh host).

## Changes

- **Adopt `MockVta::grant_super_admin`** (#429) in place of the raw
  `acl_ks.insert(format!("acl:{did}"), …)` stopgap — removes the hand-rolled
  `authorize_super_admin` helper and the `vta_service::acl` import.
- **Add `persona_did_webvh_mint_round_trips`** (`#[ignore]`d): against
  `MockVta::start_with_webvh_host` (an in-process stub webvh host + a resolvable
  server DID registered under `WEBVH_SERVER_ID`), `create_did_webvh` mints a
  server-managed `did:webvh` persona — the **State-B mint** that previously 500'd
  for want of a hosting backend (#431). Asserts a minted `did:webvh` + server id
  + SCID.
- Bump the `vta-service` git dev-dep to the #433 tip (0.9.4; the `"0.9"` +
  version-pin are unchanged, so `cargo deny` stays green).

With this, the MockVta harness covers **State-A bootstrap (provision +
`create_context`) → State-B persona mint**, alongside the mediator join/lifecycle
from #120 — the full bootstrap→join→mint surface against real harnesses.

## Gate
- `cargo fmt`; `clippy -p openvtc-core --tests -D warnings` — clean.
- `cargo test --workspace` — green (the e2e is `#[ignore]`d).
- The 3 ignored bootstrap e2e pass over MockVta (admin rotation, create_context
  + webvh server, **persona did:webvh mint**).
- `cargo deny check` — green (advisories/bans/licenses/sources).
