### PR TITLE
feat(core): fuzzing hooks — config re-export, decrypt/parse split, key-injected VRC verify (#124)

### DIFF
--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -38,6 +38,11 @@ pub mod public_config;
 pub mod saving;
 pub mod secured_config;
 
+// Convenience re-export so the plaintext config model is reachable as
+// `openvtc_core::config::PublicConfig` (it derives `Deserialize`; a clean
+// parse surface for fuzzing / external consumers).
+pub use public_config::PublicConfig;
+
 /// Derives a 32-byte key from a user-provided passphrase using Argon2id.
 ///
 /// Uses Argon2id (RFC 9106) with a domain-specific salt derived from `info`.

--- a/openvtc-core/src/config/protected_config.rs
+++ b/openvtc-core/src/config/protected_config.rs
@@ -286,7 +286,15 @@ impl ProtectedConfig {
             &bytes,
         )?;
 
-        Ok(serde_json::from_slice(&bytes)?)
+        Self::parse(&bytes)
+    }
+
+    /// Deserialize a [`ProtectedConfig`] from already-decrypted plaintext JSON —
+    /// the post-decrypt half of [`load`](Self::load), split out so the
+    /// deserializer can be exercised directly (e.g. by fuzz harnesses) without a
+    /// keyring or real keys.
+    pub fn parse(plaintext: &[u8]) -> Result<ProtectedConfig, OpenVTCError> {
+        Ok(serde_json::from_slice(plaintext)?)
     }
 
     pub fn get_seed(
@@ -356,6 +364,15 @@ impl ProtectedConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_accepts_plaintext_json_and_rejects_garbage() {
+        // `parse` is the post-decrypt serde half of `load` — no keyring needed.
+        let bytes = serde_json::to_vec(&ProtectedConfig::default()).unwrap();
+        assert!(ProtectedConfig::parse(&bytes).is_ok());
+        assert!(ProtectedConfig::parse(b"not json at all").is_err());
+        assert!(ProtectedConfig::parse(&[]).is_err());
+    }
 
     fn test_seed() -> SecretBox<Vec<u8>> {
         SecretBox::new(Box::new(vec![42u8; 32]))

--- a/openvtc-core/src/config/secured_config.rs
+++ b/openvtc-core/src/config/secured_config.rs
@@ -443,6 +443,43 @@ impl SecuredConfig {
         Ok(())
     }
 
+    /// Deserialize the stored `SecuredConfig` wire blob from raw bytes — the
+    /// serde half of [`load`](Self::load), split out so the deserializer can be
+    /// exercised directly (e.g. by a fuzz harness) with no OS keyring. Tries the
+    /// current tagged format, then the legacy untagged shape (with `bool` =
+    /// "needs migration"); errors only if neither parses. No key material is
+    /// touched — that happens later in [`load`] under `unlock`.
+    fn parse_format(secret: &[u8]) -> Result<(SecuredConfigFormat, bool), OpenVTCError> {
+        match serde_json::from_slice::<SecuredConfigFormat>(secret) {
+            Ok(format) => Ok((format, false)),
+            Err(tagged_err) => match serde_json::from_slice::<LegacySecuredConfigFormat>(secret) {
+                Ok(legacy) => {
+                    warn!(
+                        "Tagged SecuredConfig parse failed ({tagged_err}); migrating legacy untagged blob"
+                    );
+                    Ok((SecuredConfigFormat::from(legacy), true))
+                }
+                Err(legacy_err) => {
+                    error!(
+                        "Format of SecuredConfig in OS Secure store is invalid! \
+                         Tagged: {tagged_err}; legacy: {legacy_err}"
+                    );
+                    Err(OpenVTCError::Config(format!(
+                        "Couldn't load openvtc secured configuration. Reason: {tagged_err}"
+                    )))
+                }
+            },
+        }
+    }
+
+    /// Parse-check the stored `SecuredConfig` wire blob (tagged or legacy) from
+    /// raw bytes, without an OS keyring. `Ok(())` if it deserializes into either
+    /// format; the encrypted key material is not decrypted. Exposed for fuzzing
+    /// the deserialization surface directly.
+    pub fn parse(bytes: &[u8]) -> Result<(), OpenVTCError> {
+        Self::parse_format(bytes).map(|_| ())
+    }
+
     /// Loads secret info from the OS Secure Store
     /// token: Hardware token identifier if being used
     /// unlock: Use a Password/PIN to unlock secret storage if no hardware token
@@ -471,34 +508,10 @@ impl SecuredConfig {
             }
         };
 
-        // Try the current tagged format first. If parsing fails, fall back to
-        // the legacy untagged shape and flag the blob for migration. Anything
-        // that fails both is genuinely invalid.
-        let (raw_secured_config, needs_migration) = match serde_json::from_slice::<
-            SecuredConfigFormat,
-        >(secret.as_slice())
-        {
-            Ok(format) => (format, false),
-            Err(tagged_err) => {
-                match serde_json::from_slice::<LegacySecuredConfigFormat>(secret.as_slice()) {
-                    Ok(legacy) => {
-                        warn!(
-                            "Tagged SecuredConfig parse failed ({tagged_err}); migrating legacy untagged blob"
-                        );
-                        (SecuredConfigFormat::from(legacy), true)
-                    }
-                    Err(legacy_err) => {
-                        error!(
-                            "Format of SecuredConfig in OS Secure store is invalid! \
-                             Tagged: {tagged_err}; legacy: {legacy_err}"
-                        );
-                        return Err(OpenVTCError::Config(format!(
-                            "Couldn't load openvtc secured configuration. Reason: {tagged_err}"
-                        )));
-                    }
-                }
-            }
-        };
+        // Try the current tagged format first, falling back to the legacy
+        // untagged shape (flagged for migration). Anything that fails both is
+        // genuinely invalid.
+        let (raw_secured_config, needs_migration) = Self::parse_format(secret.as_slice())?;
 
         // Layer-2 downgrade defence: cross-check the stored variant against
         // the caller's credentials before any decryption or re-save.
@@ -746,6 +759,17 @@ pub fn passphrase_decrypt(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_accepts_tagged_blob_and_rejects_garbage() {
+        // `parse` exercises the stored-blob deserializer (tagged or legacy)
+        // without an OS keyring — the seam fuzz harnesses drive.
+        let bytes =
+            serde_json::to_vec(&SecuredConfigFormat::PlainText { text: "p".into() }).unwrap();
+        assert!(SecuredConfig::parse(&bytes).is_ok());
+        assert!(SecuredConfig::parse(b"{ not valid json").is_err());
+        assert!(SecuredConfig::parse(&[]).is_err());
+    }
 
     // ── Tagged-format downgrade defence ───────────────────────────────────────
 

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -456,10 +456,43 @@ pub fn vet_vrc_issued(
 /// public key is then resolved from the issuer's DID Document via the TDK
 /// resolver and the proof verified over the proof-stripped credential.
 pub async fn verify_vrc_proof(tdk: &TDK, vrc: &DTGCredential) -> Result<(), String> {
+    let proof = check_vrc_issuer_binding(vrc)?;
+
+    // `verify_data` expects the signed document with the proof stripped.
+    let mut unsigned = vrc.clone();
+    unsigned.credential_mut().proof = None;
+
+    tdk.verify_data(&unsigned, None, &proof)
+        .await
+        .map_err(|e| format!("proof verification failed: {e}"))?;
+    Ok(())
+}
+
+/// Verify a VRC's data-integrity proof against an **explicitly supplied** issuer
+/// verifying key (raw public-key bytes), with no live [`TDK`] / DID resolution
+/// and no network. Applies the same issuer ⇄ verification-method binding check
+/// as [`verify_vrc_proof`], then verifies the proof via `dtg-credentials`'
+/// key-based path. Lets callers (and fuzz harnesses) drive the proof verifier
+/// directly by injecting the key instead of resolving it from the issuer DID.
+pub fn verify_vrc_proof_with_key(
+    vrc: &DTGCredential,
+    public_key_bytes: &[u8],
+) -> Result<(), String> {
+    check_vrc_issuer_binding(vrc)?;
+    vrc.verify_proof_with_public_key(public_key_bytes)
+        .map_err(|e| format!("proof verification failed: {e}"))
+}
+
+/// Shared guard for the VRC proof verifiers: the credential must carry a
+/// data-integrity proof and its `verification_method` must belong to the named
+/// issuer (no "issuer signs with their own key over a credential naming someone
+/// else"). Returns the proof on success.
+fn check_vrc_issuer_binding(
+    vrc: &DTGCredential,
+) -> Result<affinidi_data_integrity::DataIntegrityProof, String> {
     let Some(proof) = vrc.credential().proof.clone() else {
         return Err("credential has no data-integrity proof".to_string());
     };
-
     let vm_did = proof
         .verification_method
         .split_once('#')
@@ -471,15 +504,7 @@ pub async fn verify_vrc_proof(tdk: &TDK, vrc: &DTGCredential) -> Result<(), Stri
             vrc.issuer()
         ));
     }
-
-    // `verify_data` expects the signed document with the proof stripped.
-    let mut unsigned = vrc.clone();
-    unsigned.credential_mut().proof = None;
-
-    tdk.verify_data(&unsigned, None, &proof)
-        .await
-        .map_err(|e| format!("proof verification failed: {e}"))?;
-    Ok(())
+    Ok(proof)
 }
 
 /// Extract the thread ID (`thid`) from a message, returning an error if missing.
@@ -1222,5 +1247,35 @@ mod tests {
         let tdk = test_tdk().await;
         let vrc = unsigned_vrc("did:webvh:example:issuer");
         assert!(verify_vrc_proof(&tdk, &vrc).await.is_err());
+    }
+
+    /// Raw Ed25519 public-key bytes embedded in a `did:key` (multibase
+    /// `z`-base58btc of `0xed01 || pubkey`; strip the 2-byte multicodec prefix).
+    fn did_key_pubkey_bytes(did_key: &str) -> Vec<u8> {
+        let mb = did_key.strip_prefix("did:key:").expect("did:key prefix");
+        let (_base, decoded) = multibase::decode(mb).expect("multibase decode");
+        decoded[2..].to_vec()
+    }
+
+    #[tokio::test]
+    async fn vrc_proof_with_key_accepts_matching_key_rejects_others() {
+        let (issuer_did, issuer_secret) =
+            DID::generate_did_key(KeyType::Ed25519).expect("did:key generates");
+        let mut vrc = unsigned_vrc(&issuer_did);
+        vrc.sign(&issuer_secret, None).await.expect("signs");
+
+        // The injected issuer key verifies — no TDK / DID resolution involved.
+        assert!(verify_vrc_proof_with_key(&vrc, &did_key_pubkey_bytes(&issuer_did)).is_ok());
+
+        // A different key must not verify the same proof.
+        let (other_did, _) = DID::generate_did_key(KeyType::Ed25519).expect("did:key generates");
+        assert!(verify_vrc_proof_with_key(&vrc, &did_key_pubkey_bytes(&other_did)).is_err());
+    }
+
+    #[test]
+    fn vrc_proof_with_key_rejects_unsigned() {
+        // The issuer-binding guard fires before any key verification.
+        let vrc = unsigned_vrc("did:webvh:example:issuer");
+        assert!(verify_vrc_proof_with_key(&vrc, &[0u8; 32]).is_err());
     }
 }


### PR DESCRIPTION
Lands the self-contained `openvtc-core` seams the cargo-fuzz harnesses in #124
need, without the fuzz workspace itself. Per the review on #124.

## What's here (issue #124 items 2–4)

**Item 2 — `pub` validators.** Mostly already true: `MessageType: TryFrom<&str>`,
`CredentialKind::from_credential`, and `messaging::validate_did` are **already
`pub`** (the issue's worry that `validate_did` "may be private" was unfounded).
Net change: re-export `PublicConfig` so the requested path
`openvtc_core::config::PublicConfig` works (it was only at `config::public_config`).

**Item 3 — split decrypt from parse.**
- `ProtectedConfig::parse(&[u8])` — the post-decrypt serde half of `load`.
- `SecuredConfig::parse(&[u8])` — parse-checks the stored wire blob (tagged or
  legacy) without unlocking.
Both reachable with no OS keyring; `load` routes through them so behaviour is
unchanged.

**Item 4 — `verify_vrc_proof` without a live TDK.** New
`verify_vrc_proof_with_key(vrc, &public_key_bytes)` verifies the proof against an
injected issuer key (no TDK / DID resolution), sharing the
issuer⇄verification-method binding guard with the TDK path via a new
`check_vrc_issuer_binding` helper. Uses dtg-credentials'
`verify_proof_with_public_key` (its `affinidi-signing` feature is default-on — no
dep change).

## Tests
- `ProtectedConfig::parse` / `SecuredConfig::parse`: accept valid, reject garbage/empty.
- `verify_vrc_proof_with_key`: accepts the matching issuer key, rejects a
  different key, rejects unsigned (binding guard).

## Not included (deliberately)
- **Item 5** (`fuzz/` workspace + `#[derive(Arbitrary)]`) — the fuzz team's
  contribution per the issue; left to them. Happy to feature-gate `Arbitrary` if
  wanted.
- **Item 1's `parsing` feature** — `--no-default-features` reachability already
  holds (it's in the CI gate); gating out the *network* deps would be a large
  refactor (they're non-optional). The issue's "drops network deps" framing is
  noted on the issue.

## Gate
`cargo fmt`; `clippy --workspace --all-targets -D warnings` (+ `openvtc-core
--no-default-features`); `cargo test --workspace` — all green. No dependency
change (`Cargo.lock` untouched).