### PR TITLE
fix(join): reject incomplete VICs at ingest; W3C-compliant join VP

### DIFF
--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -144,12 +144,20 @@ pub async fn submit_self_remove(
 /// `invitation` is the signed VIC as received out-of-band (a Data-Integrity VC,
 /// object form with its own `proof`). When `None`, the VP carries no
 /// credentials and the join falls to the community's other evidence / review.
+///
+/// The envelope carries the W3C VC Data Model 2.0 base `@context` (required: the
+/// first value MUST be `https://www.w3.org/ns/credentials/v2`) and the
+/// `VerifiablePresentation` `type`, so the artifact is a well-formed VP. It is
+/// *unsecured* by a VP-level proof on purpose — over DIDComm the authcrypt sender
+/// is the holder authentication — so it is a "presentation" the transport makes
+/// verifiable, not a self-secured one.
 pub fn build_join_vp(
     holder_did: &str,
     invitation: Option<&Value>,
     linkage: Option<&SubjectLinkage>,
 ) -> Value {
     let mut vp = serde_json::json!({
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
         "type": "VerifiablePresentation",
         "holder": holder_did,
     });
@@ -278,6 +286,76 @@ pub fn is_invitation_credential(value: &Value) -> bool {
         })
 }
 
+/// Validate that `vic` is a **complete, presentable** Invitation Credential, not
+/// a summary/display projection. Returns a human-readable error naming every
+/// missing/malformed field so a holder who pasted the wrong artifact (e.g. the
+/// operator-UI summary instead of the signed credential the VTC issued for
+/// out-of-band delivery) finds out *at ingest*, rather than silently submitting
+/// an open request the VTC refers to a moderator.
+///
+/// The required set is the intersection of:
+/// - **W3C VC Data Model 2.0** mandatory properties: `@context` (ordered set
+///   whose first value is `https://www.w3.org/ns/credentials/v2`), `type`
+///   (here ⊇ `VerifiableCredential` + `InvitationCredential`), `issuer`,
+///   `credentialSubject` (with an `id`), and a securing `proof`.
+/// - the **VIC profile** the receiving VTC enforces: a top-level `id` (the
+///   single-use consumption handle — W3C makes `id` optional, the VIC profile
+///   does not), `validUntil` (the invite's expiry), and `credentialStatus`
+///   (issuance burns a revocation slot, so a VIC always carries one).
+///
+/// `proof` / `credentialStatus` are not *re-verified* here (that is the VTC's
+/// job at submit) — their mere presence is what distinguishes a real signed VIC
+/// from a stripped copy.
+pub fn validate_invitation_credential(vic: &Value) -> Result<(), String> {
+    let mut missing: Vec<&str> = Vec::new();
+
+    // @context — present, an array, first element the v2 base URL.
+    match vic.get("@context").and_then(Value::as_array) {
+        Some(ctx)
+            if ctx.first().and_then(Value::as_str) == Some("https://www.w3.org/ns/credentials/v2") => {}
+        _ => missing.push("@context (must be an array whose first item is \"https://www.w3.org/ns/credentials/v2\")"),
+    }
+    if !is_invitation_credential(vic) {
+        missing
+            .push("type (array containing \"VerifiableCredential\" and \"InvitationCredential\")");
+    } else if !vic
+        .get("type")
+        .and_then(Value::as_array)
+        .is_some_and(|t| t.iter().any(|v| v.as_str() == Some("VerifiableCredential")))
+    {
+        missing.push("type entry \"VerifiableCredential\"");
+    }
+    if invitation_issuer(vic).is_none() {
+        missing.push("issuer (a DID string or an object with an `id`)");
+    }
+    if invitation_subject(vic).is_none() {
+        missing.push("credentialSubject.id");
+    }
+    if invitation_id(vic).is_none() {
+        missing.push("id (top-level, the single-use consumption handle)");
+    }
+    if vic.get("validUntil").and_then(Value::as_str).is_none() {
+        missing.push("validUntil (RFC3339 expiry)");
+    }
+    if vic.get("credentialStatus").is_none() {
+        missing.push("credentialStatus (revocation handle)");
+    }
+    if vic.get("proof").is_none() {
+        missing.push("proof (the issuer's Data-Integrity signature)");
+    }
+
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "not a complete Invitation Credential — missing or malformed: {}. \
+             Paste the full signed credential the community issued (the copy/QR \
+             payload), not a summary view.",
+            missing.join("; ")
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -351,6 +429,57 @@ mod tests {
     }
 
     #[test]
+    fn vp_carries_the_w3c_base_context() {
+        // W3C VC Data Model 2.0: a VP MUST carry `@context` whose first value is
+        // the v2 base URL.
+        let vp = build_join_vp("did:webvh:example.com:alice", None, None);
+        assert_eq!(
+            vp["@context"][0], "https://www.w3.org/ns/credentials/v2",
+            "VP @context must lead with the W3C v2 base context"
+        );
+    }
+
+    /// A complete, presentable VIC — every field `validate_invitation_credential`
+    /// requires. Distinct from [`sample_vic`], which is intentionally minimal.
+    fn complete_vic() -> Value {
+        json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "id": "urn:uuid:vic-1",
+            "type": ["VerifiableCredential", "InvitationCredential"],
+            "issuer": "did:webvh:example.com:community",
+            "credentialSubject": { "id": "did:webvh:example.com:alice" },
+            "validUntil": "2099-01-01T00:00:00Z",
+            "credentialStatus": { "type": "BitstringStatusListEntry" },
+            "proof": { "type": "DataIntegrityProof" }
+        })
+    }
+
+    #[test]
+    fn validate_accepts_a_complete_vic() {
+        assert!(validate_invitation_credential(&complete_vic()).is_ok());
+        // Object-form issuer is accepted too.
+        let mut v = complete_vic();
+        v["issuer"] = json!({ "id": "did:webvh:example.com:community" });
+        assert!(validate_invitation_credential(&v).is_ok());
+    }
+
+    #[test]
+    fn validate_names_every_missing_field_on_a_stripped_vic() {
+        // The exact shape that silently fell through to moderator review: a
+        // summary missing id / proof / validUntil / credentialStatus / @context.
+        let stripped = json!({
+            "type": ["VerifiableCredential", "DTGCredential", "InvitationCredential"],
+            "issuer": "did:webvh:example.com:community",
+            "credentialSubject": { "id": "did:webvh:example.com:alice" },
+            "validFrom": "2026-06-20T23:11:53Z"
+        });
+        let err = validate_invitation_credential(&stripped).expect_err("incomplete");
+        for needle in ["@context", "id", "validUntil", "credentialStatus", "proof"] {
+            assert!(err.contains(needle), "error should name `{needle}`: {err}");
+        }
+    }
+
+    #[test]
     fn subject_and_id_extractors() {
         let vic = sample_vic();
         assert_eq!(
@@ -389,7 +518,10 @@ mod tests {
             doc.recipient.as_deref(),
             Some("did:webvh:example.com:community")
         );
-        assert!(doc.proof.is_none(), "DIDComm submit is unsigned (authcrypt)");
+        assert!(
+            doc.proof.is_none(),
+            "DIDComm submit is unsigned (authcrypt)"
+        );
         // The submit body rides as the document payload, VIC and all.
         assert_eq!(doc.payload["vp"]["holder"], "did:webvh:example.com:alice");
         assert!(doc.payload["vp"]["verifiableCredential"].is_array());

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -114,6 +114,10 @@ async fn main() -> Result<()> {
                 .map_err(|e| anyhow::anyhow!("failed to read invitation file `{path}`: {e}"))?;
             let vic: serde_json::Value = serde_json::from_str(&raw)
                 .map_err(|e| anyhow::anyhow!("invitation file `{path}` is not valid JSON: {e}"))?;
+            // Fail fast on a stripped/summary VIC rather than silently presenting
+            // an unusable credential the VTC refers to a moderator.
+            openvtc_core::join::validate_invitation_credential(&vic)
+                .map_err(|e| anyhow::anyhow!("invitation file `{path}`: {e}"))?;
             Some(vic)
         }
         None => None,

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -115,19 +115,25 @@ impl StateHandler {
                             // VIC and stash it so the join presents it (mirrors the
                             // `--invitation <file>` launch flag).
                             match serde_json::from_str::<serde_json::Value>(&text) {
-                                Ok(vic)
-                                    if openvtc_core::join::is_invitation_credential(&vic) =>
-                                {
-                                    state.invitation_credential = Some(vic);
-                                    state.join.has_invitation = true;
-                                    state.join.vic_cleared = false;
-                                    state.join.messages.clear();
-                                }
-                                _ => {
-                                    state.join.messages.push(MessageType::Error(
-                                        "Pasted text is not a valid invitation credential."
-                                            .to_string(),
-                                    ));
+                                Ok(vic) => match openvtc_core::join::validate_invitation_credential(
+                                    &vic,
+                                ) {
+                                    Ok(()) => {
+                                        state.invitation_credential = Some(vic);
+                                        state.join.has_invitation = true;
+                                        state.join.vic_cleared = false;
+                                        state.join.messages.clear();
+                                    }
+                                    Err(why) => {
+                                        state.join.messages.push(MessageType::Error(format!(
+                                            "Pasted invitation is not usable: {why}"
+                                        )));
+                                    }
+                                },
+                                Err(e) => {
+                                    state.join.messages.push(MessageType::Error(format!(
+                                        "Pasted text is not valid JSON: {e}"
+                                    )));
                                 }
                             }
                             let _ = self.state_tx.send(state.clone());
@@ -810,16 +816,31 @@ async fn run_join_sequence(
     if presentable.is_none() {
         presentable = load_invitation_from_vault(admin_vta, &vtc_did).await;
     }
+    // Completeness gate before presenting: a VIC resolved from the vault may
+    // predate the ingest-time validation (or have lost fields in storage). An
+    // incomplete VIC is unusable — the VTC can't extract it and silently refers
+    // the join to a moderator — so drop it here and fall to an open request with
+    // a clear reason, rather than presenting junk.
+    if let Some(vic) = &presentable
+        && let Err(why) = openvtc_core::join::validate_invitation_credential(vic)
+    {
+        state.join.info(format!(
+            "Resolved invitation is incomplete ({why}) — submitting as an open request instead."
+        ));
+        presentable = None;
+    }
     state.invitation_credential = presentable;
     state.join.has_invitation = state.invitation_credential.is_some();
-    state.join.presented_invitation = state.invitation_credential.as_ref().map(|vic| {
-        PresentedInvitation {
-            id: openvtc_core::join::invitation_id(vic)
-                .unwrap_or_default()
-                .to_string(),
-            subject: openvtc_core::join::invitation_subject(vic).map(str::to_string),
-        }
-    });
+    state.join.presented_invitation =
+        state
+            .invitation_credential
+            .as_ref()
+            .map(|vic| PresentedInvitation {
+                id: openvtc_core::join::invitation_id(vic)
+                    .unwrap_or_default()
+                    .to_string(),
+                subject: openvtc_core::join::invitation_subject(vic).map(str::to_string),
+            });
 
     // Present the holder VP. When a matching, unexpired invitation (VIC) is
     // resolved it rides in the VP's `verifiableCredential` array; the VTC

--- a/openvtc/src/state_handler/vic.rs
+++ b/openvtc/src/state_handler/vic.rs
@@ -37,15 +37,14 @@ pub(crate) async fn list_vics(
     Ok(creds.iter().map(VicSummary::from_descriptor).collect())
 }
 
-/// Import a pasted VIC into the vault: validate it is an InvitationCredential,
-/// then store it via `cred_vault_receive`. The vault keys it under the VC's own
-/// `id`.
+/// Import a pasted VIC into the vault: validate it is a *complete* Invitation
+/// Credential, then store it via `cred_vault_receive`. The vault keys it under
+/// the VC's own `id` — so a stripped copy with no top-level `id` could never be
+/// retrieved for presentation anyway; rejecting it here gives a clear reason.
 pub(crate) async fn add_vic(admin_vta: &VtaClient, json: &str) -> Result<()> {
     let vic: serde_json::Value =
         serde_json::from_str(json.trim()).map_err(|e| anyhow::anyhow!("not valid JSON: {e}"))?;
-    if !openvtc_core::join::is_invitation_credential(&vic) {
-        anyhow::bail!("not an invitation credential (missing the `InvitationCredential` type tag)");
-    }
+    openvtc_core::join::validate_invitation_credential(&vic).map_err(|e| anyhow::anyhow!(e))?;
     admin_vta.cred_vault_receive(vic, None).await?;
     Ok(())
 }


### PR DESCRIPTION
## Problem

A join request presenting a **stripped/summary** invitation credential — missing the signed VC's `id`, `proof`, `validUntil`, `credentialStatus`, and `@context` — was accepted at ingest (the gate only checked the `InvitationCredential` *type tag*) and embedded verbatim in the join VP. The receiving VTC can't extract such a credential as an `InvitationCredential`, so the join **silently fell through to moderator review** (`verdict=refer`) with no signal to the holder that their invitation was unusable.

Root cause: the holder pasted/loaded a display summary rather than the complete signed VIC the VTC issues for out-of-band (copy/QR) delivery.

## W3C compliance review (requested)

Checked the join flow's VC/VP usage against [W3C VC Data Model 2.0](https://www.w3.org/TR/vc-data-model-2.0/):

- **VTC-issued VIC** — compliant (`@context` v2 base, `type`, `issuer`, `credentialSubject`, `validFrom`/`validUntil`, `credentialStatus`, `proof`).
- **Join VP (`build_join_vp`)** — was **missing the required `@context`**. Fixed here. (Spec: *"the first item is a URL with the value `https://www.w3.org/ns/credentials/v2`"*.) The VP remains VP-proof-less **by design** — over DIDComm the authcrypt sender authenticates the holder.
- **VIC `id`** — the VTC requires it, which is stricter than W3C (`id` is optional). Kept as a documented **VIC-profile** rule (single-use consumption is keyed by `id`).

## Changes

**openvtc-core**
- `validate_invitation_credential(vic)`: requires the W3C-mandatory VC properties **and** the VIC-profile fields the VTC enforces; the error lists every missing/malformed field.
- `build_join_vp`: emit the W3C-required `@context`.

**openvtc**
- Enforce the validator at both ingest points (`--invitation` file load in `main.rs`, TUI paste in `join_flow.rs`) and on `cred-vault` import (`vic.rs`), surfacing the precise reason.
- Re-check a vault-resolved VIC before presenting; if incomplete, fall back to an open request **with a clear message** instead of presenting junk.

## Tests

`cargo test -p openvtc-core --lib join::` — 14 pass, including new `vp_carries_the_w3c_base_context`, `validate_accepts_a_complete_vic`, and `validate_names_every_missing_field_on_a_stripped_vic`. Build green for both crates.

## Note

The complementary VTC-side change (return a typed `malformedRequest` when a `verifiableCredential` is present but structurally unusable, instead of silently referring to moderator) lands separately in the `verifiable-trust-infrastructure` repo.