### PR TITLE
feat(join): flag Pending joins the VTC never acknowledged

### DIFF
--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -205,6 +205,14 @@ pub struct CommunityRecord {
     pub member_since: Option<DateTime<Utc>>,
     /// When the join request was submitted — anchors the 7-day timeout (D16).
     pub requested_at: Option<DateTime<Utc>>,
+    /// When the VTC first acknowledged the join (any correlated response: verdict
+    /// refer/request_more, status deferred, recoverable trust-task-error, or the
+    /// legacy submit-receipt). `Some` means the submit reached the VTC and is
+    /// awaiting a decision; `None` while still `Pending` past the grace window
+    /// means the submit may have been dropped (size limit / unhandled type) —
+    /// surfaced in the UI so it isn't mistaken for a healthy wait (D16).
+    #[serde(default)]
+    pub receipt_at: Option<DateTime<Utc>>,
     /// DIDComm relationships scoped to this community.
     #[serde(default)]
     pub relationships: Relationships,
@@ -258,6 +266,8 @@ struct CommunityRecordShadow {
     acknowledged: bool,
     member_since: Option<DateTime<Utc>>,
     requested_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    receipt_at: Option<DateTime<Utc>>,
     #[serde(default)]
     relationships: Relationships,
     #[serde(default)]
@@ -313,6 +323,7 @@ impl From<CommunityRecordShadow> for CommunityRecord {
             acknowledged: shadow.acknowledged,
             member_since: shadow.member_since,
             requested_at: shadow.requested_at,
+            receipt_at: shadow.receipt_at,
             relationships: shadow.relationships,
             tasks: shadow.tasks,
             vrcs_issued: shadow.vrcs_issued,
@@ -325,6 +336,13 @@ impl From<CommunityRecordShadow> for CommunityRecord {
 /// Client-side timeout for an unanswered `Pending` join (D16 / R-B-7): a join
 /// request with no decision after this many days transitions to `Expired`.
 pub const PENDING_TIMEOUT_DAYS: i64 = 7;
+
+/// Grace period before a `Pending` join with no VTC acknowledgement
+/// ([`CommunityRecord::receipt_at`] still `None`) is flagged as possibly-dropped.
+/// A verdict/receipt normally returns within seconds; 2 minutes absorbs a slow
+/// but healthy round-trip while surfacing a dropped submit (size limit / unhandled
+/// type) far earlier than the 7-day [`PENDING_TIMEOUT_DAYS`].
+pub const PENDING_ACK_GRACE_SECS: i64 = 120;
 
 impl CommunityRecord {
     /// Build a fresh `Pending` join record (State-B join request, R-B-*).
@@ -352,6 +370,7 @@ impl CommunityRecord {
             acknowledged: false,
             member_since: None,
             requested_at: Some(now),
+            receipt_at: None,
             relationships: Relationships::default(),
             tasks: Tasks::default(),
             vrcs_issued: Vrcs::default(),
@@ -463,6 +482,33 @@ impl CommunityRecord {
             return true;
         }
         false
+    }
+
+    /// Record that the VTC has acknowledged this join — i.e. *some* correlated
+    /// response arrived (verdict refer/request_more, status deferred, a
+    /// recoverable trust-task-error, or the legacy submit-receipt). Stamps
+    /// [`receipt_at`](Self::receipt_at) once with `now`; subsequent calls are
+    /// no-ops (the first contact is what matters). Returns `true` if it set the
+    /// timestamp (the caller should persist). Only meaningful while `Pending`.
+    pub fn mark_acknowledged(&mut self, now: DateTime<Utc>) -> bool {
+        if self.receipt_at.is_none() {
+            self.receipt_at = Some(now);
+            return true;
+        }
+        false
+    }
+
+    /// Whether this is a `Pending` join the VTC has not acknowledged within
+    /// [`PENDING_ACK_GRACE_SECS`] of submission — the signal that the submit may
+    /// have been dropped (size limit / unhandled type) rather than healthily
+    /// awaiting a decision. False once any response has set `receipt_at`, for
+    /// non-`Pending` states, or while still inside the grace window.
+    pub fn pending_unacknowledged(&self, now: DateTime<Utc>) -> bool {
+        matches!(self.status, CommunityStatus::Pending { .. })
+            && self.receipt_at.is_none()
+            && self
+                .requested_at
+                .is_some_and(|r| now - r >= TimeDelta::seconds(PENDING_ACK_GRACE_SECS))
     }
 }
 
@@ -688,6 +734,7 @@ mod tests {
             acknowledged: false,
             member_since: None,
             requested_at: None,
+            receipt_at: None,
             relationships: Relationships::default(),
             tasks: Tasks::default(),
             vrcs_issued: Vrcs::default(),
@@ -1082,6 +1129,48 @@ mod tests {
         let mut no_ts = community("v", pid, pending());
         no_ts.requested_at = None;
         assert!(!no_ts.expire_if_stale(now));
+    }
+
+    #[test]
+    fn mark_acknowledged_stamps_once() {
+        let pid = PersonaId::new();
+        let now = Utc::now();
+        let mut c = community("v", pid, pending());
+        assert!(c.receipt_at.is_none());
+        // First contact stamps; returns true (caller persists).
+        assert!(c.mark_acknowledged(now));
+        assert_eq!(c.receipt_at, Some(now));
+        // A later contact is a no-op — first contact is what matters.
+        assert!(!c.mark_acknowledged(now + TimeDelta::seconds(10)));
+        assert_eq!(c.receipt_at, Some(now));
+    }
+
+    #[test]
+    fn pending_unacknowledged_flags_only_unacked_pending_past_grace() {
+        let pid = PersonaId::new();
+        let now = Utc::now();
+        let grace = TimeDelta::seconds(PENDING_ACK_GRACE_SECS);
+
+        // Pending, no receipt, within grace: not yet flagged.
+        let mut fresh = community("v", pid, pending());
+        fresh.requested_at = Some(now - grace + TimeDelta::seconds(1));
+        assert!(!fresh.pending_unacknowledged(now));
+
+        // Pending, no receipt, past grace: flagged (possibly dropped).
+        let mut stuck = community("v", pid, pending());
+        stuck.requested_at = Some(now - grace);
+        assert!(stuck.pending_unacknowledged(now));
+
+        // Pending but acknowledged: never flagged, however old.
+        let mut acked = community("v", pid, pending());
+        acked.requested_at = Some(now - TimeDelta::days(1));
+        acked.mark_acknowledged(now - TimeDelta::days(1));
+        assert!(!acked.pending_unacknowledged(now));
+
+        // Non-Pending is never flagged.
+        let mut active = community("v", pid, CommunityStatus::Active);
+        active.requested_at = Some(now - TimeDelta::days(1));
+        assert!(!active.pending_unacknowledged(now));
     }
 
     #[test]

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -184,6 +184,7 @@ mod tests {
             acknowledged: false,
             member_since: None,
             requested_at: None,
+            receipt_at: None,
             relationships: Default::default(),
             tasks: Default::default(),
             vrcs_issued: Default::default(),

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -205,6 +205,8 @@ pub fn handle_join_submit_receipt(
         record.status = CommunityStatus::Pending {
             request_id: body.request_id,
         };
+        // The receipt is the VTC's acknowledgement that the submit arrived.
+        record.mark_acknowledged(chrono::Utc::now());
         info!(
             vtc = %from_did,
             vtc_request_id = %body.request_id,
@@ -307,13 +309,18 @@ pub fn handle_join_status_response(
         }
         "deferred" => {
             // "More info required" — stays Pending (still raises actions-required);
-            // evaluating `needs` / presenting the DCQL is deferred to D4.
+            // evaluating `needs` / presenting the DCQL is deferred to D4. The VTC
+            // responded, so the submit was acknowledged (not dropped).
+            let changed = record.mark_acknowledged(chrono::Utc::now());
             info!(
                 vtc = %from_did,
                 needs = ?body.needs,
                 "join deferred — more information required (handling deferred to D4)"
             );
-            StatusOutcome::NONE
+            StatusOutcome {
+                changed,
+                inactivated: false,
+            }
         }
         other => {
             debug!(vtc = %from_did, status = %other, "status-response: no transition");
@@ -381,20 +388,32 @@ pub fn handle_join_verdict(account: &mut Account, message: &Message, from_did: &
             }
         }
         VerdictEffect::Refer => {
+            // The VTC responded — submit acknowledged — but the decision is
+            // deferred to human review; stays Pending.
+            let changed = record.mark_acknowledged(chrono::Utc::now());
             info!(
                 vtc = %from_did,
                 queue = body.verdict.with.queue.as_deref().unwrap_or(""),
                 "join referred for human review — stays Pending"
             );
-            StatusOutcome::NONE
+            StatusOutcome {
+                changed,
+                inactivated: false,
+            }
         }
         VerdictEffect::RequestMore => {
+            // The VTC responded — submit acknowledged — but needs more evidence;
+            // stays Pending.
+            let changed = record.mark_acknowledged(chrono::Utc::now());
             info!(
                 vtc = %from_did,
                 needs = ?body.verdict.with.needs,
                 "join needs more evidence — stays Pending"
             );
-            StatusOutcome::NONE
+            StatusOutcome {
+                changed,
+                inactivated: false,
+            }
         }
     }
 }
@@ -547,14 +566,19 @@ pub fn handle_join_trust_task_error(
     } else {
         // Not a policy denial — a malformed / unsupported / internal / transient
         // failure. Surface it, but keep the join recoverable (stays Pending) so a
-        // corrected retry can still succeed.
+        // corrected retry can still succeed. The VTC did respond, so the submit
+        // was acknowledged (not silently dropped).
+        let changed = record.mark_acknowledged(chrono::Utc::now());
         warn!(
             vtc = %from_did,
             code = %code,
             detail = %detail,
             "join submit failed (trust-task-error) — left Pending (recoverable)"
         );
-        StatusOutcome::NONE
+        StatusOutcome {
+            changed,
+            inactivated: false,
+        }
     }
 }
 
@@ -1068,10 +1092,14 @@ mod tests {
         let out =
             handle_join_status_response(&mut acct, &status_response(vtc, rid, "deferred"), vtc);
         assert!(
-            !out.changed,
-            "more-info handling is a D4 stub — stays Pending"
+            out.changed,
+            "deferred is an acknowledgement — stamps receipt_at, needs persisting"
         );
         assert!(!out.inactivated);
+        assert!(
+            acct.communities.get(vtc).unwrap().receipt_at.is_some(),
+            "the VTC responded — acknowledged"
+        );
         assert!(matches!(
             acct.communities.get(vtc).unwrap().status,
             CommunityStatus::Pending { .. }
@@ -1145,11 +1173,10 @@ mod tests {
             &verdict(&rid.to_string(), vtc, "request_more", with),
             vtc,
         );
-        assert!(!out.changed);
-        assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
-            CommunityStatus::Pending { .. }
-        ));
+        assert!(out.changed, "request_more acknowledges — stamps receipt_at");
+        let rec = acct.communities.get(vtc).unwrap();
+        assert!(matches!(rec.status, CommunityStatus::Pending { .. }));
+        assert!(rec.receipt_at.is_some(), "the VTC responded — acknowledged");
     }
 
     #[test]
@@ -1229,14 +1256,19 @@ mod tests {
             &trust_task_error(&rid.to_string(), vtc, "malformedRequest", "missing field `id`"),
             vtc,
         );
-        assert!(!out.changed, "a recoverable error makes no terminal change");
-        assert!(!out.inactivated);
         assert!(
-            matches!(
-                acct.communities.get(vtc).unwrap().status,
-                CommunityStatus::Pending { .. }
-            ),
+            out.changed,
+            "the VTC responded — stamps receipt_at, needs persisting"
+        );
+        assert!(!out.inactivated, "recoverable — no terminal transition");
+        let rec = acct.communities.get(vtc).unwrap();
+        assert!(
+            matches!(rec.status, CommunityStatus::Pending { .. }),
             "stays Pending so a corrected retry can succeed"
+        );
+        assert!(
+            rec.receipt_at.is_some(),
+            "a trust-task-error is still an acknowledgement the submit arrived"
         );
     }
 

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -180,6 +180,10 @@ pub struct CommunitySummary {
     /// Whether the membership is `Pending` — the only state whose join can be
     /// cancelled (withdrawn).
     pub is_pending: bool,
+    /// Whether this is a `Pending` join the VTC hasn't acknowledged within the
+    /// grace window — the submit may have been dropped rather than healthily
+    /// awaiting a decision. Drives a warning hint on the row (D16).
+    pub pending_unacknowledged: bool,
     /// Whether this community is archived (R-C-8); only shown when "show archived"
     /// is on, with a marker.
     pub archived: bool,

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -418,6 +418,7 @@ impl MainPageState {
         // archived excluded, with the actions-required count for the badge.
         let mut community_items = Vec::new();
         let show_archived = self.content_panel.communities.show_archived;
+        let now = chrono::Utc::now();
         for c in config.account.communities_for_display(show_archived) {
             let persona = config.account.personas.get(&c.persona_ref);
             let persona_label = persona
@@ -448,6 +449,7 @@ impl MainPageState {
                     c.status,
                     openvtc_core::config::account::CommunityStatus::Pending { .. }
                 ),
+                pending_unacknowledged: c.pending_unacknowledged(now),
                 archived: c.archived,
                 needs_attention: c.needs_attention(),
                 persona_did: persona.map(|p| p.did.clone()).unwrap_or_default(),

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -103,6 +103,18 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         };
         lines.push(Line::from(Span::styled(detail, detail_style)));
 
+        // A Pending join the VTC hasn't acknowledged within the grace window: the
+        // submit may have been dropped (size limit / unhandled type) rather than
+        // healthily awaiting a decision. Surface it so a stuck join is visible
+        // long before the 7-day Expired (D16).
+        if c.pending_unacknowledged {
+            lines.push(Line::from(Span::styled(
+                "    ⚠ no response from the community yet — the request may not have been received"
+                    .to_string(),
+                Style::new().fg(COLOR_ORANGE),
+            )));
+        }
+
         // Expanded troubleshooting detail for the selected community: which
         // persona this community actually uses (full DID), the VTC, the
         // sub-context, the in-flight request id, and which credentials are held.

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2408,6 +2408,7 @@ mod key_handler_tests {
             is_active,
             is_inactive,
             is_pending,
+            pending_unacknowledged: false,
             archived: false,
             needs_attention: false,
             persona_did: "did:example:persona".to_string(),


### PR DESCRIPTION
## Why

A join submit the VTC silently drops (the bridge file-size limit you hit, or an unhandled message type) produces **no problem-report back**. The membership then sat `Pending` forever, indistinguishable from a healthy wait — only the 7-day `Expired` timeout would eventually flag it. This surfaces a dropped/unanswered submit within minutes.

This is the "awaiting receipt" backstop we discussed alongside the trust-task-error handler (#139) — it covers failures we *never receive*, which the inbound handler by definition cannot.

## What

- **`receipt_at: Option<DateTime<Utc>>` on `CommunityRecord`** (additive, `#[serde(default)]` — old configs load unchanged). Stamped once via `mark_acknowledged` whenever *any* correlated VTC response keeps the join `Pending`:
  - verdict `refer` / `request_more`
  - status-response `deferred`
  - a recoverable `trust-task-error`
  - the legacy `submit-receipt`

  In the trust-task model the synchronous verdict `#response` replaced the old receipt, so "acknowledged" means **"we've heard *anything* back"**, not specifically a receipt.

- **`pending_unacknowledged(now)`** — true for a `Pending` join with no `receipt_at` past a **2-minute** grace (`PENDING_ACK_GRACE_SECS`; a verdict normally returns in seconds).

- **Communities panel** shows, on such a row:
  `⚠ no response from the community yet — the request may not have been received`

## Scope / testing

- VTC untouched. The grace window is a single tunable constant.
- `cargo build`, `cargo clippy --all-targets` clean; full suite green. New unit tests: stamp-once semantics, the grace-window predicate (within/past grace, acknowledged, non-Pending), and the four handler paths now stamping `receipt_at`.

This was the last of the queued join-robustness follow-ups from this session (the outbound size guard remains, separately).
