### PR TITLE
fix(join): send join-request submit as a Trust Task document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5511,6 +5511,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "trust-tasks-rs",
  "url",
  "uuid",
  "vta-sdk 0.18.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ tokio-stream = "0.1"
 tokio-util = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+trust-tasks-rs = "0.2"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -53,6 +53,7 @@ sysinfo.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+trust-tasks-rs.workspace = true
 url.workspace = true
 uuid.workspace = true
 x25519-dalek.workspace = true

--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -17,6 +17,7 @@ use affinidi_tdk::{
 };
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+use trust_tasks_rs::TrustTask;
 use uuid::Uuid;
 use vta_sdk::protocols::join_requests::{
     JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitBody, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
@@ -45,13 +46,7 @@ pub async fn submit_join_request(
     mediator_did: &str,
     vp: Value,
 ) -> Result<Uuid, OpenVTCError> {
-    let body = JoinRequestSubmitBody {
-        vp,
-        registry_consent: false,
-        extensions: Value::Null,
-    };
-    let body = serde_json::to_value(&body)
-        .map_err(|e| OpenVTCError::Config(format!("join submit body serialize: {e}")))?;
+    let body = build_join_submit_document(persona_did, vtc_did, vp)?;
 
     let msg_id = Uuid::new_v4();
     let now = Utc::now().timestamp().max(0) as u64;
@@ -67,6 +62,37 @@ pub async fn submit_join_request(
 
     crate::pack_and_send(atm, profile, &msg, persona_did, vtc_did, mediator_did).await?;
     Ok(msg_id)
+}
+
+/// Build the DIDComm body for a join-request submit: a Trust Task *document*
+/// (`trust_tasks_rs::TrustTask`) wrapping the [`JoinRequestSubmitBody`] payload.
+///
+/// The VTC deserializes the message body as `TrustTask<Value>` and rejects a
+/// `malformedRequest` ("missing field `id`") when handed the bare payload, so the
+/// payload must ride as the document's `payload` field. The document carries the
+/// required `id` (a fresh `urn:uuid`) and `type`, plus the audience-binding
+/// `issuer` (the applicant persona) and `recipient` (the VTC). No `proof` is
+/// attached — over DIDComm the authcrypt sender authenticates the applicant (the
+/// VTC reads it from the envelope), matching the SDK's documented DIDComm shape.
+fn build_join_submit_document(
+    persona_did: &str,
+    vtc_did: &str,
+    vp: Value,
+) -> Result<Value, OpenVTCError> {
+    let payload = JoinRequestSubmitBody {
+        vp,
+        registry_consent: false,
+        extensions: Value::Null,
+    };
+    let type_uri = JOIN_REQUEST_SUBMIT_TYPE
+        .parse()
+        .map_err(|e| OpenVTCError::Config(format!("join submit type URI parse: {e}")))?;
+    let mut doc = TrustTask::new(format!("urn:uuid:{}", Uuid::new_v4()), type_uri, payload);
+    doc.issuer = Some(persona_did.to_string());
+    doc.recipient = Some(vtc_did.to_string());
+    doc.issued_at = Some(Utc::now());
+    serde_json::to_value(&doc)
+        .map_err(|e| OpenVTCError::Config(format!("join submit document serialize: {e}")))
 }
 
 /// Send a member self-removal (`MEMBER_SELF_REMOVE`) to a VTC over DIDComm to
@@ -333,6 +359,40 @@ mod tests {
         );
         assert_eq!(invitation_id(&vic), Some("urn:uuid:vic-1"));
         assert_eq!(invitation_subject(&json!({})), None);
+    }
+
+    #[test]
+    fn join_submit_body_is_a_trust_task_document_the_vtc_can_parse() {
+        use trust_tasks_rs::TrustTask;
+
+        let vp = build_join_vp("did:webvh:example.com:alice", Some(&sample_vic()), None);
+        let body = build_join_submit_document(
+            "did:webvh:example.com:alice",
+            "did:webvh:example.com:community",
+            vp,
+        )
+        .expect("build document");
+
+        // The exact deserialization the VTC performs — this is what was failing
+        // with "missing field `id`" when we sent the bare payload.
+        let doc: TrustTask<serde_json::Value> =
+            serde_json::from_value(body.clone()).expect("body parses as a TrustTask document");
+
+        assert!(doc.id.starts_with("urn:uuid:"), "document carries an id");
+        assert_eq!(
+            doc.type_uri.to_string(),
+            JOIN_REQUEST_SUBMIT_TYPE,
+            "type URI is the submit type"
+        );
+        assert_eq!(doc.issuer.as_deref(), Some("did:webvh:example.com:alice"));
+        assert_eq!(
+            doc.recipient.as_deref(),
+            Some("did:webvh:example.com:community")
+        );
+        assert!(doc.proof.is_none(), "DIDComm submit is unsigned (authcrypt)");
+        // The submit body rides as the document payload, VIC and all.
+        assert_eq!(doc.payload["vp"]["holder"], "did:webvh:example.com:alice");
+        assert!(doc.payload["vp"]["verifiableCredential"].is_array());
     }
 
     #[test]


### PR DESCRIPTION
## Why

Joining a community failed server-side with:

```
status=400 code=malformedRequest
reason="malformed request: body did not parse as a Trust Task document: missing field `id`"
```

The VTC deserializes the DIDComm join-submit message body as `trust_tasks_rs::TrustTask<Value>`, but `submit_join_request` was sending the **bare `JoinRequestSubmitBody` payload** — the pre-Trust-Task-envelope calling convention. vta-sdk 0.18.1's own module docs are explicit: *"the message body is the TrustTask document"* and `JoinRequestSubmitBody` is only its `payload`. So the request never parsed, and no member or pending request was created on the VTC.

This answers "are we using the latest trust task specs?" — we were not, on the submit path.

## What

`openvtc-core::join` now wraps the payload in a `trust_tasks_rs::TrustTask` document:

- `id` — a fresh `urn:uuid` (the field whose absence triggered the rejection)
- `type` — the submit Type URI
- `issuer` / `recipient` — applicant persona + VTC (audience binding)
- `payload` — the `JoinRequestSubmitBody` (vp, registryConsent, extensions)
- **no `proof`** — over DIDComm the authcrypt sender authenticates the applicant (matching the SDK's documented DIDComm shape)

Adds `trust-tasks-rs = "0.2"` (already in the tree via vta-sdk) as a direct dep. The document construction is extracted into a testable `build_join_submit_document`; a regression test round-trips the body as `TrustTask<Value>` — the exact parse the VTC performs.

## Scope / follow-ups

- VTC untouched (per the repo split).
- Known related gaps, tracked separately: we don't yet handle the VTC's `trust-task-error` failure document (a failed ceremony is silently dropped), and joining with an existing identity can hit "Listener already exists". PRs to follow.

## Testing

`cargo build`, `cargo clippy --all-targets` clean; full suite green; new unit test `join_submit_body_is_a_trust_task_document_the_vtc_can_parse`.
