### PR TITLE
feat(docker): add containerized support for dev and deployment [signoff]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+target/
+**/*.backup
+**/*.jsonl
+.DS_Store
+*.swp
+*.swo
+
+# Secrets and credentials
+.env
+.env.*
+*.pem
+*.key
+*.p12
+environments.json
+
+# IDE
+.idea/
+.vscode/
+
+# Logs and OS artifacts
+*.log
+Thumbs.db
+
+# Docker
+.dockerignore
+docker/
+*.md
+.git
+.github

--- a/README.md
+++ b/README.md
@@ -404,6 +404,10 @@ git commit -m "signed with my DID"
 
 See the [did-git-sign README](./did-git-sign/README.md) for full documentation.
 
+## Containerization
+
+Details on containerization, development, and use inside of Docker can be found in the [DOCKER.md](./docker/DOCKER.md) file.
+
 ## Additional Resources
 
 Additional resources to learn more about the Open Verifiable Trust Community (OpenVTC) Tool.

--- a/docker/DOCKER.md
+++ b/docker/DOCKER.md
@@ -1,0 +1,39 @@
+# OpenVTC in Docker
+
+The `docker` folder contains `Dockerfile`s that can be used for generating a build environment and a slim, deployable OpenVTC container.
+
+## Containerized deployment
+
+To build the OpenVTC containerized deployment:
+
+```bash
+docker build -t openvtc -f ./docker/Dockerfile .
+```
+
+To run OpenVTC in the container:
+
+```bash
+docker run \
+  --rm \
+  -ti \
+  -v "${PWD}/.vscode/data/root:/root" \
+  --network host \
+  openvtc
+```
+
+## Containerized build environment
+
+To build the container for development:
+
+```bash
+docker build -t openvtc-builder -f ./docker/builder.Dockerfile .
+```
+
+To utilize cargo inside the build environment as your current user, while keeping the cargo cache and user home directory in a centralized folder under `.vscode/data`, use:
+
+```bash
+alias cargo='docker run --rm -ti -v "/etc/passwd:/etc/passwd:ro" -v "${PWD}/.vscode/data/home:${HOME}" -v "${PWD}:${PWD}" -w "${PWD}" -e CARGO_HOME=${HOME}/cargo --user $(id -u):$(id -g) -e HOME=${HOME} --network host openvtc-builder cargo'
+```
+
+From here out, all use of `cargo` will work just like using a standard Rust dev environment.
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:1 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN \
+    addgroup --system messagebus &&\
+    apt update &&\
+    apt install -y libdbus-1-dev pkg-config libpcsclite-dev
+
+ADD . /build
+WORKDIR /build
+
+# Cache a build layer for downloads
+RUN cargo fetch
+RUN cargo build
+
+# Create the actual image
+FROM debian:trixie-slim
+ARG DEBIAN_FRONTEND=noninteractive
+RUN \
+    apt-get update &&\
+    apt-get install -y ca-certificates libpcsclite1 &&\
+    apt-get clean &&\
+    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/target/debug/openvtc /openvtc
+WORKDIR /data
+ENTRYPOINT ["/openvtc"]

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,0 +1,8 @@
+FROM rust:1
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN \
+    addgroup --system messagebus &&\
+    apt update &&\
+    apt install -y libdbus-1-dev pkg-config libpcsclite-dev


### PR DESCRIPTION
As I'm getting set up to see how MyTerms would fit into TOS management for communities, containerized development was required. This PR introduces Docker-based build and deployment workflows for OpenVTC, enabling reproducible builds and simplified local development.

Changes:

- `docker/Dockerfile` - Multi-stage build: compiles OpenVTC from rust:1, then produces a slim debian:trixie-slim deployment image with only runtime dependencies (ca-certificates, libpcsclite1).
- `docker/builder.Dockerfile` - Standalone development container with Rust toolchain and build dependencies (libdbus-1-dev, pkg-config, libpcsclite-dev).
- `.dockerignore` - Excludes secrets, IDE artifacts, logs, and git metadata from Docker build context.
- `docker/DOCKER.md` - Documentation covering containerized deployment and development workflows, including a convenience cargo alias for running commands as the host user.
- `README.md` - Added reference to the Docker documentation.

In the future, this could be set up to auto-build a package image in the GitHub Container Registry, as well.