### PR TITLE
feat(join): store/load the invitation via the VTA credential vault (#2)

### DIFF
--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -408,6 +408,24 @@ fn invitation_subject_persona(config: &Config, state: &State) -> Option<PersonaI
     config.account.persona_id_for_did(subject)
 }
 
+/// #2: load an invitation credential the VTA already holds for the holder, if
+/// any. Queries the credential vault for `purpose = invite` and fetches the
+/// first match's body. Best-effort — any error / empty result yields `None`.
+async fn load_invitation_from_vault(admin_vta: &VtaClient) -> Option<serde_json::Value> {
+    let listing = admin_vta
+        .cred_vault_query(serde_json::json!({ "purpose": "invite" }))
+        .await
+        .ok()?;
+    let id = listing
+        .get("credentials")
+        .and_then(|c| c.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|d| d.get("id"))
+        .and_then(|i| i.as_str())?;
+    let got = admin_vta.cred_vault_get(id).await.ok()?;
+    got.get("credential").cloned()
+}
+
 /// Whether a pasted/loaded JSON value is an InvitationCredential (its `type`
 /// array carries the `InvitationCredential` tag).
 fn is_invitation_credential(value: &serde_json::Value) -> bool {
@@ -721,6 +739,20 @@ async fn run_join_sequence(
             return;
         }
     };
+    // #2: the VTA credential vault is the durable home for the holder's VIC.
+    // If one is loaded (file / paste), persist it; if not, try loading one the
+    // VTA already holds for this community. Both are best-effort — the join
+    // proceeds regardless (the in-memory VIC, if any, is still presented).
+    if let Some(vic) = state.invitation_credential.clone() {
+        if let Err(e) = admin_vta.cred_vault_receive(vic, None).await {
+            debug!(error = %e, "storing invitation in the VTA vault failed (continuing)");
+        }
+    } else if let Some(vic) = load_invitation_from_vault(admin_vta).await {
+        state.invitation_credential = Some(vic);
+        state.join.has_invitation = true;
+        let _ = handler.state_tx.send(state.clone());
+    }
+
     // Present the holder VP. When the applicant loaded an invitation credential
     // (VIC) at startup (`--invitation`), it rides in the VP's
     // `verifiableCredential` array; the VTC verifies it and auto-admits on a


### PR DESCRIPTION
## Summary

Wires OpenVTC to the VTA **credential vault** so the holder's invitation credential (VIC) has a durable home in the VTA rather than living only in memory / a file.

At join time (`run_join_sequence`):
- if a VIC is loaded (via `--invitation <file>` or paste), **persist** it — `admin_vta.cred_vault_receive(vic)`;
- if none is loaded, **load** one the VTA already holds — `cred_vault_query({purpose: "invite"})` → `cred_vault_get(id)` → present it.

Both are **best-effort**: the join proceeds on the in-memory VIC regardless, so a VTA without the credential-vault surface (or without the vault capability on the session) degrades cleanly.

Uses the always-on admin VTA session already threaded into the join flow and the `cred_vault_*` methods shipped in **vta-sdk 0.17** (verifiable-trust-infrastructure #524).

## Remaining (this completes #2; #1b build-side still open)
The subject-linkage **build** side (#1b) — signing `TAG‖vic_id‖presenter` with the subject persona's key to join under a *fresh* DID — is still open. It's a privacy-niche path (the join-as-subject default, #1a, already auto-presents the invited persona) and needs cross-persona key access + a "present a fresh identity" choice. The VTC verify side + the OpenVTC `sign`-bytes/`SubjectLinkage` groundwork are already merged.

## Tests
`openvtc` builds clean against tdk 0.8 / vta-sdk 0.17; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)