### PR TITLE
feat(community): support multiple memberships per community (distinct personas)

### DIFF
--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -533,19 +533,106 @@ pub struct Account {
     /// Account personas, keyed by stable id.
     #[serde(default)]
     pub personas: HashMap<PersonaId, PersonaRecord>,
-    /// Community memberships, keyed by VTC DID.
-    #[serde(default)]
-    pub communities: HashMap<VtcDid, CommunityRecord>,
+    /// Community memberships, grouped by VTC DID. A community may hold more than
+    /// one membership, each presenting a **different** persona — the
+    /// `(vtc_did, persona_ref)` pair is unique. Backward compatible:
+    /// [`de_communities`] folds the legacy one-record-per-VTC shape (and a bare
+    /// record) into the grouped form on load.
+    #[serde(default, deserialize_with = "de_communities")]
+    pub communities: HashMap<VtcDid, Vec<CommunityRecord>>,
+}
+
+/// Deserialize [`Account::communities`] tolerantly: each VTC's value may be a
+/// list of memberships (the current shape) or a single record (legacy configs
+/// written before multi-membership). Both fold into `Vec<CommunityRecord>`.
+fn de_communities<'de, D>(d: D) -> Result<HashMap<VtcDid, Vec<CommunityRecord>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        // Try the list shape first; a legacy object value fails the seq parse
+        // and falls through to the single-record variant.
+        Many(Vec<CommunityRecord>),
+        One(Box<CommunityRecord>),
+    }
+    let raw: HashMap<VtcDid, OneOrMany> = HashMap::deserialize(d)?;
+    Ok(raw
+        .into_iter()
+        .map(|(k, v)| {
+            let list = match v {
+                OneOrMany::Many(list) => list,
+                OneOrMany::One(rec) => vec![*rec],
+            };
+            (k, list)
+        })
+        .collect())
 }
 
 impl Account {
-    /// Resolve the persona presented to a given community, following
-    /// `persona_ref`. Returns `None` if the community is unknown or its
-    /// `persona_ref` dangles (a referential-integrity violation; see
-    /// [`Self::dangling_refs`]).
-    pub fn persona_for(&self, vtc: &VtcDid) -> Option<&PersonaRecord> {
-        let community = self.communities.get(vtc)?;
-        self.personas.get(&community.persona_ref)
+    /// Every membership across all communities (flattened). A community may
+    /// contribute more than one — one per presented persona.
+    pub fn memberships(&self) -> impl Iterator<Item = &CommunityRecord> {
+        self.communities.values().flatten()
+    }
+
+    /// Mutable iterator over every membership.
+    pub fn memberships_mut(&mut self) -> impl Iterator<Item = &mut CommunityRecord> {
+        self.communities.values_mut().flatten()
+    }
+
+    /// The memberships held with one community (empty if none).
+    pub fn memberships_for(&self, vtc: &str) -> &[CommunityRecord] {
+        self.communities.get(vtc).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// A specific membership: community `vtc` presented as `persona`. The
+    /// `(vtc, persona)` pair is unique, so this resolves at most one.
+    pub fn membership(&self, vtc: &str, persona: PersonaId) -> Option<&CommunityRecord> {
+        self.memberships_for(vtc)
+            .iter()
+            .find(|c| c.persona_ref == persona)
+    }
+
+    /// Mutable [`Self::membership`] — for applying a lifecycle transition.
+    pub fn membership_mut(&mut self, vtc: &str, persona: PersonaId) -> Option<&mut CommunityRecord> {
+        self.communities
+            .get_mut(vtc)?
+            .iter_mut()
+            .find(|c| c.persona_ref == persona)
+    }
+
+    /// The pending membership of community `vtc` awaiting the join reply with
+    /// `request_id` — the disambiguator when several personas have joined the
+    /// same community (each Pending submit carries a unique id). Resolves at most
+    /// one membership.
+    pub fn membership_by_pending_request(
+        &mut self,
+        vtc: &str,
+        request_id: Uuid,
+    ) -> Option<&mut CommunityRecord> {
+        self.communities.get_mut(vtc)?.iter_mut().find(
+            |c| matches!(&c.status, CommunityStatus::Pending { request_id: r } if *r == request_id),
+        )
+    }
+
+    /// Add a new membership. Callers gate on [`Self::has_live_membership`] first
+    /// (R-B-9): a community may hold many memberships, but not two for the same
+    /// persona.
+    pub fn add_membership(&mut self, record: CommunityRecord) {
+        self.communities
+            .entry(record.vtc_did.clone())
+            .or_default()
+            .push(record);
+    }
+
+    /// Whether a *live* (Active/Pending) membership already exists for
+    /// `(vtc, persona)`. Join idempotency is per-persona: a live membership as
+    /// *this* persona blocks a duplicate, but the same community may still be
+    /// joined as a different persona.
+    pub fn has_live_membership(&self, vtc: &str, persona: PersonaId) -> bool {
+        self.membership(vtc, persona).is_some_and(|c| c.is_live())
     }
 
     /// The id of the account persona whose `did` equals `did`, if any. Maps an
@@ -558,13 +645,19 @@ impl Account {
             .map(|(id, _)| *id)
     }
 
-    /// True if any community references this persona.
+    /// Resolve the persona presented for a specific membership.
+    pub fn membership_persona(&self, vtc: &str, persona: PersonaId) -> Option<&PersonaRecord> {
+        self.membership(vtc, persona)
+            .and_then(|c| self.personas.get(&c.persona_ref))
+    }
+
+    /// True if any membership references this persona.
     pub fn persona_referenced(&self, id: &PersonaId) -> bool {
-        self.communities.values().any(|c| &c.persona_ref == id)
+        self.memberships().any(|c| &c.persona_ref == id)
     }
 
     /// Whether a persona may be deleted (R-P-1): it must exist and not be
-    /// referenced by any community.
+    /// referenced by any membership.
     pub fn can_delete_persona(&self, id: &PersonaId) -> bool {
         self.personas.contains_key(id) && !self.persona_referenced(id)
     }
@@ -574,106 +667,91 @@ impl Account {
     pub fn dangling_refs(&self) -> Vec<(&VtcDid, &PersonaId)> {
         self.communities
             .iter()
+            .flat_map(|(vtc, list)| list.iter().map(move |c| (vtc, c)))
             .filter(|(_, c)| !self.personas.contains_key(&c.persona_ref))
             .map(|(vtc, c)| (vtc, &c.persona_ref))
             .collect()
     }
 
-    /// Iterator over communities in the `Active` (live) state.
+    /// Iterator over memberships in the `Active` (live) state.
     pub fn active_communities(&self) -> impl Iterator<Item = &CommunityRecord> {
-        self.communities.values().filter(|c| c.status.is_active())
-    }
-
-    /// A membership by VTC DID.
-    pub fn community(&self, vtc: &VtcDid) -> Option<&CommunityRecord> {
-        self.communities.get(vtc)
-    }
-
-    /// A mutable membership by VTC DID — for applying a lifecycle transition.
-    pub fn community_mut(&mut self, vtc: &VtcDid) -> Option<&mut CommunityRecord> {
-        self.communities.get_mut(vtc)
-    }
-
-    /// A *live* membership (Active or Pending) for this VTC, if any.
-    ///
-    /// State B uses this for join idempotency (R-B-9): a live membership is
-    /// surfaced to the user instead of submitting a duplicate, while an inactive
-    /// one (`Left`/`Rejected`/`Removed`/`Expired`) may be re-joined.
-    pub fn live_community(&self, vtc: &VtcDid) -> Option<&CommunityRecord> {
-        self.communities.get(vtc).filter(|c| c.is_live())
+        self.memberships().filter(|c| c.status.is_active())
     }
 
     /// Sweep all `Pending` memberships, expiring any past the client timeout
-    /// (R-B-7 / D16). Returns the VTC DIDs that transitioned to `Expired` so the
-    /// caller can persist and raise the actions-required indicator (R-S-2).
-    pub fn expire_stale_pending(&mut self, now: DateTime<Utc>) -> Vec<VtcDid> {
+    /// (R-B-7 / D16). Returns the `(vtc, persona)` of each membership that
+    /// transitioned to `Expired` so the caller can persist and raise the
+    /// actions-required indicator (R-S-2).
+    pub fn expire_stale_pending(&mut self, now: DateTime<Utc>) -> Vec<(VtcDid, PersonaId)> {
         let mut expired = Vec::new();
-        for (vtc, community) in self.communities.iter_mut() {
+        for community in self.memberships_mut() {
             if community.expire_if_stale(now) {
-                expired.push(vtc.clone());
+                expired.push((community.vtc_did.clone(), community.persona_ref));
             }
         }
         expired
     }
 
-    /// Number of communities currently raising the actions-required indicator
-    /// (R-C-3): see [`CommunityRecord::needs_attention`]. Archived communities
-    /// are excluded — archiving hides a membership from the default list, so it
-    /// no longer nags.
+    /// Number of memberships currently raising the actions-required indicator
+    /// (R-C-3): see [`CommunityRecord::needs_attention`]. Archived memberships
+    /// are excluded — archiving hides one from the default list, so it no longer
+    /// nags.
     pub fn actions_required_count(&self) -> usize {
-        self.communities
-            .values()
+        self.memberships()
             .filter(|c| !c.archived && c.needs_attention())
             .count()
     }
 
-    /// Communities for the overview page in display order (R-C-4): favourites
-    /// first, then by display name (case-insensitive; unnamed last), then VTC
-    /// DID as a stable tiebreak. Archived communities are excluded unless
-    /// `include_archived` (R-C-8).
+    /// Memberships for the overview page in display order (R-C-4): grouped by
+    /// community (display name, case-insensitive, unnamed last; then VTC DID),
+    /// favourites first within the list, then by presented persona for a stable
+    /// order. Archived memberships are excluded unless `include_archived` (R-C-8).
     pub fn communities_for_display(&self, include_archived: bool) -> Vec<&CommunityRecord> {
         let mut list: Vec<&CommunityRecord> = self
-            .communities
-            .values()
+            .memberships()
             .filter(|c| include_archived || !c.archived)
             .collect();
         list.sort_by(|a, b| {
             // Favourites first.
             b.favourite
                 .cmp(&a.favourite)
-                // Then by display name, case-insensitive; the unnamed sort last.
+                // Then group by display name, case-insensitive; unnamed last.
                 .then_with(|| match (&a.display_name, &b.display_name) {
                     (Some(an), Some(bn)) => an.to_lowercase().cmp(&bn.to_lowercase()),
                     (Some(_), None) => std::cmp::Ordering::Less,
                     (None, Some(_)) => std::cmp::Ordering::Greater,
                     (None, None) => std::cmp::Ordering::Equal,
                 })
-                // Finally the VTC DID for a stable, deterministic order.
+                // Then the VTC DID, then the persona, for a stable order that
+                // keeps a community's memberships adjacent (for grouped display).
                 .then_with(|| a.vtc_did.cmp(&b.vtc_did))
+                .then_with(|| a.persona_ref.cmp(&b.persona_ref))
         });
         list
     }
 
-    /// The community to use as the default working context (D10 / R-C-6/7) when
-    /// the user hasn't explicitly selected one: the first **Active** community in
-    /// display order (favourites first, then by name, then VTC DID). Returns
-    /// `None` when there is no active community (the "no active community" state).
-    /// Deterministic so the working context is stable across launches.
-    pub fn default_working_community(&self) -> Option<VtcDid> {
+    /// The membership to use as the default working context (D10 / R-C-6/7) when
+    /// the user hasn't explicitly selected one: the first **Active** membership
+    /// in display order. Returns `None` when there is none. Deterministic so the
+    /// working context is stable across launches.
+    pub fn default_working_membership(&self) -> Option<(VtcDid, PersonaId)> {
         self.communities_for_display(false)
             .into_iter()
             .find(|c| c.status.is_active())
-            .map(|c| c.vtc_did.clone())
+            .map(|c| (c.vtc_did.clone(), c.persona_ref))
     }
 
-    /// Archive an inactive community (R-C-8): retain its data but hide it from
-    /// the default list. Errors if the community is unknown or still
+    /// Archive an inactive membership (R-C-8): retain its data but hide it from
+    /// the default list. Errors if the membership is unknown or still
     /// active/pending (it must be left first).
-    pub fn archive_community(&mut self, vtc: &VtcDid) -> Result<(), OpenVTCError> {
+    pub fn archive_membership(
+        &mut self,
+        vtc: &str,
+        persona: PersonaId,
+    ) -> Result<(), OpenVTCError> {
         let community = self
-            .communities
-            .get_mut(vtc)
-            .ok_or_else(|| OpenVTCError::Config(format!("Unknown community: {vtc}")))?;
+            .membership_mut(vtc, persona)
+            .ok_or_else(|| OpenVTCError::Config(format!("Unknown membership: {vtc}")))?;
         if !community.can_archive_or_delete() {
             return Err(OpenVTCError::Config(format!(
                 "Cannot archive an active/pending community ({vtc}); leave it first"
@@ -683,21 +761,33 @@ impl Account {
         Ok(())
     }
 
-    /// Delete an inactive community's local record (R-C-8), returning the removed
-    /// record. Errors if the community is unknown or still active/pending. The
-    /// presented persona is retained even if now unreferenced (R-P-2); explicit
-    /// persona deletion is a separate action.
-    pub fn delete_community(&mut self, vtc: &VtcDid) -> Result<CommunityRecord, OpenVTCError> {
-        match self.communities.get(vtc) {
-            None => Err(OpenVTCError::Config(format!("Unknown community: {vtc}"))),
-            Some(c) if !c.can_archive_or_delete() => Err(OpenVTCError::Config(format!(
+    /// Delete an inactive membership's local record (R-C-8), returning the removed
+    /// record. Errors if it is unknown or still active/pending. The presented
+    /// persona is retained even if now unreferenced (R-P-2).
+    pub fn delete_membership(
+        &mut self,
+        vtc: &str,
+        persona: PersonaId,
+    ) -> Result<CommunityRecord, OpenVTCError> {
+        let list = self
+            .communities
+            .get_mut(vtc)
+            .ok_or_else(|| OpenVTCError::Config(format!("Unknown membership: {vtc}")))?;
+        let idx = list
+            .iter()
+            .position(|c| c.persona_ref == persona)
+            .ok_or_else(|| OpenVTCError::Config(format!("Unknown membership: {vtc}")))?;
+        if !list[idx].can_archive_or_delete() {
+            return Err(OpenVTCError::Config(format!(
                 "Cannot delete an active/pending community ({vtc}); leave it first"
-            ))),
-            Some(_) => Ok(self
-                .communities
-                .remove(vtc)
-                .expect("presence checked above")),
+            )));
         }
+        let removed = list.remove(idx);
+        // Drop the community's bucket once its last membership is gone.
+        if list.is_empty() {
+            self.communities.remove(vtc);
+        }
+        Ok(removed)
     }
 }
 
@@ -759,31 +849,26 @@ mod tests {
     fn default_working_community_prefers_favourite_active_and_skips_inactive() {
         let p = persona("p");
         let mut acct = Account::default();
+        let vtc = |a: &Account| a.default_working_membership().map(|(v, _)| v);
         // No communities → no working context.
-        assert_eq!(acct.default_working_community(), None);
+        assert_eq!(vtc(&acct), None);
 
         // An inactive (Left) community is never the working context.
         let left = community("did:web:left", p.persona_id, CommunityStatus::Left);
-        acct.communities.insert(left.vtc_did.clone(), left);
-        assert_eq!(acct.default_working_community(), None);
+        acct.add_membership(left);
+        assert_eq!(vtc(&acct), None);
 
         // A plain active community becomes the default.
         let act = community("did:web:active", p.persona_id, CommunityStatus::Active);
-        acct.communities.insert(act.vtc_did.clone(), act);
-        assert_eq!(
-            acct.default_working_community().as_deref(),
-            Some("did:web:active")
-        );
+        acct.add_membership(act);
+        assert_eq!(vtc(&acct).as_deref(), Some("did:web:active"));
 
         // A favourited active community wins (sorts first in display order).
         let mut fav = community("did:web:fav", p.persona_id, CommunityStatus::Active);
         fav.favourite = true;
-        acct.communities.insert(fav.vtc_did.clone(), fav);
+        acct.add_membership(fav);
         acct.personas.insert(p.persona_id, p);
-        assert_eq!(
-            acct.default_working_community().as_deref(),
-            Some("did:web:fav")
-        );
+        assert_eq!(vtc(&acct).as_deref(), Some("did:web:fav"));
     }
 
     #[test]
@@ -900,10 +985,12 @@ mod tests {
         assert!(!rec.favourite && !rec.archived && !rec.acknowledged);
 
         // Idempotency (R-B-9): a pending join is a live membership, so a re-join
-        // attempt finds it via `live_community`.
+        // attempt as the same persona finds it.
         let mut acct = Account::default();
-        acct.communities.insert(rec.vtc_did.clone(), rec.clone());
-        assert!(acct.live_community(&rec.vtc_did).is_some());
+        let pref = rec.persona_ref;
+        let vtc = rec.vtc_did.clone();
+        acct.add_membership(rec.clone());
+        assert!(acct.has_live_membership(&vtc, pref));
     }
 
     #[test]
@@ -941,14 +1028,11 @@ mod tests {
         let p = persona("alice");
         let pid = p.persona_id;
         acct.personas.insert(pid, p);
-        acct.communities.insert(
-            "vtc:a".into(),
-            community("vtc:a", pid, CommunityStatus::Active),
-        );
+        acct.add_membership(community("vtc:a", pid, CommunityStatus::Active));
 
-        let resolved = acct.persona_for(&"vtc:a".to_string()).expect("resolves");
+        let resolved = acct.membership_persona("vtc:a", pid).expect("resolves");
         assert_eq!(resolved.persona_id, pid);
-        assert!(acct.persona_for(&"vtc:missing".to_string()).is_none());
+        assert!(acct.membership_persona("vtc:missing", pid).is_none());
         assert!(acct.dangling_refs().is_empty());
     }
 
@@ -963,10 +1047,7 @@ mod tests {
         assert!(acct.can_delete_persona(&pid));
 
         // Now referenced by an active community: not deletable (R-P-1).
-        acct.communities.insert(
-            "vtc:b".into(),
-            community("vtc:b", pid, CommunityStatus::Active),
-        );
+        acct.add_membership(community("vtc:b", pid, CommunityStatus::Active));
         assert!(acct.persona_referenced(&pid));
         assert!(!acct.can_delete_persona(&pid));
 
@@ -980,20 +1061,15 @@ mod tests {
         let p = persona("carol");
         let pid = p.persona_id;
         acct.personas.insert(pid, p);
-        acct.communities
-            .insert("a".into(), community("a", pid, CommunityStatus::Active));
-        acct.communities
-            .insert("b".into(), community("b", pid, CommunityStatus::Left));
-        acct.communities.insert(
-            "c".into(),
-            community(
-                "c",
-                pid,
-                CommunityStatus::Pending {
-                    request_id: Uuid::new_v4(),
-                },
-            ),
-        );
+        acct.add_membership(community("a", pid, CommunityStatus::Active));
+        acct.add_membership(community("b", pid, CommunityStatus::Left));
+        acct.add_membership(community(
+            "c",
+            pid,
+            CommunityStatus::Pending {
+                request_id: Uuid::new_v4(),
+            },
+        ));
         assert_eq!(acct.active_communities().count(), 1);
     }
 
@@ -1009,10 +1085,11 @@ mod tests {
         let pid = p.persona_id;
         let req = Uuid::new_v4();
         acct.personas.insert(pid, p);
-        acct.communities.insert(
-            "vtc:x".into(),
-            community("vtc:x", pid, CommunityStatus::Pending { request_id: req }),
-        );
+        acct.add_membership(community(
+            "vtc:x",
+            pid,
+            CommunityStatus::Pending { request_id: req },
+        ));
 
         let json = serde_json::to_string(&acct).expect("serialize");
         let back: Account = serde_json::from_str(&json).expect("deserialize");
@@ -1022,7 +1099,7 @@ mod tests {
         assert_eq!(back.personas.len(), 1);
         let bp = back.personas.get(&pid).expect("persona survives");
         assert_eq!(bp.did, "did:webvh:example.com:dave");
-        let bc = back.communities.get("vtc:x").expect("community survives");
+        let bc = back.membership("vtc:x", pid).expect("community survives");
         assert_eq!(bc.persona_ref, pid);
         assert_eq!(bc.status, CommunityStatus::Pending { request_id: req });
     }
@@ -1177,22 +1254,17 @@ mod tests {
     fn live_community_filters_inactive() {
         let mut acct = Account::default();
         let pid = PersonaId::new();
-        acct.communities.insert(
-            "active".into(),
-            community("active", pid, CommunityStatus::Active),
-        );
-        acct.communities
-            .insert("left".into(), community("left", pid, CommunityStatus::Left));
-        acct.communities
-            .insert("pend".into(), community("pend", pid, pending()));
+        acct.add_membership(community("active", pid, CommunityStatus::Active));
+        acct.add_membership(community("left", pid, CommunityStatus::Left));
+        acct.add_membership(community("pend", pid, pending()));
 
-        assert!(acct.live_community(&"active".to_string()).is_some());
-        assert!(acct.live_community(&"pend".to_string()).is_some());
+        assert!(acct.has_live_membership("active", pid));
+        assert!(acct.has_live_membership("pend", pid));
         assert!(
-            acct.live_community(&"left".to_string()).is_none(),
+            !acct.has_live_membership("left", pid),
             "Left is not a live membership"
         );
-        assert!(acct.live_community(&"missing".to_string()).is_none());
+        assert!(!acct.has_live_membership("missing", pid));
     }
 
     #[test]
@@ -1234,7 +1306,7 @@ mod tests {
         archived.archived = true;
 
         for c in [zebra, acme, fav, archived] {
-            acct.communities.insert(c.vtc_did.clone(), c);
+            acct.add_membership(c);
         }
 
         // Default: archived excluded; favourite first, then name (ci).
@@ -1258,25 +1330,21 @@ mod tests {
     fn archive_and_delete_respect_guards() {
         let mut acct = Account::default();
         let pid = PersonaId::new();
-        acct.communities.insert(
-            "active".into(),
-            community("active", pid, CommunityStatus::Active),
-        );
-        acct.communities
-            .insert("left".into(), community("left", pid, CommunityStatus::Left));
+        acct.add_membership(community("active", pid, CommunityStatus::Active));
+        acct.add_membership(community("left", pid, CommunityStatus::Left));
 
         // Active cannot be archived or deleted.
-        assert!(acct.archive_community(&"active".to_string()).is_err());
-        assert!(acct.delete_community(&"active".to_string()).is_err());
+        assert!(acct.archive_membership("active", pid).is_err());
+        assert!(acct.delete_membership("active", pid).is_err());
         // Unknown errors too.
-        assert!(acct.archive_community(&"missing".to_string()).is_err());
+        assert!(acct.archive_membership("missing", pid).is_err());
 
         // Inactive archives, then deletes.
-        acct.archive_community(&"left".to_string()).unwrap();
-        assert!(acct.communities["left"].archived);
-        let removed = acct.delete_community(&"left".to_string()).unwrap();
+        acct.archive_membership("left", pid).unwrap();
+        assert!(acct.membership("left", pid).unwrap().archived);
+        let removed = acct.delete_membership("left", pid).unwrap();
         assert_eq!(removed.vtc_did, "left");
-        assert!(!acct.communities.contains_key("left"));
+        assert!(acct.membership("left", pid).is_none());
     }
 
     #[test]
@@ -1287,25 +1355,28 @@ mod tests {
 
         let mut stale = community("stale", pid, pending());
         stale.requested_at = Some(now - TimeDelta::days(10));
-        acct.communities.insert("stale".into(), stale);
+        acct.add_membership(stale);
 
         let mut fresh = community("fresh", pid, pending());
         fresh.requested_at = Some(now - TimeDelta::days(1));
-        acct.communities.insert("fresh".into(), fresh);
+        acct.add_membership(fresh);
 
-        acct.communities.insert(
-            "active".into(),
-            community("active", pid, CommunityStatus::Active),
-        );
+        acct.add_membership(community("active", pid, CommunityStatus::Active));
 
         let expired = acct.expire_stale_pending(now);
-        assert_eq!(expired, vec!["stale".to_string()]);
-        assert_eq!(acct.communities["stale"].status, CommunityStatus::Expired);
+        assert_eq!(expired, vec![("stale".to_string(), pid)]);
+        assert_eq!(
+            acct.membership("stale", pid).unwrap().status,
+            CommunityStatus::Expired
+        );
         assert!(matches!(
-            acct.communities["fresh"].status,
+            acct.membership("fresh", pid).unwrap().status,
             CommunityStatus::Pending { .. }
         ));
-        assert_eq!(acct.communities["active"].status, CommunityStatus::Active);
+        assert_eq!(
+            acct.membership("active", pid).unwrap().status,
+            CommunityStatus::Active
+        );
     }
 
     #[test]
@@ -1352,33 +1423,80 @@ mod tests {
     fn actions_required_count_excludes_acknowledged_and_archived() {
         let mut acct = Account::default();
         let pid = PersonaId::new();
-        acct.communities
-            .insert("pending".into(), community("pending", pid, pending()));
-        acct.communities.insert(
-            "active".into(),
-            community("active", pid, CommunityStatus::Active),
-        );
-
-        // Unacknowledged Rejected → counts.
-        let mut rejected = community("rejected", pid, CommunityStatus::Rejected);
+        acct.add_membership(community("pending", pid, pending()));
+        acct.add_membership(community("active", pid, CommunityStatus::Active));
 
         // Acknowledged Removed → does not count.
         let mut acked = community("acked", pid, CommunityStatus::Removed);
         acked.acknowledge();
-        acct.communities.insert("acked".into(), acked);
+        acct.add_membership(acked);
 
         // Archived (unacknowledged) Expired → hidden, so does not count.
         let mut archived = community("archived", pid, CommunityStatus::Expired);
         archived.archived = true;
-        acct.communities.insert("archived".into(), archived);
+        acct.add_membership(archived);
 
-        acct.communities.insert("rejected".into(), rejected.clone());
+        // Unacknowledged Rejected → counts.
+        acct.add_membership(community("rejected", pid, CommunityStatus::Rejected));
         // pending + rejected.
         assert_eq!(acct.actions_required_count(), 2);
 
         // Acknowledging the rejection drops the count to just the pending.
-        rejected.acknowledge();
-        acct.communities.insert("rejected".into(), rejected);
+        acct.membership_mut("rejected", pid).unwrap().acknowledge();
         assert_eq!(acct.actions_required_count(), 1);
+    }
+
+    #[test]
+    fn multiple_memberships_per_community_keyed_by_persona() {
+        let mut acct = Account::default();
+        let alice = PersonaId::new();
+        let bob = PersonaId::new();
+        let vtc = "did:web:acme";
+        // The same community joined as two different personas — both coexist.
+        acct.add_membership(community(vtc, alice, CommunityStatus::Active));
+        acct.add_membership(community(vtc, bob, pending()));
+        assert_eq!(acct.memberships_for(vtc).len(), 2);
+        assert_eq!(acct.memberships().count(), 2);
+
+        // Per-persona resolution + idempotency: a live membership blocks only the
+        // same persona, never another.
+        assert!(acct.membership(vtc, alice).is_some());
+        assert!(acct.membership(vtc, bob).is_some());
+        assert!(acct.has_live_membership(vtc, alice));
+        assert!(acct.has_live_membership(vtc, bob));
+        assert!(!acct.has_live_membership(vtc, PersonaId::new()));
+
+        // Deleting one membership leaves the other (and the community bucket).
+        acct.membership_mut(vtc, alice).unwrap().leave();
+        acct.delete_membership(vtc, alice).unwrap();
+        assert!(acct.membership(vtc, alice).is_none());
+        assert!(acct.membership(vtc, bob).is_some());
+    }
+
+    #[test]
+    fn legacy_single_record_config_loads_into_grouped_form() {
+        // Pre-multi-membership configs stored ONE CommunityRecord per VTC DID —
+        // the value was the record object, not a list. It must still load.
+        let pid = PersonaId::new();
+        let rec = community("did:web:acme", pid, CommunityStatus::Active);
+        let legacy = serde_json::json!({
+            "vta_did": "",
+            "vta_url": "",
+            "top_context_id": "",
+            "communities": { "did:web:acme": rec },
+        });
+        let acct: Account = serde_json::from_value(legacy).expect("legacy config loads");
+        assert_eq!(acct.memberships().count(), 1);
+        assert!(acct.membership("did:web:acme", pid).is_some());
+
+        // And a new-format config (value is a list) round-trips through the same path.
+        let modern = serde_json::json!({
+            "vta_did": "",
+            "vta_url": "",
+            "top_context_id": "",
+            "communities": { "did:web:acme": [community("did:web:acme", pid, CommunityStatus::Active)] },
+        });
+        let acct: Account = serde_json::from_value(modern).expect("modern config loads");
+        assert_eq!(acct.memberships().count(), 1);
     }
 }

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -286,8 +286,7 @@ impl Config {
                 // is identifiable (not a generic "Persona") — matches the runtime
                 // listener label (`Config::persona_profile_label`).
                 let profile_label = account
-                    .communities
-                    .values()
+                    .memberships()
                     .find(|c| c.persona_ref == *persona_id)
                     .map(|c| {
                         c.display_name.clone().unwrap_or_else(|| {

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -426,8 +426,7 @@ impl Config {
     /// listener per persona so each is named after its community.
     pub fn persona_profile_label_for(&self, persona_id: account::PersonaId) -> String {
         self.account
-            .communities
-            .values()
+            .memberships()
             .find(|c| c.persona_ref == persona_id)
             .map(|c| {
                 c.display_name.clone().unwrap_or_else(|| {

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -61,10 +61,16 @@ impl<'a> IdentityRegistry<'a> {
         Self { account }
     }
 
-    /// Resolve a community to its identity (community + presented persona).
-    /// Returns `None` if the community is unknown or its `persona_ref` dangles.
-    pub fn get(&self, vtc: &VtcDid) -> Option<IdentityRef<'a>> {
-        let community = self.account.communities.get(vtc)?;
+    /// Resolve a specific membership (community `vtc` presented as `persona`) to
+    /// its identity. Returns `None` if there is no such membership or its
+    /// `persona_ref` dangles.
+    pub fn get(&self, vtc: &str, persona: PersonaId) -> Option<IdentityRef<'a>> {
+        let community = self
+            .account
+            .communities
+            .get(vtc)?
+            .iter()
+            .find(|c| c.persona_ref == persona)?;
         let persona = self.account.personas.get(&community.persona_ref)?;
         Some(IdentityRef { community, persona })
     }
@@ -72,15 +78,19 @@ impl<'a> IdentityRegistry<'a> {
     /// Iterator over all resolvable memberships (skips any with a dangling
     /// `persona_ref`, which [`Account::dangling_refs`] reports separately).
     pub fn all(&self) -> impl Iterator<Item = IdentityRef<'a>> {
-        self.account.communities.values().filter_map(move |c| {
-            self.account
-                .personas
-                .get(&c.persona_ref)
-                .map(|persona| IdentityRef {
-                    community: c,
-                    persona,
-                })
-        })
+        self.account
+            .communities
+            .values()
+            .flatten()
+            .filter_map(move |c| {
+                self.account
+                    .personas
+                    .get(&c.persona_ref)
+                    .map(|persona| IdentityRef {
+                        community: c,
+                        persona,
+                    })
+            })
     }
 
     /// Memberships in the `Active` (live) state.
@@ -97,7 +107,7 @@ impl<'a> IdentityRegistry<'a> {
     /// [`CommunityStatus::requires_live_session`]: crate::config::account::CommunityStatus::requires_live_session
     pub fn sessions(&self) -> HashMap<PersonaId, Vec<&'a VtcDid>> {
         let mut map: HashMap<PersonaId, Vec<&'a VtcDid>> = HashMap::new();
-        for c in self.account.communities.values() {
+        for c in self.account.communities.values().flatten() {
             if c.status.requires_live_session()
                 && self.account.personas.contains_key(&c.persona_ref)
             {
@@ -199,11 +209,10 @@ mod tests {
         let p = persona();
         let pid = p.persona_id;
         acct.personas.insert(pid, p);
-        acct.communities
-            .insert("a".into(), community("a", pid, CommunityStatus::Active));
+        acct.add_membership(community("a", pid, CommunityStatus::Active));
 
         let reg = IdentityRegistry::new(&acct);
-        let id = reg.get(&"a".to_string()).expect("resolves");
+        let id = reg.get("a", pid).expect("resolves");
         assert_eq!(id.session_key(), pid);
         assert_eq!(id.persona_did(), "did:webvh:example:p");
         assert_eq!(id.mediator_did(), Some("did:webvh:mediator"));
@@ -216,10 +225,8 @@ mod tests {
         let pid = p.persona_id;
         acct.personas.insert(pid, p);
         // Two Active communities present the SAME persona.
-        acct.communities
-            .insert("a".into(), community("a", pid, CommunityStatus::Active));
-        acct.communities
-            .insert("b".into(), community("b", pid, CommunityStatus::Active));
+        acct.add_membership(community("a", pid, CommunityStatus::Active));
+        acct.add_membership(community("b", pid, CommunityStatus::Active));
 
         let reg = IdentityRegistry::new(&acct);
         let sessions = reg.sessions();
@@ -237,18 +244,14 @@ mod tests {
         acct.personas.insert(id1, p1);
         acct.personas.insert(id2, p2);
         // p1 → Pending (needs session); p2 → Left (does not).
-        acct.communities.insert(
-            "pending".into(),
-            community(
-                "pending",
-                id1,
-                CommunityStatus::Pending {
-                    request_id: Uuid::new_v4(),
-                },
-            ),
-        );
-        acct.communities
-            .insert("left".into(), community("left", id2, CommunityStatus::Left));
+        acct.add_membership(community(
+            "pending",
+            id1,
+            CommunityStatus::Pending {
+                request_id: Uuid::new_v4(),
+            },
+        ));
+        acct.add_membership(community("left", id2, CommunityStatus::Left));
 
         let reg = IdentityRegistry::new(&acct);
         let keys = reg.active_session_keys();
@@ -261,12 +264,10 @@ mod tests {
     fn dangling_ref_is_skipped() {
         let mut acct = Account::default();
         // Community references a persona that doesn't exist.
-        acct.communities.insert(
-            "x".into(),
-            community("x", PersonaId::new(), CommunityStatus::Active),
-        );
+        let ghost = PersonaId::new();
+        acct.add_membership(community("x", ghost, CommunityStatus::Active));
         let reg = IdentityRegistry::new(&acct);
-        assert!(reg.get(&"x".to_string()).is_none());
+        assert!(reg.get("x", ghost).is_none());
         assert_eq!(reg.all().count(), 0);
         assert!(reg.sessions().is_empty());
     }

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -20,7 +20,7 @@ use vta_sdk::protocols::join_requests::{
 };
 
 use crate::config::Config;
-use crate::config::account::{Account, CommunityStatus};
+use crate::config::account::{Account, CommunityStatus, PersonaId};
 use crate::relationships::{RelationshipState, Relationships};
 use crate::tasks::{TaskType, Tasks};
 
@@ -191,52 +191,46 @@ pub fn handle_join_submit_receipt(
         }
     };
 
-    let Some(record) = account.communities.get_mut(from_did) else {
-        warn!(vtc = %from_did, "join submit-receipt from an unknown community — ignoring");
-        return false;
-    };
-    // Copy the current placeholder out (Uuid: Copy) so the immutable match
-    // borrow ends before we re-assign `status`.
-    let current = match &record.status {
-        CommunityStatus::Pending { request_id } => Some(*request_id),
-        _ => None,
-    };
-    if current == Some(placeholder) {
-        record.status = CommunityStatus::Pending {
-            request_id: body.request_id,
-        };
-        // The receipt is the VTC's acknowledgement that the submit arrived.
-        record.mark_acknowledged(chrono::Utc::now());
-        info!(
-            vtc = %from_did,
-            vtc_request_id = %body.request_id,
-            receipt_status = %body.status,
-            "reconciled join request id from VTC submit-receipt",
-        );
-        true
-    } else {
+    // Correlate to the specific pending membership (a community may now hold
+    // several, one per persona) by the placeholder = our submit id.
+    let Some(record) = account.membership_by_pending_request(from_did, placeholder) else {
         warn!(
             vtc = %from_did,
             thid,
             "join submit-receipt did not match a pending join with that id — ignoring",
         );
-        false
-    }
+        return false;
+    };
+    record.status = CommunityStatus::Pending {
+        request_id: body.request_id,
+    };
+    // The receipt is the VTC's acknowledgement that the submit arrived.
+    record.mark_acknowledged(chrono::Utc::now());
+    info!(
+        vtc = %from_did,
+        vtc_request_id = %body.request_id,
+        receipt_status = %body.status,
+        "reconciled join request id from VTC submit-receipt",
+    );
+    true
 }
 
 /// Outcome of applying a VTC `join-requests/status-response` to a community.
 pub struct StatusOutcome {
     /// The community record changed and the config needs saving.
     pub changed: bool,
-    /// The community transitioned to an inactive (read-only) status, so the
-    /// runtime must deregister its live session (R-S-3 / D15).
-    pub inactivated: bool,
+    /// When the membership transitioned to an inactive (read-only) status, the
+    /// persona whose session for this community must be deregistered (R-S-3 /
+    /// D15) — `None` when nothing inactivated. Carrying the persona (not just a
+    /// bool) is required for multi-membership: the VTC alone no longer identifies
+    /// which session to tear down.
+    pub inactivated: Option<PersonaId>,
 }
 
 impl StatusOutcome {
     const NONE: StatusOutcome = StatusOutcome {
         changed: false,
-        inactivated: false,
+        inactivated: None,
     };
 }
 
@@ -265,19 +259,13 @@ pub fn handle_join_status_response(
             return StatusOutcome::NONE;
         }
     };
-    let Some(record) = account.communities.get_mut(from_did) else {
-        warn!(vtc = %from_did, "status-response from an unknown community — ignoring");
-        return StatusOutcome::NONE;
-    };
-    // Correlate: only resolve a Pending record whose request id matches the reply.
-    let matches = matches!(
-        &record.status,
-        CommunityStatus::Pending { request_id } if *request_id == body.request_id
-    );
-    if !matches {
+    // Correlate to the specific pending membership by the authoritative
+    // request id (a community may hold several memberships).
+    let Some(record) = account.membership_by_pending_request(from_did, body.request_id) else {
         warn!(vtc = %from_did, "status-response did not match a pending request id — ignoring");
         return StatusOutcome::NONE;
-    }
+    };
+    let persona = record.persona_ref;
 
     match body.status.as_str() {
         "approved" => {
@@ -285,7 +273,7 @@ pub fn handle_join_status_response(
             info!(vtc = %from_did, "join approved by VTC — now Active");
             StatusOutcome {
                 changed: true,
-                inactivated: false,
+                inactivated: None,
             }
         }
         "rejected" => {
@@ -293,7 +281,7 @@ pub fn handle_join_status_response(
             info!(vtc = %from_did, "join rejected by VTC");
             StatusOutcome {
                 changed: true,
-                inactivated: true,
+                inactivated: Some(persona),
             }
         }
         "withdrawn" => {
@@ -304,7 +292,7 @@ pub fn handle_join_status_response(
             info!(vtc = %from_did, "join withdrawn — reconciled to Withdrawn");
             StatusOutcome {
                 changed,
-                inactivated: changed,
+                inactivated: changed.then_some(persona),
             }
         }
         "deferred" => {
@@ -319,7 +307,7 @@ pub fn handle_join_status_response(
             );
             StatusOutcome {
                 changed,
-                inactivated: false,
+                inactivated: None,
             }
         }
         other => {
@@ -352,18 +340,11 @@ pub fn handle_join_verdict(account: &mut Account, message: &Message, from_did: &
             return StatusOutcome::NONE;
         }
     };
-    let Some(record) = account.communities.get_mut(from_did) else {
-        warn!(vtc = %from_did, "verdict from an unknown community — ignoring");
-        return StatusOutcome::NONE;
-    };
-    let matches = matches!(
-        &record.status,
-        CommunityStatus::Pending { request_id } if *request_id == placeholder
-    );
-    if !matches {
+    let Some(record) = account.membership_by_pending_request(from_did, placeholder) else {
         warn!(vtc = %from_did, "verdict did not match a pending request id — ignoring");
         return StatusOutcome::NONE;
-    }
+    };
+    let persona = record.persona_ref;
 
     match body.verdict.effect {
         VerdictEffect::Allow => {
@@ -371,7 +352,7 @@ pub fn handle_join_verdict(account: &mut Account, message: &Message, from_did: &
             info!(vtc = %from_did, "join allowed by VTC — now Active");
             StatusOutcome {
                 changed: true,
-                inactivated: false,
+                inactivated: None,
             }
         }
         VerdictEffect::Deny => {
@@ -384,7 +365,7 @@ pub fn handle_join_verdict(account: &mut Account, message: &Message, from_did: &
             );
             StatusOutcome {
                 changed: true,
-                inactivated: true,
+                inactivated: Some(persona),
             }
         }
         VerdictEffect::Refer => {
@@ -398,7 +379,7 @@ pub fn handle_join_verdict(account: &mut Account, message: &Message, from_did: &
             );
             StatusOutcome {
                 changed,
-                inactivated: false,
+                inactivated: None,
             }
         }
         VerdictEffect::RequestMore => {
@@ -412,7 +393,7 @@ pub fn handle_join_verdict(account: &mut Account, message: &Message, from_did: &
             );
             StatusOutcome {
                 changed,
-                inactivated: false,
+                inactivated: None,
             }
         }
     }
@@ -439,18 +420,11 @@ pub fn handle_join_problem_report(
         return StatusOutcome::NONE;
     };
     let (code, comment) = vta_sdk::protocols::extract_problem_report(&message.body);
-    let Some(record) = account.communities.get_mut(from_did) else {
-        warn!(vtc = %from_did, code = %code, "problem-report from an unknown community — ignoring");
-        return StatusOutcome::NONE;
-    };
-    let matches = matches!(
-        &record.status,
-        CommunityStatus::Pending { request_id } if *request_id == placeholder
-    );
-    if !matches {
+    let Some(record) = account.membership_by_pending_request(from_did, placeholder) else {
         warn!(vtc = %from_did, code = %code, "problem-report did not match a pending request id — ignoring");
         return StatusOutcome::NONE;
-    }
+    };
+    let persona = record.persona_ref;
 
     if code == codes::FORBIDDEN {
         record.reject();
@@ -461,7 +435,7 @@ pub fn handle_join_problem_report(
         );
         StatusOutcome {
             changed: true,
-            inactivated: true,
+            inactivated: Some(persona),
         }
     } else {
         // bad-request / internal / other: the submit didn't admit, but it's not a
@@ -538,18 +512,10 @@ pub fn handle_join_trust_task_error(
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_string();
-    let Some(record) = account.communities.get_mut(from_did) else {
-        warn!(vtc = %from_did, code = %code, "trust-task-error from an unknown community — ignoring");
-        return StatusOutcome::NONE;
-    };
-    let matches = matches!(
-        &record.status,
-        CommunityStatus::Pending { request_id } if *request_id == placeholder
-    );
-    if !matches {
+    let Some(record) = account.membership_by_pending_request(from_did, placeholder) else {
         warn!(vtc = %from_did, code = %code, "trust-task-error did not match a pending request id — ignoring");
         return StatusOutcome::NONE;
-    }
+    };
 
     if is_join_denial_code(&code) {
         record.reject();
@@ -561,7 +527,7 @@ pub fn handle_join_trust_task_error(
         );
         StatusOutcome {
             changed: true,
-            inactivated: true,
+            inactivated: Some(record.persona_ref),
         }
     } else {
         // Not a policy denial — a malformed / unsupported / internal / transient
@@ -577,7 +543,7 @@ pub fn handle_join_trust_task_error(
         );
         StatusOutcome {
             changed,
-            inactivated: false,
+            inactivated: None,
         }
     }
 }
@@ -600,18 +566,9 @@ pub fn handle_credential_issue(account: &mut Account, message: &Message, from_di
         return false;
     };
 
-    // Resolve the target community (the sender is the issuing VTC) + its persona.
-    let Some(record) = account.communities.get(from_did) else {
-        warn!(vtc = %from_did, "credential-issue from an unknown community — ignoring");
-        return false;
-    };
-    let persona_ref = record.persona_ref;
-    let Some(persona_did) = account.personas.get(&persona_ref).map(|p| p.did.clone()) else {
-        warn!(vtc = %from_did, "community persona missing — ignoring credential");
-        return false;
-    };
-
-    // Anti-misdelivery: issuer must be this community's VTC, subject our persona.
+    // Anti-misdelivery: issuer must be this community's VTC. The credential's
+    // subject (a persona DID) also selects WHICH membership it is for — a
+    // community may now hold several, one per persona.
     let issuer = credential.get("issuer").and_then(|i| match i {
         Value::String(s) => Some(s.as_str()),
         Value::Object(o) => o.get("id").and_then(Value::as_str),
@@ -621,14 +578,20 @@ pub fn handle_credential_issue(account: &mut Account, message: &Message, from_di
         warn!(vtc = %from_did, ?issuer, "issued credential's issuer is not the community VTC — ignoring");
         return false;
     }
-    let subject = credential
+    let Some(subject) = credential
         .get("credentialSubject")
         .and_then(|s| s.get("id"))
-        .and_then(Value::as_str);
-    if subject != Some(persona_did.as_str()) {
+        .and_then(Value::as_str)
+    else {
+        warn!(vtc = %from_did, "issued credential has no subject — ignoring");
+        return false;
+    };
+    // The subject must be one of our personas, and that persona must hold a
+    // membership with this community.
+    let Some(persona_id) = account.persona_id_for_did(subject) else {
         warn!(vtc = %from_did, "issued credential subject is not our persona — ignoring");
         return false;
-    }
+    };
 
     // Classify the credential against the typed registry — the one place that
     // knows credential kinds, so a new kind is handled here without edits.
@@ -637,10 +600,10 @@ pub fn handle_credential_issue(account: &mut Account, message: &Message, from_di
         return false;
     };
 
-    let record = account
-        .communities
-        .get_mut(from_did)
-        .expect("community present (checked above)");
+    let Some(record) = account.membership_mut(from_did, persona_id) else {
+        warn!(vtc = %from_did, "credential-issue for a community we don't hold a matching membership with — ignoring");
+        return false;
+    };
     record.credentials.insert(kind, credential);
     if kind.activates_membership() && !record.status.is_active() {
         record.activate(chrono::Utc::now());
@@ -933,19 +896,23 @@ mod tests {
         JOIN_REQUEST_STATUS_RESPONSE_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
     };
 
+    /// The (single) membership a test set up for `vtc`.
+    fn only<'a>(acct: &'a Account, vtc: &str) -> &'a CommunityRecord {
+        acct.memberships()
+            .find(|c| c.vtc_did == vtc)
+            .expect("membership present")
+    }
+
     fn pending_account(vtc: &str, placeholder: Uuid) -> Account {
         let mut acct = Account::default();
-        acct.communities.insert(
+        acct.add_membership(CommunityRecord::new_pending(
             vtc.to_string(),
-            CommunityRecord::new_pending(
-                vtc.to_string(),
-                None,
-                "openvtc/x".to_string(),
-                PersonaId::new(),
-                placeholder,
-                Utc::now(),
-            ),
-        );
+            None,
+            "openvtc/x".to_string(),
+            PersonaId::new(),
+            placeholder,
+            Utc::now(),
+        ));
         acct
     }
 
@@ -970,7 +937,7 @@ mod tests {
         let m = receipt(&placeholder.to_string(), vtc, real, "pending");
         assert!(handle_join_submit_receipt(&mut acct, &m, vtc));
 
-        match &acct.communities.get(vtc).unwrap().status {
+        match &only(&acct, vtc).status {
             CommunityStatus::Pending { request_id } => assert_eq!(*request_id, real),
             other => panic!("expected Pending, got {other:?}"),
         }
@@ -990,7 +957,7 @@ mod tests {
             "pending",
         );
         assert!(!handle_join_submit_receipt(&mut acct, &m, "did:webvh:evil"));
-        match &acct.communities.get(vtc).unwrap().status {
+        match &only(&acct, vtc).status {
             CommunityStatus::Pending { request_id } => assert_eq!(*request_id, placeholder),
             other => panic!("expected unchanged Pending, got {other:?}"),
         }
@@ -1005,7 +972,7 @@ mod tests {
         // thid does not match the stored placeholder.
         let m = receipt(&Uuid::new_v4().to_string(), vtc, Uuid::new_v4(), "pending");
         assert!(!handle_join_submit_receipt(&mut acct, &m, vtc));
-        match &acct.communities.get(vtc).unwrap().status {
+        match &only(&acct, vtc).status {
             CommunityStatus::Pending { request_id } => assert_eq!(*request_id, placeholder),
             other => panic!("expected unchanged Pending, got {other:?}"),
         }
@@ -1032,8 +999,8 @@ mod tests {
         let out =
             handle_join_status_response(&mut acct, &status_response(vtc, rid, "approved"), vtc);
         assert!(out.changed);
-        assert!(!out.inactivated, "approval keeps the live session");
-        let rec = acct.communities.get(vtc).unwrap();
+        assert!(out.inactivated.is_none(), "approval keeps the live session");
+        let rec = only(&acct, vtc);
         assert!(rec.status.is_active());
         assert!(
             rec.member_since.is_some(),
@@ -1051,10 +1018,10 @@ mod tests {
             handle_join_status_response(&mut acct, &status_response(vtc, rid, "rejected"), vtc);
         assert!(out.changed);
         assert!(
-            out.inactivated,
+            out.inactivated.is_some(),
             "a rejection must deregister the session (R-S-3)"
         );
-        let rec = acct.communities.get(vtc).unwrap();
+        let rec = only(&acct, vtc);
         assert!(matches!(rec.status, CommunityStatus::Rejected));
         assert!(
             rec.needs_attention(),
@@ -1072,10 +1039,10 @@ mod tests {
             handle_join_status_response(&mut acct, &status_response(vtc, rid, "withdrawn"), vtc);
         assert!(out.changed);
         assert!(
-            out.inactivated,
+            out.inactivated.is_some(),
             "a withdrawal must deregister the session (R-S-3)"
         );
-        let rec = acct.communities.get(vtc).unwrap();
+        let rec = only(&acct, vtc);
         assert!(matches!(rec.status, CommunityStatus::Withdrawn));
         assert!(
             !rec.needs_attention(),
@@ -1095,13 +1062,13 @@ mod tests {
             out.changed,
             "deferred is an acknowledgement — stamps receipt_at, needs persisting"
         );
-        assert!(!out.inactivated);
+        assert!(out.inactivated.is_none());
         assert!(
-            acct.communities.get(vtc).unwrap().receipt_at.is_some(),
+            only(&acct, vtc).receipt_at.is_some(),
             "the VTC responded — acknowledged"
         );
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Pending { .. }
         ));
     }
@@ -1134,9 +1101,9 @@ mod tests {
             vtc,
         );
         assert!(out.changed);
-        assert!(!out.inactivated);
+        assert!(out.inactivated.is_none());
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Active
         ));
     }
@@ -1154,9 +1121,9 @@ mod tests {
             vtc,
         );
         assert!(out.changed);
-        assert!(out.inactivated, "a deny deregisters the session");
+        assert!(out.inactivated.is_some(), "a deny deregisters the session");
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Rejected
         ));
     }
@@ -1174,7 +1141,7 @@ mod tests {
             vtc,
         );
         assert!(out.changed, "request_more acknowledges — stamps receipt_at");
-        let rec = acct.communities.get(vtc).unwrap();
+        let rec = only(&acct, vtc);
         assert!(matches!(rec.status, CommunityStatus::Pending { .. }));
         assert!(rec.receipt_at.is_some(), "the VTC responded — acknowledged");
     }
@@ -1191,9 +1158,53 @@ mod tests {
         );
         assert!(!out.changed);
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Pending { .. }
         ));
+    }
+
+    #[test]
+    fn reply_routes_to_the_matching_membership_only() {
+        // Two personas joined the SAME community; each Pending submit has its own
+        // request id. A verdict threaded on one must transition only that one.
+        let vtc = "did:webvh:example:vtc";
+        let (rid_a, rid_b) = (Uuid::new_v4(), Uuid::new_v4());
+        let (pa, pb) = (PersonaId::new(), PersonaId::new());
+        let mut acct = Account::default();
+        acct.add_membership(CommunityRecord::new_pending(
+            vtc.into(),
+            None,
+            "openvtc/x".into(),
+            pa,
+            rid_a,
+            Utc::now(),
+        ));
+        acct.add_membership(CommunityRecord::new_pending(
+            vtc.into(),
+            None,
+            "openvtc/x".into(),
+            pb,
+            rid_b,
+            Utc::now(),
+        ));
+
+        let out = handle_join_verdict(
+            &mut acct,
+            &verdict(&rid_a.to_string(), vtc, "allow", serde_json::json!({})),
+            vtc,
+        );
+        assert!(out.changed);
+        assert!(
+            acct.membership(vtc, pa).unwrap().status.is_active(),
+            "the membership whose request id matched is activated"
+        );
+        assert!(
+            matches!(
+                acct.membership(vtc, pb).unwrap().status,
+                CommunityStatus::Pending { .. }
+            ),
+            "the other persona's membership is untouched"
+        );
     }
 
     /// A framework `trust-task-error/0.2` document threaded on `thid`, carrying
@@ -1238,9 +1249,9 @@ mod tests {
             vtc,
         );
         assert!(out.changed);
-        assert!(out.inactivated, "a denial deregisters the session");
+        assert!(out.inactivated.is_some(), "a denial deregisters the session");
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Rejected
         ));
     }
@@ -1260,8 +1271,8 @@ mod tests {
             out.changed,
             "the VTC responded — stamps receipt_at, needs persisting"
         );
-        assert!(!out.inactivated, "recoverable — no terminal transition");
-        let rec = acct.communities.get(vtc).unwrap();
+        assert!(out.inactivated.is_none(), "recoverable — no terminal transition");
+        let rec = only(&acct, vtc);
         assert!(
             matches!(rec.status, CommunityStatus::Pending { .. }),
             "stays Pending so a corrected retry can succeed"
@@ -1283,7 +1294,7 @@ mod tests {
         );
         assert!(!out.changed);
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Pending { .. }
         ));
     }
@@ -1311,9 +1322,9 @@ mod tests {
             vtc,
         );
         assert!(out.changed);
-        assert!(out.inactivated);
+        assert!(out.inactivated.is_some());
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Rejected
         ));
     }
@@ -1331,7 +1342,7 @@ mod tests {
         );
         assert!(!out.changed, "a client/transient error must not mark Rejected");
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Pending { .. }
         ));
     }
@@ -1348,9 +1359,9 @@ mod tests {
             vtc,
         );
         assert!(!out.changed);
-        assert!(!out.inactivated);
+        assert!(out.inactivated.is_none());
         assert!(matches!(
-            acct.communities.get(vtc).unwrap().status,
+            only(&acct, vtc).status,
             CommunityStatus::Pending { .. }
         ));
     }
@@ -1384,17 +1395,14 @@ mod tests {
                 label: None,
             },
         );
-        acct.communities.insert(
+        acct.add_membership(CommunityRecord::new_pending(
             vtc.to_string(),
-            CommunityRecord::new_pending(
-                vtc.to_string(),
-                None,
-                "openvtc/x".to_string(),
-                pid,
-                Uuid::new_v4(),
-                Utc::now(),
-            ),
-        );
+            None,
+            "openvtc/x".to_string(),
+            pid,
+            Uuid::new_v4(),
+            Utc::now(),
+        ));
         acct
     }
 
@@ -1432,7 +1440,7 @@ mod tests {
         );
         assert!(handle_credential_issue(&mut acct, &m, vtc));
 
-        let rec = acct.communities.get(vtc).unwrap();
+        let rec = only(&acct, vtc);
         assert!(rec.status.is_active());
         assert!(
             rec.credentials
@@ -1456,7 +1464,7 @@ mod tests {
         );
         assert!(handle_credential_issue(&mut acct, &m, vtc));
 
-        let rec = acct.communities.get(vtc).unwrap();
+        let rec = only(&acct, vtc);
         assert!(
             !rec.status.is_active(),
             "role VEC must not activate on its own"
@@ -1483,7 +1491,7 @@ mod tests {
                 handle_credential_issue(&mut acct, &m, vtc),
                 "kind {kind:?} should be accepted",
             );
-            let rec = acct.communities.get(vtc).unwrap();
+            let rec = only(&acct, vtc);
             assert!(
                 rec.credentials.contains_key(kind),
                 "kind {kind:?} should be stored under its registry key",
@@ -1512,7 +1520,7 @@ mod tests {
             ),
         );
         assert!(!handle_credential_issue(&mut acct, &m, vtc));
-        assert!(!acct.communities.get(vtc).unwrap().status.is_active());
+        assert!(!only(&acct, vtc).status.is_active());
     }
 
     #[test]
@@ -1531,7 +1539,7 @@ mod tests {
             ),
         );
         assert!(!handle_credential_issue(&mut acct, &m, vtc));
-        assert!(!acct.communities.get(vtc).unwrap().status.is_active());
+        assert!(!only(&acct, vtc).status.is_active());
     }
 
     #[test]

--- a/openvtc-core/tests/join_lifecycle_e2e.rs
+++ b/openvtc-core/tests/join_lifecycle_e2e.rs
@@ -104,17 +104,14 @@ async fn connect_persona_and_vtc(
 /// `vtc_did`, awaiting the VTC's decision on `request_id`.
 fn pending_account(vtc_did: &str, request_id: Uuid) -> Account {
     let mut account = Account::default();
-    account.communities.insert(
+    account.add_membership(CommunityRecord::new_pending(
         vtc_did.to_string(),
-        CommunityRecord::new_pending(
-            vtc_did.to_string(),
-            Some("Integration Test Community".to_string()),
-            "openvtc/integration-test".to_string(),
-            PersonaId::new(),
-            request_id,
-            Utc::now(),
-        ),
-    );
+        Some("Integration Test Community".to_string()),
+        "openvtc/integration-test".to_string(),
+        PersonaId::new(),
+        request_id,
+        Utc::now(),
+    ));
     account
 }
 
@@ -230,9 +227,12 @@ async fn join_submit_and_approval_activates() {
 
     let outcome = handle_join_status_response(&mut account, &delivered, &vtc_did);
     assert!(outcome.changed, "approval transitions the record");
-    assert!(!outcome.inactivated, "approval keeps the live session");
+    assert!(
+        outcome.inactivated.is_none(),
+        "approval keeps the live session"
+    );
 
-    let record = account.communities.get(&vtc_did).expect("community");
+    let record = account.memberships().next().expect("community");
     assert!(record.status.is_active(), "Pending -> Active on approval");
     assert!(
         record.member_since.is_some(),
@@ -270,11 +270,11 @@ async fn join_submit_and_rejection_inactivates() {
     let outcome = handle_join_status_response(&mut account, &delivered, &vtc_did);
     assert!(outcome.changed, "rejection transitions the record");
     assert!(
-        outcome.inactivated,
+        outcome.inactivated.is_some(),
         "rejection must deregister the live session (R-S-3)"
     );
 
-    let record = account.communities.get(&vtc_did).expect("community");
+    let record = account.memberships().next().expect("community");
     assert!(matches!(record.status, CommunityStatus::Rejected));
     assert!(
         record.needs_attention(),
@@ -297,8 +297,8 @@ async fn member_self_remove_round_trip() {
     // An already-Active membership the persona now leaves.
     let mut account = pending_account(&vtc_did, Uuid::new_v4());
     account
-        .communities
-        .get_mut(&vtc_did)
+        .memberships_mut()
+        .next()
         .expect("community")
         .activate(Utc::now());
 
@@ -330,7 +330,7 @@ async fn member_self_remove_round_trip() {
     assert_eq!(parsed.disposition.as_deref(), Some("tombstone"));
 
     // On send success the local membership becomes read-only `Left` (R-L-1).
-    let record = account.communities.get_mut(&vtc_did).expect("community");
+    let record = account.memberships_mut().next().expect("community");
     record.leave();
     assert!(matches!(record.status, CommunityStatus::Left));
     assert!(

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -152,17 +152,10 @@ impl StateHandler {
                             let Some(vtc_did) = validate_join_input(&vtc_did) else {
                                 continue;
                             };
-                            // Idempotency (R-B-9): refuse a duplicate live/pending
-                            // membership before bothering the user with an identity
-                            // choice.
-                            if is_duplicate_membership(config, &vtc_did) {
-                                state.join.page = JoinPage::Progress;
-                                state.join.fail(
-                                    "Already a member of (or have a pending request for) this community.",
-                                );
-                                let _ = self.state_tx.send(state.clone());
-                                continue;
-                            }
+                            // Idempotency is now per-persona (R-B-9): a community may
+                            // be joined as more than one persona, so the duplicate
+                            // check happens once the identity is chosen (in the
+                            // sequence) rather than at the community level here.
                             // Identity first: collect the invitations available for
                             // this community so each persona can be badged with its
                             // usable-invitation count, then let the operator pick the
@@ -432,8 +425,7 @@ fn build_persona_options(config: &Config, vics: &[AvailableVic]) -> Vec<PersonaO
         .map(|p| {
             let mut linked_communities: Vec<String> = config
                 .account
-                .communities
-                .values()
+                .memberships()
                 .filter(|c| c.persona_ref == p.persona_id)
                 .map(|c| {
                     c.display_name
@@ -618,15 +610,13 @@ async fn build_linkage_proof(
 /// Idempotency decision (R-B-9): is there already a *live* (Active/Pending)
 /// membership for this VTC?
 ///
-/// Pure decision peeled out of step 1 of [`run_join_sequence`]; a `true` result
-/// surfaces the "already a member" failure instead of submitting a duplicate.
-/// Delegates to [`Account::live_community`] so the live/inactive policy stays in
-/// one place.
-fn is_duplicate_membership(config: &Config, vtc_did: &str) -> bool {
-    config
-        .account
-        .live_community(&vtc_did.to_string())
-        .is_some()
+/// Whether a *live* (Active/Pending) membership already exists for this community
+/// **as this persona** — the per-persona join idempotency gate (R-B-9). A
+/// community may be joined more than once, but not twice as the same persona, so
+/// the check is keyed on `(vtc, persona)` and only blocks the reuse path (a
+/// freshly minted persona can never collide).
+fn is_duplicate_membership(config: &Config, vtc_did: &str, persona: PersonaId) -> bool {
+    config.account.has_live_membership(vtc_did, persona)
 }
 
 /// Build the `Pending` [`CommunityRecord`] recorded on a successful submit.
@@ -703,6 +693,14 @@ async fn run_join_sequence(
     let (persona_id, persona_did) = match choice {
         JoinIdentityChoice::Reuse(persona_id) => match config.identities.get(&persona_id) {
             Some(ident) => {
+                // Per-persona idempotency (R-B-9): block a second live membership
+                // as the *same* persona, while still allowing other personas.
+                if is_duplicate_membership(config, &vtc_did, persona_id) {
+                    state.join.fail(
+                        "Already a member of (or have a pending request for) this community as this persona.",
+                    );
+                    return;
+                }
                 let did = ident.persona_did().to_string();
                 state.join.info(format!("Reusing persona {did}…"));
                 let _ = handler.state_tx.send(state.clone());
@@ -835,11 +833,7 @@ async fn run_join_sequence(
     // 6. Derive the per-community sub-context id (D9, collision-safe).
     let sub_context_id =
         match build_sub_context_id(&top_context_id, display_name.as_deref(), &vtc_did, |id| {
-            config
-                .account
-                .communities
-                .values()
-                .any(|c| c.sub_context_id == id)
+            config.account.memberships().any(|c| c.sub_context_id == id)
         }) {
             Ok(id) => id,
             Err(e) => {
@@ -1045,7 +1039,7 @@ async fn run_join_sequence(
         request_id,
         Utc::now(),
     );
-    config.account.communities.insert(vtc_did, record.clone());
+    config.account.add_membership(record.clone());
     if let Err(e) = save_config(config, profile) {
         state
             .join
@@ -1205,6 +1199,7 @@ mod tests {
             (Some(CommunityStatus::Expired), false),
         ];
         let vtc = "did:vtc:known";
+        let persona = PersonaId::new();
         for (status, expected) in cases {
             let mut config = test_config();
             if let Some(status) = status {
@@ -1212,22 +1207,27 @@ mod tests {
                     vtc.to_string(),
                     None,
                     "ctx/slug".to_string(),
-                    PersonaId::new(),
+                    persona,
                     uuid::Uuid::new_v4(),
                     chrono::Utc::now(),
                 );
                 rec.status = status.clone();
-                config.account.communities.insert(vtc.to_string(), rec);
+                config.account.add_membership(rec);
             }
             assert_eq!(
-                is_duplicate_membership(&config, vtc),
+                is_duplicate_membership(&config, vtc, persona),
                 *expected,
                 "is_duplicate_membership for status {status:?}"
             );
             // An unrelated DID is never a duplicate regardless of registered state.
             assert!(
-                !is_duplicate_membership(&config, "did:vtc:other"),
+                !is_duplicate_membership(&config, "did:vtc:other", persona),
                 "unknown DID is not a duplicate (status {status:?})"
+            );
+            // The same community as a *different* persona is not a duplicate.
+            assert!(
+                !is_duplicate_membership(&config, vtc, PersonaId::new()),
+                "different persona is not a duplicate (status {status:?})"
             );
         }
     }

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -149,11 +149,17 @@ pub enum CreatePersonaPhase {
 /// One entry in the community switcher overlay.
 #[derive(Clone, Debug)]
 pub struct SwitcherItem {
-    /// The community's VTC DID — the switch target.
+    /// The community's VTC DID — half of the switch target.
     pub vtc_did: openvtc_core::config::account::VtcDid,
+    /// The presented persona — the other half of the target, since a community
+    /// may hold more than one membership.
+    pub persona_ref: openvtc_core::config::account::PersonaId,
     /// Display name (resolved name, or the shortened VTC DID when unnamed).
     pub display_name: String,
-    /// Whether this is the current working community.
+    /// The presented persona's label, shown to disambiguate multiple memberships
+    /// of the same community.
+    pub persona_label: String,
+    /// Whether this is the current working membership.
     pub is_current: bool,
 }
 

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -387,10 +387,7 @@ impl MainPageState {
             .map(|p| content::ManagedDid {
                 did: p.did.clone(),
                 label: p.label.clone().unwrap_or_default(),
-                bound_communities: config
-                    .account
-                    .communities
-                    .values()
+                bound_communities: config.account.memberships()
                     .filter(|c| c.persona_ref == p.persona_id)
                     .count(),
                 is_active: p.did.as_str() == persona_did,
@@ -539,7 +536,7 @@ fn collect_vrcs(
 /// `alias` carries "<community> — Membership/Role" and `remote_p_did` the VTC.
 fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
     let mut result = Vec::new();
-    for c in config.account.communities.values() {
+    for c in config.account.memberships() {
         let community = c
             .display_name
             .clone()
@@ -718,10 +715,7 @@ impl From<&Config> for MainMenuConfigState {
         // bar once the user is actually in a community (an Active membership). A
         // State-A account or a still-Pending join shows no persona name/DID up
         // there — the persona belongs to a community context, not the chrome.
-        let in_community = config
-            .account
-            .communities
-            .values()
+        let in_community = config.account.memberships()
             .any(|c| c.status.is_active());
         // The working community (R-C-7a): the Active community whose persona is
         // the active one. `active_persona` is kept in lockstep with the selected

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -54,7 +54,7 @@ pub async fn process_inbound_message(
     service: &DIDCommService,
     seen: &mut SeenMessages,
     message: &Message,
-    inactivated: &mut Vec<VtcDid>,
+    inactivated: &mut Vec<(VtcDid, openvtc_core::config::account::PersonaId)>,
 ) -> Result<bool, anyhow::Error> {
     // Drop messages outside the replay / freshness window before doing
     // any state-mutating work. Saves us from acting on stale captures
@@ -157,8 +157,8 @@ pub async fn process_inbound_message(
     // rejection inactivates the community so the loop deregisters the session.
     if message.typ == JOIN_REQUEST_SUBMIT_RESPONSE_TYPE {
         let outcome = handle_join_verdict(&mut config.account, message, &from_did);
-        if outcome.inactivated {
-            inactivated.push(from_did.to_string());
+        if let Some(persona) = outcome.inactivated {
+            inactivated.push((from_did.to_string(), persona));
         }
         return Ok(outcome.changed);
     }
@@ -170,8 +170,8 @@ pub async fn process_inbound_message(
     // is no longer silently dropped into a stuck `Pending`.
     if message.typ == PROBLEM_REPORT_TYPE {
         let outcome = handle_join_problem_report(&mut config.account, message, &from_did);
-        if outcome.inactivated {
-            inactivated.push(from_did.to_string());
+        if let Some(persona) = outcome.inactivated {
+            inactivated.push((from_did.to_string(), persona));
         }
         return Ok(outcome.changed);
     }
@@ -183,8 +183,8 @@ pub async fn process_inbound_message(
     // into a stuck `Pending`. Matched by type prefix (version-agnostic).
     if is_trust_task_error_type(&message.typ) {
         let outcome = handle_join_trust_task_error(&mut config.account, message, &from_did);
-        if outcome.inactivated {
-            inactivated.push(from_did.to_string());
+        if let Some(persona) = outcome.inactivated {
+            inactivated.push((from_did.to_string(), persona));
         }
         return Ok(outcome.changed);
     }
@@ -195,8 +195,8 @@ pub async fn process_inbound_message(
     // VTC DID up so the loop deregisters the session (R-S-3).
     if message.typ == JOIN_REQUEST_STATUS_RESPONSE_TYPE {
         let outcome = handle_join_status_response(&mut config.account, message, &from_did);
-        if outcome.inactivated {
-            inactivated.push(from_did.to_string());
+        if let Some(persona) = outcome.inactivated {
+            inactivated.push((from_did.to_string(), persona));
         }
         return Ok(outcome.changed);
     }

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -510,11 +510,7 @@ impl StateHandler {
         // the first event re-syncs (the per-path syncs above run with no
         // selection set yet).
         state.reconcile_selected_community(&config.account);
-        let initial_active = state
-            .selected_community
-            .as_ref()
-            .and_then(|vtc| config.account.community(vtc))
-            .map(|c| c.persona_ref);
+        let initial_active = state.selected_community.as_ref().map(|(_, persona)| *persona);
         config.set_active_persona(initial_active);
         state.main_page.sync_from_config(&config);
 
@@ -708,11 +704,10 @@ impl StateHandler {
                         // connection is torn down with the community, not left
                         // dangling.
                         if let Some((vtc, pid)) = target {
-                            let removed = session_manager.deregister(&vtc);
+                            let removed = session_manager.deregister(pid, &vtc);
                             let still_live = config
                                 .account
-                                .communities
-                                .values()
+                                .memberships()
                                 .any(|c| c.persona_ref == pid && c.is_live());
                             if !still_live
                                 && let Some(did) =
@@ -735,7 +730,7 @@ impl StateHandler {
                         }
                         // Drop the global messaging status only when NO persona
                         // has a live community left.
-                        if !config.account.communities.values().any(|c| c.is_live()) {
+                        if !config.account.memberships().any(|c| c.is_live()) {
                             state.connection.status = state::MediatorStatus::NoActiveCommunity;
                             state.connection.messaging_active = false;
                         }
@@ -751,7 +746,7 @@ impl StateHandler {
                             .filter(|c| c.status.is_active())
                             .map(|c| (c.vtc_did.clone(), c.persona_ref));
                         if let Some((vtc, persona)) = target {
-                            state.selected_community = Some(vtc);
+                            state.selected_community = Some((vtc, persona));
                             config.set_active_persona(Some(persona));
                             // Refilter the community-scoped panels immediately so
                             // the switch is reflected this frame.
@@ -762,13 +757,13 @@ impl StateHandler {
                         // R-C-4: flip the star on the community at display index
                         // `i`, persist (coalesced), then keep the highlight on it
                         // as the list re-sorts (favourites float to the top).
-                        let vtc = config
+                        let target = config
                             .account
                             .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .get(i)
-                            .map(|c| c.vtc_did.clone());
-                        if let Some(vtc) = vtc {
-                            if let Some(c) = config.account.community_mut(&vtc) {
+                            .map(|c| (c.vtc_did.clone(), c.persona_ref));
+                        if let Some((vtc, persona)) = target {
+                            if let Some(c) = config.account.membership_mut(&vtc, persona) {
                                 c.toggle_favourite();
                             }
                             save.mark_dirty();
@@ -777,7 +772,7 @@ impl StateHandler {
                                 .account
                                 .communities_for_display(state.main_page.content_panel.communities.show_archived)
                                 .iter()
-                                .position(|c| c.vtc_did == vtc)
+                                .position(|c| c.vtc_did == vtc && c.persona_ref == persona)
                             {
                                 state.main_page.content_panel.communities.selected_index =
                                     new_idx;
@@ -787,13 +782,13 @@ impl StateHandler {
                     Action::AcknowledgeCommunity(i) => {
                         // R-S-2: clear the actions-required badge on a terminal
                         // outcome (Rejected / Expired) the user has now seen.
-                        let vtc = config
+                        let target = config
                             .account
                             .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .get(i)
-                            .map(|c| c.vtc_did.clone());
-                        if let Some(vtc) = vtc
-                            && let Some(c) = config.account.community_mut(&vtc)
+                            .map(|c| (c.vtc_did.clone(), c.persona_ref));
+                        if let Some((vtc, persona)) = target
+                            && let Some(c) = config.account.membership_mut(&vtc, persona)
                         {
                             c.acknowledge();
                             save.mark_dirty();
@@ -833,7 +828,9 @@ impl StateHandler {
                             };
                             match send {
                                 Ok(_) => {
-                                    if let Some(c) = config.account.community_mut(&vtc) {
+                                    if let Some(c) =
+                                        config.account.membership_mut(&vtc, persona_id)
+                                    {
                                         c.leave();
                                     }
                                     save.mark_dirty();
@@ -843,6 +840,7 @@ impl StateHandler {
                                         &config,
                                         &mut state,
                                         &vtc,
+                                        persona_id,
                                     )
                                     .await;
                                     state.main_page.sync_from_config(&config);
@@ -876,8 +874,8 @@ impl StateHandler {
                                 c.status,
                                 openvtc_core::config::account::CommunityStatus::Pending { .. }
                             ))
-                            .map(|c| c.vtc_did.clone());
-                        if let Some(vtc) = target {
+                            .map(|c| (c.vtc_did.clone(), c.persona_ref));
+                        if let Some((vtc, persona)) = target {
                             // Best-effort VTC notification. The applicant-side
                             // withdraw DIDComm message does not exist in vta-sdk
                             // yet (only the `withdrawn` *status* the VTC reports),
@@ -891,7 +889,7 @@ impl StateHandler {
                             );
                             if config
                                 .account
-                                .community_mut(&vtc)
+                                .membership_mut(&vtc, persona)
                                 .is_some_and(|c| c.withdraw())
                             {
                                 save.mark_dirty();
@@ -901,6 +899,7 @@ impl StateHandler {
                                     &config,
                                     &mut state,
                                     &vtc,
+                                    persona,
                                 )
                                 .await;
                                 state.main_page.sync_from_config(&config);
@@ -916,13 +915,13 @@ impl StateHandler {
                     Action::ArchiveCommunity(i) => {
                         // R-C-8: archive an inactive community (hide it, retain the
                         // record). Guarded inactive-only by `archive_community`.
-                        let vtc = config
+                        let target = config
                             .account
                             .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .get(i)
-                            .map(|c| c.vtc_did.clone());
-                        if let Some(vtc) = vtc {
-                            match config.account.archive_community(&vtc) {
+                            .map(|c| (c.vtc_did.clone(), c.persona_ref));
+                        if let Some((vtc, persona)) = target {
+                            match config.account.archive_membership(&vtc, persona) {
                                 Ok(()) => {
                                     save.mark_dirty();
                                     state.main_page.sync_from_config(&config);
@@ -960,13 +959,24 @@ impl StateHandler {
                             .communities_for_display(state.main_page.content_panel.communities.show_archived)
                             .into_iter()
                             .filter(|c| c.status.is_active())
-                            .map(|c| main_page::content::SwitcherItem {
-                                vtc_did: c.vtc_did.clone(),
-                                display_name: c
-                                    .display_name
-                                    .clone()
-                                    .unwrap_or_else(|| main_page::shorten_did(&c.vtc_did, 40)),
-                                is_current: Some(&c.vtc_did) == current.as_ref(),
+                            .map(|c| {
+                                let persona_label = config
+                                    .account
+                                    .personas
+                                    .get(&c.persona_ref)
+                                    .and_then(|p| p.label.clone())
+                                    .unwrap_or_default();
+                                main_page::content::SwitcherItem {
+                                    vtc_did: c.vtc_did.clone(),
+                                    persona_ref: c.persona_ref,
+                                    display_name: c
+                                        .display_name
+                                        .clone()
+                                        .unwrap_or_else(|| main_page::shorten_did(&c.vtc_did, 40)),
+                                    persona_label,
+                                    is_current: current.as_ref()
+                                        == Some(&(c.vtc_did.clone(), c.persona_ref)),
+                                }
                             })
                             .collect();
                         // Don't pop an empty overlay when there's nothing to switch.
@@ -984,19 +994,19 @@ impl StateHandler {
                         // Switch the working context to the highlighted Active
                         // community, then close the overlay (R-C-6 / R-C-7).
                         let target = state.main_page.switcher.as_ref().and_then(|sw| {
-                            sw.items.get(sw.selected).map(|it| it.vtc_did.clone())
+                            sw.items
+                                .get(sw.selected)
+                                .map(|it| (it.vtc_did.clone(), it.persona_ref))
                         });
-                        if let Some(vtc) = target {
-                            let persona = config
+                        if let Some((vtc, persona)) = target
+                            && config
                                 .account
-                                .community(&vtc)
-                                .filter(|c| c.status.is_active())
-                                .map(|c| c.persona_ref);
-                            if let Some(persona) = persona {
-                                state.selected_community = Some(vtc);
-                                config.set_active_persona(Some(persona));
-                                state.main_page.sync_from_config(&config);
-                            }
+                                .membership(&vtc, persona)
+                                .is_some_and(|c| c.status.is_active())
+                        {
+                            state.selected_community = Some((vtc, persona));
+                            config.set_active_persona(Some(persona));
+                            state.main_page.sync_from_config(&config);
                         }
                         state.main_page.switcher = None;
                     },
@@ -1352,13 +1362,14 @@ impl StateHandler {
                                     // status (e.g. a rejection) — tear down its
                                     // live session so a dead community stops
                                     // holding a mediator connection.
-                                    for vtc in &inactivated {
+                                    for (vtc, persona) in &inactivated {
                                         deregister_inactive_community(
                                             &mut session_manager,
                                             &didcomm_service,
                                             &config,
                                             &mut state,
                                             vtc,
+                                            *persona,
                                         )
                                         .await;
                                     }
@@ -1572,13 +1583,14 @@ impl StateHandler {
                     let expired = config.account.expire_stale_pending(chrono::Utc::now());
                     if !expired.is_empty() {
                         save.mark_dirty();
-                        for vtc in &expired {
+                        for (vtc, persona) in &expired {
                             deregister_inactive_community(
                                 &mut session_manager,
                                 &didcomm_service,
                                 &config,
                                 &mut state,
                                 vtc,
+                                *persona,
                             )
                             .await;
                         }
@@ -1640,11 +1652,7 @@ impl StateHandler {
             // the default shifted), refilter the community-scoped panels so the UI
             // reflects the new context this frame.
             state.reconcile_selected_community(&config.account);
-            let active_persona = state
-                .selected_community
-                .as_ref()
-                .and_then(|vtc| config.account.community(vtc))
-                .map(|c| c.persona_ref);
+            let active_persona = state.selected_community.as_ref().map(|(_, persona)| *persona);
             if active_persona != config.active_persona {
                 config.set_active_persona(active_persona);
                 state.main_page.sync_from_config(&config);
@@ -1924,21 +1932,21 @@ impl StateHandler {
         save: &mut save_coalesce::SaveScheduler,
         index: usize,
     ) {
-        let Some(vtc) = config
+        let Some((vtc, persona)) = config
             .account
             .communities_for_display(state.main_page.content_panel.communities.show_archived)
             .get(index)
-            .map(|c| c.vtc_did.clone())
+            .map(|c| (c.vtc_did.clone(), c.persona_ref))
         else {
             return;
         };
         // The confirmation is now resolved.
         state.main_page.content_panel.communities.confirm_delete = None;
         // Delete is inactive-only (R-C-8): an Active/Pending community must be
-        // left first (the `d` key is gated to inactive rows, and `delete_community`
+        // left first (the `d` key is gated to inactive rows, and `delete_membership`
         // re-checks). We no longer silently `leave()` here — that conflated leave
         // with delete and skipped the protocol self-removal.
-        match config.account.delete_community(&vtc) {
+        match config.account.delete_membership(&vtc, persona) {
             Ok(_) => {
                 // R11: coalesced save (was an inline `config.save`). The
                 // Exit/shutdown force-flush guarantees the deletion is persisted
@@ -1994,8 +2002,7 @@ impl StateHandler {
         // Guard: refuse to delete an identity any community still presents.
         let bound = config
             .account
-            .communities
-            .values()
+            .memberships()
             .filter(|c| c.persona_ref == persona_id)
             .count();
         if bound > 0 {
@@ -2445,17 +2452,14 @@ async fn deregister_inactive_community(
     config: &Config,
     state: &mut State,
     vtc: &openvtc_core::config::account::VtcDid,
+    pid: openvtc_core::config::account::PersonaId,
 ) {
-    // The persona that served this (now-inactive but retained) community.
-    let Some(pid) = config.account.community(vtc).map(|c| c.persona_ref) else {
-        session_manager.deregister(vtc);
-        return;
-    };
-    let removed = session_manager.deregister(vtc);
+    let removed = session_manager.deregister(pid, vtc);
+    // The persona's listener stays up while it still serves any live membership
+    // (it may belong to several communities, or this same VTC as another state).
     let still_live = config
         .account
-        .communities
-        .values()
+        .memberships()
         .any(|c| c.persona_ref == pid && c.is_live());
     if !still_live && let Some(did) = config.identities.get(&pid).map(|id| id.did.clone()) {
         // Prefer the listener id the manager recorded; fall back to deriving it.
@@ -2470,7 +2474,7 @@ async fn deregister_inactive_community(
             .log("Community inactive — persona listener stopped.");
     }
     // Drop the global messaging indicator when no persona has a live community.
-    if !config.account.communities.values().any(|c| c.is_live()) {
+    if !config.account.memberships().any(|c| c.is_live()) {
         state.connection.status = state::MediatorStatus::NoActiveCommunity;
         state.connection.messaging_active = false;
     }
@@ -2546,7 +2550,7 @@ async fn register_joined_session(
                 None => {
                     // The join just wrote this identity, so this is unexpected — but
                     // never leave a registered session with no listener behind it.
-                    session_manager.deregister(&joined.vtc_did);
+                    session_manager.deregister(joined.persona_id, &joined.vtc_did);
                     state.main_page.log(
                         "Joined, but its identity could not be resolved to start a live session.",
                     );
@@ -2787,7 +2791,9 @@ mod tests {
 
         let item = |n: &str| SwitcherItem {
             vtc_did: format!("did:example:{n}"),
+            persona_ref: openvtc_core::config::account::PersonaId::new(),
             display_name: n.to_string(),
+            persona_label: String::new(),
             is_current: false,
         };
         let mut state = State::default();

--- a/openvtc/src/state_handler/session_manager.rs
+++ b/openvtc/src/state_handler/session_manager.rs
@@ -137,18 +137,15 @@ impl SessionManager {
         RegisterOutcome::Created
     }
 
-    /// Deregister `vtc` from its persona's session.
+    /// Deregister `vtc` from `persona`'s session.
     ///
-    /// Removes `vtc` from whichever session serves it. If that session now serves
-    /// no communities, it is removed and returned so the caller can tear down its
+    /// Removes `vtc` from that persona's session. If the session now serves no
+    /// communities, it is removed and returned so the caller can tear down its
     /// listener; otherwise (the persona still serves other communities) `None` is
-    /// returned and the shared connection stays up. Isolation: only the affected
-    /// session is touched.
-    pub fn deregister(&mut self, vtc: &str) -> Option<Session> {
-        let persona = self
-            .sessions
-            .iter()
-            .find_map(|(pid, s)| s.communities.iter().any(|c| c == vtc).then_some(*pid))?;
+    /// returned and the shared connection stays up. Taking the persona explicitly
+    /// is required for multi-membership: two personas may both serve the same VTC,
+    /// so the VTC alone no longer identifies the session.
+    pub fn deregister(&mut self, persona: PersonaId, vtc: &str) -> Option<Session> {
         let session = self.sessions.get_mut(&persona)?;
         session.communities.remove(vtc);
         if session.communities.is_empty() {
@@ -310,18 +307,18 @@ mod tests {
         mgr.mark_connected("lid-a");
 
         // Leaving the first community keeps the session up (still serves vtc-2).
-        assert!(mgr.deregister("vtc-1").is_none());
+        assert!(mgr.deregister(a, "vtc-1").is_none());
         assert_eq!(mgr.session_count(), 1);
         assert!(mgr.sessions[&a].status.is_connected());
 
         // Leaving the last one tears the session down — returned for listener
         // teardown by the caller.
-        let removed = mgr.deregister("vtc-2").expect("session removed");
+        let removed = mgr.deregister(a, "vtc-2").expect("session removed");
         assert_eq!(removed.listener_id, "lid-a");
         assert_eq!(mgr.session_count(), 0);
         assert!(!mgr.any_connected());
 
         // Deregistering something unknown is a harmless no-op.
-        assert!(mgr.deregister("vtc-unknown").is_none());
+        assert!(mgr.deregister(a, "vtc-unknown").is_none());
     }
 }

--- a/openvtc/src/state_handler/state.rs
+++ b/openvtc/src/state_handler/state.rs
@@ -24,7 +24,14 @@ pub struct State {
     ///
     /// Runtime-only (not persisted): re-defaulted from the account on each launch
     /// via [`State::reconcile_selected_community`].
-    pub selected_community: Option<openvtc_core::config::account::VtcDid>,
+    ///
+    /// A *membership* reference — the community DID plus the presented persona —
+    /// since a community may hold more than one membership (one per persona). The
+    /// persona half is the working persona that scopes the panels.
+    pub selected_community: Option<(
+        openvtc_core::config::account::VtcDid,
+        openvtc_core::config::account::PersonaId,
+    )>,
 
     /// Rotating-tip index for the startup loading screen, advanced as startup
     /// steps stream so the tip changes during the load/connect.
@@ -70,15 +77,15 @@ impl State {
         &mut self,
         account: &openvtc_core::config::account::Account,
     ) {
-        if let Some(selected) = &self.selected_community
+        if let Some((vtc, persona)) = &self.selected_community
             && !account
-                .community(selected)
+                .membership(vtc, *persona)
                 .is_some_and(|c| c.status.is_active())
         {
             self.selected_community = None;
         }
         if self.selected_community.is_none() {
-            self.selected_community = account.default_working_community();
+            self.selected_community = account.default_working_membership();
         }
     }
 }
@@ -299,19 +306,22 @@ mod tests {
             now,
         );
         active.activate(now);
-        account.communities.insert(active.vtc_did.clone(), active);
+        account.add_membership(active);
 
         let mut state = State::default();
         assert_eq!(state.selected_community, None);
 
         // With one active community and no selection, reconcile defaults to it.
         state.reconcile_selected_community(&account);
-        assert_eq!(state.selected_community.as_deref(), Some("did:web:vtc-a"));
+        assert_eq!(
+            state.selected_community,
+            Some(("did:web:vtc-a".to_string(), pid))
+        );
 
         // Once it leaves (no longer active), the stale selection is dropped and
         // there is nothing to default to → no active community.
         account
-            .community_mut(&"did:web:vtc-a".to_string())
+            .membership_mut("did:web:vtc-a", pid)
             .unwrap()
             .leave();
         state.reconcile_selected_community(&account);

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -65,31 +65,44 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
 
     for (i, c) in state.items.iter().enumerate() {
         let is_selected = i == state.selected_index;
-        let prefix = if is_selected { "▸ " } else { "  " };
-        let name_style = if is_selected {
+        // A community may hold several memberships (one per persona). Rows are
+        // grouped: the community name is shown once as a header, then each
+        // membership is a selectable sub-row labelled by its presented persona.
+        let new_group = i == 0 || state.items[i - 1].vtc_did != c.vtc_did;
+        if new_group {
+            lines.push(Line::from(Span::styled(
+                format!("  {}", c.display_name),
+                Style::new().fg(COLOR_TEXT_DEFAULT).bold(),
+            )));
+        }
+
+        let row_style = if is_selected {
             Style::new().fg(COLOR_SUCCESS).bold()
         } else if c.is_inactive {
-            // Inactive communities are read-only (D14) — dimmed in the list.
+            // Inactive memberships are read-only (D14) — dimmed in the list.
             Style::new().fg(COLOR_DARK_GRAY)
         } else {
             Style::new().fg(COLOR_TEXT_DEFAULT)
         };
-
-        let star = if c.favourite { "★ " } else { "  " };
+        let prefix = if is_selected { "    ▸ " } else { "      " };
+        let star = if c.favourite { "★ " } else { "" };
         let attention = if c.needs_attention { " ●" } else { "" };
+        let persona = if c.persona_label.is_empty() {
+            c.persona_did.clone()
+        } else {
+            c.persona_label.clone()
+        };
 
+        // Membership sub-row: the presented persona is the selectable label.
         lines.push(Line::from(vec![
-            Span::styled(prefix, name_style),
+            Span::styled(prefix, row_style),
             Span::styled(star, Style::new().fg(COLOR_ORANGE)),
-            Span::styled(c.display_name.clone(), name_style),
+            Span::styled(format!("as {persona}"), row_style),
             Span::styled(attention, Style::new().fg(COLOR_ORANGE)),
         ]));
 
-        // Secondary line: status · persona · member-since.
-        let mut detail = format!("    {}", c.status_label);
-        if !c.persona_label.is_empty() {
-            detail.push_str(&format!("  ·  as {}", c.persona_label));
-        }
+        // Secondary line: status · member-since.
+        let mut detail = format!("        {}", c.status_label);
         if !c.member_since.is_empty() {
             detail.push_str(&format!("  ·  since {}", c.member_since));
         }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2116,13 +2116,20 @@ impl MainPage {
             .map(|(i, item)| {
                 let marker = if i == switcher.selected { "▸ " } else { "  " };
                 let current = if item.is_current { "  (active)" } else { "" };
+                // Disambiguate multiple memberships of the same community by the
+                // presented persona.
+                let persona = if item.persona_label.is_empty() {
+                    String::new()
+                } else {
+                    format!("  as {}", item.persona_label)
+                };
                 let style = if i == switcher.selected {
                     Style::new().fg(COLOR_SUCCESS).bold()
                 } else {
                     Style::new().fg(COLOR_TEXT_DEFAULT)
                 };
                 Line::from(Span::styled(
-                    format!("{marker}{}{current}", item.display_name),
+                    format!("{marker}{}{persona}{current}", item.display_name),
                     style,
                 ))
             })
@@ -2423,7 +2430,9 @@ mod key_handler_tests {
     fn switcher_item(name: &str, is_current: bool) -> SwitcherItem {
         SwitcherItem {
             vtc_did: format!("did:example:{name}"),
+            persona_ref: openvtc_core::config::account::PersonaId::new(),
             display_name: name.to_string(),
+            persona_label: String::new(),
             is_current,
         }
     }


### PR DESCRIPTION
## Why

A community could only be joined once: memberships were keyed by VTC DID (`HashMap<VtcDid, CommunityRecord>`), so the data model, the message handlers, and the working-community switcher all assumed one membership per community. This enables joining the same community as **more than one persona**, with the invariant that the `(community, persona)` pair is unique (you can't join the same community twice as the *same* persona).

## What

**Data model (openvtc-core)**
- `communities: HashMap<VtcDid, Vec<CommunityRecord>>` — grouped by community. Backward-compatible load: `de_communities` folds both the legacy one-record-per-VTC shape (a bare object value) and the new list shape into the grouped form, so existing configs load unchanged.
- Membership API: `memberships()`, `memberships_for(vtc)`, `membership(vtc, persona)`, `membership_mut`, `add_membership`, `has_live_membership`, `membership_by_pending_request`, `archive_membership`/`delete_membership`, `default_working_membership`. `expire_stale_pending` returns `(vtc, persona)`.

**Correlation — the 6 inbound handlers** no longer assume "the" record for a sender:
- join replies (verdict / submit-receipt / status-response / problem-report / trust-task-error) correlate by the **unique request id**;
- credential-issue routes by `credentialSubject` = the persona DID.
- `StatusOutcome.inactivated` now carries the `PersonaId` whose session to deregister.

**Sessions** — `SessionManager::deregister(persona, vtc)` (two personas may serve the same VTC); `deregister_inactive_community` is persona-scoped.

**Join flow** — idempotency is per-persona: a second persona may join a community already joined as another; the same persona is still blocked (the check moved to where the identity is known).

**UI** — the working selection is a membership `(VtcDid, PersonaId)`; the Communities panel groups memberships under one community header with a persona sub-row each; the switcher lists per-membership and shows the persona.

## Testing

`cargo build`, `cargo clippy --all-targets` clean; full suite green. New tests: multi-membership coexistence + per-persona idempotency, legacy + modern config load (`de_communities`), and per-membership reply routing (a verdict transitions only the matching persona's membership).
