### PR TITLE
fix(persona): create-persona does nothing on a State-A account

### DIFF
--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1996,6 +1996,39 @@ impl StateHandler {
                             );
                         }
                     }
+                    Action::CreatePersonaSubmit => {
+                        // Minting needs only the admin VTA session + account
+                        // context, both present in State-A — so a brand-new account
+                        // (which runs here) can create its first persona DID.
+                        if let Some(ctx) = join_ctx.as_mut() {
+                            self.run_create_persona(
+                                state,
+                                &ctx.tdk,
+                                &mut ctx.config,
+                                ctx.admin_vta.as_ref(),
+                            )
+                            .await;
+                        } else if let Some(o) = state.main_page.create_persona.as_mut() {
+                            o.phase = main_page::content::CreatePersonaPhase::Failed;
+                            o.messages = vec![
+                                "VTA session unavailable — cannot create a persona right now."
+                                    .to_string(),
+                            ];
+                        }
+                    }
+                    Action::CreatePersonaCopy => {
+                        if let Some(did) = state
+                            .main_page
+                            .create_persona
+                            .as_ref()
+                            .and_then(|o| o.did.clone())
+                        {
+                            let copied = crate::clipboard::copy_to_clipboard(&did).is_ok();
+                            if let Some(o) = state.main_page.create_persona.as_mut() {
+                                o.copied = copied;
+                            }
+                        }
+                    }
                     // Messaging-only actions (Inbox / Relationship / Credential /
                     // Settings / Contact, DeleteDid) are intentionally inert in the
                     // degraded loop — there's no live messaging/admin context to
@@ -2447,7 +2480,10 @@ mod tests {
             "ToggleShowArchived re-syncs from config in the loop"
         );
         // The persona mint (and its clipboard copy) reach the loop, not the pure
-        // reducer (network + config mutation).
+        // reducer (network + config mutation). NB: being loop-local, these must be
+        // wired in BOTH the runtime loop and `run_degraded_loop` — the State-A
+        // (no-identity) account that runs the degraded loop is exactly when a user
+        // creates their first persona DID.
         assert!(
             !handle_nav_action(&mut state, &Action::CreatePersonaSubmit),
             "CreatePersonaSubmit mints via the VTA in the loop"


### PR DESCRIPTION
## Symptom

In the **Create Persona DID** overlay, pressing Enter after typing a label did nothing — no progress, no error, no DID. (Reported right after #134 merged.)

## Root cause

A **State-A** account — bootstrapped (VTA + context) but with no persona/community yet — runs `run_degraded_loop`, not the main runtime loop. That's exactly when you'd create your *first* persona DID.

The overlay's open and label-edit actions go through the shared `handle_nav_action` reducer, so they worked (the typed name appeared). But `CreatePersonaSubmit` / `CreatePersonaCopy` are **loop-local** and were only wired into the runtime loop — the degraded loop's catch-all `_ => {}` silently dropped them.

## Fix

Wire both arms into `run_degraded_loop`, minting via the join context's admin VTA + config (minting needs only the admin session + account context, both present in State-A — `ctx.profile == self.profile`, so `run_create_persona`'s persist path is correct).

Also documented the dual-loop contract in the `nav_reducer_defers_loop_local_arms` test so the next loop-local action isn't dropped the same way.

## Verification

- `cargo build`, `cargo clippy --all-targets`, and `cargo test -p openvtc` (160 passed) all clean.
- Not driven against a live VTA from CI; verified by build/tests + root-cause analysis. Manual check after merge: fresh account → menu "Create Persona DID" → type a label → Enter → progress then the DID.

Follow-up (not in this PR): the runtime and degraded loops duplicate several loop-local arms (StartJoin, DeleteCommunity, now CreatePersona) — a shared loop-local dispatcher would prevent this whole class of "handled in one loop, dropped in the other" bug.