### PR TITLE
feat(loading): show the build version under the logo

### DIFF
--- a/openvtc/src/ui/pages/loading/mod.rs
+++ b/openvtc/src/ui/pages/loading/mod.rs
@@ -245,14 +245,19 @@ impl ComponentRender<()> for LoadingScreen {
             .flex(Flex::Center)
             .areas(area);
 
+        // +2: one line for the version under the logo, one as a spacer.
         let [banner_area, body_area, footer_area] =
-            Layout::vertical([Length(BANNER.len() as u16 + 1), Min(0), Length(1)]).areas(col);
+            Layout::vertical([Length(BANNER.len() as u16 + 2), Min(0), Length(1)]).areas(col);
 
-        // Banner.
-        let banner: Vec<Line> = BANNER
+        // Banner, with the build version under the logo.
+        let mut banner: Vec<Line> = BANNER
             .iter()
             .map(|l| Line::styled(*l, Style::new().fg(COLOR_SOFT_PURPLE).bold()))
             .collect();
+        banner.push(Line::styled(
+            format!("v{}", env!("CARGO_PKG_VERSION")),
+            Style::new().fg(COLOR_DARK_GRAY),
+        ));
         frame.render_widget(Paragraph::new(banner).centered(), banner_area);
 
         let mut lines: Vec<Line> = Vec::new();


### PR DESCRIPTION
## What

The startup/loading screen showed the OpenVTC logo with no version. This adds a dim `v<version>` line directly under the banner, resolved at compile time from `CARGO_PKG_VERSION`.

```
  ___                __     _______ ___
 / _ \ _ __  ___ _ _ \ \   / |_   _/ __|
| (_) | '_ \/ -_) ' \ \ \ / /  | || (__
 \___/| .__/\___|_||_| \_V_/   |_| \___|
      |_|
                 v0.2.1
```

The banner area height is bumped by one row so the spacer between the logo and the body is preserved. Styled in the muted gray used elsewhere on the screen.

## Testing

`cargo build` + `cargo clippy -p openvtc` clean.