### PR TITLE
feat(community): cancel a pending join to withdraw + remove it

### DIFF
--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -113,6 +113,11 @@ pub enum CommunityStatus {
     Active,
     /// Member voluntarily left (`MEMBER_SELF_REMOVE`).
     Left,
+    /// Applicant cancelled a `Pending` join before the VTC decided — the
+    /// request is withdrawn. A voluntary, user-chosen outcome (like `Left`), so
+    /// it never raises the actions-required badge. The protocol's status
+    /// vocabulary calls this `withdrawn`.
+    Withdrawn,
     /// Join request denied by the VTC.
     Rejected,
     /// Member removed by the VTC (involuntary).
@@ -133,12 +138,13 @@ impl CommunityStatus {
     }
 
     /// True for terminal/inactive states eligible for archive or delete (R-C-8):
-    /// `Left`, `Rejected`, `Removed`, `Expired`. (`Pending` is not — it is still
-    /// in flight.)
+    /// `Left`, `Withdrawn`, `Rejected`, `Removed`, `Expired`. (`Pending` is not —
+    /// it is still in flight; cancelling it transitions to `Withdrawn` first.)
     pub fn is_inactive(&self) -> bool {
         matches!(
             self,
             CommunityStatus::Left
+                | CommunityStatus::Withdrawn
                 | CommunityStatus::Rejected
                 | CommunityStatus::Removed
                 | CommunityStatus::Expired
@@ -394,6 +400,21 @@ impl CommunityRecord {
         self.acknowledged = false;
     }
 
+    /// Transition to `Withdrawn` — the applicant cancelled a `Pending` join
+    /// before the VTC decided. Like `Left`, a voluntary outcome that never
+    /// raises the actions-required badge. The record becomes inactive, so it can
+    /// then be deleted or re-joined. No-op (returns `false`) unless currently
+    /// `Pending`; callers gate the action to pending rows, and this re-checks so
+    /// a stray call can't withdraw an active/terminal membership.
+    pub fn withdraw(&mut self) -> bool {
+        if !matches!(self.status, CommunityStatus::Pending { .. }) {
+            return false;
+        }
+        self.status = CommunityStatus::Withdrawn;
+        self.acknowledged = false;
+        true
+    }
+
     /// Acknowledge a terminal outcome (`Rejected`/`Removed`/`Expired`), clearing
     /// the actions-required badge for this community (R-S-2). No effect on the
     /// `Pending` badge, which only clears when the request resolves.
@@ -411,7 +432,7 @@ impl CommunityRecord {
             CommunityStatus::Rejected | CommunityStatus::Removed | CommunityStatus::Expired => {
                 !self.acknowledged
             }
-            CommunityStatus::Active | CommunityStatus::Left => false,
+            CommunityStatus::Active | CommunityStatus::Left | CommunityStatus::Withdrawn => false,
         }
     }
 
@@ -846,6 +867,7 @@ mod tests {
 
         for s in [
             CommunityStatus::Left,
+            CommunityStatus::Withdrawn,
             CommunityStatus::Rejected,
             CommunityStatus::Removed,
             CommunityStatus::Expired,
@@ -862,6 +884,8 @@ mod tests {
         assert!(pending.needs_attention());
         assert!(CommunityStatus::Rejected.needs_attention());
         assert!(!CommunityStatus::Left.needs_attention());
+        // Withdrawn is a voluntary outcome (like Left) — it never nags.
+        assert!(!CommunityStatus::Withdrawn.needs_attention());
     }
 
     #[test]
@@ -963,6 +987,8 @@ mod tests {
         assert_eq!(j, r#"{"state":"active"}"#);
         let j = serde_json::to_string(&CommunityStatus::Expired).unwrap();
         assert_eq!(j, r#"{"state":"expired"}"#);
+        let j = serde_json::to_string(&CommunityStatus::Withdrawn).unwrap();
+        assert_eq!(j, r#"{"state":"withdrawn"}"#);
     }
 
     fn pending() -> CommunityStatus {
@@ -1000,6 +1026,33 @@ mod tests {
         let mut l = community("v", pid, CommunityStatus::Active);
         l.leave();
         assert_eq!(l.status, CommunityStatus::Left);
+    }
+
+    #[test]
+    fn withdraw_cancels_a_pending_join() {
+        let pid = PersonaId::new();
+
+        // Pending → Withdrawn: succeeds, becomes inactive, and never nags.
+        let mut p = community("v", pid, pending());
+        p.acknowledged = false;
+        assert!(p.withdraw(), "withdraw applies to a pending join");
+        assert_eq!(p.status, CommunityStatus::Withdrawn);
+        assert!(
+            p.can_archive_or_delete(),
+            "withdrawn is deletable/archivable"
+        );
+        assert!(!p.needs_attention(), "a withdrawn join must not nag");
+        assert!(!p.is_live(), "withdrawn needs no live session");
+
+        // Idempotent / guarded: a second call (now Withdrawn) is a no-op, and an
+        // Active membership can't be withdrawn (only left).
+        assert!(!p.withdraw(), "withdraw is a no-op once not pending");
+        let mut active = community("v", pid, CommunityStatus::Active);
+        assert!(
+            !active.withdraw(),
+            "withdraw must not touch an active membership"
+        );
+        assert_eq!(active.status, CommunityStatus::Active);
     }
 
     #[test]

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -294,6 +294,17 @@ pub fn handle_join_status_response(
                 inactivated: true,
             }
         }
+        "withdrawn" => {
+            // The VTC reports the request withdrawn — reconcile our local record
+            // (it may have been cancelled from another client). `withdraw` is a
+            // no-op unless still Pending.
+            let changed = record.withdraw();
+            info!(vtc = %from_did, "join withdrawn — reconciled to Withdrawn");
+            StatusOutcome {
+                changed,
+                inactivated: changed,
+            }
+        }
         "deferred" => {
             // "More info required" — stays Pending (still raises actions-required);
             // evaluating `needs` / presenting the DCQL is deferred to D4.
@@ -788,6 +799,27 @@ mod tests {
         assert!(
             rec.needs_attention(),
             "an unacknowledged rejection nags (R-S-2)"
+        );
+    }
+
+    #[test]
+    fn status_response_withdrawn_inactivates_without_badge() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out =
+            handle_join_status_response(&mut acct, &status_response(vtc, rid, "withdrawn"), vtc);
+        assert!(out.changed);
+        assert!(
+            out.inactivated,
+            "a withdrawal must deregister the session (R-S-3)"
+        );
+        let rec = acct.communities.get(vtc).unwrap();
+        assert!(matches!(rec.status, CommunityStatus::Withdrawn));
+        assert!(
+            !rec.needs_attention(),
+            "a voluntary withdrawal never nags (like Left)"
         );
     }
 

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -296,6 +296,18 @@ pub enum Action {
     /// the user confirms.
     LeaveCommunity(usize),
 
+    /// Arm a cancel confirmation for the Pending join at this index (the panel
+    /// prompts y/n before withdrawing).
+    CommunityConfirmWithdraw(usize),
+
+    /// Dismiss a pending cancel confirmation without withdrawing.
+    CommunityCancelWithdraw,
+
+    /// Cancel the Pending join at this index: best-effort notify the VTC, then
+    /// set it `Withdrawn` and deregister its session so it can be deleted or
+    /// re-joined. Only sent after the user confirms.
+    WithdrawJoin(usize),
+
     /// Archive the inactive community at this index (hide from the default list,
     /// retain the record) (R-C-8).
     ArchiveCommunity(usize),

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -93,6 +93,10 @@ pub struct CommunitiesState {
     /// When `Some(index)`, leaving that community is awaiting `y`/`n`
     /// confirmation (R-L-1).
     pub confirm_leave: Option<usize>,
+    /// When `Some(index)`, cancelling that community's pending join is awaiting
+    /// `y`/`n` confirmation. Transitions the record to `Withdrawn` so it can then
+    /// be deleted or re-joined.
+    pub confirm_withdraw: Option<usize>,
     /// Whether archived communities are included in the list (R-C-8). Off by
     /// default; toggled so archived records stay discoverable.
     pub show_archived: bool,
@@ -136,9 +140,13 @@ pub struct CommunitySummary {
     /// Whether the membership is Active — the only state you can leave (R-L-1)
     /// or set as the working context (R-C-6).
     pub is_active: bool,
-    /// Whether the membership is inactive (Left/Rejected/Removed/Expired) — the
-    /// only states that can be archived or deleted, and rendered read-only (D14).
+    /// Whether the membership is inactive (Left/Withdrawn/Rejected/Removed/
+    /// Expired) — the only states that can be archived or deleted, and rendered
+    /// read-only (D14).
     pub is_inactive: bool,
+    /// Whether the membership is `Pending` — the only state whose join can be
+    /// cancelled (withdrawn).
+    pub is_pending: bool,
     /// Whether this community is archived (R-C-8); only shown when "show archived"
     /// is on, with a marker.
     pub archived: bool,

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -433,6 +433,10 @@ impl MainPageState {
                 favourite: c.favourite,
                 is_active: c.status.is_active(),
                 is_inactive: c.status.is_inactive(),
+                is_pending: matches!(
+                    c.status,
+                    openvtc_core::config::account::CommunityStatus::Pending { .. }
+                ),
                 archived: c.archived,
                 needs_attention: c.needs_attention(),
                 persona_did: persona.map(|p| p.did.clone()).unwrap_or_default(),
@@ -463,6 +467,7 @@ fn community_status_label(status: &openvtc_core::config::account::CommunityStatu
         CommunityStatus::Pending { .. } => "Pending",
         CommunityStatus::Active => "Active",
         CommunityStatus::Left => "Left",
+        CommunityStatus::Withdrawn => "Withdrawn",
         CommunityStatus::Rejected => "Rejected",
         CommunityStatus::Removed => "Removed",
         CommunityStatus::Expired => "Expired",

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -859,6 +859,56 @@ impl StateHandler {
                             }
                         }
                     },
+                    Action::WithdrawJoin(i) => {
+                        // Cancel a Pending join: best-effort notify the VTC, set
+                        // the record `Withdrawn`, and tear down its now-dead
+                        // session (R-S-3) so it can be deleted or re-joined.
+                        state.main_page.content_panel.communities.confirm_withdraw = None;
+                        let target = config
+                            .account
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
+                            .get(i)
+                            .filter(|c| matches!(
+                                c.status,
+                                openvtc_core::config::account::CommunityStatus::Pending { .. }
+                            ))
+                            .map(|c| c.vtc_did.clone());
+                        if let Some(vtc) = target {
+                            // Best-effort VTC notification. The applicant-side
+                            // withdraw DIDComm message does not exist in vta-sdk
+                            // yet (only the `withdrawn` *status* the VTC reports),
+                            // so there is nothing to send. The cancel is otherwise
+                            // fully local; the request will also lapse to the VTC's
+                            // own timeout. TODO(VTI): once vta-sdk gains a
+                            // `join-requests/withdraw/1.0` message, send it here.
+                            debug!(
+                                vtc = %vtc,
+                                "cancel pending join: VTC notify pending protocol support (vta-sdk withdraw message)"
+                            );
+                            if config
+                                .account
+                                .community_mut(&vtc)
+                                .is_some_and(|c| c.withdraw())
+                            {
+                                save.mark_dirty();
+                                deregister_inactive_community(
+                                    &mut session_manager,
+                                    &didcomm_service,
+                                    &config,
+                                    &mut state,
+                                    &vtc,
+                                )
+                                .await;
+                                state.main_page.sync_from_config(&config);
+                                state
+                                    .main_page
+                                    .content_panel
+                                    .communities
+                                    .status_message =
+                                    Some("Join cancelled — request withdrawn.".to_string());
+                            }
+                        }
+                    },
                     Action::ArchiveCommunity(i) => {
                         // R-C-8: archive an inactive community (hide it, retain the
                         // record). Guarded inactive-only by `archive_community`.
@@ -1963,6 +2013,12 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
         }
         Action::CommunityCancelLeave => {
             state.main_page.content_panel.communities.confirm_leave = None;
+        }
+        Action::CommunityConfirmWithdraw(i) => {
+            state.main_page.content_panel.communities.confirm_withdraw = Some(*i);
+        }
+        Action::CommunityCancelWithdraw => {
+            state.main_page.content_panel.communities.confirm_withdraw = None;
         }
         Action::CommunitySwitcherMove(i) => {
             if let Some(switcher) = state.main_page.switcher.as_mut() {

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -164,6 +164,16 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
             .fg(COLOR_ORANGE)
             .bold(),
         );
+    } else if let Some(idx) = state.confirm_withdraw {
+        lines.push(
+            Line::from(format!(
+                "Cancel the pending join to “{}”? The request will be marked withdrawn.   \
+                 y: confirm    n: cancel",
+                confirm_name(idx)
+            ))
+            .fg(COLOR_ORANGE)
+            .bold(),
+        );
     } else {
         let archived_hint = if state.show_archived {
             "v: hide archived"
@@ -173,7 +183,7 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         lines.push(
             Line::from(format!(
                 "↑/↓ navigate   ⏎ open   f: ★   a: acknowledge   l: leave   \
-                 x: archive   d: delete   j: join   {archived_hint}"
+                 c: cancel   x: archive   d: delete   j: join   {archived_hint}"
             ))
             .fg(COLOR_DARK_GRAY),
         );

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -420,10 +420,23 @@ impl MainPage {
             }
             return true;
         }
+        // A cancel-pending-join confirmation is pending: same y/n gate.
+        if let Some(idx) = comms.confirm_withdraw {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    let _ = self.action_tx.send(Action::WithdrawJoin(idx));
+                }
+                _ => {
+                    let _ = self.action_tx.send(Action::CommunityCancelWithdraw);
+                }
+            }
+            return true;
+        }
 
         // Status of the highlighted row gates which management keys apply.
         let sel_active = comms.items.get(selected).is_some_and(|c| c.is_active);
         let sel_inactive = comms.items.get(selected).is_some_and(|c| c.is_inactive);
+        let sel_pending = comms.items.get(selected).is_some_and(|c| c.is_pending);
 
         match key.code {
             KeyCode::Char('j') => {
@@ -460,6 +473,14 @@ impl MainPage {
             KeyCode::Char('l') if sel_active => {
                 // Leave an Active community (R-L-1) — arm the y/n confirmation.
                 let _ = self.action_tx.send(Action::CommunityConfirmLeave(selected));
+                true
+            }
+            // Cancel is pending-only: a Pending join can be withdrawn (arming on
+            // any other state would only fail downstream, so it's gated).
+            KeyCode::Char('c') if sel_pending => {
+                let _ = self
+                    .action_tx
+                    .send(Action::CommunityConfirmWithdraw(selected));
                 true
             }
             KeyCode::Char('x') if sel_inactive => {
@@ -1970,12 +1991,17 @@ mod key_handler_tests {
 
     /// A minimal Communities-panel summary row for key-routing tests.
     fn community_summary(name: &str) -> CommunitySummary {
-        community_summary_with(name, true, false)
+        community_summary_with(name, true, false, false)
     }
 
-    /// A summary with explicit active/inactive status, for the leave/archive/
-    /// delete key-gating tests.
-    fn community_summary_with(name: &str, is_active: bool, is_inactive: bool) -> CommunitySummary {
+    /// A summary with explicit active/inactive/pending status, for the leave/
+    /// cancel/archive/delete key-gating tests.
+    fn community_summary_with(
+        name: &str,
+        is_active: bool,
+        is_inactive: bool,
+        is_pending: bool,
+    ) -> CommunitySummary {
         CommunitySummary {
             display_name: name.to_string(),
             status_label: if is_active { "Active" } else { "Left" }.to_string(),
@@ -1984,6 +2010,7 @@ mod key_handler_tests {
             favourite: false,
             is_active,
             is_inactive,
+            is_pending,
             archived: false,
             needs_attention: false,
             persona_did: "did:example:persona".to_string(),
@@ -2104,7 +2131,7 @@ mod key_handler_tests {
         let active = || {
             page_for(MainMenu::Communities, |s| {
                 s.main_page.content_panel.communities.items =
-                    vec![community_summary_with("a", true, false)].into();
+                    vec![community_summary_with("a", true, false, false)].into();
             })
         };
         let (mut page, mut rx) = active();
@@ -2113,6 +2140,13 @@ mod key_handler_tests {
             Ok(Action::CommunityConfirmLeave(0)) => {}
             _ => panic!("expected CommunityConfirmLeave(0)"),
         }
+        // Active row: `c` (cancel pending join) does nothing.
+        let (mut page, mut rx) = active();
+        page.handle_key_event(press(KeyCode::Char('c')));
+        assert!(
+            rx.try_recv().is_err(),
+            "cancel is gated off for Active rows"
+        );
         let (mut page, mut rx) = active();
         page.handle_key_event(press(KeyCode::Char('d')));
         assert!(
@@ -2130,7 +2164,7 @@ mod key_handler_tests {
         let inactive = || {
             page_for(MainMenu::Communities, |s| {
                 s.main_page.content_panel.communities.items =
-                    vec![community_summary_with("a", false, true)].into();
+                    vec![community_summary_with("a", false, true, false)].into();
             })
         };
         let (mut page, mut rx) = inactive();
@@ -2151,6 +2185,28 @@ mod key_handler_tests {
             rx.try_recv().is_err(),
             "leave is gated off for inactive rows"
         );
+
+        // Pending row: `c` arms a cancel; `d`/`x`/`l` do nothing.
+        let pending = || {
+            page_for(MainMenu::Communities, |s| {
+                s.main_page.content_panel.communities.items =
+                    vec![community_summary_with("a", false, false, true)].into();
+            })
+        };
+        let (mut page, mut rx) = pending();
+        page.handle_key_event(press(KeyCode::Char('c')));
+        match rx.try_recv() {
+            Ok(Action::CommunityConfirmWithdraw(0)) => {}
+            _ => panic!("expected CommunityConfirmWithdraw(0)"),
+        }
+        for (k, what) in [('d', "delete"), ('x', "archive"), ('l', "leave")] {
+            let (mut page, mut rx) = pending();
+            page.handle_key_event(press(KeyCode::Char(k)));
+            assert!(
+                rx.try_recv().is_err(),
+                "{what} is gated off for pending rows"
+            );
+        }
     }
 
     #[test]
@@ -2171,6 +2227,27 @@ mod key_handler_tests {
         match rx.try_recv() {
             Ok(Action::CommunityCancelLeave) => {}
             _ => panic!("expected CommunityCancelLeave"),
+        }
+    }
+
+    #[test]
+    fn communities_cancel_confirm_commits_and_cancels() {
+        let (mut page, mut rx) = page_for(MainMenu::Communities, |s| {
+            s.main_page.content_panel.communities.confirm_withdraw = Some(0);
+        });
+        page.handle_key_event(press(KeyCode::Char('y')));
+        match rx.try_recv() {
+            Ok(Action::WithdrawJoin(0)) => {}
+            _ => panic!("expected WithdrawJoin(0)"),
+        }
+
+        let (mut page, mut rx) = page_for(MainMenu::Communities, |s| {
+            s.main_page.content_panel.communities.confirm_withdraw = Some(0);
+        });
+        page.handle_key_event(press(KeyCode::Char('n')));
+        match rx.try_recv() {
+            Ok(Action::CommunityCancelWithdraw) => {}
+            _ => panic!("expected CommunityCancelWithdraw"),
         }
     }
 


### PR DESCRIPTION
## Problem

A `Pending` community (from a join request) could not be deleted, archived, or left — those actions are all gated to inactive states, and `Pending` is neither. The only escape was the 7-day client timeout. A user who joined the wrong community (or hit a stale DIDComm session that leaves the join stuck `Pending`) had no way to back out and retry.

## What this does

Adds a **cancel pending join** action:

- **`c`** on a Pending row (y/n confirmed) → transitions the membership to a new terminal `CommunityStatus::Withdrawn` and tears down its now-dead DIDComm session.
- `Withdrawn` is **inactive** (archive/delete eligible) and re-joinable, and — like `Left` — a voluntary outcome that **never raises the actions-required badge**.
- The user can then press **`d`** to delete it, or just re-join. Mirrors the existing `leave → delete` pattern.

## VTC notification is best-effort (for now)

vta-sdk — including 0.17, the version the library/binary actually build against (the 0.12 git pin is test-only via `vta-service`) — has **no applicant-side withdraw DIDComm message**, only the `withdrawn` *status* the VTC reports in a status-response. So the cancel is **fully local** for now; the request also lapses to the VTC's own timeout.

- The inbound status-response handler now reconciles a VTC-reported `withdrawn` to the same `Withdrawn` state.
- Real VTC notification is a follow-up: it needs a `join-requests/withdraw/1.0` message added to vta-sdk in the VTI repo first (the protocol layer lives there), then wired at the `TODO(VTI)` in the `WithdrawJoin` action.

## Changes (8 files)

- `openvtc-core/src/config/account.rs` — `Withdrawn` variant; `is_inactive()` / `needs_attention()` updates; guarded `withdraw()` transition (Pending-only).
- `openvtc-core/src/messaging.rs` — inbound `"withdrawn"` reconciliation.
- `openvtc/src/state_handler/...` — `Action::{CommunityConfirmWithdraw, CommunityCancelWithdraw, WithdrawJoin}`, arm/disarm nav handling, and the async `WithdrawJoin` handler (best-effort notify + transition + session teardown).
- `openvtc/src/state_handler/main_page/...` — `is_pending` summary field, `Withdrawn` status label.
- `openvtc/src/ui/pages/main/...` — `c`-key gating (pending-only), confirm prompt, help-text `c: cancel`.

## Tests

New unit tests for: the `withdraw()` transition + guards, status classification, the `withdrawn` serde tag, inbound status-response reconciliation, and the `c`-key gating + confirm flow.

`cargo build`, `cargo test`, and `cargo clippy` all green (one pre-existing clippy warning at `mod.rs:138`, untouched).

## Follow-up

- VTI: add `join-requests/withdraw/1.0` to vta-sdk so cancel can actively notify the VTC, then wire the send here (see `TODO(VTI)`).