### PR TITLE
feat(community): issue a reciprocal member VMC to the community

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,7 +2497,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -5463,7 +5463,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5514,7 +5514,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "vta-service",
  "x25519-dalek",
  "zeroize",
@@ -8928,7 +8928,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "vti-common",
  "x25519-dalek",
 ]
@@ -8965,9 +8965,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c4f9cca1d6a6721a4ef53aab46337f6b8555fa4303c8ebe47f6b93974089bb"
+checksum = "4d3a736a39a3d285dc729b7fb347c95d3567697c4f74b72c178c3c54460d4cfe"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9072,7 +9072,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "vti-common",
  "vti-secrets",
  "vti-webauthn",
@@ -9116,7 +9116,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.1",
+ "vta-sdk 0.18.2",
  "webauthn-rs",
  "zeroize",
 ]

--- a/openvtc-core/src/config/keys.rs
+++ b/openvtc-core/src/config/keys.rs
@@ -92,6 +92,43 @@ impl Config {
         })
     }
 
+    /// Like [`Self::get_persona_keys`] but for a *specific* persona, not the active
+    /// one — needed when an action targets a membership whose persona is not the
+    /// current working identity (e.g. issuing a member VMC from a community row).
+    pub async fn get_persona_keys_for(
+        &self,
+        persona_id: crate::config::account::PersonaId,
+        tdk: &TDK,
+    ) -> Result<PersonaDIDKeys, OpenVTCError> {
+        let doc = self
+            .identities
+            .get(&persona_id)
+            .ok_or_else(|| OpenVTCError::Config("Unknown persona identity".to_string()))?
+            .document();
+        let signing = resolve_key_from_document(
+            &doc.assertion_method,
+            "assertion methods",
+            tdk,
+            &self.key_info,
+        )
+        .await?;
+        let authentication = resolve_key_from_document(
+            &doc.authentication,
+            "authentication methods",
+            tdk,
+            &self.key_info,
+        )
+        .await?;
+        let decryption =
+            resolve_key_from_document(&doc.key_agreement, "key agreements", tdk, &self.key_info)
+                .await?;
+        Ok(PersonaDIDKeys {
+            signing,
+            authentication,
+            decryption,
+        })
+    }
+
     /// Build a subject-linkage proof (#1b) authorizing `presenter_did` to redeem
     /// the invitation `vic_id` that is bound to `subject_did` — one of *our*
     /// personas. Signs `TAG‖vic_id‖presenter` with that persona's signing key

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod errors;
 pub mod identity;
 pub mod join;
 pub mod logs;
+pub mod members;
 pub mod messaging;
 #[cfg(feature = "openpgp-card")]
 pub mod openpgp_card;

--- a/openvtc-core/src/members.rs
+++ b/openvtc-core/src/members.rs
@@ -1,0 +1,55 @@
+//! Member → VTC reciprocal membership-credential (VMC) exchange (the `members`
+//! protocol family).
+//!
+//! Membership between a persona and a VTC is a *pair* of VMCs: the VTC issues one
+//! to the member at admission (community → member, stored on the membership via
+//! [`handle_credential_issue`](crate::messaging::handle_credential_issue)), and
+//! the member issues one back (member → community). This module sends the
+//! member's half over DIDComm.
+//!
+//! The VMC is a Data-Integrity VC whose `issuer` is the member persona and whose
+//! `credentialSubject.id` is the community VTC DID; the VTC verifies the proof +
+//! binding and stores it (vta-sdk `protocols::members`, type `members/vmc/1.0`).
+
+use std::sync::Arc;
+
+use affinidi_tdk::{
+    didcomm::Message,
+    messaging::{ATM, profiles::ATMProfile},
+};
+use chrono::Utc;
+use serde_json::Value;
+use uuid::Uuid;
+use vta_sdk::protocols::members::{MEMBER_VMC_TYPE, MemberVmcBody};
+
+use crate::errors::OpenVTCError;
+
+/// Send a member-issued VMC to the community's VTC over DIDComm
+/// (`members/vmc/1.0`). `vc` is the **signed** membership credential — `issuer`
+/// = the member persona (`member_did`), `credentialSubject.id` = the community
+/// (`vtc_did`). The message is packed authcrypt and forwarded via the persona's
+/// mediator; the VTC reads the member from the envelope and verifies the VC's own
+/// issuer proof. Returns the DIDComm message id (the thread root the VTC's
+/// `#response` receipt references).
+pub async fn submit_member_vmc(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    member_did: &str,
+    vtc_did: &str,
+    mediator_did: &str,
+    vc: Value,
+) -> Result<Uuid, OpenVTCError> {
+    let body = serde_json::to_value(MemberVmcBody { vc })
+        .map_err(|e| OpenVTCError::Config(format!("member vmc body serialize: {e}")))?;
+
+    let msg_id = Uuid::new_v4();
+    let now = Utc::now().timestamp().max(0) as u64;
+    let msg = Message::build(msg_id.to_string(), MEMBER_VMC_TYPE.to_string(), body)
+        .from(member_did.to_string())
+        .to(vtc_did.to_string())
+        .created_time(now)
+        .finalize();
+
+    crate::pack_and_send(atm, profile, &msg, member_did, vtc_did, mediator_did).await?;
+    Ok(msg_id)
+}

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -257,6 +257,11 @@ pub enum Action {
     /// selection (or mint).
     JoinInvitationChoose,
 
+    /// Issue this Active membership's reciprocal VMC (member → community) and
+    /// send it to the community's VTC over DIDComm (`members/vmc/1.0`). Indexed
+    /// into the Communities display list.
+    IssueMemberVmc(usize),
+
     /// Cancel the join flow and return to the main page.
     JoinCancel,
 

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -35,6 +35,7 @@ use vta_sdk::protocols::join_requests::{
     JOIN_REQUEST_STATUS_RESPONSE_TYPE, JOIN_REQUEST_SUBMIT_RECEIPT_TYPE,
     JOIN_REQUEST_SUBMIT_RESPONSE_TYPE,
 };
+use vta_sdk::protocols::members::{MEMBER_REQUEST_VMC_TYPE, MEMBER_VMC_RESPONSE_TYPE};
 
 /// Maximum allowed message body size in bytes (1 MB).
 const MAX_MESSAGE_BODY_SIZE: usize = 1_048_576;
@@ -199,6 +200,24 @@ pub async fn process_inbound_message(
             inactivated.push((from_did.to_string(), persona));
         }
         return Ok(outcome.changed);
+    }
+
+    // VTC member-VMC receipt (`members/vmc/1.0#response`): the VTC acknowledging
+    // the reciprocal VMC we sent. Informational — log and move on.
+    if message.typ == MEMBER_VMC_RESPONSE_TYPE {
+        info!(vtc = %from_did, "VTC acknowledged our membership credential (member VMC receipt)");
+        return Ok(false);
+    }
+
+    // VTC → member: "please issue + send your VMC" (`members/request-vmc/1.0`).
+    // Surfaced so it isn't dropped as unknown; the member answers with the
+    // `m` action on the community (auto-answer is a follow-up).
+    if message.typ == MEMBER_REQUEST_VMC_TYPE {
+        info!(
+            vtc = %from_did,
+            "community requested our membership credential — issue it from the community row ('m')"
+        );
+        return Ok(false);
     }
 
     let msg_type = match MessageType::try_from(message) {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -861,6 +861,96 @@ impl StateHandler {
                             }
                         }
                     },
+                    Action::IssueMemberVmc(i) => {
+                        // Issue this membership's reciprocal VMC (member -> community)
+                        // and send it to the VTC over DIDComm (members/vmc/1.0). The
+                        // VMC's issuer is the membership's persona, its subject is the
+                        // community VTC DID; it's signed with that persona's key.
+                        use openvtc_core::errors::OpenVTCError;
+                        let target = config
+                            .account
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
+                            .get(i)
+                            .filter(|c| c.status.is_active())
+                            .map(|c| (c.vtc_did.clone(), c.persona_ref));
+                        if let Some((vtc, persona_id)) = target {
+                            let member_did = config
+                                .identities
+                                .get(&persona_id)
+                                .map(|id| id.persona_did().to_string());
+                            let send: Result<(), OpenVTCError> = match (member_did, tdk.atm.as_ref()) {
+                                (Some(member_did), Some(atm)) => {
+                                    let mut vmc = dtg_credentials::DTGCredential::new_vmc(
+                                        member_did.clone(),
+                                        vtc.clone(),
+                                        chrono::Utc::now(),
+                                        None,
+                                        false,
+                                    );
+                                    match config.get_persona_keys_for(persona_id, &tdk).await {
+                                        Ok(keys) => match vmc.sign(&keys.signing.secret, None).await {
+                                            Ok(_) => {
+                                                let vc = serde_json::to_value(&vmc).map_err(|e| {
+                                                    OpenVTCError::Config(format!(
+                                                        "serialize member VMC: {e}"
+                                                    ))
+                                                });
+                                                let routing = config.identities.get(&persona_id).map(
+                                                    |id| {
+                                                        (
+                                                            id.profile().clone(),
+                                                            id.mediator_did.clone().unwrap_or_default(),
+                                                        )
+                                                    },
+                                                );
+                                                match (vc, routing) {
+                                                    (Ok(vc), Some((profile, mediator))) => {
+                                                        openvtc_core::members::submit_member_vmc(
+                                                            atm,
+                                                            &profile,
+                                                            &member_did,
+                                                            &vtc,
+                                                            &mediator,
+                                                            vc,
+                                                        )
+                                                        .await
+                                                        .map(|_| ())
+                                                    }
+                                                    (Err(e), _) => Err(e),
+                                                    (_, None) => Err(OpenVTCError::Config(
+                                                        "Persona runtime identity unavailable.".into(),
+                                                    )),
+                                                }
+                                            }
+                                            Err(e) => Err(OpenVTCError::Config(format!(
+                                                "sign member VMC: {e}"
+                                            ))),
+                                        },
+                                        Err(e) => Err(e),
+                                    }
+                                }
+                                _ => Err(OpenVTCError::Config(
+                                    "Messaging/identity unavailable — cannot issue the membership credential."
+                                        .into(),
+                                )),
+                            };
+                            match send {
+                                Ok(()) => {
+                                    state.main_page.content_panel.communities.status_message = Some(
+                                        "Membership credential issued and sent to the community."
+                                            .to_string(),
+                                    );
+                                }
+                                Err(e) => {
+                                    state
+                                        .main_page
+                                        .log_error("Issue membership credential failed", &e);
+                                    state.main_page.content_panel.communities.status_message =
+                                        Some(format!("Couldn't issue the membership credential: {e}"));
+                                }
+                            }
+                        }
+                    },
                     Action::WithdrawJoin(i) => {
                         // Cancel a Pending join: best-effort notify the VTC, set
                         // the record `Withdrawn`, and tear down its now-dead

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -207,8 +207,8 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         };
         lines.push(
             Line::from(format!(
-                "↑/↓ navigate   ⏎ open   f: ★   a: acknowledge   l: leave   \
-                 c: cancel   x: archive   d: delete   j: join   {archived_hint}"
+                "↑/↓ navigate   ⏎ open   f: ★   a: acknowledge   m: issue VMC   \
+                 l: leave   c: cancel   x: archive   d: delete   j: join   {archived_hint}"
             ))
             .fg(COLOR_DARK_GRAY),
         );

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -596,6 +596,12 @@ impl MainPage {
                 let _ = self.action_tx.send(Action::CommunityConfirmLeave(selected));
                 true
             }
+            KeyCode::Char('m') if sel_active => {
+                // Issue this membership's reciprocal VMC back to the community and
+                // send it to the VTC (members/vmc/1.0). Active-only.
+                let _ = self.action_tx.send(Action::IssueMemberVmc(selected));
+                true
+            }
             // Cancel is pending-only: a Pending join can be withdrawn (arming on
             // any other state would only fail downstream, so it's gated).
             KeyCode::Char('c') if sel_pending => {
@@ -2546,6 +2552,13 @@ mod key_handler_tests {
         match rx.try_recv() {
             Ok(Action::CommunityConfirmLeave(0)) => {}
             _ => panic!("expected CommunityConfirmLeave(0)"),
+        }
+        // Active row: `m` issues this membership's reciprocal VMC to the community.
+        let (mut page, mut rx) = active();
+        page.handle_key_event(press(KeyCode::Char('m')));
+        match rx.try_recv() {
+            Ok(Action::IssueMemberVmc(0)) => {}
+            _ => panic!("expected IssueMemberVmc(0)"),
         }
         // Active row: `c` (cancel pending join) does nothing.
         let (mut page, mut rx) = active();


### PR DESCRIPTION
## Why

Membership between a persona and a VTC is a **pair of VMCs** — the VTC issues one to the member at admission (community → member, already handled), and the member issues one back (member → community). The VTC side just landed upstream:
- `verifiable-trust-infrastructure#549` — `members/*` protocol (vta-sdk **0.18.2**) + the VTC's inbound handler.
- `#553`/`#554` — the verifier now accepts the **DTG-canonical `MembershipCredential`** tag, so a standard `dtg-credentials` VMC verifies (no library fork, our inbound path unaffected).

This adds the **member half**: a Communities action to issue the reciprocal VMC and send it to the VTC.

## What

- **vta-sdk 0.18.1 → 0.18.2** (additive; brings `protocols::members`).
- **`openvtc-core::members::submit_member_vmc`** — wraps the signed VMC in `MemberVmcBody` and sends `members/vmc/1.0` to the VTC over DIDComm (mirrors `submit_self_remove`).
- **`Config::get_persona_keys_for(persona_id, tdk)`** — resolve a *specific* persona's keys, since the action targets a community row whose persona may not be the active/working identity (multi-membership).
- **`m` on an Active community row → `Action::IssueMemberVmc`**: builds `DTGCredential::new_vmc(issuer = the membership's persona, subject = the VTC DID)`, signs with that persona's key, and sends it. The VMC's `credentialSubject.id` is the community (the direction the VTC verifies).
- **message_dispatch** recognizes the VTC's receipt (`members/vmc/1.0#response`) and its request (`members/request-vmc/1.0`) — logged rather than dropped as "unknown type".
- Panel key hint (`m: issue VMC`) + a key-routing test.

## Scope / follow-up

- **Auto-answering** an inbound `members/request-vmc/1.0` (the VTC admin's "Request member VMC" button) is logged with a hint to press `m`; auto-issue-on-request is a deliberate follow-up (it needs an async issue+send from the dispatch path).
- The send is the explicit ask; receipt is informational (the VTC stores the VMC and surfaces it in its admin UI).

## Testing

`cargo build`, `cargo clippy --all-targets` clean; full suite green; new key-routing test (`m` on an Active row → `IssueMemberVmc`).
