### PR TITLE
fix(relationships): repair R-DID key_info ids to stop mediator auth loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-common"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18abdd07cabd1f40beaecabc506e2b678395d7545e05c0ebe2ab8fc82a0cd9b7"
+checksum = "5f36c0ae3c4991f7d059358e2d9a637c826110df3c72d4ce8caf20204ed55647"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-didcomm-service"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aefecceb14df23f6577a5f035fd747488066c0d40b5d4db159b5ea073f0d47cf"
+checksum = "dd18ea796887a95e6f3719a6de2e5971880978024c85418610e220884f9a343a"
 dependencies = [
  "affinidi-messaging-didcomm",
  "affinidi-messaging-sdk",
@@ -298,14 +298,15 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.16.3"
+version = "0.16.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bf9a9bb2346c6cd28ee0a3519753825a8ff92258084b951356852f64cd372b"
+checksum = "bf291ddc972151cfd3edff54c72bb10846543e82c4982a2e704ce12b125d9509"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -358,6 +359,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "trust-tasks-rs",
  "url",
  "uuid",
  "vta-sdk 0.16.1",
@@ -365,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.15"
+version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de97156c77842ec60f2a3156da1a8aa2a05ef214b12e796c7989eb369b9b5371"
+checksum = "c03122eaf3023dab93a876df19468d37b09e055c3e8692cbdda3e468a366c88f"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.12",
@@ -415,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.12"
+version = "0.18.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2022cd5c4baa0ed5f872f3febd8c9cb7fe7fd92330f0c758d5cf05de6c46368"
+checksum = "9ceee57cd19a86e57d319ff19f05f807119287391f834c5b822b4030ac8c7aeb"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -442,14 +444,15 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "trust-tasks-rs",
  "uuid",
 ]
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.12"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737aac41d73b6651218c664ff9ce530f3849e2dead9e04cd3efdfae389c7b895"
+checksum = "6dd001f23b575438669dc9a47af7cd226922c02a74918ec78fd3c9c17af6547d"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -832,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apple-native-keyring-store"
@@ -928,9 +931,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "asn1-rs"
@@ -1245,9 +1248,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "hex-conservative",
 ]
@@ -1296,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -1455,9 +1458,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "byteview"
@@ -1540,9 +1543,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1593,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -2497,7 +2500,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.14",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -2551,7 +2554,7 @@ dependencies = [
  "async-trait",
  "base58",
  "chrono",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "percent-encoding",
  "reqwest 0.13.4",
  "serde",
@@ -3308,17 +3311,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -3518,7 +3519,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec 0.7.7",
 ]
 
 [[package]]
@@ -3909,12 +3910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idea"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4454,12 +4449,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "left-right"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4684,9 +4673,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom"
@@ -5109,7 +5098,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec 0.7.7",
  "itoa",
 ]
 
@@ -5463,7 +5452,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.14",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5514,7 +5503,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.14",
  "vta-service",
  "x25519-dalek",
  "zeroize",
@@ -6070,16 +6059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6178,9 +6157,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.23"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3db184a8b66cfe87f0263a1de147a6b554c864d1767c6f7fa4eb0e5497b565"
+checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -6188,9 +6167,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -6208,9 +6187,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6244,9 +6223,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -6296,8 +6275,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -6380,14 +6359,15 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
  "serde",
@@ -6395,15 +6375,14 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.0",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "indoc",
  "itertools 0.14.0",
  "kasuari",
  "lru",
@@ -6418,9 +6397,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -6430,19 +6409,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
-version = "0.1.1"
+name = "ratatui-termina"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -6450,9 +6440,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",
@@ -6523,9 +6513,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fd510128eda94d1d49b9f81487744d5c451422431cce41238fe2853d29f4cc"
+checksum = "bae41a63fd0b8a5372f82b21e810e09a316f5dd7efd96bf08e678fb240fc1918"
 dependencies = [
  "ahash 0.8.12",
  "arc-swap",
@@ -6822,9 +6812,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7985,9 +7975,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
 dependencies = [
  "libc",
  "memchr",
@@ -8059,9 +8049,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
  "windows-sys 0.61.2",
 ]
 
@@ -8193,9 +8196,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "libc",
@@ -8215,9 +8218,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8629,9 +8632,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.4"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a85927618441eae15a2ef20da38cc939c940bc05ac6089b2f0e32de54b3ab82"
+checksum = "ccbddb304248cc6cb1e2e6385bd2f7042df71c805d9e128d6cb40125322a9274"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8871,12 +8874,12 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "rand 0.10.1",
  "serde_core",
@@ -8909,9 +8912,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af94a523177532ee4fde73fa7c79f2373a516dcd74cb739c05626168439e4393"
+checksum = "0afc206662c93bf777d74299aeed1f6197af9ec904fd6e864e610ab132d33a53"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -8928,7 +8931,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.14",
  "vti-common",
  "x25519-dalek",
 ]
@@ -8950,7 +8953,7 @@ dependencies = [
  "curve25519-dalek",
  "didwebvh-rs",
  "ed25519-dalek",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "multibase",
  "reqwest 0.13.4",
  "serde",
@@ -8965,9 +8968,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.18.2"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3a736a39a3d285dc729b7fb347c95d3567697c4f74b72c178c3c54460d4cfe"
+checksum = "2bab5ab7ffa4362d8362ef3f9767e965395d54c9f7e0512071231aeb7db6656b"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8984,7 +8987,7 @@ dependencies = [
  "curve25519-dalek",
  "didwebvh-rs",
  "ed25519-dalek",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hpke",
  "multibase",
  "reqwest 0.13.4",
@@ -9005,9 +9008,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.10.1"
+version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e52e43ff5a4cc7ad8b494ddfcfcec34586a4a89ed42f3c40b46e55d62af12a"
+checksum = "fa23fc7a3ffdc66a059fe2debd06eb9e644742340612b49cfb09b58689e07c3a"
 dependencies = [
  "aes-gcm",
  "affinidi-crypto",
@@ -9072,7 +9075,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.14",
  "vti-common",
  "vti-secrets",
  "vti-webauthn",
@@ -9084,9 +9087,9 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1606f67812497ee90e40fc12975ade36a7ae1c7b7fb3f473337b8eb38c185c5f"
+checksum = "890bb2cdd8c36729f267e9abcceaf47b58e0252c8f9fa9b997392d769fde625e"
 dependencies = [
  "aes-gcm",
  "affinidi-did-resolver-cache-sdk",
@@ -9116,7 +9119,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.18.2",
+ "vta-sdk 0.18.14",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9194,23 +9197,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9221,9 +9215,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9231,9 +9225,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9241,9 +9235,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9254,45 +9248,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -9322,9 +9282,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.13.0",
  "wayland-backend",
@@ -9377,9 +9337,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9958,97 +9918,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.118",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -10274,9 +10146,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -77,7 +77,7 @@ impl Config {
 
         report_progress(&on_progress, "Local configuration", "Decrypting secrets");
 
-        let sc = SecuredConfig::load(
+        let mut sc = SecuredConfig::load(
             profile,
             #[cfg(feature = "openpgp-card")]
             token_user_pin,
@@ -148,7 +148,7 @@ impl Config {
         };
 
         // Unencrypt the private config data, with migration from legacy seed
-        let (private_cfg, needs_migration) = if let Some(private_cfg_str) = &public_config.private {
+        let (mut private_cfg, needs_migration) = if let Some(private_cfg_str) = &public_config.private {
             match ProtectedConfig::load(&encryption_seed, private_cfg_str) {
                 Ok(cfg) => (cfg, false),
                 Err(_) => {
@@ -396,6 +396,29 @@ impl Config {
                     .iter()
                     .map(|(_, did, _, _)| did.to_string())
                     .collect();
+
+                // Repair relationship (R-DID) `key_info` entries that older
+                // builds persisted under pre-`did:peer`-mint placeholder ids,
+                // BEFORE registering profiles below (which key off the canonical
+                // `{r_did}#key-N` ids). Offline + idempotent; like the
+                // seed-derivation migration above, the rewritten `key_info` is
+                // persisted on the next save rather than forced here.
+                let repair = private_cfg
+                    .relationships
+                    .repair_key_info_ids(tdk, &our_p_dids, &mut sc.key_info, &key_backend)
+                    .await;
+                if repair.changed() {
+                    info!(
+                        repaired = repair.repaired,
+                        unrecoverable = repair.unrecoverable.len(),
+                        "repaired relationship key ids; config will be rewritten on next save"
+                    );
+                    for r_did in &repair.unrecoverable {
+                        warn!(r_did = %r_did,
+                            "relationship has unrecoverable keys and must be re-established");
+                    }
+                }
+
                 private_cfg
                     .relationships
                     .generate_profiles(
@@ -531,6 +554,7 @@ mod tests {
                 created: chrono::Utc::now(),
                 state: RelationshipState::Established,
                 our_persona: None,
+                needs_reestablishment: false,
             },
         );
 

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -1587,6 +1587,7 @@ mod tests {
             created: Utc::now(),
             state,
             our_persona: None,
+            needs_reestablishment: false,
         }
     }
 

--- a/openvtc-core/src/relationships.rs
+++ b/openvtc-core/src/relationships.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use affinidi_tdk::{
     TDK,
+    did_common::{document::DocumentExt, verification_method::VerificationMethod},
     didcomm::Message,
     messaging::{ATM, profiles::ATMProfile},
     secrets_resolver::{SecretsResolver, secrets::Secret},
@@ -117,6 +118,108 @@ pub struct Relationship {
     /// `None` so older configs round-trip byte-identically (R20 invariant).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub our_persona: Option<PersonaId>,
+
+    /// Set by [`Relationships::repair_key_info_ids`] when this relationship's
+    /// R-DID secrets were lost to an older build's key-id bug and could not be
+    /// recovered. Such a relationship cannot send or receive: its messaging
+    /// profile is skipped (so it does not loop on mediator auth) and the UI
+    /// shows a "needs re-establishment" badge prompting the user to re-create
+    /// it. Re-establishing replaces the entry with a fresh one (flag false).
+    /// Defaults to false and is omitted from serialization when false, so
+    /// unaffected configs round-trip byte-identically (R20 invariant).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub needs_reestablishment: bool,
+}
+
+/// serde `skip_serializing_if` predicate: omit a `bool` field when it is false.
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// Outcome of [`Relationships::repair_key_info_ids`].
+#[derive(Debug, Default)]
+pub struct KeyInfoRepairReport {
+    /// Number of `key_info` entries re-keyed to their canonical `{r_did}#key-N`
+    /// ids. Non-zero means `key_info` changed and the config should be re-saved.
+    pub repaired: usize,
+    /// R-DIDs whose relationship keys could not be recovered. Their messaging
+    /// profiles are skipped (no auth loop); the relationships must be
+    /// re-established.
+    pub unrecoverable: Vec<Arc<String>>,
+}
+
+impl KeyInfoRepairReport {
+    /// Whether the pass changed anything worth persisting / reporting.
+    pub fn changed(&self) -> bool {
+        self.repaired > 0 || !self.unrecoverable.is_empty()
+    }
+}
+
+/// Locate the source material for one R-DID verification method, returning
+/// `(existing_key_info_id_to_replace, source, create_time)` or `None` if the key
+/// cannot be recovered offline. Strategy, in order:
+///
+/// 1. **Multibase-keyed entry (VTA path):** the stored `key_info` id is the
+///    public-key multibase, which equals the VM's `publicKeyMultibase` — a
+///    direct map lookup that also preserves the entry's `VtaManaged` key id.
+/// 2. **Reconstruct + byte-match:** re-derive each stored BIP32 `Derived` path
+///    (or rebuild each `Imported` seed) and compare raw public-key bytes.
+/// 3. **BIP32 rescan:** keys lost to the `"x25519"` collision have no surviving
+///    entry, so rescan derivation paths `m/3'/1'/1'/{i}'` up to `path_pointer`
+///    and mint a fresh `Derived` source on a byte match.
+fn find_key_source(
+    vm: &VerificationMethod,
+    target_bytes: &[u8],
+    kp: KeyPurpose,
+    key_info: &HashMap<String, KeyInfoConfig>,
+    key_backend: &KeyBackend,
+    path_pointer: u32,
+) -> Option<(Option<String>, KeySourceMaterial, DateTime<Utc>)> {
+    // (1) The VM's publicKeyMultibase doubles as the old VTA-style key_info id.
+    if let Some(mb) = vm
+        .property_set
+        .get("publicKeyMultibase")
+        .and_then(|v| v.as_str())
+        && let Some(ki) = key_info.get(mb)
+    {
+        return Some((Some(mb.to_string()), ki.path.clone(), ki.create_time));
+    }
+
+    // (2) Reconstruct each candidate entry's public key and match bytes.
+    for (id, ki) in key_info.iter() {
+        let bytes = match &ki.path {
+            KeySourceMaterial::Derived { path } => match key_backend {
+                KeyBackend::Bip32 { root, .. } => root
+                    .get_secret_from_path(path, kp)
+                    .ok()
+                    .map(|s| s.get_public_bytes().to_vec()),
+                _ => None,
+            },
+            KeySourceMaterial::Imported { seed } => Secret::from_multibase(seed.expose_secret(), None)
+                .ok()
+                .map(|s| s.get_public_bytes().to_vec()),
+            // VTA-managed secrets aren't reconstructable offline; the (1) path
+            // handles them via their multibase id.
+            KeySourceMaterial::VtaManaged { .. } => None,
+        };
+        if bytes.as_deref() == Some(target_bytes) {
+            return Some((Some(id.clone()), ki.path.clone(), ki.create_time));
+        }
+    }
+
+    // (3) BIP32 rescan for keys with no surviving entry (collision casualties).
+    if let KeyBackend::Bip32 { root, .. } = key_backend {
+        for i in 0..path_pointer {
+            let path = format!("m/3'/1'/1'/{i}'");
+            if let Ok(s) = root.get_secret_from_path(&path, kp)
+                && s.get_public_bytes() == target_bytes
+            {
+                return Some((None, KeySourceMaterial::Derived { path }, Utc::now()));
+            }
+        }
+    }
+
+    None
 }
 
 impl From<RelationshipsShadow> for Relationships {
@@ -229,6 +332,11 @@ impl Relationships {
                             | RelationshipState::RequestSent
                             | RelationshipState::RequestAccepted
                     ) && !our_p_dids.contains(rel.our_did.as_str())
+                        // Skip relationships whose R-DID keys were lost (flagged
+                        // by `repair_key_info_ids`): registering a profile here is
+                        // what caused the mediator-auth loop. They await
+                        // re-establishment.
+                        && !rel.needs_reestablishment
                     {
                         Some(rel.our_did.clone())
                     } else {
@@ -249,6 +357,28 @@ impl Relationships {
             let mut vta_fetches: Vec<PendingVtaFetch> = Vec::new();
 
             for our_did in &r_did_entries {
+                // Skip any R-DID that has no canonical key-agreement (encryption)
+                // entry in `key_info`. Registering a messaging profile for such a
+                // DID is exactly what produced the historical mediator-auth loop:
+                // packing the authentication message as the R-DID fails forever
+                // with "sender has no usable key agreement key". This is the
+                // unrecoverable set left by `repair_key_info_ids` (keys lost to an
+                // older build's id bug); flag it for the user to re-establish
+                // rather than spin. Recoverable R-DIDs were re-keyed to
+                // `{r_did}#key-2` by the repair pass and pass this check.
+                let has_key_agreement = key_info.iter().any(|(k, v)| {
+                    k.starts_with(our_did.as_str())
+                        && matches!(v.purpose, KeyTypes::RelationshipEncryption)
+                });
+                if !has_key_agreement {
+                    warn!(
+                        r_did = %our_did,
+                        "relationship R-DID has no usable key-agreement key; skipping its \
+                         messaging profile — this relationship must be re-established"
+                    );
+                    continue;
+                }
+
                 // Create ATM profile (no network — just registration)
                 let profile =
                     ATMProfile::new(&atm, None, our_did.to_string(), Some(mediator.to_string()))
@@ -346,6 +476,136 @@ impl Relationships {
         profiles_result?;
 
         Ok(profiles)
+    }
+
+    /// One-time, offline, idempotent repair of relationship-DID (R-DID)
+    /// `key_info` entries whose ids were persisted *before* the `did:peer` mint
+    /// by older builds (the `create_io` id-ordering bug). Such entries are keyed
+    /// by a placeholder id — a random base58 string for the Ed25519 verification
+    /// key and the constant `"x25519"` for the X25519 key-agreement key —
+    /// instead of the canonical `{r_did}#key-1` / `#key-2` verification-method
+    /// ids that `Config` key resolution and [`Relationships::generate_profiles`]
+    /// require. Because the encryption id is a constant, multiple relationships'
+    /// encryption entries also collide in the `key_info` map and all but one are
+    /// lost.
+    ///
+    /// For each R-DID relationship not already keyed canonically, this resolves
+    /// the `did:peer` document (self-describing — no network) for the
+    /// authoritative verification-method ids and public keys, locates each key's
+    /// source material — by the stored multibase id (VTA), by re-deriving stored
+    /// BIP32 paths, or, for keys lost to the collision, by rescanning the BIP32
+    /// derivation space — and re-keys it to the canonical id. Relationships whose
+    /// keys cannot be recovered are returned in [`KeyInfoRepairReport::
+    /// unrecoverable`]; `generate_profiles` then skips their profiles (no auth
+    /// loop) and the caller logs them for re-establishment.
+    pub async fn repair_key_info_ids(
+        &mut self,
+        tdk: &TDK,
+        our_p_dids: &HashSet<String>,
+        key_info: &mut HashMap<String, KeyInfoConfig>,
+        key_backend: &KeyBackend,
+    ) -> KeyInfoRepairReport {
+        let mut report = KeyInfoRepairReport::default();
+
+        // Snapshot (remote_p_did, r_did) for every R-DID relationship up front so
+        // the `needs_reestablishment` flag can be set afterwards without a borrow
+        // clash against this read-only pass.
+        let targets: Vec<(Arc<String>, Arc<String>)> = self
+            .relationships
+            .values()
+            .filter(|rel| {
+                matches!(
+                    rel.state,
+                    RelationshipState::Established
+                        | RelationshipState::RequestSent
+                        | RelationshipState::RequestAccepted
+                ) && !our_p_dids.contains(rel.our_did.as_str())
+            })
+            .map(|rel| (rel.remote_p_did.clone(), rel.our_did.clone()))
+            .collect();
+
+        let path_pointer = self.path_pointer;
+        // remote_p_dids to flag once the immutable snapshot above is consumed.
+        let mut to_flag: Vec<Arc<String>> = Vec::new();
+
+        for (remote_p_did, r_did) in targets {
+            // Already canonical (created post-fix or previously repaired): a
+            // cheap string scan keeps the whole pass idempotent.
+            if key_info.keys().any(|k| k.starts_with(r_did.as_str())) {
+                continue;
+            }
+
+            let doc = match tdk.did_resolver().resolve(r_did.as_str()).await {
+                Ok(resp) => resp.doc,
+                Err(e) => {
+                    warn!(r_did = %r_did, error = %e,
+                        "repair: could not resolve R-DID; relationship must be re-established");
+                    report.unrecoverable.push(r_did);
+                    to_flag.push(remote_p_did);
+                    continue;
+                }
+            };
+
+            // Resolve every verification method to (canonical id, purpose,
+            // source material). Bail to "unrecoverable" if any one can't be
+            // located so we never half-register an R-DID.
+            let mut rekeys: Vec<(Option<String>, String, KeyInfoConfig)> = Vec::new();
+            let mut recovered = true;
+            for vm in &doc.verification_method {
+                let Ok(target_bytes) = vm.get_public_key_bytes() else {
+                    continue; // non-Multikey VM; not one of our R-DID keys
+                };
+                let (kp, purpose) = if doc.contains_key_agreement(vm.id.as_str()) {
+                    (KeyPurpose::Encryption, KeyTypes::RelationshipEncryption)
+                } else {
+                    (KeyPurpose::Signing, KeyTypes::RelationshipVerification)
+                };
+                match find_key_source(vm, &target_bytes, kp, key_info, key_backend, path_pointer) {
+                    Some((old_id, source, created)) => rekeys.push((
+                        old_id,
+                        vm.id.as_str().to_string(),
+                        KeyInfoConfig {
+                            path: source,
+                            create_time: created,
+                            purpose,
+                        },
+                    )),
+                    None => {
+                        recovered = false;
+                        break;
+                    }
+                }
+            }
+
+            if !recovered || rekeys.is_empty() {
+                warn!(r_did = %r_did,
+                    "repair: relationship keys could not be recovered; must be re-established");
+                report.unrecoverable.push(r_did);
+                to_flag.push(remote_p_did);
+                continue;
+            }
+
+            for (old_id, new_id, new_ki) in rekeys {
+                if let Some(old) = old_id
+                    && old != new_id
+                {
+                    key_info.remove(&old);
+                }
+                key_info.insert(new_id, new_ki);
+                report.repaired += 1;
+            }
+            debug!(r_did = %r_did, "repair: re-keyed relationship key_info to canonical ids");
+        }
+
+        // Persist the badge: mark unrecoverable relationships so the UI surfaces
+        // them and `generate_profiles` skips their (unusable) messaging profiles.
+        for pdid in to_flag {
+            if let Some(rel) = self.relationships.get_mut(&pdid) {
+                rel.needs_reestablishment = true;
+            }
+        }
+
+        report
     }
 
     /// Removes a relationship by its task ID, along with any associated VRCs.
@@ -588,6 +848,8 @@ pub async fn create_send_message_accepted(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ed25519_dalek_bip32::ExtendedSigningKey;
+    use secrecy::SecretString;
 
     fn make_relationship(
         task_id: &str,
@@ -604,7 +866,233 @@ mod tests {
             created: Utc::now(),
             state,
             our_persona: None,
+            needs_reestablishment: false,
         }
+    }
+
+    // --- R-DID key_info repair (migration) -------------------------------
+
+    async fn empty_tdk() -> TDK {
+        use affinidi_tdk::common::config::TDKConfig;
+        TDK::new(
+            TDKConfig::builder()
+                .with_load_environment(false)
+                .build()
+                .expect("TDK config builds"),
+            None,
+        )
+        .await
+        .expect("TDK builds")
+    }
+
+    /// Mint an R-DID from a BIP32 root exactly as `create_io` does: derive the
+    /// verification (Signing) and key-agreement (Encryption) keys at the given
+    /// paths, then build the `did:peer` (which rewrites the secret ids to
+    /// `#key-1` / `#key-2`). Returns the canonical R-DID string.
+    fn mint_rdid(root: &ExtendedSigningKey, v_path: &str, e_path: &str) -> String {
+        use affinidi_tdk::dids::{DID, PeerKeyRole};
+        let mut v = root
+            .get_secret_from_path(v_path, KeyPurpose::Signing)
+            .expect("v key");
+        let mut e = root
+            .get_secret_from_path(e_path, KeyPurpose::Encryption)
+            .expect("e key");
+        let mut keys = vec![
+            (PeerKeyRole::Verification, &mut v),
+            (PeerKeyRole::Encryption, &mut e),
+        ];
+        DID::generate_did_peer_from_secrets(&mut keys, Some("did:web:mediator.example".to_string()))
+            .expect("did:peer")
+    }
+
+    fn broken_entry(path: &str, purpose: KeyTypes) -> KeyInfoConfig {
+        KeyInfoConfig {
+            path: KeySourceMaterial::Derived {
+                path: path.to_string(),
+            },
+            create_time: Utc::now(),
+            purpose,
+        }
+    }
+
+    #[tokio::test]
+    async fn repair_rekeys_bip32_rdid_keyinfo_to_canonical_ids() {
+        let root = ExtendedSigningKey::from_seed(&[42u8; 32]).expect("root");
+        let key_backend = KeyBackend::Bip32 {
+            root: ExtendedSigningKey::from_seed(&[42u8; 32]).expect("root"),
+            seed: SecretString::new("seed".into()),
+        };
+        let (v_path, e_path) = ("m/3'/1'/1'/0'", "m/3'/1'/1'/1'");
+        let r_did = mint_rdid(&root, v_path, e_path);
+
+        // key_info as an older build persisted it: placeholder ids (a random id
+        // for the Ed25519 key, the constant "x25519" for X25519).
+        let mut key_info = HashMap::new();
+        key_info.insert(
+            "random-v-id".to_string(),
+            broken_entry(v_path, KeyTypes::RelationshipVerification),
+        );
+        key_info.insert(
+            "x25519".to_string(),
+            broken_entry(e_path, KeyTypes::RelationshipEncryption),
+        );
+
+        let mut rels = Relationships {
+            path_pointer: 2,
+            ..Default::default()
+        };
+        rels.relationships.insert(
+            Arc::new("did:remote:p".to_string()),
+            make_relationship(
+                "task-1",
+                &r_did,
+                "did:remote:r",
+                "did:remote:p",
+                RelationshipState::Established,
+            ),
+        );
+
+        let tdk = empty_tdk().await;
+        let report = rels
+            .repair_key_info_ids(&tdk, &HashSet::new(), &mut key_info, &key_backend)
+            .await;
+
+        assert_eq!(report.repaired, 2, "both keys re-keyed");
+        assert!(report.unrecoverable.is_empty());
+        let v_id = format!("{r_did}#key-1");
+        let e_id = format!("{r_did}#key-2");
+        assert!(key_info.contains_key(&v_id), "verification → {v_id}");
+        assert!(key_info.contains_key(&e_id), "key-agreement → {e_id}");
+        assert!(matches!(
+            key_info[&e_id].purpose,
+            KeyTypes::RelationshipEncryption
+        ));
+        assert!(matches!(
+            key_info[&v_id].purpose,
+            KeyTypes::RelationshipVerification
+        ));
+        assert!(!key_info.contains_key("random-v-id"));
+        assert!(!key_info.contains_key("x25519"));
+        assert!(
+            !rels.relationships[&Arc::new("did:remote:p".to_string())].needs_reestablishment,
+            "recovered relationship is not flagged"
+        );
+
+        // Idempotent: re-running changes nothing (entries already canonical).
+        let again = rels
+            .repair_key_info_ids(&tdk, &HashSet::new(), &mut key_info, &key_backend)
+            .await;
+        assert_eq!(again.repaired, 0);
+        assert!(!again.changed());
+    }
+
+    #[tokio::test]
+    async fn repair_recovers_encryption_key_lost_to_x25519_collision() {
+        let root = ExtendedSigningKey::from_seed(&[7u8; 32]).expect("root");
+        let key_backend = KeyBackend::Bip32 {
+            root: ExtendedSigningKey::from_seed(&[7u8; 32]).expect("root"),
+            seed: SecretString::new("seed".into()),
+        };
+        // Two relationships at paths (0,1) and (2,3).
+        let a = mint_rdid(&root, "m/3'/1'/1'/0'", "m/3'/1'/1'/1'");
+        let b = mint_rdid(&root, "m/3'/1'/1'/2'", "m/3'/1'/1'/3'");
+
+        // Both encryption entries were stored under the constant "x25519", so
+        // only the last survives; the other E key has NO entry and must be
+        // recovered by rescanning the derivation space.
+        let mut key_info = HashMap::new();
+        key_info.insert(
+            "rand-a".to_string(),
+            broken_entry("m/3'/1'/1'/0'", KeyTypes::RelationshipVerification),
+        );
+        key_info.insert(
+            "rand-b".to_string(),
+            broken_entry("m/3'/1'/1'/2'", KeyTypes::RelationshipVerification),
+        );
+        key_info.insert(
+            "x25519".to_string(),
+            broken_entry("m/3'/1'/1'/3'", KeyTypes::RelationshipEncryption),
+        );
+
+        let mut rels = Relationships {
+            path_pointer: 4,
+            ..Default::default()
+        };
+        for (i, did) in [&a, &b].into_iter().enumerate() {
+            rels.relationships.insert(
+                Arc::new(format!("did:remote:p{i}")),
+                make_relationship(
+                    &format!("task-{i}"),
+                    did,
+                    "did:remote:r",
+                    &format!("did:remote:p{i}"),
+                    RelationshipState::Established,
+                ),
+            );
+        }
+
+        let tdk = empty_tdk().await;
+        let report = rels
+            .repair_key_info_ids(&tdk, &HashSet::new(), &mut key_info, &key_backend)
+            .await;
+
+        assert!(
+            report.unrecoverable.is_empty(),
+            "rescan recovers the collided key: {:?}",
+            report.unrecoverable
+        );
+        for did in [&a, &b] {
+            assert!(
+                key_info.contains_key(&format!("{did}#key-1")),
+                "{did} verification key present"
+            );
+            assert!(
+                key_info.contains_key(&format!("{did}#key-2")),
+                "{did} key-agreement key present (rescan-recovered if collided)"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn repair_flags_unrecoverable_relationship() {
+        // R-DID minted from a DIFFERENT root than the backend, with no matching
+        // key_info — its keys cannot be reconstructed offline.
+        let foreign = ExtendedSigningKey::from_seed(&[99u8; 32]).expect("foreign root");
+        let r_did = mint_rdid(&foreign, "m/3'/1'/1'/0'", "m/3'/1'/1'/1'");
+        let key_backend = KeyBackend::Bip32 {
+            root: ExtendedSigningKey::from_seed(&[1u8; 32]).expect("local root"),
+            seed: SecretString::new("seed".into()),
+        };
+
+        let mut key_info = HashMap::new();
+        let mut rels = Relationships {
+            path_pointer: 4,
+            ..Default::default()
+        };
+        rels.relationships.insert(
+            Arc::new("did:remote:p".to_string()),
+            make_relationship(
+                "task-1",
+                &r_did,
+                "did:remote:r",
+                "did:remote:p",
+                RelationshipState::Established,
+            ),
+        );
+
+        let tdk = empty_tdk().await;
+        let report = rels
+            .repair_key_info_ids(&tdk, &HashSet::new(), &mut key_info, &key_backend)
+            .await;
+
+        assert_eq!(report.repaired, 0);
+        assert_eq!(report.unrecoverable.len(), 1);
+        assert_eq!(report.unrecoverable[0].as_str(), r_did.as_str());
+        assert!(key_info.is_empty());
+        assert!(
+            rels.relationships[&Arc::new("did:remote:p".to_string())].needs_reestablishment,
+            "unrecoverable relationship is flagged for re-establishment"
+        );
     }
 
     #[test]

--- a/openvtc-core/tests/relationships.rs
+++ b/openvtc-core/tests/relationships.rs
@@ -18,6 +18,7 @@ fn make_relationship(
         created: chrono::Utc::now(),
         state,
         our_persona: None,
+        needs_reestablishment: false,
     }
 }
 

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -424,6 +424,7 @@ impl InboxOutcome {
                                 // persona (`task.our_persona`) always equals the
                                 // active persona — tag and signing persona agree.
                                 our_persona: config.active_persona,
+                                needs_reestablishment: false,
                             },
                         );
                         config.private.tasks.remove(&task_id);

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -578,6 +578,11 @@ pub struct RelationshipSummary {
     pub vrcs_issued: Vec<RelationshipVrc>,
     /// VRCs we received from this party
     pub vrcs_received: Vec<RelationshipVrc>,
+    /// Whether this relationship's R-DID keys were lost and could not be
+    /// recovered at load (see `Relationship::needs_reestablishment`). When set,
+    /// the list shows a "needs re-establishment" badge: the relationship can no
+    /// longer send or receive and must be re-created.
+    pub needs_reestablishment: bool,
 }
 
 /// VRC info for display in the relationship detail view.

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -290,6 +290,7 @@ impl MainPageState {
                     created: rel.created.format("%Y-%m-%d %H:%M").to_string(),
                     vrcs_issued,
                     vrcs_received,
+                    needs_reestablishment: rel.needs_reestablishment,
                 }
             })
             .collect();

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -149,7 +149,14 @@ impl RDidPlan {
         remote_p_did: &str,
     ) -> Result<CreatedRDid> {
         let mediator = self.mediator().to_string();
-        let (mut v_secret, mut e_secret, key_info) = match self {
+        // Mint the keys and capture each one's *source material* (BIP32 path or
+        // VTA key id) in verification-then-encryption order. Note we do NOT record
+        // the secret ids yet: a freshly generated `Secret` carries a placeholder id
+        // (`generate_ed25519` → a random base64 string, `generate_x25519` →
+        // `"x25519"`), and `generate_did_peer_from_secrets` below rewrites those
+        // ids to the did:peer verification-method ids. `key_info` must be built
+        // from the *rewritten* ids — see the comment on that step.
+        let (mut v_secret, mut e_secret, v_source, e_source) = match self {
             RDidPlan::Bip32 {
                 root,
                 v_path,
@@ -167,38 +174,30 @@ impl RDidPlan {
                 // stack; ed25519-dalek-bip32 does not Zeroize, a known limitation.
                 drop(v_key);
                 drop(e_key);
-                let key_info = vec![
-                    (
-                        v_secret.id.clone(),
-                        KeySourceMaterial::Derived { path: v_path },
-                    ),
-                    (
-                        e_secret.id.clone(),
-                        KeySourceMaterial::Derived { path: e_path },
-                    ),
-                ];
-                (v_secret, e_secret, key_info)
+                (
+                    v_secret,
+                    e_secret,
+                    KeySourceMaterial::Derived { path: v_path },
+                    KeySourceMaterial::Derived { path: e_path },
+                )
             }
             RDidPlan::Vta { admin_vta, .. } => {
                 let (v_secret, e_secret, sign_key_id, enc_key_id) =
                     create_relationship_keys(&admin_vta).await?;
-                let key_info = vec![
-                    (
-                        v_secret.id.clone(),
-                        KeySourceMaterial::VtaManaged {
-                            key_id: sign_key_id,
-                        },
-                    ),
-                    (
-                        e_secret.id.clone(),
-                        KeySourceMaterial::VtaManaged { key_id: enc_key_id },
-                    ),
-                ];
-                (v_secret, e_secret, key_info)
+                (
+                    v_secret,
+                    e_secret,
+                    KeySourceMaterial::VtaManaged {
+                        key_id: sign_key_id,
+                    },
+                    KeySourceMaterial::VtaManaged { key_id: enc_key_id },
+                )
             }
         };
 
-        // Build the did:peer from the secrets.
+        // Build the did:peer from the secrets. This REWRITES each secret's `id` to
+        // the did:peer verification-method id (`{did}#key-1` for verification,
+        // `{did}#key-2` for the key-agreement key).
         let mut keys = vec![
             (PeerKeyRole::Verification, &mut v_secret),
             (PeerKeyRole::Encryption, &mut e_secret),
@@ -207,25 +206,33 @@ impl RDidPlan {
             .map_err(|e| anyhow::anyhow!("Failed to create relationship DID: {e}"))?;
         drop(keys);
 
-        // Pair each secret id with its config-level metadata (verification first,
-        // encryption second — same order the old inline path inserted them).
-        let key_info: Vec<(String, KeyInfoConfig)> = key_info
-            .into_iter()
-            .zip([
-                KeyTypes::RelationshipVerification,
-                KeyTypes::RelationshipEncryption,
-            ])
-            .map(|((id, path), purpose)| {
-                (
-                    id,
-                    KeyInfoConfig {
-                        path,
-                        create_time: Utc::now(),
-                        purpose,
-                    },
-                )
-            })
-            .collect();
+        // Record `key_info` under the FINAL did:peer-relative secret ids (set by
+        // the call above), pairing each with its source material. This MUST run
+        // after the did:peer mint: the reload path (`Relationships::
+        // generate_profiles`) only re-registers a stored secret when its id
+        // `starts_with` the R-DID, and packs DIDComm as the R-DID using the
+        // `#key-1`/`#key-2` verification-method ids. Persisting the pre-mint
+        // placeholder ids (the historical bug) left the reloaded R-DID with no
+        // usable key-agreement secret, so mediator authentication looped forever
+        // ("sender has no usable key agreement key").
+        let key_info: Vec<(String, KeyInfoConfig)> = vec![
+            (
+                v_secret.id.clone(),
+                KeyInfoConfig {
+                    path: v_source,
+                    create_time: Utc::now(),
+                    purpose: KeyTypes::RelationshipVerification,
+                },
+            ),
+            (
+                e_secret.id.clone(),
+                KeyInfoConfig {
+                    path: e_source,
+                    create_time: Utc::now(),
+                    purpose: KeyTypes::RelationshipEncryption,
+                },
+            ),
+        ];
 
         // Register the new R-DID listener from the just-minted secrets (the old
         // inline path did this right after key creation; failure is non-fatal).
@@ -1168,6 +1175,7 @@ async fn prepare_submit(
             // Tag the relationship with the working community's persona (D10) so
             // it scopes to the right community on the main page (R-C-6).
             our_persona: config.active_persona,
+            needs_reestablishment: false,
         },
     );
 
@@ -1572,6 +1580,7 @@ mod tests {
             created: Utc::now(),
             state: RelationshipState::Established,
             our_persona: config.active_persona,
+            needs_reestablishment: false,
         };
         config.private.relationships.relationships.insert(key, rel);
     }
@@ -1675,6 +1684,7 @@ mod tests {
                 created: Utc::now(),
                 state: RelationshipState::RequestSent,
                 our_persona: None,
+                needs_reestablishment: false,
             },
         );
     }

--- a/openvtc/src/ui/pages/main/components/relationships_panel.rs
+++ b/openvtc/src/ui/pages/main/components/relationships_panel.rs
@@ -88,7 +88,7 @@ fn render_list(state: &RelationshipsState) -> Vec<Line<'static>> {
                 .unwrap_or(&rel.remote_p_did)
                 .to_string();
 
-            lines.push(Line::from(vec![
+            let mut spans = vec![
                 Span::styled(prefix, style),
                 Span::styled(display_name, style),
                 Span::styled("  ", Style::default()),
@@ -102,7 +102,18 @@ fn render_list(state: &RelationshipsState) -> Vec<Line<'static>> {
                 ),
                 Span::styled("  ", Style::default()),
                 Span::styled(rel.created.clone(), Style::new().fg(COLOR_DARK_GRAY)),
-            ]));
+            ];
+            // Surface relationships whose R-DID keys were lost and could not be
+            // recovered at load: they can no longer send or receive and must be
+            // re-established. (See `Relationship::needs_reestablishment`.)
+            if rel.needs_reestablishment {
+                spans.push(Span::styled("  ", Style::default()));
+                spans.push(Span::styled(
+                    "⚠ needs re-establishment",
+                    Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED).bold(),
+                ));
+            }
+            lines.push(Line::from(spans));
         }
 
         lines.push(Line::from(""));

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2453,6 +2453,7 @@ mod key_handler_tests {
             created: String::new(),
             vrcs_issued: Vec::new(),
             vrcs_received: Vec::new(),
+            needs_reestablishment: false,
         }
     }
 


### PR DESCRIPTION
## Problem

A debug log showed a never-ending "messaging loop." It was **not** the VTC — it was three **Relationship-DID** (R-DID, `did:peer`) profiles failing **mediator** authentication forever with `DIDComm("sender has no usable key agreement key")`, each retrying with exponential backoff.

**Root cause** (`relationship_actions.rs::create_io`): `key_info` captured each secret's id *before* `generate_did_peer_from_secrets` rewrites it to the canonical `{r_did}#key-1`/`#key-2` verification-method id. The persisted ids were therefore placeholders — a random base58 string for the Ed25519 key and the **constant `"x25519"`** for X25519. The constant id also means multiple relationships' encryption entries **collide in the `key_info` HashMap**, so all but one are lost.

On reload, neither `generate_profiles` (`id.starts_with(r_did)`) nor DID-document key resolution (`config/keys.rs::key_info.get(vm.id)`) could find the R-DID's key-agreement secret → the loop. In-session creation worked because it inserted the post-mint secrets directly, so the bug was invisible until restart.

## Changes

- **`create_io`**: build `key_info` *after* the `did:peer` mint, recording the canonical ids. New relationships round-trip correctly.
- **Migration** — `Relationships::repair_key_info_ids`: offline, idempotent, run at load before `generate_profiles`. Resolves each `did:peer` document (self-describing, no network) for authoritative VM ids/pubkeys and re-keys recoverable entries:
  - **VTA**: stored id *is* the pubkey multibase → direct match.
  - **BIP32**: re-derive stored paths; for encryption keys lost to the `"x25519"` collision, **rescan** the derivation space (`m/3'/1'/1'/{i}'`) to rebuild them.
- **Persisted badge** — `Relationship::needs_reestablishment`: set for relationships whose keys can't be recovered. `generate_profiles` skips their profiles (no auth loop), and the relationships list shows a bold-red **`⚠ needs re-establishment`** so the user re-creates them. Re-establishing replaces the entry, clearing the flag.
- **Crates**: `cargo update` to the latest published Affinidi/VTA versions (already at the newest of each; no major/minor jump available).

The serde field uses `default` + `skip_serializing_if`, so unaffected configs round-trip **byte-identically** (R20 invariant).

## Tests

New `openvtc-core` unit tests:
- `repair_rekeys_bip32_rdid_keyinfo_to_canonical_ids` — re-key + idempotency + flag stays false.
- `repair_recovers_encryption_key_lost_to_x25519_collision` — rescan recovers the collided key.
- `repair_flags_unrecoverable_relationship` — foreign-root R-DID is flagged.

Full suite green (openvtc-core 229 lib + integration, openvtc 172), clippy `--all-targets` clean, R20 byte-identical round-trip passes.
