### PR TITLE
fix(join): reuse an existing persona listener instead of erroring

### DIFF
--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -2504,6 +2504,33 @@ async fn register_joined_session(
             ));
         }
         RegisterOutcome::Created => {
+            // SessionManager had no session for this persona, but the DIDComm
+            // service may already hold a listener for it — a persona reused across
+            // communities can already be live via the relationship path, or a
+            // listener SessionManager isn't tracking may linger. `add_listener`
+            // errors on a duplicate id ("Listener already exists"), so reuse the
+            // existing listener rather than failing the join's live session (D1).
+            if let Some(existing) = service
+                .list_listeners()
+                .await
+                .into_iter()
+                .find(|l| l.id == lid)
+            {
+                if existing.state == affinidi_messaging_didcomm_service::ListenerState::Running {
+                    session_manager.mark_connected(&lid);
+                    state
+                        .main_page
+                        .log("New community attached to the persona's existing live session.");
+                } else {
+                    // The listener exists but isn't Running (Stopped/Failed): leave
+                    // the session Connecting (as `register` set it) and let the
+                    // restart policy / next launch bring it back — don't re-add it.
+                    state.main_page.log(
+                        "New community attached to the persona's existing session (reconnecting…).",
+                    );
+                }
+                return;
+            }
             match didcomm::persona_listener_config_for(config, tdk, joined.persona_id).await {
                 Some(cfg) => {
                     if let Err(e) = service.add_listener(cfg).await {


### PR DESCRIPTION
## Why

Joining a community with an **existing identity** logged:

```
Joined, but couldn't start its live session now (it will connect on next launch):
Listener 'did:webvh:…:inherit-lyrics' already exists
```

In `register_joined_session`, `SessionManager::register` returns `Created` when it has no *community* session tracked for that persona — but the DIDComm service may already hold a listener for that persona (created by the relationship/contact path, or one SessionManager isn't tracking). `add_listener` rejects a duplicate listener id, so a perfectly good live session was reported as a failure.

## What

In the `Created` arm, before adding a listener, check `service.list_listeners()` for the persona's listener id:

- **already exists & `Running`** → reuse it: `mark_connected`, log "attached to the persona's existing live session."
- **already exists, not Running** (Stopped/Failed) → leave the session `Connecting` (as `register` set it) and let the restart policy / next launch bring it back — don't re-add (still a duplicate id).
- **doesn't exist** → unchanged: build config + `add_listener` as before.

Idempotent live-session startup on join (D1: a reused persona shares one session across communities).

## Scope / testing

- Pure decision logic (`register` → `Created`/`JoinedExisting`/`AtCapacity`) is already unit-tested in `session_manager`; the added reuse step is at the async `DIDCommService` boundary (no unit test for the live service interaction). `cargo build`, `cargo clippy --all-targets` clean; `openvtc` test suite green.
- Remaining queued follow-ups from this session: the "awaiting receipt" indicator (Pending joins that never get acknowledged) and the outbound message-size guard.
