### PR TITLE
feat(join): let the operator choose whether to use an available VIC

### DIFF
--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -249,6 +249,14 @@ pub enum Action {
     /// Dismiss the reuse linkage warning without choosing.
     JoinReuseCancel,
 
+    /// Move the invitation-choice highlight: `0` = use the invitation, `1` =
+    /// join without it.
+    JoinInvitationSelect(usize),
+
+    /// Commit the highlighted invitation choice and proceed to identity
+    /// selection (or mint).
+    JoinInvitationChoose,
+
     /// Cancel the join flow and return to the main page.
     JoinCancel,
 

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -17,6 +17,10 @@ pub enum JoinPage {
     /// Operator enters the community (VTC) DID.
     #[default]
     EnterDid,
+    /// Choose whether to present an available invitation (VIC) for this
+    /// community, or join as an open request. Shown only when a VIC is actually
+    /// available (loaded-and-matching or held in the vault); skipped otherwise.
+    InvitationChoice,
     /// Choose the identity to present (R-B-3 / D1): reuse an existing persona or
     /// mint a fresh one. Skipped when the account has no personas yet.
     IdentityChoice,
@@ -96,6 +100,15 @@ pub struct JoinState {
     /// generic "no VIC" tip. Distinguishes a deliberate clear from never having
     /// had one; re-pasting a VIC (`JoinPasteVic`) flips it back to `false`.
     pub vic_cleared: bool,
+    /// Highlighted row on the [`InvitationChoice`](JoinPage::InvitationChoice)
+    /// page: `0` = "use the invitation" (default), `1` = "join without it".
+    pub invitation_use_selected: usize,
+    /// The committed invitation decision, read by the join sequence. `true`
+    /// presents an available VIC (loaded-matching or vault); `false` suppresses
+    /// it and submits an open request — overriding the vault fallback, so the
+    /// choice is honoured. Set from [`invitation_use_selected`](Self::invitation_use_selected)
+    /// on the invitation-choice page, or directly when no VIC is available.
+    pub present_invitation: bool,
 }
 
 impl JoinState {

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -163,51 +163,35 @@ impl StateHandler {
                                 let _ = self.state_tx.send(state.clone());
                                 continue;
                             }
-                            // #1a / #1b: a loaded invitation bound to one of our
-                            // personas. Show the identity choice with that persona
-                            // pre-selected — pressing Enter joins as the invited
-                            // identity (#1a, presenter == VIC subject, no linkage);
-                            // choosing a different / fresh identity builds a
-                            // subject-linkage proof so the invited persona
-                            // authorizes the presented one (#1b).
-                            if let Some(pid) = invitation_subject_persona(config, state) {
-                                let options = build_persona_options(config);
-                                let idx = options.iter().position(|o| o.id == pid).unwrap_or(0);
+                            // When an invitation is available for THIS community —
+                            // a loaded VIC that matches, or one held in the vault —
+                            // let the operator choose whether to present it or join
+                            // as an open request (default: present it). Shown only
+                            // when one actually exists; otherwise there's nothing to
+                            // choose and we go straight to identity selection.
+                            if invitation_available_for(state, admin_vta, &vtc_did).await {
                                 state.join.pending_vtc = Some(vtc_did);
-                                state.join.persona_options = options;
-                                state.join.identity_selected = idx;
-                                state.join.reuse_confirm = None;
-                                state.join.page = JoinPage::IdentityChoice;
+                                state.join.invitation_use_selected = 0; // default: use it
+                                state.join.present_invitation = true;
+                                state.join.page = JoinPage::InvitationChoice;
                                 let _ = self.state_tx.send(state.clone());
                                 continue;
                             }
-                            // R-B-3 / D1: with existing personas, let the user choose
-                            // to reuse one or mint a fresh identity; with none (the
-                            // first join), there's nothing to reuse — mint directly.
-                            let options = build_persona_options(config);
-                            if options.is_empty() {
-                                if let Some(interrupted) = self
-                                    .launch_join_sequence(
-                                        JoinIdentityChoice::Mint,
-                                        vtc_did,
-                                        interrupt_rx,
-                                        state,
-                                        tdk,
-                                        config,
-                                        admin_vta,
-                                        profile,
-                                    )
-                                    .await
-                                {
-                                    return Ok(JoinExit::Exit(interrupted));
-                                }
-                            } else {
-                                state.join.pending_vtc = Some(vtc_did);
-                                state.join.persona_options = options;
-                                state.join.identity_selected = 0;
-                                state.join.reuse_confirm = None;
-                                state.join.page = JoinPage::IdentityChoice;
-                                let _ = self.state_tx.send(state.clone());
+                            // No invitation available — nothing to present.
+                            state.join.present_invitation = false;
+                            if let Some(interrupted) = self
+                                .proceed_after_invitation_choice(
+                                    vtc_did,
+                                    interrupt_rx,
+                                    state,
+                                    tdk,
+                                    config,
+                                    admin_vta,
+                                    profile,
+                                )
+                                .await
+                            {
+                                return Ok(JoinExit::Exit(interrupted));
                             }
                         }
                         Action::JoinIdentitySelect(i) => {
@@ -273,6 +257,32 @@ impl StateHandler {
                             state.join.reuse_confirm = None;
                             let _ = self.state_tx.send(state.clone());
                         }
+                        Action::JoinInvitationSelect(i) => {
+                            // Two rows: 0 = use the invitation, 1 = join without it.
+                            state.join.invitation_use_selected = i.min(1);
+                            let _ = self.state_tx.send(state.clone());
+                        }
+                        Action::JoinInvitationChoose => {
+                            let Some(vtc_did) = state.join.pending_vtc.clone() else {
+                                continue;
+                            };
+                            state.join.present_invitation =
+                                state.join.invitation_use_selected == 0;
+                            if let Some(interrupted) = self
+                                .proceed_after_invitation_choice(
+                                    vtc_did,
+                                    interrupt_rx,
+                                    state,
+                                    tdk,
+                                    config,
+                                    admin_vta,
+                                    profile,
+                                )
+                                .await
+                            {
+                                return Ok(JoinExit::Exit(interrupted));
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -282,6 +292,64 @@ impl StateHandler {
             }
             let _ = self.state_tx.send(state.clone());
         }
+    }
+
+    /// Route from the invitation choice (or directly when no invitation is
+    /// available) to identity selection. When we'll present a loaded VIC bound to
+    /// one of our personas, pre-select that persona (#1a/#1b); otherwise offer the
+    /// persona list, or mint directly on a first join. Returns `Some(interrupted)`
+    /// only when a direct mint launched and was interrupted mid-sequence.
+    #[allow(clippy::too_many_arguments)]
+    async fn proceed_after_invitation_choice(
+        &self,
+        vtc_did: String,
+        interrupt_rx: &mut broadcast::Receiver<Interrupted>,
+        state: &mut State,
+        tdk: &TDK,
+        config: &mut Config,
+        admin_vta: Option<&VtaClient>,
+        profile: &str,
+    ) -> Option<Interrupted> {
+        // #1a/#1b: a loaded invitation bound to one of our personas — pre-select
+        // it so Enter joins as the invited identity (no linkage), and a different
+        // choice builds the subject-linkage proof. Only when we'll present it.
+        if state.join.present_invitation
+            && let Some(pid) = invitation_subject_persona(config, state)
+        {
+            let options = build_persona_options(config);
+            let idx = options.iter().position(|o| o.id == pid).unwrap_or(0);
+            state.join.pending_vtc = Some(vtc_did);
+            state.join.persona_options = options;
+            state.join.identity_selected = idx;
+            state.join.reuse_confirm = None;
+            state.join.page = JoinPage::IdentityChoice;
+            let _ = self.state_tx.send(state.clone());
+            return None;
+        }
+        // R-B-3 / D1: with existing personas, let the user choose to reuse one or
+        // mint a fresh identity; with none (the first join), mint directly.
+        let options = build_persona_options(config);
+        if options.is_empty() {
+            return self
+                .launch_join_sequence(
+                    JoinIdentityChoice::Mint,
+                    vtc_did,
+                    interrupt_rx,
+                    state,
+                    tdk,
+                    config,
+                    admin_vta,
+                    profile,
+                )
+                .await;
+        }
+        state.join.pending_vtc = Some(vtc_did);
+        state.join.persona_options = options;
+        state.join.identity_selected = 0;
+        state.join.reuse_confirm = None;
+        state.join.page = JoinPage::IdentityChoice;
+        let _ = self.state_tx.send(state.clone());
+        None
     }
 
     /// Move to the progress page and run [`run_join_sequence`] for the chosen
@@ -422,6 +490,30 @@ fn invitation_subject_persona(config: &Config, state: &State) -> Option<PersonaI
     let vic = state.invitation_credential.as_ref()?;
     let subject = openvtc_core::join::invitation_subject(vic)?;
     config.account.persona_id_for_did(subject)
+}
+
+/// Whether an invitation for `vtc_did` is available to present — a loaded VIC
+/// that matches this community and is currently usable, or a community-matched,
+/// valid VIC held in the vault. Drives the invitation-choice step, which is shown
+/// only when one actually exists. Best-effort: with no admin VTA only a loaded
+/// VIC counts. The vault check fetches the candidate body; the join sequence
+/// re-resolves it independently, so this stays a pure availability probe.
+async fn invitation_available_for(
+    state: &State,
+    admin_vta: Option<&VtaClient>,
+    vtc_did: &str,
+) -> bool {
+    if let Some(vic) = state.invitation_credential.as_ref()
+        && openvtc_core::join::invitation_matches_community(vic, vtc_did)
+        && !openvtc_core::join::invitation_is_expired(vic, Utc::now())
+        && openvtc_core::join::validate_invitation_credential(vic).is_ok()
+    {
+        return true;
+    }
+    match admin_vta {
+        Some(vta) => load_invitation_from_vault(vta, vtc_did).await.is_some(),
+        None => false,
+    }
 }
 
 /// #2: load a *presentable* invitation the VTA already holds for the community
@@ -796,25 +888,39 @@ async fn run_join_sequence(
     // best-effort — the join proceeds regardless.
     let loaded = state.invitation_credential.take();
     let mut presentable: Option<serde_json::Value> = None;
-    if let Some(vic) = loaded {
-        if let Err(e) = admin_vta.cred_vault_receive(vic.clone(), None).await {
+    if state.join.present_invitation {
+        // The operator chose to present an invitation (or one was available and
+        // they accepted the default). Resolve the one to present.
+        if let Some(vic) = loaded {
+            if let Err(e) = admin_vta.cred_vault_receive(vic.clone(), None).await {
+                debug!(error = %e, "storing invitation in the VTA vault failed (continuing)");
+            }
+            if !openvtc_core::join::invitation_matches_community(&vic, &vtc_did) {
+                state.join.info(
+                    "Loaded invitation is for a different community — \
+                     looking for one that matches…",
+                );
+            } else if openvtc_core::join::invitation_is_expired(&vic, Utc::now()) {
+                state
+                    .join
+                    .info("Loaded invitation has expired — looking for a valid one…");
+            } else {
+                presentable = Some(vic);
+            }
+        }
+        if presentable.is_none() {
+            presentable = load_invitation_from_vault(admin_vta, &vtc_did).await;
+        }
+    } else if let Some(vic) = loaded {
+        // The operator chose to join *without* an invitation. Still store a
+        // loaded VIC in the vault (its durable home) but present nothing — this
+        // is what honours the choice over the vault fallback above.
+        if let Err(e) = admin_vta.cred_vault_receive(vic, None).await {
             debug!(error = %e, "storing invitation in the VTA vault failed (continuing)");
         }
-        if !openvtc_core::join::invitation_matches_community(&vic, &vtc_did) {
-            state.join.info(
-                "Loaded invitation is for a different community — \
-                 looking for one that matches…",
-            );
-        } else if openvtc_core::join::invitation_is_expired(&vic, Utc::now()) {
-            state
-                .join
-                .info("Loaded invitation has expired — looking for a valid one…");
-        } else {
-            presentable = Some(vic);
-        }
-    }
-    if presentable.is_none() {
-        presentable = load_invitation_from_vault(admin_vta, &vtc_did).await;
+        state
+            .join
+            .info("Joining without an invitation — submitting an open request (awaiting approval).");
     }
     // Completeness gate before presenting: a VIC resolved from the vault may
     // predate the ingest-time validation (or have lost fields in storage). An
@@ -851,12 +957,15 @@ async fn run_join_sequence(
         state
             .join
             .info("Presenting your invitation credential to the community…");
-    } else {
+    } else if state.join.present_invitation {
+        // Wanted to present one, but none resolved to a usable VIC.
         state.join.info(
             "No valid invitation for this community — \
              submitting as an open request (awaiting approval).",
         );
     }
+    // (When the operator chose to join without an invitation, the note was
+    // already surfaced above where the VIC was suppressed.)
     let _ = handler.state_tx.send(state.clone());
     // Subject-linkage (#1b): when the presenting DID differs from the VIC
     // subject, prove the subject authorized this presenter (signed with the

--- a/openvtc/src/ui/pages/join_flow/invitation_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/invitation_choice.rs
@@ -1,0 +1,201 @@
+//! Join flow — invitation choice.
+//!
+//! Shown only when an invitation credential (VIC) is actually available for the
+//! community being joined (a loaded VIC that matches, or one held in the vault).
+//! The operator chooses whether to present it — auto-joining on a valid, trusted
+//! invitation — or to join as an open request the community approves manually.
+//! Mirrors the other join pages' component shape; the default highlight is "use
+//! it", so pressing Enter preserves the auto-join behaviour.
+
+use crate::colors::{
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Layout, Margin,
+    },
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+
+use crate::{
+    state_handler::{actions::Action, join::JoinState},
+    ui::pages::join_flow::JoinFlow,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct InvitationChoice;
+
+impl InvitationChoice {
+    pub fn handle_key_event(state: &mut JoinFlow, key: KeyEvent) {
+        if state.props.state.processing {
+            return;
+        }
+        let selected = state.props.state.invitation_use_selected;
+        match key.code {
+            KeyCode::F(10) => {
+                let _ = state.action_tx.send(Action::Exit);
+            }
+            KeyCode::Up => {
+                let _ = state
+                    .action_tx
+                    .send(Action::JoinInvitationSelect(selected.saturating_sub(1)));
+            }
+            KeyCode::Down => {
+                let _ = state
+                    .action_tx
+                    .send(Action::JoinInvitationSelect((selected + 1).min(1)));
+            }
+            KeyCode::Enter => {
+                let _ = state.action_tx.send(Action::JoinInvitationChoose);
+            }
+            KeyCode::Esc => {
+                let _ = state.action_tx.send(Action::JoinCancel);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn render(&self, state: &JoinState, frame: &mut Frame<'_>) {
+        let [middle, bottom] = Layout::vertical([Min(0), Length(3)]).areas(frame.area());
+
+        frame.render_widget(
+            Block::bordered()
+                .fg(COLOR_BORDER)
+                .padding(Padding::proportional(1))
+                .title(" Use your invitation for this community? "),
+            middle,
+        );
+        let inner = middle.inner(Margin::new(3, 2));
+
+        let mut lines = vec![
+            Line::styled(
+                "An invitation for this community is available.",
+                Style::new().fg(COLOR_BORDER).bold(),
+            ),
+            Line::default(),
+        ];
+
+        // Two rows: 0 = use it (auto-join), 1 = join without it (open request).
+        let rows = [
+            (
+                "Use it — auto-join with your invitation",
+                "The community admits you automatically on a valid, trusted invitation.",
+            ),
+            (
+                "Join without it — send an open request",
+                "Submit a request the community reviews and approves manually.",
+            ),
+        ];
+        for (i, (title, detail)) in rows.iter().enumerate() {
+            let is_sel = i == state.invitation_use_selected;
+            let marker = if is_sel { "▸ " } else { "  " };
+            let style = if is_sel {
+                Style::new().fg(COLOR_SUCCESS).bold()
+            } else {
+                Style::new().fg(COLOR_TEXT_DEFAULT)
+            };
+            lines.push(Line::from(Span::styled(format!("{marker}{title}"), style)));
+            lines.push(Line::styled(
+                format!("    {detail}"),
+                Style::new().fg(COLOR_DARK_GRAY),
+            ));
+        }
+
+        lines.push(Line::default());
+        lines.push(Line::styled(
+            "You can still choose which identity to present on the next step.",
+            Style::new().fg(COLOR_SOFT_PURPLE),
+        ));
+        lines.push(Line::default());
+        lines.push(Line::from(vec![
+            Span::styled("[↑/↓]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" select   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" choose   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" cancel", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]));
+
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+
+        let bottom_line = Line::from(vec![
+            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]);
+        frame.render_widget(
+            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
+            bottom,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Key-routing tests for the invitation-choice page. `Action` derives neither
+    //! `PartialEq` nor `Debug`, so assertions pattern-match the variant.
+    use super::*;
+    use crate::state_handler::{
+        join::{JoinPage, JoinState},
+        state::State,
+    };
+    use crate::ui::component::Component;
+    use crossterm::event::KeyModifiers;
+    use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+    fn flow_with(mutate: impl FnOnce(&mut JoinState)) -> (JoinFlow, UnboundedReceiver<Action>) {
+        let (tx, rx) = unbounded_channel();
+        let mut state = State::default();
+        state.join.page = JoinPage::InvitationChoice;
+        mutate(&mut state.join);
+        (JoinFlow::new(&state, tx), rx)
+    }
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn down_moves_to_join_without_it() {
+        let (mut flow, mut rx) = flow_with(|_| {});
+        InvitationChoice::handle_key_event(&mut flow, press(KeyCode::Down));
+        match rx.try_recv() {
+            Ok(Action::JoinInvitationSelect(1)) => {}
+            _ => panic!("expected JoinInvitationSelect(1)"),
+        }
+    }
+
+    #[test]
+    fn up_clamps_at_use_it() {
+        let (mut flow, mut rx) = flow_with(|js| js.invitation_use_selected = 0);
+        InvitationChoice::handle_key_event(&mut flow, press(KeyCode::Up));
+        match rx.try_recv() {
+            Ok(Action::JoinInvitationSelect(0)) => {}
+            _ => panic!("expected JoinInvitationSelect(0)"),
+        }
+    }
+
+    #[test]
+    fn enter_chooses_the_highlight() {
+        let (mut flow, mut rx) = flow_with(|_| {});
+        InvitationChoice::handle_key_event(&mut flow, press(KeyCode::Enter));
+        match rx.try_recv() {
+            Ok(Action::JoinInvitationChoose) => {}
+            _ => panic!("expected JoinInvitationChoose"),
+        }
+    }
+
+    #[test]
+    fn esc_cancels_the_flow() {
+        let (mut flow, mut rx) = flow_with(|_| {});
+        InvitationChoice::handle_key_event(&mut flow, press(KeyCode::Esc));
+        match rx.try_recv() {
+            Ok(Action::JoinCancel) => {}
+            _ => panic!("expected JoinCancel"),
+        }
+    }
+}

--- a/openvtc/src/ui/pages/join_flow/mod.rs
+++ b/openvtc/src/ui/pages/join_flow/mod.rs
@@ -16,8 +16,8 @@ use crate::{
     ui::{
         component::{Component, ComponentRender},
         pages::join_flow::{
-            identity_choice::IdentityChoice, join_progress::JoinProgress,
-            vtc_enter_did::VtcEnterDid,
+            identity_choice::IdentityChoice, invitation_choice::InvitationChoice,
+            join_progress::JoinProgress, vtc_enter_did::VtcEnterDid,
         },
     },
 };
@@ -27,6 +27,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tui_input::Input;
 
 pub mod identity_choice;
+pub mod invitation_choice;
 pub mod join_progress;
 pub mod vtc_enter_did;
 
@@ -42,6 +43,7 @@ pub struct JoinFlow {
 
     // Page handlers (zero-sized — they read from `props.state`).
     pub vtc_enter_did: VtcEnterDid,
+    pub invitation_choice: InvitationChoice,
     pub identity_choice: IdentityChoice,
     pub join_progress: JoinProgress,
 
@@ -71,6 +73,7 @@ impl Component for JoinFlow {
             action_tx,
             vtc_did: Input::default(),
             vtc_enter_did: VtcEnterDid,
+            invitation_choice: InvitationChoice,
             identity_choice: IdentityChoice,
             join_progress: JoinProgress,
             props: Props::from(state),
@@ -94,6 +97,7 @@ impl Component for JoinFlow {
         }
         match self.props.state.page {
             JoinPage::EnterDid => VtcEnterDid::handle_key_event(self, key),
+            JoinPage::InvitationChoice => InvitationChoice::handle_key_event(self, key),
             JoinPage::IdentityChoice => IdentityChoice::handle_key_event(self, key),
             JoinPage::Progress => JoinProgress::handle_key_event(self, key),
         }
@@ -123,6 +127,7 @@ impl ComponentRender<()> for JoinFlow {
                 self.vtc_enter_did
                     .render(&self.props.state, &self.vtc_did, frame)
             }
+            JoinPage::InvitationChoice => self.invitation_choice.render(&self.props.state, frame),
             JoinPage::IdentityChoice => self.identity_choice.render(&self.props.state, frame),
             JoinPage::Progress => self.join_progress.render(&self.props.state, frame),
         }


### PR DESCRIPTION
## Why

The join ceremony auto-resolved a community-matched VIC (loaded or from the vault) and presented it with **no user say**. Worse, the vault fallback overrode an explicit "clear" of a loaded VIC — so even when you wanted to join *without* an invitation, a vault VIC would be presented anyway. There was no way to deliberately send an open request when an invitation existed.

## What

A **contextual invitation-choice step**, shown only when a VIC is actually available for the entered community — a loaded VIC that matches and is usable, or a community-matched, valid VIC held in the vault:

```
An invitation for this community is available.

  > Use it — auto-join with your invitation
    Join without it — send an open request (needs approval)
```

- Default highlight is **"Use it"**, so Enter preserves today's auto-join behaviour (opt-out, per the agreed design).
- When there's no available VIC, the step is skipped entirely — straight to identity selection.
- The decision (`present_invitation`) is honoured in the join sequence: choosing "without" **suppresses** any loaded/vault VIC (a loaded one is still stored in the vault as its durable home, just not presented) and submits a plain open request — fixing the vault-fallback override of the clear.

Mechanics: new `JoinPage::InvitationChoice` + `JoinInvitationSelect/Choose` actions + an `invitation_choice` page mirroring `identity_choice`. Identity routing is factored into `proceed_after_invitation_choice`, reached from both the no-VIC path and the choice (the `#1a/#1b` invited-persona pre-select runs only when we'll present the VIC). `invitation_available_for` probes the loaded VIC and the vault.

## Flow

`EnterDid → [InvitationChoice — only if a VIC exists] → IdentityChoice → Progress`

## Testing

`cargo build`, `cargo clippy --all-targets` clean; full suite green. New key-routing tests for the invitation-choice page (select up/down/clamp, choose, cancel).
