### PR TITLE
feat(join): community-matched VIC selection + invitation summary clarity

### DIFF
--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -15,7 +15,7 @@ use affinidi_tdk::{
     didcomm::Message,
     messaging::{ATM, profiles::ATMProfile},
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 use uuid::Uuid;
 use vta_sdk::protocols::join_requests::{
@@ -202,6 +202,42 @@ pub fn invitation_id(vic: &Value) -> Option<&str> {
     vic.get("id").and_then(Value::as_str)
 }
 
+/// The DID that issued a VIC. For an `InvitationCredential` the issuer **is** the
+/// community's VTC DID (the VTC signs it with its own issuer key, so
+/// `issuer = signer.issuer_did()`), which is what a presentable invitation must
+/// match against the community being joined. Accepts both the string issuer form
+/// and the object form (`{ "id": "did:…" }`).
+pub fn invitation_issuer(vic: &Value) -> Option<&str> {
+    match vic.get("issuer")? {
+        Value::String(s) => Some(s.as_str()),
+        Value::Object(_) => vic.pointer("/issuer/id").and_then(Value::as_str),
+        _ => None,
+    }
+}
+
+/// Whether a VIC is bound to the community identified by `vtc_did` — i.e. the VIC
+/// was issued by that VTC. A held/loaded VIC issued by a *different* community
+/// must not be presented: the VTC would reject the mismatched binding, so it is
+/// no better than presenting nothing (and worse, it looks like a failed
+/// invitation rather than an open request).
+pub fn invitation_matches_community(vic: &Value, vtc_did: &str) -> bool {
+    invitation_issuer(vic) == Some(vtc_did)
+}
+
+/// Whether a VIC's declared validity window has elapsed as of `now`. A VIC with
+/// no `validUntil` is treated as non-expiring here (the VTC re-checks validity at
+/// submit). A malformed `validUntil` is treated as expired (fail closed) so a
+/// broken credential is never presented.
+pub fn invitation_is_expired(vic: &Value, now: DateTime<Utc>) -> bool {
+    match vic.get("validUntil").and_then(Value::as_str) {
+        None => false,
+        Some(s) => match DateTime::parse_from_rfc3339(s) {
+            Ok(t) => t.with_timezone(&Utc) <= now,
+            Err(_) => true,
+        },
+    }
+}
+
 /// Whether a JSON value is an InvitationCredential (its `type` array carries
 /// the `InvitationCredential` tag). Used to validate a pasted/loaded VIC
 /// before stashing it (join flow) or storing it in the vault (VIC manager).
@@ -297,6 +333,53 @@ mod tests {
         );
         assert_eq!(invitation_id(&vic), Some("urn:uuid:vic-1"));
         assert_eq!(invitation_subject(&json!({})), None);
+    }
+
+    #[test]
+    fn issuer_extractor_handles_string_and_object_forms() {
+        // String issuer (the form the VTC emits).
+        assert_eq!(
+            invitation_issuer(&sample_vic()),
+            Some("did:webvh:example.com:community")
+        );
+        // Object issuer (`{ "id": … }`).
+        let obj = json!({ "issuer": { "id": "did:webvh:example.com:community" } });
+        assert_eq!(
+            invitation_issuer(&obj),
+            Some("did:webvh:example.com:community")
+        );
+        // Missing / wrong-typed issuer.
+        assert_eq!(invitation_issuer(&json!({})), None);
+        assert_eq!(invitation_issuer(&json!({ "issuer": 42 })), None);
+    }
+
+    #[test]
+    fn community_match_keys_on_the_issuer() {
+        let vic = sample_vic();
+        assert!(invitation_matches_community(
+            &vic,
+            "did:webvh:example.com:community"
+        ));
+        assert!(!invitation_matches_community(
+            &vic,
+            "did:webvh:example.com:other-community"
+        ));
+    }
+
+    #[test]
+    fn expiry_uses_valid_until_and_fails_closed() {
+        let now = "2026-06-21T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        // No validUntil → never expired.
+        assert!(!invitation_is_expired(&sample_vic(), now));
+        // Future window → not expired.
+        let future = json!({ "validUntil": "2027-01-01T00:00:00Z" });
+        assert!(!invitation_is_expired(&future, now));
+        // Past window → expired.
+        let past = json!({ "validUntil": "2025-01-01T00:00:00Z" });
+        assert!(invitation_is_expired(&past, now));
+        // Malformed → treated as expired (fail closed).
+        let bad = json!({ "validUntil": "not-a-date" });
+        assert!(invitation_is_expired(&bad, now));
     }
 
     #[test]

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -24,6 +24,18 @@ pub enum JoinPage {
     Progress,
 }
 
+/// Summary of the invitation credential (VIC) actually presented with a join,
+/// shown on the success page so the operator can tell *whether* and *which*
+/// invitation was used (vs. an open request awaiting manual approval). `None` on
+/// the join state means no VIC was presented.
+#[derive(Clone, Debug)]
+pub struct PresentedInvitation {
+    /// The VIC's top-level `id` (its consumption / linkage handle).
+    pub id: String,
+    /// The persona DID the VIC is bound to (`credentialSubject.id`), if present.
+    pub subject: Option<String>,
+}
+
 /// One selectable existing persona on the identity-choice page (R-B-3).
 #[derive(Clone, Debug)]
 pub struct PersonaOption {
@@ -73,6 +85,12 @@ pub struct JoinState {
     /// survives `reset`, which is called once at open) so the entry page can show
     /// the operator that their invitation will be used.
     pub has_invitation: bool,
+    /// The invitation actually presented to the community, resolved at submit
+    /// time (community-matched + unexpired). `Some` drives the success page's
+    /// "Invitation: Presented" detail; `None` reads as an open request. Distinct
+    /// from [`has_invitation`](Self::has_invitation), which reflects what was
+    /// *loaded* on the entry page before community matching.
+    pub presented_invitation: Option<PresentedInvitation>,
     /// True when the operator explicitly cleared a loaded VIC on the entry page,
     /// so the status text reads "joining without an invitation" rather than the
     /// generic "no VIC" tip. Distinguishes a deliberate clear from never having

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -29,7 +29,8 @@ use crate::{
     state_handler::{
         StateHandler,
         actions::Action,
-        join::{JoinPage, JoinState, PersonaOption},
+        join::{JoinPage, JoinState, PersonaOption, PresentedInvitation},
+        main_page::content::{VicLifecycle, VicSummary},
         main_page::shorten_did,
         setup_sequence::{Completion, MessageType, config::ConfigExtension, vta},
         state::{ActivePage, State},
@@ -417,21 +418,32 @@ fn invitation_subject_persona(config: &Config, state: &State) -> Option<PersonaI
     config.account.persona_id_for_did(subject)
 }
 
-/// #2: load an invitation credential the VTA already holds for the holder, if
-/// any. Queries the credential vault for `purpose = invite` and fetches the
-/// first match's body. Best-effort — any error / empty result yields `None`.
-async fn load_invitation_from_vault(admin_vta: &VtaClient) -> Option<serde_json::Value> {
+/// #2: load a *presentable* invitation the VTA already holds for the community
+/// being joined (`vtc_did`). Queries the credential vault for `purpose = invite`
+/// and selects an active, vault-valid (not expired / revoked) VIC whose issuer is
+/// this community — preferring the one that stays valid longest — then fetches
+/// its body. The first-match grab this replaced could present a VIC for the wrong
+/// community (or an expired one), which the VTC then rejected. Best-effort: any
+/// error / no match yields `None`, and the join proceeds as an open request.
+async fn load_invitation_from_vault(
+    admin_vta: &VtaClient,
+    vtc_did: &str,
+) -> Option<serde_json::Value> {
     let listing = admin_vta
         .cred_vault_query(serde_json::json!({ "purpose": "invite" }))
         .await
         .ok()?;
-    let id = listing
-        .get("credentials")
-        .and_then(|c| c.as_array())
-        .and_then(|arr| arr.first())
-        .and_then(|d| d.get("id"))
-        .and_then(|i| i.as_str())?;
-    let got = admin_vta.cred_vault_get(id).await.ok()?;
+    let descriptors = listing.get("credentials").and_then(|c| c.as_array())?;
+    // Community-matched, active, vault-valid candidates; prefer the latest
+    // `validUntil` (longest-lived). RFC 3339 timestamps sort lexicographically.
+    let best = descriptors
+        .iter()
+        .map(VicSummary::from_descriptor)
+        .filter(|v| {
+            v.issuer == vtc_did && v.status == "valid" && v.lifecycle == VicLifecycle::Active
+        })
+        .max_by(|a, b| a.valid_until.cmp(&b.valid_until))?;
+    let got = admin_vta.cred_vault_get(&best.id).await.ok()?;
     got.get("credential").cloned()
 }
 
@@ -765,30 +777,66 @@ async fn run_join_sequence(
             return;
         }
     };
-    // #2: the VTA credential vault is the durable home for the holder's VIC.
-    // If one is loaded (file / paste), persist it; if not, try loading one the
-    // VTA already holds for this community. Both are best-effort — the join
-    // proceeds regardless (the in-memory VIC, if any, is still presented).
-    if let Some(vic) = state.invitation_credential.clone() {
-        if let Err(e) = admin_vta.cred_vault_receive(vic, None).await {
+    // #2: resolve the VIC to present for THIS community. A VIC's issuer is the
+    // community's VTC DID, so a presentable invitation must match `vtc_did` and
+    // be unexpired — presenting a mismatched or expired one only earns a VTC
+    // rejection (and reads as a failed invitation rather than an open request).
+    // An explicitly loaded VIC (--invitation / paste) is still stored in the
+    // vault regardless (its durable home), but only *presented* when it matches;
+    // otherwise we fall back to a community-matched VIC the vault already holds,
+    // else submit as an open request. Setting `state.invitation_credential` to
+    // the resolved VIC keeps the VP, the linkage proof, and the summary all
+    // consistent with what is actually presented. All vault calls are
+    // best-effort — the join proceeds regardless.
+    let loaded = state.invitation_credential.take();
+    let mut presentable: Option<serde_json::Value> = None;
+    if let Some(vic) = loaded {
+        if let Err(e) = admin_vta.cred_vault_receive(vic.clone(), None).await {
             debug!(error = %e, "storing invitation in the VTA vault failed (continuing)");
         }
-    } else if let Some(vic) = load_invitation_from_vault(admin_vta).await {
-        state.invitation_credential = Some(vic);
-        state.join.has_invitation = true;
-        let _ = handler.state_tx.send(state.clone());
+        if !openvtc_core::join::invitation_matches_community(&vic, &vtc_did) {
+            state.join.info(
+                "Loaded invitation is for a different community — \
+                 looking for one that matches…",
+            );
+        } else if openvtc_core::join::invitation_is_expired(&vic, Utc::now()) {
+            state
+                .join
+                .info("Loaded invitation has expired — looking for a valid one…");
+        } else {
+            presentable = Some(vic);
+        }
     }
+    if presentable.is_none() {
+        presentable = load_invitation_from_vault(admin_vta, &vtc_did).await;
+    }
+    state.invitation_credential = presentable;
+    state.join.has_invitation = state.invitation_credential.is_some();
+    state.join.presented_invitation = state.invitation_credential.as_ref().map(|vic| {
+        PresentedInvitation {
+            id: openvtc_core::join::invitation_id(vic)
+                .unwrap_or_default()
+                .to_string(),
+            subject: openvtc_core::join::invitation_subject(vic).map(str::to_string),
+        }
+    });
 
-    // Present the holder VP. When the applicant loaded an invitation credential
-    // (VIC) at startup (`--invitation`), it rides in the VP's
-    // `verifiableCredential` array; the VTC verifies it and auto-admits on a
-    // valid, trusted, unconsumed invitation (no manual approval).
+    // Present the holder VP. When a matching, unexpired invitation (VIC) is
+    // resolved it rides in the VP's `verifiableCredential` array; the VTC
+    // verifies it and auto-admits on a valid, trusted, unconsumed invitation (no
+    // manual approval). With no presentable invitation the join is an open
+    // request the community reviews and approves manually.
     if state.invitation_credential.is_some() {
         state
             .join
             .info("Presenting your invitation credential to the community…");
-        let _ = handler.state_tx.send(state.clone());
+    } else {
+        state.join.info(
+            "No valid invitation for this community — \
+             submitting as an open request (awaiting approval).",
+        );
     }
+    let _ = handler.state_tx.send(state.clone());
     // Subject-linkage (#1b): when the presenting DID differs from the VIC
     // subject, prove the subject authorized this presenter (signed with the
     // subject persona's key). On the join-as-subject path (#1a) this is `None`.

--- a/openvtc/src/ui/pages/join_flow/join_progress.rs
+++ b/openvtc/src/ui/pages/join_flow/join_progress.rs
@@ -108,6 +108,47 @@ impl JoinProgress {
                         Span::styled("  Status:        ", Style::new().fg(COLOR_SUCCESS)),
                         Span::styled("Pending", Style::new().fg(COLOR_ORANGE)),
                     ]));
+                    // Whether an invitation was actually presented (auto-admit
+                    // path) or this is an open request (manual approval) — the
+                    // distinction that determines what happens next.
+                    match &state.presented_invitation {
+                        Some(vic) => {
+                            lines.push(Line::from(vec![
+                                Span::styled(
+                                    "  Invitation:    ",
+                                    Style::new().fg(COLOR_SUCCESS),
+                                ),
+                                Span::styled(
+                                    format!("Presented  ·  {}", vic.id),
+                                    Style::new().fg(COLOR_SOFT_PURPLE),
+                                ),
+                            ]));
+                            if let Some(subject) = &vic.subject {
+                                lines.push(Line::from(vec![
+                                    Span::styled(
+                                        "  Bound to:      ",
+                                        Style::new().fg(COLOR_SUCCESS),
+                                    ),
+                                    Span::styled(
+                                        subject.clone(),
+                                        Style::new().fg(COLOR_SOFT_PURPLE),
+                                    ),
+                                ]));
+                            }
+                        }
+                        None => {
+                            lines.push(Line::from(vec![
+                                Span::styled(
+                                    "  Invitation:    ",
+                                    Style::new().fg(COLOR_SUCCESS),
+                                ),
+                                Span::styled(
+                                    "None  ·  open request (awaiting approval)",
+                                    Style::new().fg(COLOR_ORANGE),
+                                ),
+                            ]));
+                        }
+                    }
                 }
                 lines.push(Line::default());
                 lines.push(Line::styled(


### PR DESCRIPTION
## Why

Two problems in the State-B join flow, both surfaced while joining a real community:

1. **The wrong invitation could be presented.** When no VIC was loaded via `--invitation`/paste, the vault fallback grabbed the *first* `purpose: invite` credential it held — regardless of which community issued it or whether it had expired. A VIC's `issuer` **is** the community's VTC DID, so a non-matching VIC fails the VTC's holder-binding check; the join was then rejected (or, when the rejection wasn't delivered, sat `Pending`).
2. **The summary never said whether an invitation was used.** The "Join request submitted" page showed Community / persona / Status: Pending but nothing about the invitation — so the operator couldn't tell an auto-admit (by invitation) from an open request (manual approval), the distinction that determines what happens next.

## What

- **openvtc-core** (`join.rs`): add `invitation_issuer`, `invitation_matches_community`, `invitation_is_expired`. Issuer extraction handles both the string and `{ "id": … }` forms; a malformed `validUntil` fails closed (never presented).
- **join_flow**: resolve the VIC to present *for this community*. A loaded VIC is still stored in the vault (its durable home) but only **presented** when its issuer matches `vtc_did` and it hasn't expired; otherwise fall back to a community-matched, valid, active held VIC (preferring the longest-lived), else submit as an open request. `state.invitation_credential` is set to the resolved VIC so the VP, subject-linkage proof, and summary stay consistent. INFO notes explain each fallback.
- **summary** (`join_progress.rs`): add an `Invitation:` line — `Presented · <vic id>` (+ `Bound to: <subject>`), or `None · open request (awaiting approval)`.

## Notes

- The VTC side is untouched (per the repo split — protocol/infra lives in `verifiable-trust-infrastructure`).
- Validity here trusts the vault's `status`/`validUntil` and the VIC's declared window; the VTC re-verifies the signature on receipt. Full client-side crypto verification is out of scope.
- Follow-ups (planned, separate PRs): an "awaiting receipt" indicator for Pending joins that never get acknowledged, and an outbound message-size guard.

## Testing

- `cargo build`, `cargo clippy --all-targets` — clean.
- Full workspace test suite green; 5 new unit tests cover the issuer/match/expiry helpers (incl. object-form issuer and fail-closed `validUntil`).
