### PR TITLE
feat(community): auto-answer a VTC members/request-vmc with our VMC

### DIFF
--- a/openvtc-core/src/members.rs
+++ b/openvtc-core/src/members.rs
@@ -16,13 +16,47 @@ use std::sync::Arc;
 use affinidi_tdk::{
     didcomm::Message,
     messaging::{ATM, profiles::ATMProfile},
+    secrets_resolver::secrets::Secret,
 };
 use chrono::Utc;
+use dtg_credentials::DTGCredential;
 use serde_json::Value;
 use uuid::Uuid;
 use vta_sdk::protocols::members::{MEMBER_VMC_TYPE, MemberVmcBody};
 
 use crate::errors::OpenVTCError;
+
+/// Build + sign the reciprocal member VMC and send it to the community's VTC
+/// (`members/vmc/1.0`), end to end. The VMC's `issuer` is the member persona
+/// (`member_did`) and its `credentialSubject.id` is the community (`vtc_did`) —
+/// the direction the VTC verifies. `signing_secret` is the member persona's
+/// signing key (its `id` is the persona's assertionMethod VM, which becomes the
+/// proof's `verificationMethod`). Used by both the manual "issue VMC" action and
+/// the auto-answer to a VTC `members/request-vmc/1.0`.
+///
+/// Returns the DIDComm message id (the receipt's thread root).
+pub async fn issue_and_send_member_vmc(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    signing_secret: &Secret,
+    member_did: &str,
+    vtc_did: &str,
+    mediator_did: &str,
+) -> Result<Uuid, OpenVTCError> {
+    let mut vmc = DTGCredential::new_vmc(
+        member_did.to_string(),
+        vtc_did.to_string(),
+        Utc::now(),
+        None,
+        false,
+    );
+    vmc.sign(signing_secret, None)
+        .await
+        .map_err(|e| OpenVTCError::Config(format!("sign member VMC: {e}")))?;
+    let vc = serde_json::to_value(&vmc)
+        .map_err(|e| OpenVTCError::Config(format!("serialize member VMC: {e}")))?;
+    submit_member_vmc(atm, profile, member_did, vtc_did, mediator_did, vc).await
+}
 
 /// Send a member-issued VMC to the community's VTC over DIDComm
 /// (`members/vmc/1.0`). `vc` is the **signed** membership credential — `issuer`

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -43,6 +43,40 @@ const MAX_MESSAGE_BODY_SIZE: usize = 1_048_576;
 /// Maximum number of relationships allowed before rejecting new requests.
 const MAX_RELATIONSHIPS: usize = 5_000;
 
+/// Build, sign, and send the reciprocal member VMC for `(vtc_did, persona_id)` —
+/// resolving that persona's runtime identity (DID / profile / mediator) and
+/// signing key from `config`. Shared by the manual "issue VMC" action and the
+/// auto-answer to a VTC `members/request-vmc/1.0`. Returns the DIDComm message id.
+pub(crate) async fn issue_member_vmc_for(
+    config: &Config,
+    tdk: &TDK,
+    vtc_did: &str,
+    persona_id: openvtc_core::config::account::PersonaId,
+) -> Result<uuid::Uuid, openvtc_core::errors::OpenVTCError> {
+    use openvtc_core::errors::OpenVTCError;
+    let id = config
+        .identities
+        .get(&persona_id)
+        .ok_or_else(|| OpenVTCError::Config("persona identity unavailable".into()))?;
+    let member_did = id.persona_did().to_string();
+    let profile = id.profile().clone();
+    let mediator = id.mediator_did.clone().unwrap_or_default();
+    let atm = tdk
+        .atm
+        .as_ref()
+        .ok_or_else(|| OpenVTCError::Config("messaging (ATM) unavailable".into()))?;
+    let keys = config.get_persona_keys_for(persona_id, tdk).await?;
+    openvtc_core::members::issue_and_send_member_vmc(
+        atm,
+        &profile,
+        &keys.signing.secret,
+        &member_did,
+        vtc_did,
+        &mediator,
+    )
+    .await
+}
+
 /// Process an inbound DIDComm message.
 ///
 /// Auto-processes messages that don't need human input (pong, accept, finalize, reject).
@@ -210,13 +244,35 @@ pub async fn process_inbound_message(
     }
 
     // VTC → member: "please issue + send your VMC" (`members/request-vmc/1.0`).
-    // Surfaced so it isn't dropped as unknown; the member answers with the
-    // `m` action on the community (auto-answer is a follow-up).
+    // Auto-answer: the sender is the community VTC and the recipient is one of our
+    // personas; if we hold an Active membership there, issue + send our reciprocal
+    // VMC straight back. Best-effort — a failure is logged, not surfaced as a stuck
+    // state (the admin can re-request, or the member can issue manually with `m`).
     if message.typ == MEMBER_REQUEST_VMC_TYPE {
-        info!(
-            vtc = %from_did,
-            "community requested our membership credential — issue it from the community row ('m')"
-        );
+        match recipient_persona {
+            Some(persona_id)
+                if config
+                    .account
+                    .membership(&from_did, persona_id)
+                    .is_some_and(|c| c.status.is_active()) =>
+            {
+                match issue_member_vmc_for(config, tdk, &from_did, persona_id).await {
+                    Ok(_) => info!(
+                        vtc = %from_did,
+                        "auto-issued our membership credential in response to the VTC's request"
+                    ),
+                    Err(e) => warn!(
+                        vtc = %from_did,
+                        error = %e,
+                        "failed to auto-issue our membership credential on request"
+                    ),
+                }
+            }
+            _ => warn!(
+                vtc = %from_did,
+                "members/request-vmc with no matching Active membership — ignoring"
+            ),
+        }
         return Ok(false);
     }
 

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -863,10 +863,7 @@ impl StateHandler {
                     },
                     Action::IssueMemberVmc(i) => {
                         // Issue this membership's reciprocal VMC (member -> community)
-                        // and send it to the VTC over DIDComm (members/vmc/1.0). The
-                        // VMC's issuer is the membership's persona, its subject is the
-                        // community VTC DID; it's signed with that persona's key.
-                        use openvtc_core::errors::OpenVTCError;
+                        // and send it to the VTC over DIDComm (members/vmc/1.0).
                         let target = config
                             .account
                             .communities_for_display(state.main_page.content_panel.communities.show_archived)
@@ -874,68 +871,10 @@ impl StateHandler {
                             .filter(|c| c.status.is_active())
                             .map(|c| (c.vtc_did.clone(), c.persona_ref));
                         if let Some((vtc, persona_id)) = target {
-                            let member_did = config
-                                .identities
-                                .get(&persona_id)
-                                .map(|id| id.persona_did().to_string());
-                            let send: Result<(), OpenVTCError> = match (member_did, tdk.atm.as_ref()) {
-                                (Some(member_did), Some(atm)) => {
-                                    let mut vmc = dtg_credentials::DTGCredential::new_vmc(
-                                        member_did.clone(),
-                                        vtc.clone(),
-                                        chrono::Utc::now(),
-                                        None,
-                                        false,
-                                    );
-                                    match config.get_persona_keys_for(persona_id, &tdk).await {
-                                        Ok(keys) => match vmc.sign(&keys.signing.secret, None).await {
-                                            Ok(_) => {
-                                                let vc = serde_json::to_value(&vmc).map_err(|e| {
-                                                    OpenVTCError::Config(format!(
-                                                        "serialize member VMC: {e}"
-                                                    ))
-                                                });
-                                                let routing = config.identities.get(&persona_id).map(
-                                                    |id| {
-                                                        (
-                                                            id.profile().clone(),
-                                                            id.mediator_did.clone().unwrap_or_default(),
-                                                        )
-                                                    },
-                                                );
-                                                match (vc, routing) {
-                                                    (Ok(vc), Some((profile, mediator))) => {
-                                                        openvtc_core::members::submit_member_vmc(
-                                                            atm,
-                                                            &profile,
-                                                            &member_did,
-                                                            &vtc,
-                                                            &mediator,
-                                                            vc,
-                                                        )
-                                                        .await
-                                                        .map(|_| ())
-                                                    }
-                                                    (Err(e), _) => Err(e),
-                                                    (_, None) => Err(OpenVTCError::Config(
-                                                        "Persona runtime identity unavailable.".into(),
-                                                    )),
-                                                }
-                                            }
-                                            Err(e) => Err(OpenVTCError::Config(format!(
-                                                "sign member VMC: {e}"
-                                            ))),
-                                        },
-                                        Err(e) => Err(e),
-                                    }
-                                }
-                                _ => Err(OpenVTCError::Config(
-                                    "Messaging/identity unavailable — cannot issue the membership credential."
-                                        .into(),
-                                )),
-                            };
-                            match send {
-                                Ok(()) => {
+                            match message_dispatch::issue_member_vmc_for(&config, &tdk, &vtc, persona_id)
+                                .await
+                            {
+                                Ok(_) => {
                                     state.main_page.content_panel.communities.status_message = Some(
                                         "Membership credential issued and sent to the community."
                                             .to_string(),


### PR DESCRIPTION
## Why

Follow-up to #147. The VTC can now *request* the member's reciprocal VMC (`members/request-vmc/1.0` — e.g. the admin UI's "Request member VMC" button). #147 only logged a hint to press `m`; this auto-issues and sends it back.

## What

- **openvtc-core**: `members::issue_and_send_member_vmc` — build `new_vmc(issuer = persona, subject = VTC)` + sign + send, in one place.
- **message_dispatch**: `issue_member_vmc_for(config, tdk, vtc, persona)` resolves the persona's runtime identity + signing key and calls it. The manual `Action::IssueMemberVmc` now reuses this helper (de-duplicates the inline build/sign/send from #147).
- The inbound `members/request-vmc/1.0` branch resolves the recipient persona; if we hold an **Active** membership with that `(community, persona)`, it issues + sends the VMC straight back. Best-effort — a failure is logged, never a stuck state (the admin can re-request, or the member issues manually with `m`).

## Notes

- Correlation uses the message recipient (our persona DID) + sender (the VTC), so with multiple memberships the right persona's VMC is sent.
- We don't persist our own issued VMC locally (the VTC stores it + surfaces it in its admin UI); no config change.

## Testing

`cargo build`, `cargo clippy --all-targets` clean; full suite green.