### PR TITLE
feat(core): feature-gated Arbitrary derives on parse-surface types (#124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,13 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
       - run: cargo test --workspace --no-default-features
+      # Guard the structure-aware fuzzing seam (issue #124): the cargo-fuzz
+      # harnesses build openvtc-core with `--no-default-features --features
+      # arbitrary`, so check that exact shape and run the Arbitrary seam test.
+      - name: Fuzz-shape build + Arbitrary derive seam
+        run: |
+          cargo check -p openvtc-core --no-default-features --features arbitrary
+          cargo test -p openvtc-core --features arbitrary --lib
 
   doc:
     name: Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1558,7 @@ version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
+ "arbitrary",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -2297,6 +2307,17 @@ name = "derivation-path"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "derive_builder"
@@ -5441,6 +5462,7 @@ dependencies = [
  "affinidi-messaging-test-mediator",
  "affinidi-tdk",
  "anyhow",
+ "arbitrary",
  "argon2",
  "base64 0.22.1",
  "bip39",
@@ -6111,7 +6133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ affinidi-tdk = "0.7"
 affinidi-data-integrity = "0.7"
 affinidi-messaging-didcomm-service = "0.3"
 anyhow = "1.0"
+# Structure-aware fuzzing support (issue #124). Only pulled in when a crate
+# enables its own `arbitrary` feature; the `derive` feature provides the
+# `#[derive(arbitrary::Arbitrary)]` proc-macro.
+arbitrary = { version = "1", features = ["derive"] }
 arboard = { version = "3.6.1", features = ["wayland-data-control"] }
 base64 = "0.22"
 bip39 = "2.2"

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -17,10 +17,16 @@ openpgp-card = [
   "dep:card-backend-pcsc",
   "dep:openpgp-card-rpgp",
 ]
+# Derives `Arbitrary` on the pure parse-surface config/message/credential
+# types so the cargo-fuzz harnesses can do structure-aware fuzzing
+# (issue #124). Off by default; nightly fuzz builds opt in. Pulls chrono's
+# own `arbitrary` feature for the `LogMessage` timestamp.
+arbitrary = ["dep:arbitrary", "chrono/arbitrary"]
 
 [dependencies]
 aes-gcm.workspace = true
 anyhow.workspace = true
+arbitrary = { workspace = true, optional = true }
 argon2.workspace = true
 affinidi-tdk.workspace = true
 affinidi-data-integrity.workspace = true

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -182,6 +182,7 @@ impl UnlockCode {
 
 /// Describes how the configuration secrets are protected at rest.
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ConfigProtectionType {
     /// Requires a hardware token with the Token ID to unlock config
     /// Will need to provide the USER PIN to the token

--- a/openvtc-core/src/config/public_config.rs
+++ b/openvtc-core/src/config/public_config.rs
@@ -36,6 +36,7 @@ pub struct DeleteProfileSummary {
 
 /// Primary structure used for storing [crate::config::Config] data that is not sensitive
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PublicConfig {
     /// Config format version for migration support.
     /// Absent in pre-0.2.0 configs (treated as version 0).
@@ -389,5 +390,21 @@ mod tests {
         assert!(pc.friendly_name.is_empty());
         assert!(pc.private.is_none());
         assert_eq!(pc.config_version, 0);
+    }
+
+    /// Smoke-test the `arbitrary` fuzz seam (issue #124): a `PublicConfig`
+    /// must be constructible from raw bytes via `Arbitrary` and the result
+    /// must round-trip through serde, so structure-aware fuzz harnesses can
+    /// generate inputs and feed them straight at the deserializer.
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn test_public_config_arbitrary_roundtrips() {
+        use arbitrary::{Arbitrary, Unstructured};
+
+        let raw: Vec<u8> = (0..=255u8).cycle().take(512).collect();
+        let mut u = Unstructured::new(&raw);
+        let pc = PublicConfig::arbitrary(&mut u).expect("construct from bytes");
+        let json = serde_json::to_string(&pc).expect("serialize arbitrary config");
+        serde_json::from_str::<PublicConfig>(&json).expect("re-parse serialized config");
     }
 }

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -167,6 +167,7 @@ pub mod protocol_urls {
 /// assert_eq!(url, "https://didcomm.org/trust-ping/2.0/ping");
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum MessageType {
     /// A request to establish a new relationship with a remote party.
@@ -283,6 +284,7 @@ impl TryFrom<&Message> for MessageType {
 /// message type and one DIDComm route, so the router needs no per-kind
 /// registration.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[non_exhaustive]
 pub enum CredentialKind {
     /// The membership credential (VMC) proving admission to the community.

--- a/openvtc-core/src/logs.rs
+++ b/openvtc-core/src/logs.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 /// Category of a log message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum LogFamily {
     /// Relationship lifecycle events.
     Relationship,
@@ -35,6 +36,7 @@ impl Display for LogFamily {
 
 /// A single timestamped log entry.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LogMessage {
     /// When the log message was created.
     pub created: chrono::DateTime<Utc>,
@@ -48,6 +50,7 @@ pub struct LogMessage {
 
 /// Bounded FIFO log that evicts the oldest entries when the limit is reached.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Logs {
     /// Log entries in insertion order (oldest first).
     pub messages: VecDeque<LogMessage>,


### PR DESCRIPTION
Closes the last actionable ask on #124 — item 5's derive half. The fuzz consumer ([comment](https://github.com/OpenVTC/openvtc/issues/124#issuecomment)) confirmed items 2–4 (PR #125) are exactly what they need and explicitly requested feature-gated `#[derive(Arbitrary)]` on the config/credential parse surfaces for structure-aware fuzzing. The `fuzz/` workspace + structure-aware targets remain their contribution.

## What's here
- **New optional `arbitrary` feature** on `openvtc-core` (off by default): `arbitrary = ["dep:arbitrary", "chrono/arbitrary"]`. Nightly fuzz builds opt in; the default and `--no-default-features` dependency graphs are unchanged.
- **`#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]`** on the self-contained parse-surface types:
  - `PublicConfig` and its local tree (`ConfigProtectionType`, `Logs`, `LogMessage`, `LogFamily`)
  - `MessageType`, `CredentialKind`
- **`ProtectedConfig` intentionally excluded** — it cascades into foreign VRC/credential types that don't implement `Arbitrary`. This matches the consumer's note that the `verify_vrc_proof_with_key` harness (needs a constructed VRC + keypair) lands *after* the derives.
- **Seam test:** `PublicConfig::arbitrary(&mut Unstructured)` constructs from raw bytes and serde round-trips — proves the harness path end to end.
- **CI:** the no-default-features job now also checks the exact fuzz build shape (`--no-default-features --features arbitrary`) and runs the seam test, so the feature can't bitrot.

## Gate
- `cargo fmt`
- `cargo clippy --workspace --all-targets -D warnings` — default, `--features arbitrary`, and `--no-default-features`
- `cargo test --workspace` + `cargo test -p openvtc-core --features arbitrary`
- `cargo deny check` — advisories/bans/licenses/sources ok (`arbitrary`/`derive_arbitrary` are MIT/Apache-2.0)

Closes #124.