### PR TITLE
VIC lifecycle management + verdict-model join + explicit VIC selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,16 +561,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-sd-jwt-vc"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c85a1cd2ffb74ee591912a8145f5a83369d2a25aaec2a15163664e15fba6538"
+checksum = "e8c9b05d34d0456f24d858fb346c4e78953da8235618819396eb9987d6e700f7"
 dependencies = [
- "affinidi-sd-jwt",
- "chrono",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
+ "affinidi-vc",
 ]
 
 [[package]]
@@ -704,20 +699,6 @@ dependencies = [
  "tokio",
  "tracing",
  "windows-native-keyring-store",
-]
-
-[[package]]
-name = "affinidi-vc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d37a13101e2361c97cb3059a2b2a200c679274dabc91467ebd92a0a33a1641"
-dependencies = [
- "chrono",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -2516,7 +2497,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.1",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -5482,7 +5463,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.1",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5532,7 +5513,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "vta-sdk 0.17.0",
+ "vta-sdk 0.18.1",
  "vta-service",
  "x25519-dalek",
  "zeroize",
@@ -5683,6 +5664,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -8844,6 +8831,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.118",
+ "uuid",
+]
+
+[[package]]
 name = "uuid"
 version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8883,8 +8908,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vta-cli-common"
-version = "0.9.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af94a523177532ee4fde73fa7c79f2373a516dcd74cb739c05626168439e4393"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -8901,44 +8927,9 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
- "vta-sdk 0.12.0",
+ "vta-sdk 0.18.1",
+ "vti-common",
  "x25519-dalek",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.12.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
-dependencies = [
- "affinidi-crypto",
- "affinidi-data-integrity",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci 0.1.3",
- "affinidi-openid4vp",
- "affinidi-secrets-resolver",
- "affinidi-tdk 0.7.4",
- "affinidi-vc 0.1.2",
- "base64 0.22.1",
- "chrono",
- "ciborium",
- "curve25519-dalek",
- "didwebvh-rs",
- "ed25519-dalek",
- "getrandom 0.4.2",
- "hpke",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "uuid",
- "x25519-dalek",
- "zeroize",
 ]
 
 [[package]]
@@ -8973,9 +8964,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3618f04cc29d1432cf9acfc324384a15875710d0b72c27a0d56999d859506d78"
+checksum = "37c4f9cca1d6a6721a4ef53aab46337f6b8555fa4303c8ebe47f6b93974089bb"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8985,7 +8976,7 @@ dependencies = [
  "affinidi-openid4vp",
  "affinidi-secrets-resolver",
  "affinidi-tdk 0.8.3",
- "affinidi-vc 0.2.1",
+ "affinidi-vc",
  "base64 0.22.1",
  "chrono",
  "ciborium",
@@ -8996,6 +8987,7 @@ dependencies = [
  "hpke",
  "multibase",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -9004,6 +8996,7 @@ dependencies = [
  "tracing",
  "trust-tasks-rs",
  "url",
+ "utoipa",
  "uuid",
  "x25519-dalek",
  "zeroize",
@@ -9011,8 +9004,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.9.4"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10e52e43ff5a4cc7ad8b494ddfcfcec34586a4a89ed42f3c40b46e55d62af12a"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9020,13 +9014,13 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-messaging-didcomm-service",
- "affinidi-openid4vci 0.1.3",
+ "affinidi-openid4vci 0.2.1",
  "affinidi-openid4vp",
  "affinidi-sd-jwt",
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk 0.7.4",
+ "affinidi-tdk 0.8.3",
  "affinidi-tdk-common",
  "argon2",
  "async-trait",
@@ -9073,10 +9067,13 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "urlencoding",
+ "utoipa",
+ "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.12.0",
+ "vta-sdk 0.18.1",
  "vti-common",
+ "vti-secrets",
  "vti-webauthn",
  "webauthn-rs",
  "webauthn-rs-proto",
@@ -9086,12 +9083,13 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.10.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1606f67812497ee90e40fc12975ade36a7ae1c7b7fb3f473337b8eb38c185c5f"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
- "affinidi-tdk 0.7.4",
+ "affinidi-tdk 0.8.3",
  "async-trait",
  "axum",
  "axum-extra",
@@ -9114,16 +9112,32 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "utoipa",
+ "utoipa-axum",
  "uuid",
- "vta-sdk 0.12.0",
+ "vta-sdk 0.18.1",
  "webauthn-rs",
  "zeroize",
 ]
 
 [[package]]
+name = "vti-secrets"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa43407f03dbd60a633199cce92590f9e4fd4a4726d5f613bdb08cf2ec59bc29"
+dependencies = [
+ "hex",
+ "serde",
+ "tokio",
+ "tracing",
+ "vti-common",
+]
+
+[[package]]
 name = "vti-webauthn"
 version = "0.1.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=82097382702a88cc86f2268a1a37068027d9831c#82097382702a88cc86f2268a1a37068027d9831c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234719328d299d2845a540ecffb7e20f9c745092fcc5385b6e916cde2dcd6bef"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-vta-sdk = { version = "0.17", features = [
+vta-sdk = { version = "0.18", features = [
   "session",
   "client",
   "didcomm",

--- a/deny.toml
+++ b/deny.toml
@@ -94,9 +94,3 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Verifiable Trust Infrastructure — source of the `vta-service` git
-# dev-dependency (the in-process MockVta harness for the bootstrap e2e).
-# It is the VTA server crate and is not published to crates.io, so the
-# integration test consumes it from git. Dev/test-only; no production
-# (`cargo build`) artifact pulls from this source.
-allow-git = ["https://github.com/OpenVTC/verifiable-trust-infrastructure"]

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -78,11 +78,10 @@ criterion = { version = "0.8", features = ["html_reports"] }
 affinidi-messaging-test-mediator = "0.2"
 affinidi-messaging-didcomm-service = { workspace = true }
 # In-process MockVta for the bootstrap e2e (VTI#406/#427 test-support seams).
-# `vta-service` is the VTA server crate — not published to crates.io — so it's
-# consumed as a git dev-dependency (the VTI git source is allow-listed in
-# deny.toml). Pinned to a commit on `origin/main` carrying vta-sdk 0.12.0 +
-# `provision_admin_rotated_via_rest` + the `MockVta::start_provisionable` seams.
-vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "82097382702a88cc86f2268a1a37068027d9831c", version = "0.9", default-features = false, features = ["test-support", "rest", "didcomm"] }
+# `vta-service` is the VTA server crate; 0.10 carries the credential-vault
+# lifecycle tasks (receive/query/archive/delete/restore/purge) + the
+# `MockVta::start_provisionable` seams used by the e2e tests.
+vta-service = { version = "0.10", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -202,6 +202,20 @@ pub fn invitation_id(vic: &Value) -> Option<&str> {
     vic.get("id").and_then(Value::as_str)
 }
 
+/// Whether a JSON value is an InvitationCredential (its `type` array carries
+/// the `InvitationCredential` tag). Used to validate a pasted/loaded VIC
+/// before stashing it (join flow) or storing it in the vault (VIC manager).
+pub fn is_invitation_credential(value: &Value) -> bool {
+    value
+        .get("type")
+        .and_then(|t| t.as_array())
+        .is_some_and(|types| {
+            types
+                .iter()
+                .any(|t| t.as_str() == Some("InvitationCredential"))
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,6 +229,21 @@ mod tests {
             "credentialSubject": { "id": "did:webvh:example.com:alice" },
             "proof": { "type": "DataIntegrityProof" }
         })
+    }
+
+    #[test]
+    fn is_invitation_credential_checks_the_type_tag() {
+        assert!(is_invitation_credential(&sample_vic()));
+        // Missing `type`.
+        assert!(!is_invitation_credential(&json!({ "id": "x" })));
+        // Wrong tag.
+        assert!(!is_invitation_credential(
+            &json!({ "type": ["VerifiableCredential", "MembershipCredential"] })
+        ));
+        // `type` not an array.
+        assert!(!is_invitation_credential(
+            &json!({ "type": "InvitationCredential" })
+        ));
     }
 
     #[test]

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -16,7 +16,7 @@ use serde_json::{Value, json};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 use vta_sdk::protocols::join_requests::{
-    JoinRequestStatusResponseBody, JoinRequestSubmitReceiptBody,
+    JoinRequestStatusResponseBody, JoinRequestSubmitReceiptBody, VerdictEffect, VerdictResponse,
 };
 
 use crate::config::Config;
@@ -319,6 +319,136 @@ pub fn handle_join_status_response(
             debug!(vtc = %from_did, status = %other, "status-response: no transition");
             StatusOutcome::NONE
         }
+    }
+}
+
+/// Handle a VTC join-request `submit/#response` carrying a [`VerdictResponse`] —
+/// the synchronous admission decision in the trust-task join model (it replaces
+/// the old submit-receipt → status-response path). Correlate by `thid` = our
+/// submit message id (the placeholder held on the `Pending` record), then map
+/// the verdict effect: `allow` → Active, `deny` → Rejected; `refer` /
+/// `request_more` leave the record Pending (logged — they still raise the
+/// actions-required indicator). Mirrors [`handle_join_status_response`].
+pub fn handle_join_verdict(account: &mut Account, message: &Message, from_did: &str) -> StatusOutcome {
+    let Some(thid) = message.thid.as_deref() else {
+        warn!("join verdict without thid — cannot correlate; ignoring");
+        return StatusOutcome::NONE;
+    };
+    let Ok(placeholder) = Uuid::parse_str(thid) else {
+        warn!(thid = %thid, "join verdict thid is not a uuid — ignoring");
+        return StatusOutcome::NONE;
+    };
+    let body: VerdictResponse = match serde_json::from_value(message.body.clone()) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "malformed join verdict body — ignoring");
+            return StatusOutcome::NONE;
+        }
+    };
+    let Some(record) = account.communities.get_mut(from_did) else {
+        warn!(vtc = %from_did, "verdict from an unknown community — ignoring");
+        return StatusOutcome::NONE;
+    };
+    let matches = matches!(
+        &record.status,
+        CommunityStatus::Pending { request_id } if *request_id == placeholder
+    );
+    if !matches {
+        warn!(vtc = %from_did, "verdict did not match a pending request id — ignoring");
+        return StatusOutcome::NONE;
+    }
+
+    match body.verdict.effect {
+        VerdictEffect::Allow => {
+            record.activate(chrono::Utc::now());
+            info!(vtc = %from_did, "join allowed by VTC — now Active");
+            StatusOutcome {
+                changed: true,
+                inactivated: false,
+            }
+        }
+        VerdictEffect::Deny => {
+            record.reject();
+            info!(
+                vtc = %from_did,
+                code = body.verdict.with.code.as_deref().unwrap_or(""),
+                reason = body.verdict.with.reason.as_deref().unwrap_or(""),
+                "join denied by VTC policy — now Rejected"
+            );
+            StatusOutcome {
+                changed: true,
+                inactivated: true,
+            }
+        }
+        VerdictEffect::Refer => {
+            info!(
+                vtc = %from_did,
+                queue = body.verdict.with.queue.as_deref().unwrap_or(""),
+                "join referred for human review — stays Pending"
+            );
+            StatusOutcome::NONE
+        }
+        VerdictEffect::RequestMore => {
+            info!(
+                vtc = %from_did,
+                needs = ?body.verdict.with.needs,
+                "join needs more evidence — stays Pending"
+            );
+            StatusOutcome::NONE
+        }
+    }
+}
+
+/// Handle a DIDComm problem-report threaded to our join submit — the framework
+/// failure path of the trust-task join (invalid/expired/malformed VIC, bad
+/// signature). Correlate by `thid`, then branch on the `e.p.msg.*` code:
+/// `forbidden` (the invitation was not accepted) → Rejected, surfacing the
+/// `comment`; any other code (bad-request / internal) is logged but leaves the
+/// record Pending (it's a transient/client problem, not a policy rejection).
+pub fn handle_join_problem_report(
+    account: &mut Account,
+    message: &Message,
+    from_did: &str,
+) -> StatusOutcome {
+    use vta_sdk::protocols::problem_report_codes as codes;
+
+    let Some(thid) = message.thid.as_deref() else {
+        warn!("join problem-report without thid — ignoring");
+        return StatusOutcome::NONE;
+    };
+    let Ok(placeholder) = Uuid::parse_str(thid) else {
+        return StatusOutcome::NONE;
+    };
+    let (code, comment) = vta_sdk::protocols::extract_problem_report(&message.body);
+    let Some(record) = account.communities.get_mut(from_did) else {
+        warn!(vtc = %from_did, code = %code, "problem-report from an unknown community — ignoring");
+        return StatusOutcome::NONE;
+    };
+    let matches = matches!(
+        &record.status,
+        CommunityStatus::Pending { request_id } if *request_id == placeholder
+    );
+    if !matches {
+        warn!(vtc = %from_did, code = %code, "problem-report did not match a pending request id — ignoring");
+        return StatusOutcome::NONE;
+    }
+
+    if code == codes::FORBIDDEN {
+        record.reject();
+        info!(
+            vtc = %from_did,
+            comment = %comment,
+            "join rejected by VTC — invitation not accepted (now Rejected)"
+        );
+        StatusOutcome {
+            changed: true,
+            inactivated: true,
+        }
+    } else {
+        // bad-request / internal / other: the submit didn't admit, but it's not a
+        // policy rejection — surface the detail and leave the record Pending.
+        warn!(vtc = %from_did, code = %code, comment = %comment, "join submit failed — left Pending");
+        StatusOutcome::NONE
     }
 }
 
@@ -836,6 +966,145 @@ mod tests {
             "more-info handling is a D4 stub — stays Pending"
         );
         assert!(!out.inactivated);
+        assert!(matches!(
+            acct.communities.get(vtc).unwrap().status,
+            CommunityStatus::Pending { .. }
+        ));
+    }
+
+    // ----- Verdict-model join (trust-task) -----------------------------------
+
+    fn verdict(thid: &str, from: &str, effect: &str, with: serde_json::Value) -> Message {
+        Message::build(
+            Uuid::new_v4().to_string(),
+            vta_sdk::protocols::join_requests::JOIN_REQUEST_SUBMIT_RESPONSE_TYPE.to_string(),
+            serde_json::json!({
+                "requestId": Uuid::new_v4(),
+                "verdict": { "effect": effect, "with": with },
+            }),
+        )
+        .from(from.to_string())
+        .thid(thid.to_string())
+        .finalize()
+    }
+
+    #[test]
+    fn verdict_allow_activates() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out = handle_join_verdict(
+            &mut acct,
+            &verdict(&rid.to_string(), vtc, "allow", serde_json::json!({})),
+            vtc,
+        );
+        assert!(out.changed);
+        assert!(!out.inactivated);
+        assert!(matches!(
+            acct.communities.get(vtc).unwrap().status,
+            CommunityStatus::Active
+        ));
+    }
+
+    #[test]
+    fn verdict_deny_rejects_and_inactivates() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let with = serde_json::json!({ "code": "policy.denied", "reason": "no" });
+        let out = handle_join_verdict(
+            &mut acct,
+            &verdict(&rid.to_string(), vtc, "deny", with),
+            vtc,
+        );
+        assert!(out.changed);
+        assert!(out.inactivated, "a deny deregisters the session");
+        assert!(matches!(
+            acct.communities.get(vtc).unwrap().status,
+            CommunityStatus::Rejected
+        ));
+    }
+
+    #[test]
+    fn verdict_request_more_stays_pending() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let with = serde_json::json!({ "needs": ["proof-of-age"] });
+        let out = handle_join_verdict(
+            &mut acct,
+            &verdict(&rid.to_string(), vtc, "request_more", with),
+            vtc,
+        );
+        assert!(!out.changed);
+        assert!(matches!(
+            acct.communities.get(vtc).unwrap().status,
+            CommunityStatus::Pending { .. }
+        ));
+    }
+
+    #[test]
+    fn verdict_with_mismatched_thid_is_ignored() {
+        let vtc = "did:webvh:example:vtc";
+        let mut acct = pending_account(vtc, Uuid::new_v4());
+        // thid is a *different* uuid than the pending placeholder.
+        let out = handle_join_verdict(
+            &mut acct,
+            &verdict(&Uuid::new_v4().to_string(), vtc, "deny", serde_json::json!({})),
+            vtc,
+        );
+        assert!(!out.changed);
+        assert!(matches!(
+            acct.communities.get(vtc).unwrap().status,
+            CommunityStatus::Pending { .. }
+        ));
+    }
+
+    fn problem_report(thid: &str, from: &str, code: &str, comment: &str) -> Message {
+        Message::build(
+            Uuid::new_v4().to_string(),
+            vta_sdk::protocols::PROBLEM_REPORT_TYPE.to_string(),
+            serde_json::json!({ "code": code, "comment": comment }),
+        )
+        .from(from.to_string())
+        .thid(thid.to_string())
+        .finalize()
+    }
+
+    #[test]
+    fn problem_report_forbidden_rejects() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out = handle_join_problem_report(
+            &mut acct,
+            &problem_report(&rid.to_string(), vtc, "e.p.msg.forbidden", "invitation rejected"),
+            vtc,
+        );
+        assert!(out.changed);
+        assert!(out.inactivated);
+        assert!(matches!(
+            acct.communities.get(vtc).unwrap().status,
+            CommunityStatus::Rejected
+        ));
+    }
+
+    #[test]
+    fn problem_report_bad_request_stays_pending() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out = handle_join_problem_report(
+            &mut acct,
+            &problem_report(&rid.to_string(), vtc, "e.p.msg.bad-request", "malformed"),
+            vtc,
+        );
+        assert!(!out.changed, "a client/transient error must not mark Rejected");
         assert!(matches!(
             acct.communities.get(vtc).unwrap().status,
             CommunityStatus::Pending { .. }

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -365,6 +365,47 @@ pub enum Action {
     /// Close the create-persona overlay.
     CreatePersonaClose,
 
+    // ── VIC manager (VTA panel, Invitation Credentials list) ────────────────
+    /// (Re)load the VIC list from the vault (async). Sent when the operator
+    /// focuses the VIC list so the panel is populated without polling.
+    VicRefresh,
+    /// Move the VIC-list selection to this index.
+    VicSelect(usize),
+    /// Toggle keyboard focus between the Context Identities and VIC lists (Tab).
+    VicFocusToggle,
+    /// Toggle whether archived + soft-deleted VICs are listed (`i`); triggers a
+    /// re-query.
+    VicToggleInactive,
+    /// Archive the selected VIC (async).
+    VicArchive(usize),
+    /// Unarchive the selected (archived) VIC (async).
+    VicUnarchive(usize),
+    /// Restore the selected (soft-deleted) VIC (async).
+    VicRestore(usize),
+    /// Arm the soft-delete confirmation for the VIC at this index.
+    VicConfirmDelete(usize),
+    /// Dismiss the soft-delete confirmation.
+    VicCancelDelete,
+    /// Soft-delete the VIC at this index (async; after confirm).
+    DeleteVic(usize),
+    /// Arm the irreversible-purge confirmation for the VIC at this index.
+    VicConfirmPurge(usize),
+    /// Dismiss the purge confirmation.
+    VicCancelPurge,
+    /// Irreversibly purge the VIC at this index (async; after confirm).
+    PurgeVic(usize),
+
+    /// Open the "import an invitation credential" overlay (paste phase).
+    StartAddVic,
+    /// Forward a key event to the add-VIC paste input (editing keys only).
+    AddVicInput(crossterm::event::KeyEvent),
+    /// Set the add-VIC paste input to this text (bracketed-paste path).
+    AddVicPaste(String),
+    /// Validate + store the pasted VIC (async). Sent from the overlay's input phase.
+    AddVicSubmit,
+    /// Close the add-VIC overlay.
+    AddVicClose,
+
     // ************************************************************************
     // SETUP Pages
     /// Import existing Config

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -256,6 +256,10 @@ pub enum Action {
     /// credential (VIC) JSON — validated + stashed into the join flow.
     JoinPasteVic(String),
 
+    /// Clear the loaded invitation credential on the join entry page so the
+    /// join proceeds without a VIC (explicit "ignore it" choice).
+    JoinClearVic,
+
     /// Move the Communities-list selection to this index.
     CommunitySelect(usize),
 

--- a/openvtc/src/state_handler/didcomm.rs
+++ b/openvtc/src/state_handler/didcomm.rs
@@ -212,7 +212,7 @@ pub fn build_router(event_tx: mpsc::Sender<DIDCommEvent>) -> Result<Router, anyh
         // (e.g. join-requests/submit-receipt). The state handler dispatches
         // by type and ignores any it doesn't handle.
         .route_regex(
-            "https://linuxfoundation\\.org/openvtc/.*|https://firstperson\\.network/.*|https://trusttasks\\.org/openvtc/vtc/.*|https://trusttasks\\.org/spec/credential-exchange/.*",
+            "https://linuxfoundation\\.org/openvtc/.*|https://firstperson\\.network/.*|https://trusttasks\\.org/openvtc/vtc/.*|https://trusttasks\\.org/spec/credential-exchange/.*|https://didcomm\\.org/report-problem/.*",
             openvtc_handler,
         )?
         // Message pickup status — silently drop

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -73,6 +73,11 @@ pub struct JoinState {
     /// survives `reset`, which is called once at open) so the entry page can show
     /// the operator that their invitation will be used.
     pub has_invitation: bool,
+    /// True when the operator explicitly cleared a loaded VIC on the entry page,
+    /// so the status text reads "joining without an invitation" rather than the
+    /// generic "no VIC" tip. Distinguishes a deliberate clear from never having
+    /// had one; re-pasting a VIC (`JoinPasteVic`) flips it back to `false`.
+    pub vic_cleared: bool,
 }
 
 impl JoinState {
@@ -115,6 +120,17 @@ mod tests {
             did: "did:webvh:x".to_string(),
             linked_communities: Vec::new(),
         }
+    }
+
+    #[test]
+    fn vic_cleared_defaults_false_and_resets() {
+        let mut js = JoinState::default();
+        assert!(!js.vic_cleared);
+        js.vic_cleared = true;
+        js.has_invitation = true;
+        js.reset();
+        assert!(!js.vic_cleared);
+        assert!(!js.has_invitation);
     }
 
     #[test]

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -119,6 +119,7 @@ impl StateHandler {
                                 {
                                     state.invitation_credential = Some(vic);
                                     state.join.has_invitation = true;
+                                    state.join.vic_cleared = false;
                                     state.join.messages.clear();
                                 }
                                 _ => {
@@ -128,6 +129,16 @@ impl StateHandler {
                                     ));
                                 }
                             }
+                            let _ = self.state_tx.send(state.clone());
+                        }
+                        Action::JoinClearVic => {
+                            // Explicit "proceed without a VIC": drop the loaded
+                            // invitation so it isn't presented, and flag the clear so
+                            // the entry page shows "joining without an invitation".
+                            state.invitation_credential = None;
+                            state.join.has_invitation = false;
+                            state.join.vic_cleared = true;
+                            state.join.messages.clear();
                             let _ = self.state_tx.send(state.clone());
                         }
                         Action::JoinSubmitVtc(vtc_did) => {

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -114,7 +114,9 @@ impl StateHandler {
                             // VIC and stash it so the join presents it (mirrors the
                             // `--invitation <file>` launch flag).
                             match serde_json::from_str::<serde_json::Value>(&text) {
-                                Ok(vic) if is_invitation_credential(&vic) => {
+                                Ok(vic)
+                                    if openvtc_core::join::is_invitation_credential(&vic) =>
+                                {
                                     state.invitation_credential = Some(vic);
                                     state.join.has_invitation = true;
                                     state.join.messages.clear();
@@ -450,19 +452,6 @@ async fn build_linkage_proof(
             None
         }
     }
-}
-
-/// Whether a pasted/loaded JSON value is an InvitationCredential (its `type`
-/// array carries the `InvitationCredential` tag).
-fn is_invitation_credential(value: &serde_json::Value) -> bool {
-    value
-        .get("type")
-        .and_then(|t| t.as_array())
-        .is_some_and(|types| {
-            types
-                .iter()
-                .any(|t| t.as_str() == Some("InvitationCredential"))
-        })
 }
 
 /// Idempotency decision (R-B-9): is there already a *live* (Active/Pending)

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -242,6 +242,128 @@ pub struct VtaState {
     /// When `Some(index)`, a deletion of that context DID is awaiting `y`/`n`
     /// confirmation.
     pub confirm_delete_did: Option<usize>,
+
+    /// Invitation credentials (VICs) the holder holds in the VTA credential
+    /// vault, for the VIC manager. Populated by an async query (not derived from
+    /// `Config`), refreshed after each mutation. `Arc<[…]>` for cheap per-frame
+    /// clones.
+    pub vics: Arc<[VicSummary]>,
+    /// Selected index into [`Self::vics`] (VIC manager navigation).
+    pub vic_selected_index: usize,
+    /// When `Some(index)`, a soft-delete of that VIC is awaiting `y`/`n`.
+    pub confirm_delete_vic: Option<usize>,
+    /// When `Some(index)`, a *purge* (irreversible) of that VIC is awaiting
+    /// `y`/`n` — kept distinct from the soft-delete arm so the prompt is explicit.
+    pub confirm_purge_vic: Option<usize>,
+    /// Whether the VIC list includes archived + soft-deleted entries (the
+    /// `include_archived` / `include_deleted` query modifiers). Toggled with `i`.
+    pub vic_show_inactive: bool,
+    /// Which of the two manageable lists (Context Identities vs Invitation
+    /// Credentials) has keyboard focus, so `↑/↓` and the verbs apply to it.
+    pub focus: VtaFocus,
+}
+
+/// Which manageable list in the VTA panel has keyboard focus (toggled by `Tab`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum VtaFocus {
+    /// The Context Identities (persona DID) list.
+    #[default]
+    Dids,
+    /// The Invitation Credentials (VIC) list.
+    Vics,
+}
+
+/// Display summary of one held VIC, mapped from the VTA credential-vault
+/// `CredentialDescriptor` (descriptor only — the credential body is never
+/// fetched for the list). Wire fields are camelCase.
+#[derive(Clone, Debug, Default)]
+pub struct VicSummary {
+    /// Vault id — the handle for archive / delete / restore / purge.
+    pub id: String,
+    /// Issuer DID (the community that issued the invitation), if recorded.
+    pub issuer: String,
+    /// Validity status: "valid" / "expired" / "revoked" / "unknown".
+    pub status: String,
+    /// Archival lifecycle (active / archived / deleted), orthogonal to status.
+    pub lifecycle: VicLifecycle,
+    /// RFC 3339 validity-window end, if declared (shown as detail).
+    pub valid_until: String,
+}
+
+impl VicSummary {
+    /// Map one `credentials[]` descriptor (camelCase JSON) to a summary.
+    pub fn from_descriptor(d: &serde_json::Value) -> Self {
+        let s = |k: &str| d.get(k).and_then(|v| v.as_str()).unwrap_or("").to_string();
+        VicSummary {
+            id: s("id"),
+            issuer: s("issuerDid"),
+            status: {
+                let st = s("status");
+                if st.is_empty() { "unknown".to_string() } else { st }
+            },
+            lifecycle: VicLifecycle::from_wire(d.get("lifecycle").and_then(|v| v.as_str())),
+            valid_until: s("validUntil"),
+        }
+    }
+}
+
+/// The archival lifecycle state of a held VIC (vault `lifecycle` dimension).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum VicLifecycle {
+    /// Live and presentable. Omitted from the descriptor → defaults here.
+    #[default]
+    Active,
+    /// Hidden from presentation but retained; restorable via unarchive.
+    Archived,
+    /// Soft-deleted tombstone; restorable within the grace window, else purged.
+    Deleted,
+}
+
+impl VicLifecycle {
+    fn from_wire(s: Option<&str>) -> Self {
+        match s {
+            Some("archived") => VicLifecycle::Archived,
+            Some("deleted") => VicLifecycle::Deleted,
+            _ => VicLifecycle::Active,
+        }
+    }
+
+    /// Short tag for the panel row.
+    pub fn tag(self) -> &'static str {
+        match self {
+            VicLifecycle::Active => "active",
+            VicLifecycle::Archived => "archived",
+            VicLifecycle::Deleted => "deleted",
+        }
+    }
+}
+
+/// "Import an invitation credential" overlay (paste a VIC → store it in the
+/// vault). `Some` while open; floats over the main page like the create-persona
+/// overlay. Walks `Input` (paste the VIC JSON) → `Working` (the vault receive
+/// runs) → `Done` or `Failed`.
+#[derive(Clone, Debug, Default)]
+pub struct AddVicState {
+    /// Which step of the overlay is showing.
+    pub phase: AddVicPhase,
+    /// The pasted VIC JSON, used while in the `Input` phase.
+    pub input: tui_input::Input,
+    /// Progress / validation / error lines.
+    pub messages: Vec<String>,
+}
+
+/// Step of the [`AddVicState`] overlay.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum AddVicPhase {
+    /// Awaiting the pasted VIC JSON (validated on submit).
+    #[default]
+    Input,
+    /// The vault receive is running (input locked).
+    Working,
+    /// Stored successfully.
+    Done,
+    /// Validation or storage failed; show the error.
+    Failed,
 }
 
 /// A persona DID in the account's context, for the DID manager view.

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -68,6 +68,11 @@ pub struct MainPageState {
     /// top-level menu and the VTA panel.
     pub create_persona: Option<content::CreatePersonaState>,
 
+    /// "Import an invitation credential" overlay for the VIC manager. `Some`
+    /// while open; `None` (default) when closed. Page-level (like
+    /// [`create_persona`](Self::create_persona)) because it floats over the panel.
+    pub add_vic: Option<content::AddVicState>,
+
     /// Activity log entries shown in the bottom panel (newest last).
     ///
     /// Entries are wrapped in `Arc` so cloning `MainPageState` (which happens

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -16,8 +16,9 @@ use affinidi_tdk::{TDK, didcomm::Message};
 use dtg_credentials::DTGCredential;
 use openvtc_core::messaging::{
     SeenMessages, check_message_age, check_task_capacity, create_finalize_message,
-    handle_credential_issue, handle_join_status_response, handle_join_submit_receipt, require_thid,
-    validate_did, verify_vrc_proof, vet_vrc_issued,
+    handle_credential_issue, handle_join_problem_report, handle_join_status_response,
+    handle_join_submit_receipt, handle_join_verdict, require_thid, validate_did, verify_vrc_proof,
+    vet_vrc_issued,
 };
 use openvtc_core::{
     MessageType,
@@ -28,9 +29,11 @@ use openvtc_core::{
     vrc::VRCRequestReject,
 };
 use tracing::{debug, info, warn};
+use vta_sdk::protocols::PROBLEM_REPORT_TYPE;
 use vta_sdk::protocols::credential_exchange::ISSUE as CREDENTIAL_ISSUE_TYPE;
 use vta_sdk::protocols::join_requests::{
     JOIN_REQUEST_STATUS_RESPONSE_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
+    JOIN_REQUEST_SUBMIT_RESPONSE_TYPE,
 };
 
 /// Maximum allowed message body size in bytes (1 MB).
@@ -146,6 +149,31 @@ pub async fn process_inbound_message(
             message,
             &from_did,
         ));
+    }
+
+    // VTC join-requests submit `#response`: the synchronous admission verdict in
+    // the trust-task join model (allow / deny / refer / request_more), threaded
+    // (`thid`) on our submit message id. `allow` → Active, `deny` → Rejected; a
+    // rejection inactivates the community so the loop deregisters the session.
+    if message.typ == JOIN_REQUEST_SUBMIT_RESPONSE_TYPE {
+        let outcome = handle_join_verdict(&mut config.account, message, &from_did);
+        if outcome.inactivated {
+            inactivated.push(from_did.to_string());
+        }
+        return Ok(outcome.changed);
+    }
+
+    // DIDComm problem-report: the framework-failure path of the trust-task join
+    // (invalid/expired/malformed VIC, bad signature), threaded on our submit id.
+    // `e.p.msg.forbidden` (the invitation was not accepted) → Rejected; other
+    // codes are surfaced but leave the join Pending. Routed here so a rejection
+    // is no longer silently dropped into a stuck `Pending`.
+    if message.typ == PROBLEM_REPORT_TYPE {
+        let outcome = handle_join_problem_report(&mut config.account, message, &from_did);
+        if outcome.inactivated {
+            inactivated.push(from_did.to_string());
+        }
+        return Ok(outcome.changed);
     }
 
     // VTC join-requests status-response: the authoritative lifecycle resolution

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -69,6 +69,7 @@ mod setup_token_actions;
 mod setup_vta_actions;
 mod setup_wizard;
 pub mod state;
+mod vic;
 
 pub struct DeferredLoad {
     pub profile: String,
@@ -132,11 +133,13 @@ impl StateHandler {
         mut action_rx: UnboundedReceiver<Action>,
         mut interrupt_rx: broadcast::Receiver<Interrupted>,
     ) -> Result<Interrupted> {
-        let mut state = State::default();
         // Carry the launch-supplied invitation credential into the live state so
         // the join flow can present it (it survives `JoinState::reset`, which
         // only clears the transient join sub-state).
-        state.invitation_credential = self.invitation_credential.take();
+        let mut state = State {
+            invitation_credential: self.invitation_credential.take(),
+            ..State::default()
+        };
 
         let starting_mode = std::mem::replace(&mut self.starting_mode, StartingMode::NotSet);
         // The third element is the live admin VTA session handed back by
@@ -1083,6 +1086,25 @@ impl StateHandler {
                         )
                         .await;
                     },
+                    Action::VicRefresh => {
+                        self.refresh_vics(&mut state, admin_vta.as_ref()).await;
+                    },
+                    Action::VicToggleInactive => {
+                        state.main_page.content_panel.vta.vic_show_inactive =
+                            !state.main_page.content_panel.vta.vic_show_inactive;
+                        self.refresh_vics(&mut state, admin_vta.as_ref()).await;
+                    },
+                    Action::AddVicSubmit => {
+                        self.run_add_vic(&mut state, admin_vta.as_ref()).await;
+                    },
+                    Action::VicArchive(i)
+                    | Action::VicUnarchive(i)
+                    | Action::VicRestore(i)
+                    | Action::DeleteVic(i)
+                    | Action::PurgeVic(i) => {
+                        self.run_vic_lifecycle(&mut state, admin_vta.as_ref(), &action, i)
+                            .await;
+                    },
                     Action::CreatePersonaCopy => {
                         if let Some(did) = state
                             .main_page
@@ -1763,6 +1785,134 @@ impl StateHandler {
         let _ = self.state_tx.send(state.clone());
     }
 
+    /// (Re)load the VIC list from the VTA credential vault into the VTA panel,
+    /// honouring the "show inactive" toggle. Best-effort: a query failure logs
+    /// and leaves the previous list in place. Called when the operator focuses
+    /// the VIC list, toggles inactive, and after every mutation.
+    async fn refresh_vics(
+        &self,
+        state: &mut State,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+    ) {
+        let Some(admin_vta) = admin_vta else { return };
+        let include_inactive = state.main_page.content_panel.vta.vic_show_inactive;
+        match vic::list_vics(admin_vta, include_inactive).await {
+            Ok(list) => {
+                let vta = &mut state.main_page.content_panel.vta;
+                vta.vic_selected_index = vta
+                    .vic_selected_index
+                    .min(list.len().saturating_sub(1));
+                vta.vics = list.into();
+            }
+            Err(e) => {
+                state.main_page.log_error("Listing invitation credentials failed", &e);
+            }
+        }
+        let _ = self.state_tx.send(state.clone());
+    }
+
+    /// Validate + store the pasted VIC from the add-VIC overlay, then refresh the
+    /// list. Mirrors [`run_create_persona`]'s phase handling.
+    async fn run_add_vic(
+        &self,
+        state: &mut State,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+    ) {
+        use crate::state_handler::main_page::content::AddVicPhase;
+
+        let json = match state.main_page.add_vic.as_ref() {
+            Some(o) if o.phase == AddVicPhase::Input => o.input.value().to_string(),
+            _ => return,
+        };
+        if json.trim().is_empty() {
+            if let Some(o) = state.main_page.add_vic.as_mut() {
+                o.messages = vec!["Paste an invitation credential (VIC) first.".to_string()];
+            }
+            let _ = self.state_tx.send(state.clone());
+            return;
+        }
+        let Some(admin_vta) = admin_vta else {
+            if let Some(o) = state.main_page.add_vic.as_mut() {
+                o.phase = AddVicPhase::Failed;
+                o.messages = vec!["VTA session unavailable — cannot store the VIC.".to_string()];
+            }
+            let _ = self.state_tx.send(state.clone());
+            return;
+        };
+
+        if let Some(o) = state.main_page.add_vic.as_mut() {
+            o.phase = AddVicPhase::Working;
+            o.messages = vec!["Storing invitation credential…".to_string()];
+        }
+        let _ = self.state_tx.send(state.clone());
+
+        match vic::add_vic(admin_vta, &json).await {
+            Ok(()) => {
+                if let Some(o) = state.main_page.add_vic.as_mut() {
+                    o.phase = AddVicPhase::Done;
+                    o.messages.push("Invitation credential stored.".to_string());
+                }
+                state.main_page.log("Stored an invitation credential.");
+                self.refresh_vics(state, Some(admin_vta)).await;
+            }
+            Err(e) => {
+                // A validation error keeps the operator on the input phase so they
+                // can fix the paste; a storage error is terminal for this attempt.
+                if let Some(o) = state.main_page.add_vic.as_mut() {
+                    o.phase = AddVicPhase::Failed;
+                    o.messages.push(format!("Failed: {e}"));
+                }
+                state.main_page.log_error("Storing the invitation credential failed", &e);
+            }
+        }
+        let _ = self.state_tx.send(state.clone());
+    }
+
+    /// Run a VIC lifecycle verb (archive / unarchive / restore / soft-delete /
+    /// purge) against the selected VIC, clearing any confirmation arm, then
+    /// refresh the list. `index` is into the displayed VIC list.
+    async fn run_vic_lifecycle(
+        &self,
+        state: &mut State,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+        action: &Action,
+        index: usize,
+    ) {
+        // Clear the confirmation arms regardless of outcome.
+        state.main_page.content_panel.vta.confirm_delete_vic = None;
+        state.main_page.content_panel.vta.confirm_purge_vic = None;
+
+        let Some(admin_vta) = admin_vta else { return };
+        let Some(id) = state
+            .main_page
+            .content_panel
+            .vta
+            .vics
+            .get(index)
+            .map(|v| v.id.clone())
+        else {
+            return;
+        };
+
+        let (result, verb) = match action {
+            Action::VicArchive(_) => (vic::archive_vic(admin_vta, &id).await, "Archived"),
+            Action::VicUnarchive(_) => (vic::unarchive_vic(admin_vta, &id).await, "Unarchived"),
+            Action::VicRestore(_) => (vic::restore_vic(admin_vta, &id).await, "Restored"),
+            Action::DeleteVic(_) => (vic::delete_vic(admin_vta, &id).await, "Deleted"),
+            Action::PurgeVic(_) => (vic::purge_vic(admin_vta, &id).await, "Purged"),
+            _ => return,
+        };
+        match result {
+            Ok(()) => state
+                .main_page
+                .log(format!("{verb} invitation credential.")),
+            Err(e) => state
+                .main_page
+                .log_error(format!("VIC {} failed", verb.to_lowercase()), &e),
+        }
+        self.refresh_vics(state, Some(admin_vta)).await;
+    }
+
     /// Remove the community at `index` in the Communities display list: withdraw
     /// a live (Pending/Active) membership first (R-C-8 — for a pending join this
     /// is the withdrawal), then delete the record, persist, and refresh the
@@ -2016,6 +2166,28 @@ impl StateHandler {
                             ];
                         }
                     }
+                    Action::VicRefresh => {
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
+                        self.refresh_vics(state, av).await;
+                    }
+                    Action::VicToggleInactive => {
+                        state.main_page.content_panel.vta.vic_show_inactive =
+                            !state.main_page.content_panel.vta.vic_show_inactive;
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
+                        self.refresh_vics(state, av).await;
+                    }
+                    Action::AddVicSubmit => {
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
+                        self.run_add_vic(state, av).await;
+                    }
+                    Action::VicArchive(i)
+                    | Action::VicUnarchive(i)
+                    | Action::VicRestore(i)
+                    | Action::DeleteVic(i)
+                    | Action::PurgeVic(i) => {
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
+                        self.run_vic_lifecycle(state, av, &action, i).await;
+                    }
                     Action::CreatePersonaCopy => {
                         if let Some(did) = state
                             .main_page
@@ -2180,6 +2352,54 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
         }
         Action::DidCancelDelete => {
             state.main_page.content_panel.vta.confirm_delete_did = None;
+        }
+        Action::VicSelect(i) => {
+            state.main_page.content_panel.vta.vic_selected_index = *i;
+        }
+        Action::VicFocusToggle => {
+            use main_page::content::VtaFocus;
+            let vta = &mut state.main_page.content_panel.vta;
+            vta.focus = match vta.focus {
+                VtaFocus::Dids => VtaFocus::Vics,
+                VtaFocus::Vics => VtaFocus::Dids,
+            };
+        }
+        Action::VicConfirmDelete(i) => {
+            state.main_page.content_panel.vta.confirm_delete_vic = Some(*i);
+            state.main_page.content_panel.vta.confirm_purge_vic = None;
+        }
+        Action::VicCancelDelete => {
+            state.main_page.content_panel.vta.confirm_delete_vic = None;
+        }
+        Action::VicConfirmPurge(i) => {
+            state.main_page.content_panel.vta.confirm_purge_vic = Some(*i);
+            state.main_page.content_panel.vta.confirm_delete_vic = None;
+        }
+        Action::VicCancelPurge => {
+            state.main_page.content_panel.vta.confirm_purge_vic = None;
+        }
+        Action::StartAddVic => {
+            state.main_page.add_vic = Some(main_page::content::AddVicState::default());
+        }
+        Action::AddVicInput(key) => {
+            use tui_input::backend::crossterm::EventHandler;
+            if let Some(overlay) = state.main_page.add_vic.as_mut()
+                && overlay.phase == main_page::content::AddVicPhase::Input
+            {
+                overlay
+                    .input
+                    .handle_event(&crossterm::event::Event::Key(*key));
+            }
+        }
+        Action::AddVicPaste(text) => {
+            if let Some(overlay) = state.main_page.add_vic.as_mut()
+                && overlay.phase == main_page::content::AddVicPhase::Input
+            {
+                overlay.input = tui_input::Input::new(text.clone());
+            }
+        }
+        Action::AddVicClose => {
+            state.main_page.add_vic = None;
         }
         Action::StartCreatePersona => {
             // Open the overlay on its label-entry phase (the mint runs later, in

--- a/openvtc/src/state_handler/vic.rs
+++ b/openvtc/src/state_handler/vic.rs
@@ -1,0 +1,83 @@
+//! VIC (Verifiable Invitation Credential) vault management.
+//!
+//! Thin async helpers over the VTA credential-vault lifecycle tasks, backing the
+//! VTA Service panel's invitation-credential manager: list / import / archive /
+//! unarchive / soft-delete / restore / purge the VICs a holder holds
+//! (`purpose = "invite"`). Everything goes through the always-on admin VTA
+//! session's credential vault. The list is built from descriptors only — a
+//! query result never carries the credential body, so nothing here fetches one.
+
+use anyhow::Result;
+use vta_sdk::client::VtaClient;
+
+use crate::state_handler::main_page::content::VicSummary;
+
+/// Reason string stamped on lifecycle mutations (shows in the VTA audit log).
+const REASON: &str = "via OpenVTC";
+
+/// List the holder's invitation credentials. With `include_inactive`, archived
+/// and soft-deleted VICs are surfaced too (so the panel can offer restore /
+/// purge); otherwise only active ones are returned. `purpose = "invite"`
+/// satisfies the vault's ≥1-filter requirement; the include flags are modifiers.
+pub(crate) async fn list_vics(
+    admin_vta: &VtaClient,
+    include_inactive: bool,
+) -> Result<Vec<VicSummary>> {
+    let mut filter = serde_json::json!({ "purpose": "invite" });
+    if include_inactive {
+        filter["includeArchived"] = serde_json::Value::Bool(true);
+        filter["includeDeleted"] = serde_json::Value::Bool(true);
+    }
+    let listing = admin_vta.cred_vault_query(filter).await?;
+    let creds = listing
+        .get("credentials")
+        .and_then(|c| c.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    Ok(creds.iter().map(VicSummary::from_descriptor).collect())
+}
+
+/// Import a pasted VIC into the vault: validate it is an InvitationCredential,
+/// then store it via `cred_vault_receive`. The vault keys it under the VC's own
+/// `id`.
+pub(crate) async fn add_vic(admin_vta: &VtaClient, json: &str) -> Result<()> {
+    let vic: serde_json::Value =
+        serde_json::from_str(json.trim()).map_err(|e| anyhow::anyhow!("not valid JSON: {e}"))?;
+    if !openvtc_core::join::is_invitation_credential(&vic) {
+        anyhow::bail!("not an invitation credential (missing the `InvitationCredential` type tag)");
+    }
+    admin_vta.cred_vault_receive(vic, None).await?;
+    Ok(())
+}
+
+/// Archive a VIC (hidden from query/presentation, restorable via unarchive).
+pub(crate) async fn archive_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
+    admin_vta.cred_vault_archive(id, Some(REASON)).await?;
+    Ok(())
+}
+
+/// Return an archived VIC to active.
+pub(crate) async fn unarchive_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
+    admin_vta.cred_vault_unarchive(id, Some(REASON)).await?;
+    Ok(())
+}
+
+/// Soft-delete a VIC (recoverable tombstone within the grace window).
+pub(crate) async fn delete_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
+    admin_vta
+        .cred_vault_delete(id, /* force */ false, Some(REASON))
+        .await?;
+    Ok(())
+}
+
+/// Restore a soft-deleted VIC (only within the grace window).
+pub(crate) async fn restore_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
+    admin_vta.cred_vault_restore(id, Some(REASON)).await?;
+    Ok(())
+}
+
+/// Irreversibly purge a VIC and its index rows.
+pub(crate) async fn purge_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
+    admin_vta.cred_vault_purge(id, Some(REASON)).await?;
+    Ok(())
+}

--- a/openvtc/src/ui/pages/join_flow/vtc_enter_did.rs
+++ b/openvtc/src/ui/pages/join_flow/vtc_enter_did.rs
@@ -7,7 +7,7 @@
 use crate::colors::{
     COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_TEXT_DEFAULT,
 };
-use crossterm::event::{Event, KeyCode, KeyEvent};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     Frame,
     layout::{
@@ -46,6 +46,14 @@ impl VtcEnterDid {
             }
             KeyCode::Esc => {
                 let _ = state.action_tx.send(Action::JoinCancel);
+            }
+            // Ctrl+L: clear a loaded invitation and join without it. Ctrl-modified
+            // so it never collides with typing the VTC DID into the input field.
+            KeyCode::Char('l') | KeyCode::Char('L')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && state.props.state.has_invitation =>
+            {
+                let _ = state.action_tx.send(Action::JoinClearVic);
             }
             _ => {
                 state.vtc_did.handle_event(&Event::Key(key));
@@ -114,12 +122,25 @@ impl VtcEnterDid {
                 ));
             }
         }
-        // When an invitation credential was supplied at launch, show that it
-        // will be presented — the community can then auto-admit without review.
+        // Explicit VIC state so the operator knows exactly what will be presented:
+        //   loaded   → it will ride in the join VP (community can auto-admit)
+        //   cleared  → operator dropped it; joining without one (may need review)
+        //   none     → never had one; offer the paste tip
         if state.has_invitation {
             lines.push(Line::styled(
                 "✓ Invitation credential loaded — it will be presented to the community.",
                 Style::new().fg(COLOR_SOFT_PURPLE).bold(),
+            ));
+            lines.push(Line::styled(
+                "[Ctrl+L] join without it   ·   paste a different VIC to replace it",
+                Style::new().fg(COLOR_DARK_GRAY).italic(),
+            ));
+            lines.push(Line::default());
+        } else if state.vic_cleared {
+            lines.push(Line::styled(
+                "Invitation cleared — joining without a credential (the community may \
+                 require manual approval). Paste a VIC to load one.",
+                Style::new().fg(COLOR_DARK_GRAY).italic(),
             ));
             lines.push(Line::default());
         } else {

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -3,7 +3,7 @@ use crate::colors::{
     COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
 };
 use crate::state_handler::{
-    main_page::content::{ContentPanelState, VtaState},
+    main_page::content::{ContentPanelState, VicLifecycle, VtaFocus, VtaState},
     state::ConnectionState,
 };
 use ratatui::{
@@ -234,5 +234,108 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         );
     }
 
+    render_vics(state, &mut lines);
+
     lines
+}
+
+/// Render the "Invitation Credentials" (VIC) manager section: the held VICs with
+/// their lifecycle state, the confirm gates, and the focus-aware key hints.
+fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
+    let focused = state.focus == VtaFocus::Vics;
+    let header_style = if focused {
+        Style::new().fg(COLOR_SUCCESS).bold()
+    } else {
+        Style::new().fg(COLOR_DARK_GRAY).bold()
+    };
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!(" Invitation Credentials ({})", state.vics.len()),
+            header_style,
+        ),
+        Span::styled(
+            if focused { "   ◀ focus" } else { "   [Tab] focus" },
+            Style::new().fg(COLOR_DARK_GRAY),
+        ),
+    ]));
+    lines.push(Line::from(""));
+
+    if state.vics.is_empty() {
+        lines.push(
+            Line::from("No invitation credentials.   a: import a VIC   ·   i: show inactive")
+                .fg(COLOR_DARK_GRAY),
+        );
+        return;
+    }
+
+    for (i, v) in state.vics.iter().enumerate() {
+        let selected = focused && i == state.vic_selected_index;
+        let prefix = if selected { "▸ " } else { "  " };
+        let (marker, marker_style) = match v.lifecycle {
+            VicLifecycle::Active => ("● ", Style::new().fg(COLOR_SUCCESS)),
+            VicLifecycle::Archived => ("○ ", Style::new().fg(COLOR_ORANGE)),
+            VicLifecycle::Deleted => ("✗ ", Style::new().fg(COLOR_DARK_GRAY)),
+        };
+        let id_style = if selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(prefix, marker_style),
+            Span::styled(marker, marker_style),
+            Span::styled(v.id.clone(), id_style),
+        ]));
+
+        let issuer = if v.issuer.is_empty() {
+            "issuer unknown".to_string()
+        } else {
+            v.issuer.clone()
+        };
+        let mut detail = format!("      {issuer}  ·  {}", v.status);
+        if v.lifecycle != VicLifecycle::Active {
+            detail.push_str(&format!("  ·  {}", v.lifecycle.tag()));
+        }
+        if !v.valid_until.is_empty() {
+            detail.push_str(&format!("  ·  until {}", v.valid_until));
+        }
+        let detail_style = if v.lifecycle == VicLifecycle::Active {
+            Style::new().fg(COLOR_DARK_GRAY)
+        } else {
+            Style::new().fg(COLOR_ORANGE)
+        };
+        lines.push(Line::from(Span::styled(detail, detail_style)));
+    }
+
+    lines.push(Line::from(""));
+    if let Some(idx) = state.confirm_purge_vic {
+        let target = state.vics.get(idx).map(|v| v.id.as_str()).unwrap_or("this VIC");
+        lines.push(
+            Line::from(format!("Purge {target} permanently?   y: confirm    n: cancel"))
+                .fg(COLOR_ORANGE)
+                .bold(),
+        );
+    } else if let Some(idx) = state.confirm_delete_vic {
+        let target = state.vics.get(idx).map(|v| v.id.as_str()).unwrap_or("this VIC");
+        lines.push(
+            Line::from(format!("Delete {target}?   y: confirm    n: cancel"))
+                .fg(COLOR_ORANGE)
+                .bold(),
+        );
+    } else if focused {
+        let sel = state.vics.get(state.vic_selected_index);
+        let restore_verb = match sel.map(|v| v.lifecycle) {
+            Some(VicLifecycle::Archived) => "u: unarchive",
+            Some(VicLifecycle::Deleted) => "u: restore",
+            _ => "r: archive",
+        };
+        lines.push(
+            Line::from(format!(
+                "↑/↓ select   a: import   {restore_verb}   d: delete   p: purge   i: inactive"
+            ))
+            .fg(COLOR_DARK_GRAY),
+        );
+    }
 }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -123,6 +123,12 @@ impl Component for MainPage {
             return;
         }
 
+        // Add-VIC (import invitation) overlay: while open it owns all input.
+        if self.props.main_page.add_vic.is_some() {
+            self.handle_add_vic_key(key);
+            return;
+        }
+
         // Community switcher overlay (R-C-7): while open it owns all input; while
         // closed, Ctrl+K opens it from anywhere on the main page.
         if self.props.main_page.switcher.is_some() {
@@ -181,6 +187,15 @@ impl Component for MainPage {
         use crate::state_handler::main_page::content::{
             CredentialsMode, RelationshipsMode, SettingsMode,
         };
+
+        // The add-VIC overlay owns paste while open — the operator pastes the VIC
+        // JSON straight into the import field (checked before the panel guard).
+        if self.props.main_page.add_vic.is_some() {
+            let _ = self
+                .action_tx
+                .send(Action::AddVicPaste(text.trim().to_string()));
+            return;
+        }
 
         if !self.props.main_page.content_panel.selected {
             return;
@@ -344,12 +359,34 @@ impl MainPage {
     /// selection, `d`/Del removes the selected **orphan** (unbound) DID after a
     /// y/n confirmation. Returns true if consumed.
     fn handle_vta_key(&mut self, key: KeyEvent) -> bool {
-        let vta = &self.props.main_page.content_panel.vta;
-        let count = vta.context_dids.len();
-        let selected = vta.did_selected_index;
+        use crate::state_handler::main_page::content::{VicLifecycle, VtaFocus};
 
-        // A deletion confirmation is pending: only y/Enter confirms; anything
-        // else cancels.
+        let vta = &self.props.main_page.content_panel.vta;
+        let did_count = vta.context_dids.len();
+        let did_selected = vta.did_selected_index;
+        let focus = vta.focus;
+        let vic_count = vta.vics.len();
+        let vic_selected = vta.vic_selected_index;
+        let vic_lifecycle = vta.vics.get(vic_selected).map(|v| v.lifecycle);
+
+        // VIC purge / delete confirmation gates: only y/Enter confirms.
+        if let Some(idx) = vta.confirm_purge_vic {
+            let act = match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => Action::PurgeVic(idx),
+                _ => Action::VicCancelPurge,
+            };
+            let _ = self.action_tx.send(act);
+            return true;
+        }
+        if let Some(idx) = vta.confirm_delete_vic {
+            let act = match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => Action::DeleteVic(idx),
+                _ => Action::VicCancelDelete,
+            };
+            let _ = self.action_tx.send(act);
+            return true;
+        }
+        // DID deletion confirmation: only y/Enter confirms; anything else cancels.
         if let Some(idx) = vta.confirm_delete_did {
             match key.code {
                 KeyCode::Char('y') | KeyCode::Enter => {
@@ -362,43 +399,112 @@ impl MainPage {
             return true;
         }
 
+        // Keys that apply regardless of which list has focus.
         match key.code {
+            KeyCode::Tab => {
+                // Switching to the VIC list loads it on demand (no polling).
+                if focus == VtaFocus::Dids {
+                    let _ = self.action_tx.send(Action::VicRefresh);
+                }
+                let _ = self.action_tx.send(Action::VicFocusToggle);
+                return true;
+            }
             KeyCode::Char('n') => {
                 // Mint a new standalone persona DID (also on the top-level menu).
                 let _ = self.action_tx.send(Action::StartCreatePersona);
-                true
+                return true;
             }
-            KeyCode::Up if count > 0 => {
-                let _ = self
-                    .action_tx
-                    .send(Action::DidSelect(selected.saturating_sub(1)));
-                true
+            KeyCode::Char('a') => {
+                let _ = self.action_tx.send(Action::StartAddVic);
+                return true;
             }
-            KeyCode::Down if count > 0 => {
-                let _ = self
-                    .action_tx
-                    .send(Action::DidSelect((selected + 1).min(count - 1)));
-                true
-            }
-            KeyCode::Char('d') | KeyCode::Delete if selected < count => {
-                // Only orphan (unbound) personas are removable — a persona
-                // serving a community must not be deleted out from under it.
-                if vta
-                    .context_dids
-                    .get(selected)
-                    .is_some_and(|d| d.bound_communities == 0)
-                {
-                    let _ = self.action_tx.send(Action::DidConfirmDelete(selected));
-                }
-                true
+            KeyCode::Char('i') => {
+                let _ = self.action_tx.send(Action::VicToggleInactive);
+                return true;
             }
             KeyCode::Esc => {
                 let _ = self
                     .action_tx
                     .send(Action::MainPanelSwitch(MainPanel::MainMenu));
-                true
+                return true;
             }
-            _ => false,
+            _ => {}
+        }
+
+        // List-scoped keys act on whichever list has focus.
+        match focus {
+            VtaFocus::Dids => match key.code {
+                KeyCode::Up if did_count > 0 => {
+                    let _ = self
+                        .action_tx
+                        .send(Action::DidSelect(did_selected.saturating_sub(1)));
+                    true
+                }
+                KeyCode::Down if did_count > 0 => {
+                    let _ = self
+                        .action_tx
+                        .send(Action::DidSelect((did_selected + 1).min(did_count - 1)));
+                    true
+                }
+                KeyCode::Char('d') | KeyCode::Delete if did_selected < did_count => {
+                    // Only orphan (unbound) personas are removable.
+                    if vta
+                        .context_dids
+                        .get(did_selected)
+                        .is_some_and(|d| d.bound_communities == 0)
+                    {
+                        let _ = self.action_tx.send(Action::DidConfirmDelete(did_selected));
+                    }
+                    true
+                }
+                _ => false,
+            },
+            VtaFocus::Vics => match key.code {
+                KeyCode::Up if vic_count > 0 => {
+                    let _ = self
+                        .action_tx
+                        .send(Action::VicSelect(vic_selected.saturating_sub(1)));
+                    true
+                }
+                KeyCode::Down if vic_count > 0 => {
+                    let _ = self
+                        .action_tx
+                        .send(Action::VicSelect((vic_selected + 1).min(vic_count - 1)));
+                    true
+                }
+                // r: archive an active VIC (reversible, so no confirm).
+                KeyCode::Char('r') if vic_lifecycle == Some(VicLifecycle::Active) => {
+                    let _ = self.action_tx.send(Action::VicArchive(vic_selected));
+                    true
+                }
+                // u: unarchive an archived VIC, or restore a soft-deleted one.
+                KeyCode::Char('u') => {
+                    match vic_lifecycle {
+                        Some(VicLifecycle::Archived) => {
+                            let _ = self.action_tx.send(Action::VicUnarchive(vic_selected));
+                        }
+                        Some(VicLifecycle::Deleted) => {
+                            let _ = self.action_tx.send(Action::VicRestore(vic_selected));
+                        }
+                        _ => {}
+                    }
+                    true
+                }
+                // d: soft-delete (not already deleted).
+                KeyCode::Char('d') | KeyCode::Delete
+                    if vic_selected < vic_count
+                        && vic_lifecycle != Some(VicLifecycle::Deleted) =>
+                {
+                    let _ = self.action_tx.send(Action::VicConfirmDelete(vic_selected));
+                    true
+                }
+                // p: irreversible purge.
+                KeyCode::Char('p') if vic_selected < vic_count => {
+                    let _ = self.action_tx.send(Action::VicConfirmPurge(vic_selected));
+                    true
+                }
+                _ => false,
+            },
         }
     }
 
@@ -560,6 +666,33 @@ impl MainPage {
             },
             CreatePersonaPhase::Failed => {
                 let _ = self.action_tx.send(Action::CreatePersonaClose);
+            }
+        }
+    }
+
+    /// Add-VIC overlay keys. Input phase: Enter stores, Esc cancels, other keys
+    /// edit the paste field. Working swallows input. Done/Failed: any key closes.
+    /// Called only while the overlay is open, where it owns all input.
+    fn handle_add_vic_key(&mut self, key: KeyEvent) {
+        use crate::state_handler::main_page::content::AddVicPhase;
+        let Some(overlay) = self.props.main_page.add_vic.as_ref() else {
+            return;
+        };
+        match overlay.phase {
+            AddVicPhase::Input => match key.code {
+                KeyCode::Enter => {
+                    let _ = self.action_tx.send(Action::AddVicSubmit);
+                }
+                KeyCode::Esc => {
+                    let _ = self.action_tx.send(Action::AddVicClose);
+                }
+                _ => {
+                    let _ = self.action_tx.send(Action::AddVicInput(key));
+                }
+            },
+            AddVicPhase::Working => {}
+            AddVicPhase::Done | AddVicPhase::Failed => {
+                let _ = self.action_tx.send(Action::AddVicClose);
             }
         }
     }
@@ -1932,6 +2065,10 @@ impl ComponentRender<()> for MainPage {
         if let Some(overlay) = self.props.main_page.create_persona.as_ref() {
             self.render_create_persona_overlay(frame, overlay);
         }
+        // Add-VIC (import invitation) overlay floats over everything when open.
+        if let Some(overlay) = self.props.main_page.add_vic.as_ref() {
+            self.render_add_vic_overlay(frame, overlay);
+        }
     }
 }
 
@@ -2081,6 +2218,110 @@ impl MainPage {
                 )));
             }
             CreatePersonaPhase::Failed => {
+                for msg in &overlay.messages {
+                    lines.push(Line::from(Span::styled(
+                        msg.clone(),
+                        Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
+                    )));
+                }
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(
+                    "⏎/esc close",
+                    Style::new().fg(COLOR_BORDER),
+                )));
+            }
+        }
+
+        frame.render_widget(Paragraph::new(lines).block(block), popup_area);
+    }
+
+    fn render_add_vic_overlay(
+        &self,
+        frame: &mut Frame,
+        overlay: &crate::state_handler::main_page::content::AddVicState,
+    ) {
+        use crate::state_handler::main_page::content::AddVicPhase;
+        use ratatui::{
+            layout::{Constraint, Flex},
+            style::Style,
+            widgets::{Block, Clear, Padding},
+        };
+
+        let area = frame.area();
+        let popup_width = 64u16.min(area.width.saturating_sub(4));
+        let popup_height = 11u16.min(area.height.saturating_sub(2)).max(7);
+
+        let [popup_area] = Layout::vertical([Constraint::Length(popup_height)])
+            .flex(Flex::Center)
+            .areas(area);
+        let [popup_area] = Layout::horizontal([Constraint::Length(popup_width)])
+            .flex(Flex::Center)
+            .areas(popup_area);
+
+        frame.render_widget(Clear, popup_area);
+
+        let block = Block::bordered()
+            .title(" Import invitation credential ")
+            .title_style(Style::new().fg(COLOR_ORANGE).bold())
+            .border_style(Style::new().fg(COLOR_ORANGE))
+            .padding(Padding::uniform(1));
+
+        let mut lines: Vec<Line> = Vec::new();
+        match overlay.phase {
+            AddVicPhase::Input => {
+                lines.push(Line::from(Span::styled(
+                    "Paste an invitation credential (VIC) JSON, then press ⏎:",
+                    Style::new().fg(COLOR_TEXT_DEFAULT),
+                )));
+                // The pasted JSON can be long; show a char count + short preview
+                // rather than the full body in the popup.
+                let val = overlay.input.value();
+                let preview = if val.chars().count() > 40 {
+                    let head: String = val.chars().take(40).collect();
+                    format!("{head}…")
+                } else {
+                    val.to_string()
+                };
+                lines.push(Line::from(Span::styled(
+                    if val.is_empty() {
+                        "> (nothing pasted yet)".to_string()
+                    } else {
+                        format!("> {preview}   ({} chars)", val.chars().count())
+                    },
+                    Style::new().fg(COLOR_SOFT_PURPLE).bold(),
+                )));
+                lines.push(Line::default());
+                for msg in &overlay.messages {
+                    lines.push(Line::from(Span::styled(
+                        msg.clone(),
+                        Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
+                    )));
+                }
+                lines.push(Line::from(Span::styled(
+                    "⏎ store   esc cancel",
+                    Style::new().fg(COLOR_BORDER),
+                )));
+            }
+            AddVicPhase::Working => {
+                for msg in &overlay.messages {
+                    lines.push(Line::from(Span::styled(
+                        msg.clone(),
+                        Style::new().fg(COLOR_TEXT_DEFAULT),
+                    )));
+                }
+            }
+            AddVicPhase::Done => {
+                lines.push(Line::from(Span::styled(
+                    "✓ Invitation credential stored",
+                    Style::new().fg(COLOR_SUCCESS).bold(),
+                )));
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(
+                    "⏎/esc close",
+                    Style::new().fg(COLOR_BORDER),
+                )));
+            }
+            AddVicPhase::Failed => {
                 for msg in &overlay.messages {
                     lines.push(Line::from(Span::styled(
                         msg.clone(),
@@ -2580,6 +2821,171 @@ mod key_handler_tests {
         match rx.try_recv() {
             Ok(Action::CreatePersonaClose) => {}
             _ => panic!("expected CreatePersonaClose"),
+        }
+    }
+
+    // ----- VIC manager -------------------------------------------------------
+
+    use crate::state_handler::main_page::content::{
+        AddVicPhase, AddVicState, VicLifecycle, VicSummary, VtaFocus,
+    };
+
+    fn vic(id: &str, lifecycle: VicLifecycle) -> VicSummary {
+        VicSummary {
+            id: id.to_string(),
+            issuer: "did:webvh:example:community".to_string(),
+            status: "valid".to_string(),
+            lifecycle,
+            valid_until: String::new(),
+        }
+    }
+
+    /// Focus the VIC list with the given rows selected at index 0.
+    fn vta_vics(rows: Vec<VicSummary>) -> impl Fn(&mut State) {
+        move |s: &mut State| {
+            let vta = &mut s.main_page.content_panel.vta;
+            vta.focus = VtaFocus::Vics;
+            vta.vics = rows.clone().into();
+            vta.vic_selected_index = 0;
+        }
+    }
+
+    #[test]
+    fn vta_a_opens_add_vic() {
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |_| {});
+        page.handle_key_event(press(KeyCode::Char('a')));
+        match rx.try_recv() {
+            Ok(Action::StartAddVic) => {}
+            _ => panic!("expected StartAddVic"),
+        }
+    }
+
+    #[test]
+    fn vta_tab_refreshes_then_toggles_focus() {
+        // From the default (Dids) focus, Tab loads the VIC list, then switches.
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |_| {});
+        page.handle_key_event(press(KeyCode::Tab));
+        match rx.try_recv() {
+            Ok(Action::VicRefresh) => {}
+            _ => panic!("expected VicRefresh first"),
+        }
+        match rx.try_recv() {
+            Ok(Action::VicFocusToggle) => {}
+            _ => panic!("expected VicFocusToggle"),
+        }
+    }
+
+    #[test]
+    fn vta_vic_delete_confirm_cycle() {
+        // `d` on an active VIC arms the soft-delete confirmation.
+        let (mut page, mut rx) =
+            page_for(MainMenu::Vta, vta_vics(vec![vic("urn:vic:1", VicLifecycle::Active)]));
+        page.handle_key_event(press(KeyCode::Char('d')));
+        match rx.try_recv() {
+            Ok(Action::VicConfirmDelete(0)) => {}
+            _ => panic!("expected VicConfirmDelete(0)"),
+        }
+
+        // Armed: Enter commits the soft-delete.
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
+            s.main_page.content_panel.vta.confirm_delete_vic = Some(0);
+        });
+        page.handle_key_event(press(KeyCode::Enter));
+        match rx.try_recv() {
+            Ok(Action::DeleteVic(0)) => {}
+            _ => panic!("expected DeleteVic(0)"),
+        }
+
+        // Armed: any other key cancels.
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
+            s.main_page.content_panel.vta.confirm_delete_vic = Some(0);
+        });
+        page.handle_key_event(press(KeyCode::Esc));
+        match rx.try_recv() {
+            Ok(Action::VicCancelDelete) => {}
+            _ => panic!("expected VicCancelDelete"),
+        }
+    }
+
+    #[test]
+    fn vta_vic_purge_confirm_commits() {
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
+            s.main_page.content_panel.vta.confirm_purge_vic = Some(0);
+        });
+        page.handle_key_event(press(KeyCode::Char('y')));
+        match rx.try_recv() {
+            Ok(Action::PurgeVic(0)) => {}
+            _ => panic!("expected PurgeVic(0)"),
+        }
+    }
+
+    #[test]
+    fn vta_vic_unarchive_and_restore_by_lifecycle() {
+        // `u` on an archived VIC unarchives it.
+        let (mut page, mut rx) = page_for(
+            MainMenu::Vta,
+            vta_vics(vec![vic("urn:vic:1", VicLifecycle::Archived)]),
+        );
+        page.handle_key_event(press(KeyCode::Char('u')));
+        match rx.try_recv() {
+            Ok(Action::VicUnarchive(0)) => {}
+            _ => panic!("expected VicUnarchive(0)"),
+        }
+
+        // `u` on a soft-deleted VIC restores it.
+        let (mut page, mut rx) = page_for(
+            MainMenu::Vta,
+            vta_vics(vec![vic("urn:vic:1", VicLifecycle::Deleted)]),
+        );
+        page.handle_key_event(press(KeyCode::Char('u')));
+        match rx.try_recv() {
+            Ok(Action::VicRestore(0)) => {}
+            _ => panic!("expected VicRestore(0)"),
+        }
+    }
+
+    #[test]
+    fn add_vic_overlay_input_keys() {
+        let open = || {
+            page_for(MainMenu::Vta, |s| {
+                s.main_page.add_vic = Some(AddVicState::default());
+            })
+        };
+
+        let (mut page, mut rx) = open();
+        page.handle_key_event(press(KeyCode::Enter));
+        match rx.try_recv() {
+            Ok(Action::AddVicSubmit) => {}
+            _ => panic!("expected AddVicSubmit"),
+        }
+
+        let (mut page, mut rx) = open();
+        page.handle_key_event(press(KeyCode::Esc));
+        match rx.try_recv() {
+            Ok(Action::AddVicClose) => {}
+            _ => panic!("expected AddVicClose"),
+        }
+
+        let (mut page, mut rx) = open();
+        page.handle_key_event(press(KeyCode::Char('x')));
+        match rx.try_recv() {
+            Ok(Action::AddVicInput(_)) => {}
+            _ => panic!("expected AddVicInput"),
+        }
+    }
+
+    #[test]
+    fn add_vic_done_phase_closes() {
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
+            s.main_page.add_vic = Some(AddVicState {
+                phase: AddVicPhase::Done,
+                ..Default::default()
+            });
+        });
+        page.handle_key_event(press(KeyCode::Enter));
+        match rx.try_recv() {
+            Ok(Action::AddVicClose) => {}
+            _ => panic!("expected AddVicClose"),
         }
     }
 


### PR DESCRIPTION
## Why

Started from "if a join with a VIC fails, do we keep reusing that VIC?" The
answer exposed three gaps: VICs were invisible/unmanaged in the UI, join-time VIC
use was implicit, and a VTC rejection never surfaced — a community sat `Pending`
until a 7-day timeout. Two upstream releases (`vta-sdk` 0.18.1, `vta-service`
0.10.1) made a clean fix possible: a credential-vault lifecycle + enumeration,
and a redesigned trust-task join ceremony that returns a verdict.

## What

**Deps** — `vta-sdk` `0.17`→`0.18` (lifecycle methods + verdict join model);
`vta-service` git-pin → published `0.10` (credential-vault tasks + the
`include_archived`/`include_deleted` query); dropped the `deny.toml` git
exception. `is_invitation_credential` promoted to `openvtc_core::join`.

**A — verdict-model join + rejection handling.** A submit `#response`
(`VerdictResponse`) now drives admission: `allow`→Active, `deny`→Rejected,
`refer`/`request_more` stay Pending. A DIDComm problem-report threaded to the
submit is handled (`e.p.msg.forbidden`→Rejected with the comment surfaced; other
codes left Pending). Routed `didcomm.org/report-problem/*`, which the fallback
was silently dropping — the root cause of the stuck-`Pending` bug.

**B — VIC manager on the VTA Service screen.** New "Invitation Credentials"
section: list (active; archived/soft-deleted via `i`), import a pasted VIC,
archive/unarchive, soft-delete/restore, and purge — over the credential-vault
lifecycle (`state_handler/vic.rs`). `Tab` switches focus between the DID and VIC
lists; destructive verbs gate behind a y/n confirm. Includes an import overlay.

**C — explicit inline VIC selection on the join entry page.** `Ctrl+L` clears a
loaded VIC to join without it; pasting loads/replaces one; the status line shows
three explicit states (loaded / cleared / none).

## Tests
- `openvtc-core`: `is_invitation_credential`; verdict→status mapping for each
  effect; problem-report (`forbidden`→Rejected, `bad-request`→Pending); thid
  correlation.
- `openvtc`: VIC key-handler tests (add/delete/purge confirm cycles, lifecycle
  verbs, Tab focus, overlay keys); `vic_cleared` default/reset.
- Full workspace `cargo test` green; `cargo clippy --all-targets` clean.

## Follow-ups (not in this PR)
- Auto-archive the offending VIC on an `e.p.msg.forbidden` rejection (needs the
  presented VIC's vault id recorded on the pending record + an async vault call
  from the inbound dispatch). Today the rejection surfaces as `Rejected` and the
  operator manages the VIC explicitly via the new VIC panel / EnterDid selection.
- A MockVta credential-vault round-trip e2e (receive→query→archive→delete→
  restore→purge); the lifecycle wrappers are thin over the upstream-tested tasks.