### PR TITLE
feat(vta): bounded retry on transient admin-VTA round-trips

### DIFF
--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -23,6 +23,7 @@ use openvtc_core::{
     relationships::{RelationshipRequestBody, RelationshipState},
     tasks::TaskType,
 };
+use crate::state_handler::setup_sequence::vta;
 use serde_json::json;
 use tracing::info;
 use uuid::Uuid;
@@ -263,8 +264,8 @@ async fn create_relationship_keys(
     use vta_sdk::keys::KeyType;
 
     info!("creating Ed25519 signing key via VTA...");
-    let sign_resp = client
-        .create_key(CreateKeyRequest {
+    let sign_resp = vta::vta_retry("create relationship signing key", || {
+        client.create_key(CreateKeyRequest {
             key_type: KeyType::Ed25519,
             derivation_path: None,
             key_id: None,
@@ -272,19 +273,21 @@ async fn create_relationship_keys(
             label: Some("relationship-signing".to_string()),
             context_id: None,
         })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create signing key: {e}"))?;
-    let sign_secret_resp = client
-        .get_key_secret(&sign_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create signing key: {e}"))?;
+    let sign_secret_resp = vta::vta_retry("get relationship signing key secret", || {
+        client.get_key_secret(&sign_resp.key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
     let mut v_secret = vta_sdk::did_key::secret_from_key_response(&sign_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
     v_secret.id = v_secret.get_public_keymultibase()?;
 
     info!("creating X25519 encryption key via VTA...");
-    let enc_resp = client
-        .create_key(CreateKeyRequest {
+    let enc_resp = vta::vta_retry("create relationship encryption key", || {
+        client.create_key(CreateKeyRequest {
             key_type: KeyType::X25519,
             derivation_path: None,
             key_id: None,
@@ -292,12 +295,14 @@ async fn create_relationship_keys(
             label: Some("relationship-encryption".to_string()),
             context_id: None,
         })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create encryption key: {e}"))?;
-    let enc_secret_resp = client
-        .get_key_secret(&enc_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get encryption key secret: {e}"))?;
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create encryption key: {e}"))?;
+    let enc_secret_resp = vta::vta_retry("get relationship encryption key secret", || {
+        client.get_key_secret(&enc_resp.key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get encryption key secret: {e}"))?;
     let mut e_secret = vta_sdk::did_key::secret_from_key_response(&enc_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
     e_secret.id = e_secret.get_public_keymultibase()?;
@@ -970,8 +975,9 @@ impl DidDeleteJob {
             persona_id,
             key_ids,
         } = self;
-        if let Some(vta) = admin_vta
-            && let Err(e) = vta.delete_did_webvh(&did).await
+        if let Some(client) = admin_vta
+            && let Err(e) =
+                vta::vta_retry("delete WebVH DID", || client.delete_did_webvh(&did)).await
         {
             tracing::debug!("delete_did_webvh({did}) failed (continuing local cleanup): {e}");
         }

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -6,13 +6,71 @@ use affinidi_tdk::secrets_resolver::secrets::Secret;
 use anyhow::Result;
 use chrono::Utc;
 use openvtc_core::config::{KeyInfo, PersonaDIDKeys, secured_config::KeySourceMaterial};
+use std::future::Future;
+use std::time::Duration;
+use tracing::warn;
 use vta_sdk::{
     client::{CreateDidWebvhRequest, CreateKeyRequest, VtaClient},
+    error::VtaError,
     keys::KeyType,
     protocols::did_management::create::WebvhPathMode,
     session::{TokenResult, challenge_response},
     webvh::WebvhServerRecord,
 };
+
+/// Max attempts for a single VTA round-trip before giving up (1 try + 2 retries).
+const VTA_MAX_ATTEMPTS: usize = 3;
+
+/// Base back-off between retries; doubles each attempt (0.5s, then 1s). Short,
+/// because the dominant retryable fault is a stale DIDComm socket that ATM
+/// re-establishes almost immediately — we just need a beat before re-sending.
+const VTA_RETRY_BASE: Duration = Duration::from_millis(500);
+
+/// True for errors a retry might clear: transport/timeout faults where the
+/// request most likely never reached the VTA (or its reply never came back).
+///
+/// The motivating case is a stale always-on DIDComm session — the mediator
+/// dropped the idle WebSocket, the first `send_and_wait` packed into a dead
+/// socket and timed out, but ATM auto-reconnects underneath, so the *next* send
+/// lands on a live socket and succeeds. REST `Network` and 5xx `Server` errors
+/// are transient the same way. Deterministic faults (validation, conflict,
+/// not-found, auth, gone) are never retried — re-sending can't change them.
+fn vta_retryable(e: &VtaError) -> bool {
+    matches!(
+        e,
+        VtaError::DidcommTransport(_) | VtaError::Network(_) | VtaError::Server { .. }
+    )
+}
+
+/// Run a single VTA round-trip with bounded retry on transient transport faults
+/// (see [`vta_retryable`]). `op` is re-invoked from scratch each attempt, so it
+/// must rebuild any by-value request — and the caller must be content with a
+/// possible duplicate on the rare "VTA processed it but the reply was lost"
+/// timeout. That's a non-issue for reads (`get_key_secret`, `list_*`) and cheap
+/// for `create_key` (at worst an orphan key); the join flow already rolls back a
+/// half-minted persona. `label` names the op for the retry log line.
+pub(crate) async fn vta_retry<T, F, Fut>(label: &str, mut op: F) -> Result<T, VtaError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, VtaError>>,
+{
+    let mut attempt = 1;
+    loop {
+        match op().await {
+            Ok(v) => return Ok(v),
+            Err(e) if attempt < VTA_MAX_ATTEMPTS && vta_retryable(&e) => {
+                let backoff = VTA_RETRY_BASE * (1 << (attempt - 1));
+                warn!(
+                    "VTA '{label}' failed (attempt {attempt}/{VTA_MAX_ATTEMPTS}): {e} — \
+                     retrying in {backoff:?}"
+                );
+                tokio::time::sleep(backoff).await;
+                attempt += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
 
 /// Authenticate with VTA using REST challenge-response. Only valid for the
 /// REST transport — DIDComm-only VTAs authenticate implicitly when the
@@ -38,8 +96,8 @@ pub async fn create_persona_keys(
     let created = Utc::now();
 
     // Signing key (Ed25519)
-    let sign_resp = client
-        .create_key(CreateKeyRequest {
+    let sign_resp = vta_retry("create persona signing key", || {
+        client.create_key(CreateKeyRequest {
             key_type: KeyType::Ed25519,
             derivation_path: None,
             key_id: None,
@@ -47,13 +105,15 @@ pub async fn create_persona_keys(
             label: Some("persona-signing".to_string()),
             context_id: context_id.map(|s| s.to_string()),
         })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create signing key: {e}"))?;
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create signing key: {e}"))?;
 
-    let sign_secret_resp = client
-        .get_key_secret(&sign_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
+    let sign_secret_resp = vta_retry("get persona signing key secret", || {
+        client.get_key_secret(&sign_resp.key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
 
     let mut sign_secret = vta_sdk::did_key::secret_from_key_response(&sign_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
@@ -69,8 +129,8 @@ pub async fn create_persona_keys(
     };
 
     // Authentication key (Ed25519)
-    let auth_resp = client
-        .create_key(CreateKeyRequest {
+    let auth_resp = vta_retry("create persona authentication key", || {
+        client.create_key(CreateKeyRequest {
             key_type: KeyType::Ed25519,
             derivation_path: None,
             key_id: None,
@@ -78,13 +138,15 @@ pub async fn create_persona_keys(
             label: Some("persona-authentication".to_string()),
             context_id: context_id.map(|s| s.to_string()),
         })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create authentication key: {e}"))?;
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create authentication key: {e}"))?;
 
-    let auth_secret_resp = client
-        .get_key_secret(&auth_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get authentication key secret: {e}"))?;
+    let auth_secret_resp = vta_retry("get persona authentication key secret", || {
+        client.get_key_secret(&auth_resp.key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get authentication key secret: {e}"))?;
 
     let mut auth_secret = vta_sdk::did_key::secret_from_key_response(&auth_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
@@ -100,8 +162,8 @@ pub async fn create_persona_keys(
     };
 
     // Encryption key (X25519)
-    let enc_resp = client
-        .create_key(CreateKeyRequest {
+    let enc_resp = vta_retry("create persona encryption key", || {
+        client.create_key(CreateKeyRequest {
             key_type: KeyType::X25519,
             derivation_path: None,
             key_id: None,
@@ -109,13 +171,15 @@ pub async fn create_persona_keys(
             label: Some("persona-encryption".to_string()),
             context_id: context_id.map(|s| s.to_string()),
         })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create encryption key: {e}"))?;
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create encryption key: {e}"))?;
 
-    let enc_secret_resp = client
-        .get_key_secret(&enc_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get encryption key secret: {e}"))?;
+    let enc_secret_resp = vta_retry("get persona encryption key secret", || {
+        client.get_key_secret(&enc_resp.key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get encryption key secret: {e}"))?;
 
     let mut enc_secret = vta_sdk::did_key::secret_from_key_response(&enc_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
@@ -144,8 +208,8 @@ pub async fn create_update_keys(
     context_id: Option<&str>,
 ) -> Result<(Secret, Secret)> {
     // Update key (Ed25519)
-    let update_resp = client
-        .create_key(CreateKeyRequest {
+    let update_resp = vta_retry("create WebVH update key", || {
+        client.create_key(CreateKeyRequest {
             key_type: KeyType::Ed25519,
             derivation_path: None,
             key_id: None,
@@ -153,20 +217,22 @@ pub async fn create_update_keys(
             label: Some("webvh-update".to_string()),
             context_id: context_id.map(|s| s.to_string()),
         })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create WebVH update key: {e}"))?;
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create WebVH update key: {e}"))?;
 
-    let update_secret_resp = client
-        .get_key_secret(&update_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get WebVH update key secret: {e}"))?;
+    let update_secret_resp = vta_retry("get WebVH update key secret", || {
+        client.get_key_secret(&update_resp.key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get WebVH update key secret: {e}"))?;
 
     let update_secret = vta_sdk::did_key::secret_from_key_response(&update_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
 
     // Next update key (Ed25519)
-    let next_update_resp = client
-        .create_key(CreateKeyRequest {
+    let next_update_resp = vta_retry("create WebVH next-update key", || {
+        client.create_key(CreateKeyRequest {
             key_type: KeyType::Ed25519,
             derivation_path: None,
             key_id: None,
@@ -174,13 +240,15 @@ pub async fn create_update_keys(
             label: Some("webvh-next-update".to_string()),
             context_id: context_id.map(|s| s.to_string()),
         })
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create WebVH next update key: {e}"))?;
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create WebVH next update key: {e}"))?;
 
-    let next_update_secret_resp = client
-        .get_key_secret(&next_update_resp.key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get WebVH next update key secret: {e}"))?;
+    let next_update_secret_resp = vta_retry("get WebVH next-update key secret", || {
+        client.get_key_secret(&next_update_resp.key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get WebVH next update key secret: {e}"))?;
 
     let next_update_secret = vta_sdk::did_key::secret_from_key_response(&next_update_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
@@ -190,8 +258,7 @@ pub async fn create_update_keys(
 
 /// List WebVH servers available from the VTA
 pub async fn list_webvh_servers(client: &VtaClient) -> Result<Vec<WebvhServerRecord>> {
-    let result = client
-        .list_webvh_servers()
+    let result = vta_retry("list WebVH servers", || client.list_webvh_servers())
         .await
         .map_err(|e| anyhow::anyhow!("Failed to list WebVH servers: {e}"))?;
     Ok(result.servers)
@@ -215,43 +282,46 @@ pub async fn create_did_via_server(
     // Use the VTA's built-in mediator service rather than additional_services,
     // because the VTA formats the service ID as a full DID URL (e.g. "did:...#vta-didcomm")
     // which the TDK resolver requires. A relative fragment like "#public-didcomm" is rejected.
-    let req = CreateDidWebvhRequest {
-        context_id: context_id.to_string(),
-        server_id: Some(server_id.to_string()),
-        url: None,
-        path: None,
-        path_mode: Some(path_mode),
-        // No explicit hosting-domain override: the server determines the
-        // domain from the selected `server_id`.
-        domain: None,
-        label: None,
-        portable: true,
-        add_mediator_service: true,
-        additional_services: None,
-        pre_rotation_count: 1,
-        did_document: None,
-        did_log: None,
-        set_primary: false,
-        signing_key_id: None,
-        ka_key_id: None,
-        template: None,
-        template_context: None,
-        template_vars: std::collections::HashMap::new(),
-    };
-
-    let result = client
-        .create_did_webvh(req)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create DID via WebVH server: {e}"))?;
+    // Built fresh on each attempt inside the retry closure: `create_did_webvh`
+    // consumes the request by value and `CreateDidWebvhRequest` is not `Clone`.
+    let result = vta_retry("create DID via WebVH server", || {
+        let req = CreateDidWebvhRequest {
+            context_id: context_id.to_string(),
+            server_id: Some(server_id.to_string()),
+            url: None,
+            path: None,
+            path_mode: Some(path_mode.clone()),
+            // No explicit hosting-domain override: the server determines the
+            // domain from the selected `server_id`.
+            domain: None,
+            label: None,
+            portable: true,
+            add_mediator_service: true,
+            additional_services: None,
+            pre_rotation_count: 1,
+            did_document: None,
+            did_log: None,
+            set_primary: false,
+            signing_key_id: None,
+            ka_key_id: None,
+            template: None,
+            template_context: None,
+            template_vars: std::collections::HashMap::new(),
+        };
+        client.create_did_webvh(req)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create DID via WebVH server: {e}"))?;
 
     let did = result.did.clone();
     let mnemonic = result.mnemonic.clone().unwrap_or_default();
 
     // Fetch signing key secret (#key-0 = Ed25519)
-    let sign_secret_resp = client
-        .get_key_secret(&result.signing_key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
+    let sign_secret_resp = vta_retry("get WebVH DID signing key secret", || {
+        client.get_key_secret(&result.signing_key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get signing key secret: {e}"))?;
 
     let mut sign_secret = vta_sdk::did_key::secret_from_key_response(&sign_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
@@ -278,10 +348,11 @@ pub async fn create_did_via_server(
     };
 
     // Fetch KA key secret (#key-1 = X25519)
-    let ka_secret_resp = client
-        .get_key_secret(&result.ka_key_id)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to get KA key secret: {e}"))?;
+    let ka_secret_resp = vta_retry("get WebVH DID KA key secret", || {
+        client.get_key_secret(&result.ka_key_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to get KA key secret: {e}"))?;
 
     let mut ka_secret = vta_sdk::did_key::secret_from_key_response(&ka_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
@@ -331,4 +402,82 @@ pub async fn create_sub_context(
 ) -> Result<String> {
     let _ = (client, parent_id);
     Ok(sub_context_id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn retryable_covers_transport_and_5xx_only() {
+        // Transient transport / server faults — retry may clear them.
+        assert!(vta_retryable(&VtaError::DidcommTransport("timeout".into())));
+        assert!(vta_retryable(&VtaError::Server {
+            status: 503,
+            body: String::new(),
+        }));
+        // Deterministic faults — re-sending can't change the outcome.
+        assert!(!vta_retryable(&VtaError::Validation("bad".into())));
+        assert!(!vta_retryable(&VtaError::Conflict("dup".into())));
+        assert!(!vta_retryable(&VtaError::NotFound("gone".into())));
+        assert!(!vta_retryable(&VtaError::Auth("expired".into())));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn returns_immediately_on_success() {
+        let calls = Cell::new(0u32);
+        let out: Result<u8, VtaError> = vta_retry("ok", || {
+            calls.set(calls.get() + 1);
+            async { Ok(7) }
+        })
+        .await;
+        assert_eq!(out.unwrap(), 7);
+        assert_eq!(calls.get(), 1, "no retry when the first attempt succeeds");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_transient_then_succeeds() {
+        // Models a stale socket: first send times out, ATM reconnects, second
+        // send lands. The op should be retried and ultimately succeed.
+        let calls = Cell::new(0u32);
+        let out: Result<u8, VtaError> = vta_retry("stale-then-ok", || {
+            let n = calls.get() + 1;
+            calls.set(n);
+            async move {
+                if n < 2 {
+                    Err(VtaError::DidcommTransport("stale socket".into()))
+                } else {
+                    Ok(9)
+                }
+            }
+        })
+        .await;
+        assert_eq!(out.unwrap(), 9);
+        assert_eq!(calls.get(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gives_up_after_max_attempts() {
+        let calls = Cell::new(0u32);
+        let out: Result<u8, VtaError> = vta_retry("always-down", || {
+            calls.set(calls.get() + 1);
+            async { Err(VtaError::DidcommTransport("down".into())) }
+        })
+        .await;
+        assert!(out.is_err());
+        assert_eq!(calls.get(), VTA_MAX_ATTEMPTS as u32);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn does_not_retry_deterministic_error() {
+        let calls = Cell::new(0u32);
+        let out: Result<u8, VtaError> = vta_retry("validation", || {
+            calls.set(calls.get() + 1);
+            async { Err(VtaError::Validation("nope".into())) }
+        })
+        .await;
+        assert!(out.is_err());
+        assert_eq!(calls.get(), 1, "deterministic faults are not retried");
+    }
 }


### PR DESCRIPTION
## Problem

Joining a community could fail at **"Creating persona keys…"** with:

```
Failed to create persona keys: Failed to create signing key: didcomm transport error: timeout waiting for DIDComm response
```

Root cause is a **stale always-on admin DIDComm session**: the mediator quietly drops the idle WebSocket, so the first `create_key` round-trip packs into a dead socket and times out after the SDK's hardcoded 30s. The session was **never retried anywhere** — a single transient transport fault aborted the whole join. A restart (fresh session) worked first time, which pointed straight at staleness.

## Fix

Add `vta_retry()` (`pub(crate)`) in `setup_sequence/vta.rs`: **3 attempts, 0.5s→1s backoff**, retrying **only** transient `VtaError` variants (`DidcommTransport`, `Network`, `Server` 5xx) via `vta_retryable()`. Deterministic faults (validation / conflict / not-found / auth / gone) are never retried.

A plain **re-send on the same client** is the correct approach — not a session reconnect:

- The mediator enforces **one socket per DID** (vta-sdk `didcomm_session.rs`), so tearing down and re-opening the admin session would duel on the mediator and time out.
- ATM already **auto-reconnects** the WebSocket underneath, so the second send lands once it re-establishes.

### Wrapped call sites
- `vta.rs`: `create_persona_keys`, `create_update_keys`, `list_webvh_servers`, `create_did_via_server` (all `create_key` / `get_key_secret` / `create_did_webvh` calls)
- `relationship_actions.rs`: `create_relationship_keys` + the best-effort `delete_did_webvh`

## Idempotency note
On the rare "VTA processed it but the reply was lost" timeout, a retried `create_key` leaves at most an orphan key and a retried `create_did_webvh` could mint a duplicate DID. In the stale-socket case the *send* is lost (server never processes), so this is unlikely, and the join flow already rolls back a half-minted persona. Documented in the helper's doc comment.

## This is mitigation, not the root fix
The session has no keepalive/liveness probe and the 30s op timeout is hardcoded in vta-sdk. The durable fix (proactive reconnect or a pre-flight trust-ping) belongs in `verifiable-trust-infrastructure`.

## Tests
5 unit tests in `vta::tests` (paused clock, instant): retryable classification, no-retry-on-success, retry-then-succeed, give-up-at-max-attempts, no-retry-on-deterministic-error.

- `cargo build -p openvtc` ✅
- `cargo test -p openvtc vta::tests` ✅ (5 passed)
- no new clippy warnings