### PR TITLE
feat(join): identity-first with per-persona VIC badges + detail-rich invitation list

### DIFF
--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -236,6 +236,18 @@ pub fn invitation_id(vic: &Value) -> Option<&str> {
     vic.get("id").and_then(Value::as_str)
 }
 
+/// A VIC's validity-window start (`validFrom`), RFC 3339, if declared. Shown as
+/// the "Issued" detail when the operator chooses an invitation to present.
+pub fn invitation_valid_from(vic: &Value) -> Option<&str> {
+    vic.get("validFrom").and_then(Value::as_str)
+}
+
+/// A VIC's validity-window end (`validUntil`), RFC 3339, if declared. Shown as
+/// the "Expires" detail.
+pub fn invitation_valid_until(vic: &Value) -> Option<&str> {
+    vic.get("validUntil").and_then(Value::as_str)
+}
+
 /// The DID that issued a VIC. For an `InvitationCredential` the issuer **is** the
 /// community's VTC DID (the VTC signs it with its own issuer key, so
 /// `issuer = signer.issuer_did()`), which is what a presentable invitation must

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -8,6 +8,7 @@
 //! `State.setup`; this struct only tracks the join-specific surface.
 
 use openvtc_core::config::account::{CommunityRecord, PersonaId};
+use serde_json::Value;
 
 use crate::state_handler::setup_sequence::{Completion, MessageType};
 
@@ -52,6 +53,27 @@ pub struct PersonaOption {
     /// Display names of communities this persona is *already* presented to —
     /// drives the cross-community linkage warning (D1).
     pub linked_communities: Vec<String>,
+    /// Count of valid invitations (VICs) for the community being joined that are
+    /// bound to this persona — shown as a badge so the operator can pick the
+    /// identity that holds a usable invitation.
+    pub valid_vic_count: usize,
+}
+
+/// A valid invitation (VIC) available to present for the community being joined,
+/// with the fields shown on the invitation-choice step and the body to present.
+#[derive(Clone, Debug)]
+pub struct AvailableVic {
+    /// The VIC's top-level `id`.
+    pub id: String,
+    /// The persona DID it is bound to (`credentialSubject.id`), if present —
+    /// used to group invitations under each persona.
+    pub subject: Option<String>,
+    /// Validity-window start (`validFrom`, RFC 3339), shown as "Issued".
+    pub valid_from: String,
+    /// Validity-window end (`validUntil`, RFC 3339), shown as "Expires".
+    pub valid_until: String,
+    /// The signed VIC body, presented verbatim when this one is chosen.
+    pub body: Value,
 }
 
 /// Transient state for the join flow.
@@ -100,14 +122,25 @@ pub struct JoinState {
     /// generic "no VIC" tip. Distinguishes a deliberate clear from never having
     /// had one; re-pasting a VIC (`JoinPasteVic`) flips it back to `false`.
     pub vic_cleared: bool,
-    /// Highlighted row on the [`InvitationChoice`](JoinPage::InvitationChoice)
-    /// page: `0` = "use the invitation" (default), `1` = "join without it".
+    /// All valid invitations (VICs) for the community being joined, across
+    /// personas — collected once after the VTC DID is entered and used to badge
+    /// each persona with its count on the identity step.
+    pub available_vics: Vec<AvailableVic>,
+    /// The chosen persona's invitations, listed on the
+    /// [`InvitationChoice`](JoinPage::InvitationChoice) page (a subset of
+    /// [`available_vics`](Self::available_vics) bound to that persona).
+    pub invitation_options: Vec<AvailableVic>,
+    /// Which persona the invitation step is choosing for — the reuse target the
+    /// join launches with once the invitation choice is made.
+    pub invitation_for_persona: Option<PersonaId>,
+    /// Highlighted row on the invitation-choice page: `0..invitation_options.len()`
+    /// selects a specific invitation to present; `invitation_options.len()` is the
+    /// trailing "join without it" row.
     pub invitation_use_selected: usize,
     /// The committed invitation decision, read by the join sequence. `true`
-    /// presents an available VIC (loaded-matching or vault); `false` suppresses
-    /// it and submits an open request — overriding the vault fallback, so the
-    /// choice is honoured. Set from [`invitation_use_selected`](Self::invitation_use_selected)
-    /// on the invitation-choice page, or directly when no VIC is available.
+    /// presents the chosen VIC (set into `State.invitation_credential`); `false`
+    /// submits an open request. Set when the invitation choice is made, or
+    /// directly (false) on paths with no available invitation.
     pub present_invitation: bool,
 }
 
@@ -150,6 +183,7 @@ mod tests {
             label: "p".to_string(),
             did: "did:webvh:x".to_string(),
             linked_communities: Vec::new(),
+            valid_vic_count: 0,
         }
     }
 

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -29,7 +29,7 @@ use crate::{
     state_handler::{
         StateHandler,
         actions::Action,
-        join::{JoinPage, JoinState, PersonaOption, PresentedInvitation},
+        join::{AvailableVic, JoinPage, JoinState, PersonaOption, PresentedInvitation},
         main_page::content::{VicLifecycle, VicSummary},
         main_page::shorten_did,
         setup_sequence::{Completion, MessageType, config::ConfigExtension, vta},
@@ -163,35 +163,42 @@ impl StateHandler {
                                 let _ = self.state_tx.send(state.clone());
                                 continue;
                             }
-                            // When an invitation is available for THIS community —
-                            // a loaded VIC that matches, or one held in the vault —
-                            // let the operator choose whether to present it or join
-                            // as an open request (default: present it). Shown only
-                            // when one actually exists; otherwise there's nothing to
-                            // choose and we go straight to identity selection.
-                            if invitation_available_for(state, admin_vta, &vtc_did).await {
+                            // Identity first: collect the invitations available for
+                            // this community so each persona can be badged with its
+                            // usable-invitation count, then let the operator pick the
+                            // identity to present (the invitation choice, if any,
+                            // follows for the chosen persona).
+                            state.join.available_vics =
+                                collect_available_vics(state, admin_vta, &vtc_did).await;
+                            let options =
+                                build_persona_options(config, &state.join.available_vics);
+                            if options.is_empty() {
+                                // First join — nothing to reuse; mint a fresh identity.
+                                // A new persona can't hold an existing invitation.
+                                state.invitation_credential = None;
+                                state.join.present_invitation = false;
+                                if let Some(interrupted) = self
+                                    .launch_join_sequence(
+                                        JoinIdentityChoice::Mint,
+                                        vtc_did,
+                                        interrupt_rx,
+                                        state,
+                                        tdk,
+                                        config,
+                                        admin_vta,
+                                        profile,
+                                    )
+                                    .await
+                                {
+                                    return Ok(JoinExit::Exit(interrupted));
+                                }
+                            } else {
                                 state.join.pending_vtc = Some(vtc_did);
-                                state.join.invitation_use_selected = 0; // default: use it
-                                state.join.present_invitation = true;
-                                state.join.page = JoinPage::InvitationChoice;
+                                state.join.persona_options = options;
+                                state.join.identity_selected = 0;
+                                state.join.reuse_confirm = None;
+                                state.join.page = JoinPage::IdentityChoice;
                                 let _ = self.state_tx.send(state.clone());
-                                continue;
-                            }
-                            // No invitation available — nothing to present.
-                            state.join.present_invitation = false;
-                            if let Some(interrupted) = self
-                                .proceed_after_invitation_choice(
-                                    vtc_did,
-                                    interrupt_rx,
-                                    state,
-                                    tdk,
-                                    config,
-                                    admin_vta,
-                                    profile,
-                                )
-                                .await
-                            {
-                                return Ok(JoinExit::Exit(interrupted));
                             }
                         }
                         Action::JoinIdentitySelect(i) => {
@@ -206,6 +213,9 @@ impl StateHandler {
                                 let Some(vtc_did) = state.join.pending_vtc.clone() else {
                                     continue;
                                 };
+                                // A freshly minted persona holds no invitation.
+                                state.invitation_credential = None;
+                                state.join.present_invitation = false;
                                 if let Some(interrupted) = self
                                     .launch_join_sequence(
                                         JoinIdentityChoice::Mint,
@@ -237,20 +247,49 @@ impl StateHandler {
                                 continue;
                             };
                             state.join.reuse_confirm = None;
-                            if let Some(interrupted) = self
-                                .launch_join_sequence(
-                                    JoinIdentityChoice::Reuse(persona_id),
-                                    vtc_did,
-                                    interrupt_rx,
-                                    state,
-                                    tdk,
-                                    config,
-                                    admin_vta,
-                                    profile,
-                                )
-                                .await
-                            {
-                                return Ok(JoinExit::Exit(interrupted));
+                            // Invitations bound to the chosen persona for this
+                            // community. With one or more, offer the invitation
+                            // choice; with none, join as an open request.
+                            let persona_did = config
+                                .account
+                                .personas
+                                .get(&persona_id)
+                                .map(|p| p.did.clone());
+                            let invitations: Vec<AvailableVic> = persona_did
+                                .map(|did| {
+                                    state
+                                        .join
+                                        .available_vics
+                                        .iter()
+                                        .filter(|v| v.subject.as_deref() == Some(did.as_str()))
+                                        .cloned()
+                                        .collect()
+                                })
+                                .unwrap_or_default();
+                            if invitations.is_empty() {
+                                state.invitation_credential = None;
+                                state.join.present_invitation = false;
+                                if let Some(interrupted) = self
+                                    .launch_join_sequence(
+                                        JoinIdentityChoice::Reuse(persona_id),
+                                        vtc_did,
+                                        interrupt_rx,
+                                        state,
+                                        tdk,
+                                        config,
+                                        admin_vta,
+                                        profile,
+                                    )
+                                    .await
+                                {
+                                    return Ok(JoinExit::Exit(interrupted));
+                                }
+                            } else {
+                                state.join.invitation_options = invitations;
+                                state.join.invitation_for_persona = Some(persona_id);
+                                state.join.invitation_use_selected = 0;
+                                state.join.page = JoinPage::InvitationChoice;
+                                let _ = self.state_tx.send(state.clone());
                             }
                         }
                         Action::JoinReuseCancel => {
@@ -258,18 +297,31 @@ impl StateHandler {
                             let _ = self.state_tx.send(state.clone());
                         }
                         Action::JoinInvitationSelect(i) => {
-                            // Two rows: 0 = use the invitation, 1 = join without it.
-                            state.join.invitation_use_selected = i.min(1);
+                            // Rows: 0..len select an invitation; len = "join without".
+                            let max = state.join.invitation_options.len();
+                            state.join.invitation_use_selected = i.min(max);
                             let _ = self.state_tx.send(state.clone());
                         }
                         Action::JoinInvitationChoose => {
                             let Some(vtc_did) = state.join.pending_vtc.clone() else {
                                 continue;
                             };
-                            state.join.present_invitation =
-                                state.join.invitation_use_selected == 0;
+                            let Some(persona_id) = state.join.invitation_for_persona else {
+                                continue;
+                            };
+                            // A selected invitation row presents that VIC; the
+                            // trailing row joins without one.
+                            let sel = state.join.invitation_use_selected;
+                            if let Some(av) = state.join.invitation_options.get(sel) {
+                                state.invitation_credential = Some(av.body.clone());
+                                state.join.present_invitation = true;
+                            } else {
+                                state.invitation_credential = None;
+                                state.join.present_invitation = false;
+                            }
                             if let Some(interrupted) = self
-                                .proceed_after_invitation_choice(
+                                .launch_join_sequence(
+                                    JoinIdentityChoice::Reuse(persona_id),
                                     vtc_did,
                                     interrupt_rx,
                                     state,
@@ -292,64 +344,6 @@ impl StateHandler {
             }
             let _ = self.state_tx.send(state.clone());
         }
-    }
-
-    /// Route from the invitation choice (or directly when no invitation is
-    /// available) to identity selection. When we'll present a loaded VIC bound to
-    /// one of our personas, pre-select that persona (#1a/#1b); otherwise offer the
-    /// persona list, or mint directly on a first join. Returns `Some(interrupted)`
-    /// only when a direct mint launched and was interrupted mid-sequence.
-    #[allow(clippy::too_many_arguments)]
-    async fn proceed_after_invitation_choice(
-        &self,
-        vtc_did: String,
-        interrupt_rx: &mut broadcast::Receiver<Interrupted>,
-        state: &mut State,
-        tdk: &TDK,
-        config: &mut Config,
-        admin_vta: Option<&VtaClient>,
-        profile: &str,
-    ) -> Option<Interrupted> {
-        // #1a/#1b: a loaded invitation bound to one of our personas — pre-select
-        // it so Enter joins as the invited identity (no linkage), and a different
-        // choice builds the subject-linkage proof. Only when we'll present it.
-        if state.join.present_invitation
-            && let Some(pid) = invitation_subject_persona(config, state)
-        {
-            let options = build_persona_options(config);
-            let idx = options.iter().position(|o| o.id == pid).unwrap_or(0);
-            state.join.pending_vtc = Some(vtc_did);
-            state.join.persona_options = options;
-            state.join.identity_selected = idx;
-            state.join.reuse_confirm = None;
-            state.join.page = JoinPage::IdentityChoice;
-            let _ = self.state_tx.send(state.clone());
-            return None;
-        }
-        // R-B-3 / D1: with existing personas, let the user choose to reuse one or
-        // mint a fresh identity; with none (the first join), mint directly.
-        let options = build_persona_options(config);
-        if options.is_empty() {
-            return self
-                .launch_join_sequence(
-                    JoinIdentityChoice::Mint,
-                    vtc_did,
-                    interrupt_rx,
-                    state,
-                    tdk,
-                    config,
-                    admin_vta,
-                    profile,
-                )
-                .await;
-        }
-        state.join.pending_vtc = Some(vtc_did);
-        state.join.persona_options = options;
-        state.join.identity_selected = 0;
-        state.join.reuse_confirm = None;
-        state.join.page = JoinPage::IdentityChoice;
-        let _ = self.state_tx.send(state.clone());
-        None
     }
 
     /// Move to the progress page and run [`run_join_sequence`] for the chosen
@@ -427,8 +421,10 @@ impl StateHandler {
 
 /// Build the reuse options for the identity-choice page (R-B-3): every existing
 /// persona, labelled, with the communities it is already presented to (the
-/// linkage-warning detail). Sorted by label for a stable list.
-fn build_persona_options(config: &Config) -> Vec<PersonaOption> {
+/// linkage-warning detail) and the count of `vics` bound to it (the available
+/// invitations for the community being joined). Sorted by label for a stable
+/// list.
+fn build_persona_options(config: &Config, vics: &[AvailableVic]) -> Vec<PersonaOption> {
     let mut options: Vec<PersonaOption> = config
         .account
         .personas
@@ -446,16 +442,92 @@ fn build_persona_options(config: &Config) -> Vec<PersonaOption> {
                 })
                 .collect();
             linked_communities.sort();
+            let valid_vic_count = vics
+                .iter()
+                .filter(|v| v.subject.as_deref() == Some(p.did.as_str()))
+                .count();
             PersonaOption {
                 id: p.persona_id,
                 label: p.label.clone().unwrap_or_else(|| shorten_did(&p.did, 32)),
                 did: p.did.clone(),
                 linked_communities,
+                valid_vic_count,
             }
         })
         .collect();
     options.sort_by(|a, b| a.label.cmp(&b.label).then_with(|| a.did.cmp(&b.did)));
     options
+}
+
+/// Collect the valid invitations (VICs) available for the community `vtc_did`,
+/// across all personas: a loaded `--invitation`/pasted VIC that matches, plus the
+/// community-matched, valid, active VICs the vault holds. Each is validated
+/// (complete + unexpired) so the identity badges and the invitation list only
+/// ever show usable invitations. Best-effort: with no admin VTA only a loaded VIC
+/// is considered.
+async fn collect_available_vics(
+    state: &State,
+    admin_vta: Option<&VtaClient>,
+    vtc_did: &str,
+) -> Vec<AvailableVic> {
+    let now = Utc::now();
+    let usable = |vic: &serde_json::Value| {
+        openvtc_core::join::invitation_matches_community(vic, vtc_did)
+            && !openvtc_core::join::invitation_is_expired(vic, now)
+            && openvtc_core::join::validate_invitation_credential(vic).is_ok()
+    };
+    let mut out: Vec<AvailableVic> = Vec::new();
+
+    // Vault: only fetch bodies for this community's active, valid descriptors.
+    if let Some(vta) = admin_vta
+        && let Ok(listing) = vta
+            .cred_vault_query(serde_json::json!({ "purpose": "invite" }))
+            .await
+        && let Some(arr) = listing.get("credentials").and_then(|c| c.as_array())
+    {
+        for d in arr {
+            let summ = VicSummary::from_descriptor(d);
+            if summ.issuer != vtc_did
+                || summ.status != "valid"
+                || summ.lifecycle != VicLifecycle::Active
+            {
+                continue;
+            }
+            if let Ok(got) = vta.cred_vault_get(&summ.id).await
+                && let Some(body) = got.get("credential").cloned()
+                && usable(&body)
+                && let Some(av) = to_available_vic(&body)
+            {
+                out.push(av);
+            }
+        }
+    }
+
+    // A loaded VIC (--invitation / paste) that matches this community, if not
+    // already surfaced from the vault.
+    if let Some(vic) = state.invitation_credential.as_ref()
+        && usable(vic)
+        && let Some(av) = to_available_vic(vic)
+        && !out.iter().any(|o| o.id == av.id)
+    {
+        out.push(av);
+    }
+    out
+}
+
+/// Map a signed VIC body to the display+present record. `None` if it lacks an id.
+fn to_available_vic(body: &serde_json::Value) -> Option<AvailableVic> {
+    Some(AvailableVic {
+        id: openvtc_core::join::invitation_id(body)?.to_string(),
+        subject: openvtc_core::join::invitation_subject(body).map(str::to_string),
+        valid_from: openvtc_core::join::invitation_valid_from(body)
+            .unwrap_or_default()
+            .to_string(),
+        valid_until: openvtc_core::join::invitation_valid_until(body)
+            .unwrap_or_default()
+            .to_string(),
+        body: body.clone(),
+    })
 }
 
 /// Outcome of a `join_flow` invocation.
@@ -483,38 +555,6 @@ fn validate_join_input(raw: &str) -> Option<String> {
     }
 }
 
-/// #1a: the existing persona a loaded invitation is bound to, if any. When the
-/// VIC's `credentialSubject.id` matches one of our personas, the join can
-/// present that persona directly (holder-binding satisfied, no linkage proof).
-fn invitation_subject_persona(config: &Config, state: &State) -> Option<PersonaId> {
-    let vic = state.invitation_credential.as_ref()?;
-    let subject = openvtc_core::join::invitation_subject(vic)?;
-    config.account.persona_id_for_did(subject)
-}
-
-/// Whether an invitation for `vtc_did` is available to present — a loaded VIC
-/// that matches this community and is currently usable, or a community-matched,
-/// valid VIC held in the vault. Drives the invitation-choice step, which is shown
-/// only when one actually exists. Best-effort: with no admin VTA only a loaded
-/// VIC counts. The vault check fetches the candidate body; the join sequence
-/// re-resolves it independently, so this stays a pure availability probe.
-async fn invitation_available_for(
-    state: &State,
-    admin_vta: Option<&VtaClient>,
-    vtc_did: &str,
-) -> bool {
-    if let Some(vic) = state.invitation_credential.as_ref()
-        && openvtc_core::join::invitation_matches_community(vic, vtc_did)
-        && !openvtc_core::join::invitation_is_expired(vic, Utc::now())
-        && openvtc_core::join::validate_invitation_credential(vic).is_ok()
-    {
-        return true;
-    }
-    match admin_vta {
-        Some(vta) => load_invitation_from_vault(vta, vtc_did).await.is_some(),
-        None => false,
-    }
-}
 
 /// #2: load a *presentable* invitation the VTA already holds for the community
 /// being joined (`vtc_did`). Queries the credential vault for `purpose = invite`

--- a/openvtc/src/ui/pages/join_flow/identity_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/identity_choice.rs
@@ -161,8 +161,13 @@ impl IdentityChoice {
             } else {
                 Style::new().fg(COLOR_TEXT_DEFAULT)
             };
+            let badge = match opt.valid_vic_count {
+                0 => String::new(),
+                1 => "  (1 invitation)".to_string(),
+                n => format!("  ({n} invitations)"),
+            };
             lines.push(Line::from(Span::styled(
-                format!("{marker}{}", opt.label),
+                format!("{marker}{}{badge}", opt.label),
                 style,
             )));
             let detail = if opt.linked_communities.is_empty() {
@@ -247,12 +252,14 @@ mod tests {
                 label: "alice".to_string(),
                 did: "did:webvh:a".to_string(),
                 linked_communities: Vec::new(),
+                valid_vic_count: 0,
             },
             PersonaOption {
                 id: PersonaId::new(),
                 label: "bob".to_string(),
                 did: "did:webvh:b".to_string(),
                 linked_communities: Vec::new(),
+                valid_vic_count: 0,
             },
         ];
         mutate(&mut state.join);

--- a/openvtc/src/ui/pages/join_flow/invitation_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/invitation_choice.rs
@@ -1,14 +1,15 @@
 //! Join flow — invitation choice.
 //!
-//! Shown only when an invitation credential (VIC) is actually available for the
-//! community being joined (a loaded VIC that matches, or one held in the vault).
-//! The operator chooses whether to present it — auto-joining on a valid, trusted
-//! invitation — or to join as an open request the community approves manually.
-//! Mirrors the other join pages' component shape; the default highlight is "use
-//! it", so pressing Enter preserves the auto-join behaviour.
+//! Reached after the operator picks an identity that holds one or more valid
+//! invitations (VICs) for the community being joined. Each invitation is listed
+//! with its details (Issued / Expires); the operator presents one — auto-joining
+//! on a valid, trusted invitation — or chooses the trailing "join without it" row
+//! to send an open request the community approves manually. The default highlight
+//! is the first invitation, so Enter preserves the auto-join behaviour.
 
 use crate::colors::{
-    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
+    COLOR_TEXT_DEFAULT,
 };
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
@@ -30,12 +31,26 @@ use crate::{
 #[derive(Clone, Debug, Default)]
 pub struct InvitationChoice;
 
+/// Trim an RFC 3339 timestamp to its date for compact display; empty stays as a
+/// dash. Falls back to the full string if it is shorter than a date.
+fn short_date(ts: &str) -> String {
+    if ts.is_empty() {
+        "—".to_string()
+    } else if ts.len() >= 10 {
+        ts[..10].to_string()
+    } else {
+        ts.to_string()
+    }
+}
+
 impl InvitationChoice {
     pub fn handle_key_event(state: &mut JoinFlow, key: KeyEvent) {
         if state.props.state.processing {
             return;
         }
         let selected = state.props.state.invitation_use_selected;
+        // The "join without it" row sits one past the invitations.
+        let without_row = state.props.state.invitation_options.len();
         match key.code {
             KeyCode::F(10) => {
                 let _ = state.action_tx.send(Action::Exit);
@@ -48,7 +63,7 @@ impl InvitationChoice {
             KeyCode::Down => {
                 let _ = state
                     .action_tx
-                    .send(Action::JoinInvitationSelect((selected + 1).min(1)));
+                    .send(Action::JoinInvitationSelect((selected + 1).min(without_row)));
             }
             KeyCode::Enter => {
                 let _ = state.action_tx.send(Action::JoinInvitationChoose);
@@ -67,31 +82,21 @@ impl InvitationChoice {
             Block::bordered()
                 .fg(COLOR_BORDER)
                 .padding(Padding::proportional(1))
-                .title(" Use your invitation for this community? "),
+                .title(" Use an invitation for this community? "),
             middle,
         );
         let inner = middle.inner(Margin::new(3, 2));
 
         let mut lines = vec![
             Line::styled(
-                "An invitation for this community is available.",
+                "Choose an invitation to present, or join without one:",
                 Style::new().fg(COLOR_BORDER).bold(),
             ),
             Line::default(),
         ];
 
-        // Two rows: 0 = use it (auto-join), 1 = join without it (open request).
-        let rows = [
-            (
-                "Use it — auto-join with your invitation",
-                "The community admits you automatically on a valid, trusted invitation.",
-            ),
-            (
-                "Join without it — send an open request",
-                "Submit a request the community reviews and approves manually.",
-            ),
-        ];
-        for (i, (title, detail)) in rows.iter().enumerate() {
+        // One selectable row per available invitation, with its details.
+        for (i, vic) in state.invitation_options.iter().enumerate() {
             let is_sel = i == state.invitation_use_selected;
             let marker = if is_sel { "▸ " } else { "  " };
             let style = if is_sel {
@@ -99,18 +104,38 @@ impl InvitationChoice {
             } else {
                 Style::new().fg(COLOR_TEXT_DEFAULT)
             };
-            lines.push(Line::from(Span::styled(format!("{marker}{title}"), style)));
+            lines.push(Line::from(Span::styled(
+                format!("{marker}Invitation {}", vic.id),
+                style,
+            )));
             lines.push(Line::styled(
-                format!("    {detail}"),
+                format!(
+                    "    Issued {}  ·  Expires {}",
+                    short_date(&vic.valid_from),
+                    short_date(&vic.valid_until),
+                ),
                 Style::new().fg(COLOR_DARK_GRAY),
             ));
         }
 
-        lines.push(Line::default());
+        // Trailing "join without it" row.
+        let without_row = state.invitation_options.len();
+        let without_sel = state.invitation_use_selected >= without_row;
+        let marker = if without_sel { "▸ " } else { "  " };
+        let style = if without_sel {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_SOFT_PURPLE)
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker}Join without it — send an open request"),
+            style,
+        )));
         lines.push(Line::styled(
-            "You can still choose which identity to present on the next step.",
-            Style::new().fg(COLOR_SOFT_PURPLE),
+            "    The community reviews and approves the request manually.",
+            Style::new().fg(COLOR_DARK_GRAY),
         ));
+
         lines.push(Line::default());
         lines.push(Line::from(vec![
             Span::styled("[↑/↓]", Style::new().fg(COLOR_BORDER).bold()),
@@ -124,7 +149,7 @@ impl InvitationChoice {
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
 
         let bottom_line = Line::from(vec![
-            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled("[F10]", Style::new().fg(COLOR_ORANGE).bold()),
             Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
         ]);
         frame.render_widget(
@@ -140,17 +165,28 @@ mod tests {
     //! `PartialEq` nor `Debug`, so assertions pattern-match the variant.
     use super::*;
     use crate::state_handler::{
-        join::{JoinPage, JoinState},
+        join::{AvailableVic, JoinPage, JoinState},
         state::State,
     };
     use crate::ui::component::Component;
     use crossterm::event::KeyModifiers;
     use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
+    fn vic(id: &str) -> AvailableVic {
+        AvailableVic {
+            id: id.to_string(),
+            subject: Some("did:webvh:alice".to_string()),
+            valid_from: "2026-06-01T00:00:00Z".to_string(),
+            valid_until: "2026-12-01T00:00:00Z".to_string(),
+            body: serde_json::json!({ "id": id }),
+        }
+    }
+
     fn flow_with(mutate: impl FnOnce(&mut JoinState)) -> (JoinFlow, UnboundedReceiver<Action>) {
         let (tx, rx) = unbounded_channel();
         let mut state = State::default();
         state.join.page = JoinPage::InvitationChoice;
+        state.join.invitation_options = vec![vic("urn:uuid:one")];
         mutate(&mut state.join);
         (JoinFlow::new(&state, tx), rx)
     }
@@ -160,7 +196,8 @@ mod tests {
     }
 
     #[test]
-    fn down_moves_to_join_without_it() {
+    fn down_moves_toward_join_without_it() {
+        // One invitation (row 0) + the "without" row (row 1).
         let (mut flow, mut rx) = flow_with(|_| {});
         InvitationChoice::handle_key_event(&mut flow, press(KeyCode::Down));
         match rx.try_recv() {
@@ -170,12 +207,13 @@ mod tests {
     }
 
     #[test]
-    fn up_clamps_at_use_it() {
-        let (mut flow, mut rx) = flow_with(|js| js.invitation_use_selected = 0);
-        InvitationChoice::handle_key_event(&mut flow, press(KeyCode::Up));
+    fn down_clamps_at_the_without_row() {
+        let (mut flow, mut rx) = flow_with(|js| js.invitation_use_selected = 1);
+        InvitationChoice::handle_key_event(&mut flow, press(KeyCode::Down));
         match rx.try_recv() {
-            Ok(Action::JoinInvitationSelect(0)) => {}
-            _ => panic!("expected JoinInvitationSelect(0)"),
+            // len == 1, so the max row index is 1 (the "without" row).
+            Ok(Action::JoinInvitationSelect(1)) => {}
+            _ => panic!("expected JoinInvitationSelect(1)"),
         }
     }
 


### PR DESCRIPTION
## Why

Two issues with the join ceremony:

1. **Wrong order.** The invitation choice came *before* identity selection — but invitations are bound to a *persona* (subject), so the natural order is to pick the identity first.
2. **No VIC info.** When an invitation was available, nothing about it was shown — the user couldn't see when it was issued, when it expires, or which persona it's for.

## What

Reorders to **identity-first** and surfaces real invitation details.

**Identity step** badges each persona with its count of valid invitations for the community being joined:

```
Choose an identity for did:webvh:…:storm

  > alice            (1 invitation)
    bob              (no badge — none)
    ✦ Create a new identity
```

**Invitation step** (only when the chosen persona has ≥1 invitation) lists each one with details, plus a "join without it" row:

```
Choose an invitation to present, or join without one:

  > Invitation urn:uuid:1a94bc09-…
        Issued 2026-06-01  ·  Expires 2026-12-01
    Join without it — send an open request
```

Selecting an invitation presents that specific VIC; the trailing row submits an open request. A persona with no invitation (or a freshly minted one) skips the step straight to the open-request join.

New flow: `EnterDid → IdentityChoice (VIC counts) → [InvitationChoice if the chosen persona has VICs] → Progress`.

## Mechanics

- `collect_available_vics` fetches this community's valid invite VIC **bodies** once after the DID is entered (vault descriptors filtered to the community + a matching loaded VIC), since the cheap descriptor lacks `subject`/`validFrom`.
- `build_persona_options` counts them per `credentialSubject.id`.
- The chosen VIC is written into `State.invitation_credential` (+ `present_invitation`) before launch, so **`run_join_sequence` is unchanged** — it already presents whatever is set.
- `AvailableVic` carries `id/subject/validFrom/validUntil/body`; openvtc-core gains `invitation_valid_from` / `invitation_valid_until` accessors. The superseded pre-identity invitation step and its helpers are removed.

## Testing

`cargo build`, `cargo clippy --all-targets` clean; full suite green. Updated/added key-routing tests for both pages (count-badge construction, VIC-list select/clamp/choose/cancel).
