### PR TITLE
feat: did-git-sign verify-trust — commit-signature checks against the VTC Trust Registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2479,6 +2479,7 @@ dependencies = [
 name = "did-git-sign"
 version = "0.1.0"
 dependencies = [
+ "affinidi-tdk 0.8.3",
  "anyhow",
  "apple-native-keyring-store",
  "base64 0.22.1",
@@ -2490,6 +2491,7 @@ dependencies = [
  "hex",
  "keyring-core",
  "linux-keyutils-keyring-store",
+ "multibase",
  "serde",
  "serde_json",
  "serial_test",
@@ -2500,6 +2502,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "trql-client",
  "vta-sdk 0.18.14",
  "windows-native-keyring-store",
  "zeroize",
@@ -5792,7 +5795,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -8595,6 +8598,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "trql-client"
+version = "0.7.0"
+source = "git+https://github.com/affinidi/affinidi-trust-registry-rs.git?branch=feat%2Ftrql-client#1eb572b1d05afbe9040ab55448aaccba0673132a"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "trust-tasks-rs",
+]
+
+[[package]]
 name = "trust-tasks-https"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8632,9 +8650,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.12"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbddb304248cc6cb1e2e6385bd2f7042df71c805d9e128d6cb40125322a9274"
+checksum = "2998e4384fc850bfd61ed6dc648a05d8d940d6b304a102eeabaf7c129cbdf16a"
 dependencies = [
  "async-trait",
  "chrono",

--- a/did-git-sign/Cargo.toml
+++ b/did-git-sign/Cargo.toml
@@ -19,6 +19,12 @@ path = "src/main.rs"
 
 [dependencies]
 vta-sdk = { workspace = true, features = ["client", "session"] }
+# verify-trust: DID resolution for signer keys + Trust Registry queries.
+affinidi-tdk = { workspace = true }
+multibase = { workspace = true }
+# Pinned to the feat/trql-client branch until affinidi-trust-registry-rs
+# PR #94 merges and the crate is published to crates.io.
+trql-client = { git = "https://github.com/affinidi/affinidi-trust-registry-rs.git", branch = "feat/trql-client" }
 clap = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true, features = ["derive"] }

--- a/did-git-sign/src/lib.rs
+++ b/did-git-sign/src/lib.rs
@@ -10,4 +10,5 @@ pub mod config;
 pub mod init;
 pub mod policy;
 pub mod sign;
+pub mod verify_trust;
 pub mod vta;

--- a/did-git-sign/src/main.rs
+++ b/did-git-sign/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use dialoguer::{Select, theme::ColorfulTheme};
-use did_git_sign::{config, init, sign, vta};
+use did_git_sign::{config, init, sign, verify_trust, vta};
 use ed25519_dalek::SigningKey;
 use std::path::PathBuf;
 
@@ -205,6 +205,51 @@ enum Commands {
         #[arg(long)]
         did_key_id: Option<String>,
     },
+
+    /// Verify a commit range's SSH signatures against the signers' DID
+    /// documents and check each signer DID against the VTC Trust Registry.
+    /// Exits 0 only when every commit in the range is signed by a
+    /// registry-authorized DID. Designed for CI (GitHub PR checks).
+    VerifyTrust {
+        /// Commit range in `git rev-list` syntax, e.g. `origin/main..HEAD`.
+        #[arg(long)]
+        range: String,
+
+        /// Signer index file (one DID per line, `#` comments). Relative
+        /// paths resolve against --repo-dir.
+        #[arg(long, default_value = ".did-signers")]
+        signers_file: PathBuf,
+
+        /// Base URL of the Trust Registry (queries POST to
+        /// `<url>/trust-tasks`).
+        #[arg(long)]
+        registry_url: String,
+
+        /// DID of the Trust Registry (the recipient of every query).
+        #[arg(long)]
+        registry_did: String,
+
+        /// DID of the authority the trust tuple is evaluated under.
+        #[arg(long)]
+        authority: String,
+
+        /// TRQP action of the trust tuple.
+        #[arg(long, default_value = "git.commit.sign")]
+        action: String,
+
+        /// TRQP resource of the trust tuple (e.g. the `org/repo` slug).
+        /// Defaults to $GITHUB_REPOSITORY when unset.
+        #[arg(long)]
+        resource: Option<String>,
+
+        /// Repository to verify. Defaults to the current directory.
+        #[arg(long)]
+        repo_dir: Option<PathBuf>,
+
+        /// Emit a machine-readable JSON report on stdout.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[tokio::main]
@@ -278,6 +323,38 @@ async fn main() -> Result<()> {
             local,
             did_key_id,
         }) => cmd_uninstall(global, local, did_key_id),
+        Some(Commands::VerifyTrust {
+            range,
+            signers_file,
+            registry_url,
+            registry_did,
+            authority,
+            action,
+            resource,
+            repo_dir,
+            json,
+        }) => {
+            let resource = resource
+                .or_else(|| std::env::var("GITHUB_REPOSITORY").ok())
+                .context("--resource is required (or set GITHUB_REPOSITORY)")?;
+            let repo_dir = match repo_dir {
+                Some(dir) => dir,
+                None => std::env::current_dir().context("cannot determine current directory")?,
+            };
+            let code = verify_trust::handle_verify_trust(verify_trust::VerifyTrustArgs {
+                repo_dir,
+                range,
+                signers_file,
+                registry_url,
+                registry_did,
+                authority_did: authority,
+                action,
+                resource,
+                json,
+            })
+            .await?;
+            std::process::exit(code);
+        }
         None => {
             // `sign_file` is only legitimate when `-Y sign` is set (git signing
             // invocation), which is handled in the early-return block above. If

--- a/did-git-sign/src/sign.rs
+++ b/did-git-sign/src/sign.rs
@@ -194,7 +194,7 @@ pub async fn handle_sign(
 ///   reserved (empty string)
 ///   hash_algorithm (string)
 ///   signature (SSH wire format)
-fn create_ssh_signature(
+pub fn create_ssh_signature(
     signing_key: &SigningKey,
     verifying_key: &ed25519_dalek::VerifyingKey,
     namespace: &str,
@@ -237,7 +237,10 @@ fn create_ssh_signature(
     let b64 = base64_encode(&sshsig_blob);
     let mut armored = String::new();
     armored.push_str("-----BEGIN SSH SIGNATURE-----\n");
-    for chunk in b64.as_bytes().chunks(76) {
+    // OpenSSH wraps sshsig base64 at 70 columns (sshbuf_dtob64). Match it
+    // exactly: RustCrypto's ssh-encoding PEM parser rejects other widths, so
+    // any deviation makes our signatures unreadable to non-OpenSSH verifiers.
+    for chunk in b64.as_bytes().chunks(70) {
         armored.push_str(std::str::from_utf8(chunk).expect("base64 output is always valid UTF-8"));
         armored.push('\n');
     }
@@ -434,23 +437,24 @@ mod tests {
     }
 
     #[test]
-    fn test_signature_blob_line_length_at_most_76() {
+    fn test_signature_blob_wraps_at_70_like_openssh() {
         let seed = [1u8; 32];
         let signing_key = SigningKey::from_bytes(&seed);
         let verifying_key = signing_key.verifying_key();
         let armored =
             create_ssh_signature(&signing_key, &verifying_key, "git", b"check line wrap").unwrap();
 
-        for line in armored.lines() {
-            if line.starts_with("-----") {
-                continue;
-            }
-            assert!(
-                line.len() <= 76,
-                "base64 line too long: {} chars",
-                line.len()
-            );
+        let body: Vec<&str> = armored
+            .lines()
+            .filter(|line| !line.starts_with("-----"))
+            .collect();
+        // Every full line is exactly 70 columns (only the last may be
+        // shorter) — the width ssh-keygen emits and strict PEM parsers
+        // (RustCrypto ssh-encoding) require.
+        for line in &body[..body.len() - 1] {
+            assert_eq!(line.len(), 70, "base64 line is {} chars", line.len());
         }
+        assert!(body[body.len() - 1].len() <= 70);
     }
 
     #[test]

--- a/did-git-sign/src/verify_trust.rs
+++ b/did-git-sign/src/verify_trust.rs
@@ -1,0 +1,743 @@
+//! `verify-trust`: verify a git commit range against the VTC Trust Registry.
+//!
+//! For every commit in a range this module answers two questions, in order:
+//!
+//! 1. **Who signed it, cryptographically?** The commit's `gpgsig` header is
+//!    parsed as a PROTOCOL.sshsig blob; the Ed25519 public key embedded in it
+//!    is matched against the keys published in the DID documents of the
+//!    repository's declared signers, and the signature is verified over the
+//!    exact bytes git signed.
+//! 2. **Is that DID trusted, right now?** The signer DID is checked against
+//!    the Trust Registry with a TRQP authorization query
+//!    (`{entity: signer, authority, action, resource}`) via `trql-client`.
+//!
+//! The signer set comes from a committed index file (default `.did-signers`,
+//! one DID per line) that lists *identities, not keys* — keys are resolved
+//! from each DID document at verification time, so key rotation never
+//! requires touching the repository, and revoking a signer is a registry
+//! operation that takes effect on the next run.
+//!
+//! Failure is closed at every layer: an unsigned commit, a signature by an
+//! unpublished key, a cryptographically invalid signature, an unauthorized
+//! DID, and an unreachable registry all fail the check — each with its own
+//! status so an operator can tell which remediation applies.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use ssh_key::{SshSig, public::KeyData};
+use trql_client::{HttpsTransport, HttpsTransportConfig, TrqlClient, TrqlError, TrqpQuery};
+
+/// The sshsig namespace git uses for commit and tag signatures.
+pub const GIT_SSHSIG_NAMESPACE: &str = "git";
+
+/// Multicodec prefix for an Ed25519 public key in `publicKeyMultibase`.
+const ED25519_MULTICODEC_PREFIX: [u8; 2] = [0xED, 0x01];
+
+/// Everything `verify-trust` needs for one run.
+#[derive(Debug, Clone)]
+pub struct VerifyTrustArgs {
+    /// Repository to verify (a working tree with `git` available).
+    pub repo_dir: PathBuf,
+    /// Commit range in `git rev-list` syntax, e.g. `origin/main..HEAD`.
+    pub range: String,
+    /// Signer index file; relative paths resolve against `repo_dir`.
+    pub signers_file: PathBuf,
+    /// Base URL of the Trust Registry (`POST <url>/trust-tasks`).
+    pub registry_url: String,
+    /// DID of the registry (the `recipient` on every query document).
+    pub registry_did: String,
+    /// DID of the authority the tuple is evaluated under.
+    pub authority_did: String,
+    /// TRQP action, e.g. `git.commit.sign`.
+    pub action: String,
+    /// TRQP resource, e.g. the `org/repo` slug.
+    pub resource: String,
+    /// Emit machine-readable JSON on stdout instead of human lines.
+    pub json: bool,
+}
+
+/// Outcome for one commit. Ordered worst-first so a report can sort on it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase", tag = "status", content = "detail")]
+pub enum CommitStatus {
+    /// No `gpgsig` header on the commit.
+    Unsigned,
+    /// The signature did not parse as an Ed25519 sshsig.
+    Malformed(String),
+    /// The embedded key is published by none of the declared signers.
+    UnknownKey { fingerprint: String },
+    /// The key maps to a signer, but the signature does not verify.
+    BadSignature { signer_did: String },
+    /// Valid signature, but the registry did not authorize the signer.
+    Unauthorized { signer_did: String },
+    /// Valid signature, but the registry could not be consulted. Fails the
+    /// run (closed), distinctly from a denial.
+    RegistryUnavailable { signer_did: String, error: String },
+    /// Valid signature by a registry-authorized signer.
+    Trusted { signer_did: String },
+}
+
+impl CommitStatus {
+    /// Only a `Trusted` commit passes.
+    pub fn is_trusted(&self) -> bool {
+        matches!(self, Self::Trusted { .. })
+    }
+}
+
+/// One commit's verdict, as reported.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitVerdict {
+    pub sha: String,
+    #[serde(flatten)]
+    pub status: CommitStatus,
+}
+
+/// The full report for a range.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustReport {
+    pub ok: bool,
+    pub commits: Vec<CommitVerdict>,
+    /// Signer DIDs whose resolution failed (their commits show as
+    /// `unknownKey`); surfaced so the cause is visible.
+    pub unresolved_signers: BTreeMap<String, String>,
+}
+
+/// Run the check end to end: resolve the declared signers' keys, then verify
+/// the range. Returns the process exit code (0 = every commit trusted).
+pub async fn handle_verify_trust(args: VerifyTrustArgs) -> Result<i32> {
+    let signer_dids = load_signers(&args.repo_dir, &args.signers_file)?;
+    let (keys, unresolved) = resolve_signer_keys(&signer_dids).await?;
+    let report = verify_with_keys(&args, &keys, unresolved).await?;
+    print_report(&args, &report)?;
+    Ok(if report.ok { 0 } else { 1 })
+}
+
+/// Verify the range against an already-resolved key→DID map. Split from
+/// [`handle_verify_trust`] so tests can supply keys without a live resolver.
+pub async fn verify_with_keys(
+    args: &VerifyTrustArgs,
+    signer_keys: &HashMap<[u8; 32], String>,
+    unresolved_signers: BTreeMap<String, String>,
+) -> Result<TrustReport> {
+    let shas = list_commits(&args.repo_dir, &args.range)?;
+
+    // Pass 1: cryptographic verification, collecting the DIDs that signed.
+    let mut checked = Vec::with_capacity(shas.len());
+    let mut signer_dids = BTreeSet::new();
+    for sha in shas {
+        let raw = read_commit_raw(&args.repo_dir, &sha)?;
+        let signature = check_commit_signature(&raw, signer_keys);
+        if let SignatureCheck::Valid { signer_did } = &signature {
+            signer_dids.insert(signer_did.clone());
+        }
+        checked.push((sha, signature));
+    }
+
+    // Pass 2: one registry query per distinct signer DID.
+    let decisions = query_registry(args, &signer_dids).await?;
+
+    let commits: Vec<CommitVerdict> = checked
+        .into_iter()
+        .map(|(sha, signature)| CommitVerdict {
+            sha,
+            status: status_of(signature, &decisions),
+        })
+        .collect();
+
+    // An empty range passes vacuously (nothing new to verify).
+    let ok = commits.iter().all(|c| c.status.is_trusted());
+    Ok(TrustReport {
+        ok,
+        commits,
+        unresolved_signers,
+    })
+}
+
+// --- signature layer ---------------------------------------------------------
+
+/// Result of the cryptographic check for one commit.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SignatureCheck {
+    Unsigned,
+    Malformed(String),
+    UnknownKey { fingerprint: String },
+    BadSignature { signer_did: String },
+    Valid { signer_did: String },
+}
+
+/// Verify one raw commit object against the signer key map.
+pub fn check_commit_signature(
+    raw: &[u8],
+    signer_keys: &HashMap<[u8; 32], String>,
+) -> SignatureCheck {
+    let (payload, pem) = match split_signed_commit(raw) {
+        Ok(Some(parts)) => parts,
+        Ok(None) => return SignatureCheck::Unsigned,
+        Err(e) => return SignatureCheck::Malformed(e.to_string()),
+    };
+    let sig = match SshSig::from_pem(normalize_sshsig_armor(&pem).as_bytes()) {
+        Ok(sig) => sig,
+        Err(e) => return SignatureCheck::Malformed(format!("sshsig did not parse: {e}")),
+    };
+    let KeyData::Ed25519(embedded) = sig.public_key() else {
+        return SignatureCheck::Malformed(format!(
+            "unsupported signature algorithm: {}",
+            sig.algorithm()
+        ));
+    };
+    let key_bytes: [u8; 32] = embedded.0;
+    let Some(signer_did) = signer_keys.get(&key_bytes) else {
+        return SignatureCheck::UnknownKey {
+            fingerprint: hex::encode(key_bytes),
+        };
+    };
+    let public_key = ssh_key::PublicKey::from(sig.public_key().clone());
+    match public_key.verify(GIT_SSHSIG_NAMESPACE, &payload, &sig) {
+        Ok(()) => SignatureCheck::Valid {
+            signer_did: signer_did.clone(),
+        },
+        Err(_) => SignatureCheck::BadSignature {
+            signer_did: signer_did.clone(),
+        },
+    }
+}
+
+/// Re-wrap an sshsig armor's base64 body at 70 columns.
+///
+/// OpenSSH's own base64 reader accepts any line width, but the strict PEM
+/// parser underneath [`SshSig::from_pem`] requires exactly the 70-column
+/// wrapping ssh-keygen emits. Signatures created by did-git-sign before it
+/// matched ssh-keygen's width (76 columns) live on in git history, so the
+/// armor is normalized rather than trusted to be canonical.
+pub fn normalize_sshsig_armor(pem: &str) -> String {
+    let body: String = pem
+        .lines()
+        .filter(|line| !line.starts_with("-----"))
+        .map(str::trim)
+        .collect();
+    let mut normalized = String::from("-----BEGIN SSH SIGNATURE-----\n");
+    for chunk in body.as_bytes().chunks(70) {
+        // Chunks of an ASCII base64 string are always valid UTF-8.
+        normalized.push_str(&String::from_utf8_lossy(chunk));
+        normalized.push('\n');
+    }
+    normalized.push_str("-----END SSH SIGNATURE-----\n");
+    normalized
+}
+
+/// Split a raw commit object into (payload-as-signed, armored signature).
+///
+/// Git signs the commit object with the `gpgsig` header removed; the header's
+/// value spans continuation lines (each prefixed with one space). Returns
+/// `Ok(None)` for an unsigned commit.
+pub fn split_signed_commit(raw: &[u8]) -> Result<Option<(Vec<u8>, String)>> {
+    let text = std::str::from_utf8(raw).context("commit object is not UTF-8")?;
+    let Some((headers, body)) = text.split_once("\n\n") else {
+        bail!("malformed commit object: no header/body separator");
+    };
+
+    let mut kept_headers: Vec<&str> = Vec::new();
+    let mut signature_lines: Vec<&str> = Vec::new();
+    let mut in_gpgsig = false;
+    for line in headers.split('\n') {
+        if let Some(first) = line.strip_prefix("gpgsig ") {
+            in_gpgsig = true;
+            signature_lines.push(first);
+        } else if in_gpgsig && let Some(continuation) = line.strip_prefix(' ') {
+            signature_lines.push(continuation);
+        } else {
+            in_gpgsig = false;
+            kept_headers.push(line);
+        }
+    }
+
+    if signature_lines.is_empty() {
+        return Ok(None);
+    }
+
+    let mut payload = kept_headers.join("\n").into_bytes();
+    payload.extend_from_slice(b"\n\n");
+    payload.extend_from_slice(body.as_bytes());
+
+    let mut pem = signature_lines.join("\n");
+    pem.push('\n');
+    Ok(Some((payload, pem)))
+}
+
+// --- signer index & DID resolution -------------------------------------------
+
+/// Read and parse the signer index: one DID per line, `#` comments allowed.
+/// A missing or malformed file is a hard error — with no declared signers
+/// there is nothing to verify against, and the check must not silently pass.
+pub fn load_signers(repo_dir: &Path, signers_file: &Path) -> Result<Vec<String>> {
+    let path = if signers_file.is_absolute() {
+        signers_file.to_path_buf()
+    } else {
+        repo_dir.join(signers_file)
+    };
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("cannot read signer index {}", path.display()))?;
+    let dids = parse_signers(&text)?;
+    if dids.is_empty() {
+        bail!("signer index {} declares no DIDs", path.display());
+    }
+    Ok(dids)
+}
+
+/// Parse signer-index text. Rejects non-DID entries outright rather than
+/// skipping them: a typo must fail loudly, not silently drop a signer.
+pub fn parse_signers(text: &str) -> Result<Vec<String>> {
+    let mut dids = Vec::new();
+    for (number, line) in text.lines().enumerate() {
+        let entry = line.trim();
+        if entry.is_empty() || entry.starts_with('#') {
+            continue;
+        }
+        if !entry.starts_with("did:") {
+            bail!("signer index line {}: not a DID: {entry}", number + 1);
+        }
+        dids.push(entry.to_string());
+    }
+    Ok(dids)
+}
+
+/// Resolve every declared signer DID and collect the Ed25519 keys their DID
+/// documents publish. A DID that fails to resolve is recorded (its commits
+/// will fail as `unknownKey`) without blocking the other signers.
+pub async fn resolve_signer_keys(
+    dids: &[String],
+) -> Result<(HashMap<[u8; 32], String>, BTreeMap<String, String>)> {
+    use affinidi_tdk::TDK;
+    use affinidi_tdk::common::config::TDKConfig;
+
+    let tdk = TDK::new(
+        TDKConfig::builder()
+            .with_load_environment(false)
+            .build()
+            .context("TDK config")?,
+        None,
+    )
+    .await
+    .context("TDK init")?;
+
+    let mut keys = HashMap::new();
+    let mut unresolved = BTreeMap::new();
+    for did in dids {
+        match tdk.did_resolver().resolve(did).await {
+            Ok(response) => {
+                let doc = serde_json::to_value(&response.doc)
+                    .with_context(|| format!("DID document for {did} did not serialize"))?;
+                let published = ed25519_keys_from_doc(&doc);
+                if published.is_empty() {
+                    unresolved.insert(
+                        did.clone(),
+                        "DID document publishes no Ed25519 verification keys".to_string(),
+                    );
+                }
+                for key in published {
+                    keys.insert(key, did.clone());
+                }
+            }
+            Err(e) => {
+                unresolved.insert(did.clone(), format!("resolution failed: {e}"));
+            }
+        }
+    }
+    Ok((keys, unresolved))
+}
+
+/// Extract every Ed25519 public key from a DID document's verification
+/// methods (`publicKeyMultibase`, multicodec `0xED01`).
+pub fn ed25519_keys_from_doc(doc: &serde_json::Value) -> Vec<[u8; 32]> {
+    let Some(methods) = doc.get("verificationMethod").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    methods
+        .iter()
+        .filter_map(|method| method.get("publicKeyMultibase")?.as_str())
+        .filter_map(|encoded| multibase::decode(encoded).ok())
+        .filter_map(|(_base, bytes)| {
+            let raw = bytes.strip_prefix(&ED25519_MULTICODEC_PREFIX)?;
+            <[u8; 32]>::try_from(raw).ok()
+        })
+        .collect()
+}
+
+// --- registry layer -----------------------------------------------------------
+
+/// Per-DID registry decision: authorized, denied, or unavailable-with-reason.
+type RegistryDecisions = BTreeMap<String, Result<bool, String>>;
+
+/// One TRQP authorization query per distinct signer DID.
+async fn query_registry(
+    args: &VerifyTrustArgs,
+    signer_dids: &BTreeSet<String>,
+) -> Result<RegistryDecisions> {
+    let mut decisions = RegistryDecisions::new();
+    if signer_dids.is_empty() {
+        return Ok(decisions);
+    }
+    let transport = HttpsTransport::new(HttpsTransportConfig::new(&args.registry_url))?;
+    let client = TrqlClient::new(Arc::new(transport), &args.registry_did);
+    for did in signer_dids {
+        let query = TrqpQuery::new(did, &args.authority_did, &args.action, &args.resource);
+        match client.authorization(query).await {
+            Ok(response) => {
+                decisions.insert(did.clone(), Ok(response.authorized));
+            }
+            Err(e @ TrqlError::Rejected { .. }) => {
+                // The registry answered and said no (e.g. unknown tuple
+                // rejected rather than answered false) — a denial, not an
+                // availability problem.
+                decisions.insert(did.clone(), Ok(false));
+                tracing::debug!("registry rejected the query for {did}: {e}");
+            }
+            Err(e) => {
+                decisions.insert(did.clone(), Err(e.to_string()));
+            }
+        }
+    }
+    Ok(decisions)
+}
+
+/// Combine the signature check with the registry decision.
+fn status_of(signature: SignatureCheck, decisions: &RegistryDecisions) -> CommitStatus {
+    match signature {
+        SignatureCheck::Unsigned => CommitStatus::Unsigned,
+        SignatureCheck::Malformed(detail) => CommitStatus::Malformed(detail),
+        SignatureCheck::UnknownKey { fingerprint } => CommitStatus::UnknownKey { fingerprint },
+        SignatureCheck::BadSignature { signer_did } => CommitStatus::BadSignature { signer_did },
+        SignatureCheck::Valid { signer_did } => match decisions.get(&signer_did) {
+            Some(Ok(true)) => CommitStatus::Trusted { signer_did },
+            Some(Ok(false)) => CommitStatus::Unauthorized { signer_did },
+            Some(Err(error)) => CommitStatus::RegistryUnavailable {
+                signer_did,
+                error: error.clone(),
+            },
+            None => CommitStatus::RegistryUnavailable {
+                signer_did,
+                error: "no registry decision recorded".to_string(),
+            },
+        },
+    }
+}
+
+// --- git plumbing --------------------------------------------------------------
+
+/// List the commits in `range`, oldest first.
+pub fn list_commits(repo_dir: &Path, range: &str) -> Result<Vec<String>> {
+    let output = git(repo_dir, &["rev-list", "--reverse", range])?;
+    Ok(output.lines().map(str::to_string).collect())
+}
+
+/// Read one raw commit object.
+pub fn read_commit_raw(repo_dir: &Path, sha: &str) -> Result<Vec<u8>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_dir)
+        .args(["cat-file", "commit", sha])
+        .output()
+        .context("running git cat-file")?;
+    if !output.status.success() {
+        bail!(
+            "git cat-file commit {sha} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(output.stdout)
+}
+
+fn git(repo_dir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_dir)
+        .args(args)
+        .output()
+        .with_context(|| format!("running git {}", args.join(" ")))?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8(output.stdout)?.trim_end().to_string())
+}
+
+// --- reporting ------------------------------------------------------------------
+
+fn print_report(args: &VerifyTrustArgs, report: &TrustReport) -> Result<()> {
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(report)?);
+        return Ok(());
+    }
+    for commit in &report.commits {
+        let short = &commit.sha[..commit.sha.len().min(12)];
+        match &commit.status {
+            CommitStatus::Trusted { signer_did } => {
+                println!("TRUSTED      {short}  {signer_did}");
+            }
+            CommitStatus::Unauthorized { signer_did } => {
+                println!("UNAUTHORIZED {short}  {signer_did} is not authorized by the registry");
+            }
+            CommitStatus::RegistryUnavailable { signer_did, error } => {
+                println!(
+                    "UNAVAILABLE  {short}  signed by {signer_did}; registry check failed: {error}"
+                );
+            }
+            CommitStatus::BadSignature { signer_did } => {
+                println!("BAD-SIG      {short}  signature by {signer_did} does not verify");
+            }
+            CommitStatus::UnknownKey { fingerprint } => {
+                println!(
+                    "UNKNOWN-KEY  {short}  key {fingerprint} is published by no declared signer"
+                );
+            }
+            CommitStatus::Malformed(detail) => {
+                println!("MALFORMED    {short}  {detail}");
+            }
+            CommitStatus::Unsigned => {
+                println!("UNSIGNED     {short}  commit carries no signature");
+            }
+        }
+    }
+    for (did, reason) in &report.unresolved_signers {
+        println!("WARNING      declared signer {did}: {reason}");
+    }
+    let trusted = report
+        .commits
+        .iter()
+        .filter(|c| c.status.is_trusted())
+        .count();
+    println!(
+        "{}: {trusted}/{} commits trusted",
+        if report.ok { "PASS" } else { "FAIL" },
+        report.commits.len()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use crate::sign::create_ssh_signature;
+    use ed25519_dalek::SigningKey;
+
+    fn test_key() -> (SigningKey, [u8; 32]) {
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let public = signing.verifying_key().to_bytes();
+        (signing, public)
+    }
+
+    fn unsigned_commit() -> String {
+        "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\
+         author A U Thor <a@example.com> 1700000000 +0000\n\
+         committer A U Thor <a@example.com> 1700000000 +0000\n\
+         \n\
+         a message\n"
+            .to_string()
+    }
+
+    /// Insert a gpgsig header before the blank line, continuation-indented,
+    /// exactly as git stores it.
+    fn signed_commit(payload: &str, armored: &str) -> String {
+        let (headers, body) = payload.split_once("\n\n").unwrap();
+        let mut sig_header = String::from("gpgsig ");
+        let mut lines = armored.trim_end().split('\n');
+        sig_header.push_str(lines.next().unwrap());
+        for line in lines {
+            sig_header.push('\n');
+            sig_header.push(' ');
+            sig_header.push_str(line);
+        }
+        format!("{headers}\n{sig_header}\n\n{body}")
+    }
+
+    fn sign_commit(payload: &str, key: &SigningKey) -> String {
+        let armored = create_ssh_signature(
+            key,
+            &key.verifying_key(),
+            GIT_SSHSIG_NAMESPACE,
+            payload.as_bytes(),
+        )
+        .unwrap();
+        signed_commit(payload, &armored)
+    }
+
+    #[test]
+    fn split_returns_none_for_unsigned_commit() {
+        assert!(
+            split_signed_commit(unsigned_commit().as_bytes())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn split_recovers_exact_payload_and_signature() {
+        let payload = unsigned_commit();
+        let (key, _) = test_key();
+        let commit = sign_commit(&payload, &key);
+
+        let (recovered_payload, pem) = split_signed_commit(commit.as_bytes()).unwrap().unwrap();
+        assert_eq!(recovered_payload, payload.as_bytes());
+        assert!(pem.starts_with("-----BEGIN SSH SIGNATURE-----"));
+        assert!(pem.trim_end().ends_with("-----END SSH SIGNATURE-----"));
+    }
+
+    #[test]
+    fn our_encoder_and_the_decoder_agree() {
+        // Cross-check: a signature produced by sign.rs verifies through the
+        // ssh-key crate's independent implementation.
+        let payload = unsigned_commit();
+        let (key, public) = test_key();
+        let commit = sign_commit(&payload, &key);
+        let keys = HashMap::from([(public, "did:example:signer".to_string())]);
+
+        let check = check_commit_signature(commit.as_bytes(), &keys);
+        assert_eq!(
+            check,
+            SignatureCheck::Valid {
+                signer_did: "did:example:signer".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_76_column_armor_still_verifies() {
+        // Signatures created before sign.rs matched ssh-keygen's 70-column
+        // wrapping are permanent in git history and must keep verifying.
+        let payload = unsigned_commit();
+        let (key, public) = test_key();
+        let armored = create_ssh_signature(
+            &key,
+            &key.verifying_key(),
+            GIT_SSHSIG_NAMESPACE,
+            payload.as_bytes(),
+        )
+        .unwrap();
+        let body: String = armored
+            .lines()
+            .filter(|l| !l.starts_with("-----"))
+            .collect();
+        let mut legacy = String::from("-----BEGIN SSH SIGNATURE-----\n");
+        for chunk in body.as_bytes().chunks(76) {
+            legacy.push_str(std::str::from_utf8(chunk).unwrap());
+            legacy.push('\n');
+        }
+        legacy.push_str("-----END SSH SIGNATURE-----\n");
+
+        let commit = signed_commit(&payload, &legacy);
+        let keys = HashMap::from([(public, "did:example:signer".to_string())]);
+        assert_eq!(
+            check_commit_signature(commit.as_bytes(), &keys),
+            SignatureCheck::Valid {
+                signer_did: "did:example:signer".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_key_is_reported_with_fingerprint() {
+        let payload = unsigned_commit();
+        let (key, _) = test_key();
+        let commit = sign_commit(&payload, &key);
+
+        let check = check_commit_signature(commit.as_bytes(), &HashMap::new());
+        assert!(matches!(check, SignatureCheck::UnknownKey { .. }));
+    }
+
+    #[test]
+    fn tampered_payload_is_a_bad_signature() {
+        let payload = unsigned_commit();
+        let (key, public) = test_key();
+        let commit = sign_commit(&payload, &key).replace("a message", "b message");
+        let keys = HashMap::from([(public, "did:example:signer".to_string())]);
+
+        let check = check_commit_signature(commit.as_bytes(), &keys);
+        assert_eq!(
+            check,
+            SignatureCheck::BadSignature {
+                signer_did: "did:example:signer".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unsigned_commit_is_unsigned() {
+        let check = check_commit_signature(unsigned_commit().as_bytes(), &HashMap::new());
+        assert_eq!(check, SignatureCheck::Unsigned);
+    }
+
+    #[test]
+    fn signers_index_parses_and_rejects_non_dids() {
+        let parsed =
+            parse_signers("# team\n did:webvh:abc:example.com \n\ndid:webvh:def:example.com\n")
+                .unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert!(parse_signers("not-a-did\n").is_err());
+    }
+
+    #[test]
+    fn ed25519_keys_are_extracted_from_a_did_document() {
+        let (_, public) = test_key();
+        let mut multicodec = ED25519_MULTICODEC_PREFIX.to_vec();
+        multicodec.extend_from_slice(&public);
+        let encoded = multibase::encode(multibase::Base::Base58Btc, &multicodec);
+
+        let doc = serde_json::json!({
+            "id": "did:example:signer",
+            "verificationMethod": [
+                { "id": "did:example:signer#key-0", "publicKeyMultibase": encoded },
+                { "id": "did:example:signer#key-x", "publicKeyMultibase": "zInvalid!" },
+                { "id": "did:example:signer#key-jwk" }
+            ]
+        });
+        let keys = ed25519_keys_from_doc(&doc);
+        assert_eq!(keys, vec![public]);
+    }
+
+    #[test]
+    fn statuses_compose_signature_and_registry_decisions() {
+        let did = "did:example:signer".to_string();
+        let mut decisions = RegistryDecisions::new();
+        decisions.insert(did.clone(), Ok(true));
+        assert!(
+            status_of(
+                SignatureCheck::Valid {
+                    signer_did: did.clone()
+                },
+                &decisions
+            )
+            .is_trusted()
+        );
+
+        decisions.insert(did.clone(), Ok(false));
+        assert_eq!(
+            status_of(
+                SignatureCheck::Valid {
+                    signer_did: did.clone()
+                },
+                &decisions
+            ),
+            CommitStatus::Unauthorized {
+                signer_did: did.clone()
+            }
+        );
+
+        decisions.insert(did.clone(), Err("connect refused".to_string()));
+        assert!(matches!(
+            status_of(SignatureCheck::Valid { signer_did: did }, &decisions),
+            CommitStatus::RegistryUnavailable { .. }
+        ));
+    }
+}

--- a/did-git-sign/tests/verify_trust_e2e.rs
+++ b/did-git-sign/tests/verify_trust_e2e.rs
@@ -1,0 +1,300 @@
+//! End-to-end `verify-trust` test: a real git repository containing a real
+//! sshsig-signed commit object, verified against a stub Trust Registry
+//! speaking the `POST /trust-tasks` wire contract.
+//!
+//! Requires the `git` binary (present on all CI runners).
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use did_git_sign::sign::create_ssh_signature;
+use did_git_sign::verify_trust::{
+    CommitStatus, GIT_SSHSIG_NAMESPACE, VerifyTrustArgs, verify_with_keys,
+};
+use ed25519_dalek::SigningKey;
+use serde_json::{Value, json};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+// --- git helpers -------------------------------------------------------------
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .env("GIT_AUTHOR_NAME", "A U Thor")
+        .env("GIT_AUTHOR_EMAIL", "author@example.com")
+        .env("GIT_COMMITTER_NAME", "A U Thor")
+        .env("GIT_COMMITTER_EMAIL", "author@example.com")
+        // Hermetic: the host's config may enable commit signing (this very
+        // tool!), which would corrupt the fixtures.
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .expect("git runs");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string()
+}
+
+/// Rewrite `sha` as an sshsig-signed commit object and return the new sha.
+fn sign_head_commit(repo: &Path, sha: &str, key: &SigningKey) -> String {
+    let payload = {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["cat-file", "commit", sha])
+            .output()
+            .expect("git cat-file runs");
+        assert!(out.status.success());
+        out.stdout
+    };
+    let armored =
+        create_ssh_signature(key, &key.verifying_key(), GIT_SSHSIG_NAMESPACE, &payload).unwrap();
+
+    // Insert the gpgsig header before the blank line, continuation-indented
+    // exactly as git stores it.
+    let text = String::from_utf8(payload).unwrap();
+    let (headers, body) = text.split_once("\n\n").unwrap();
+    let mut sig_header = String::from("gpgsig ");
+    let mut lines = armored.trim_end().split('\n');
+    sig_header.push_str(lines.next().unwrap());
+    for line in lines {
+        sig_header.push_str("\n ");
+        sig_header.push_str(line);
+    }
+    let signed = format!("{headers}\n{sig_header}\n\n{body}");
+
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["hash-object", "-t", "commit", "-w", "--stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("git hash-object spawns");
+    {
+        use std::io::Write;
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(signed.as_bytes())
+            .unwrap();
+    }
+    let out = child.wait_with_output().unwrap();
+    assert!(out.status.success());
+    String::from_utf8_lossy(&out.stdout).trim_end().to_string()
+}
+
+/// Create a repo with one unsigned base commit, then one signed commit.
+/// Returns (base_sha, signed_sha).
+fn repo_with_signed_commit(repo: &Path, key: &SigningKey) -> (String, String) {
+    git(repo, &["init", "-q", "-b", "main"]);
+    std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+    git(repo, &["add", "a.txt"]);
+    git(repo, &["commit", "-q", "-m", "base"]);
+    let base = git(repo, &["rev-parse", "HEAD"]);
+
+    std::fs::write(repo.join("a.txt"), "two\n").unwrap();
+    git(repo, &["add", "a.txt"]);
+    git(repo, &["commit", "-q", "-m", "change"]);
+    let unsigned = git(repo, &["rev-parse", "HEAD"]);
+
+    let signed = sign_head_commit(repo, &unsigned, key);
+    git(repo, &["update-ref", "refs/heads/main", &signed]);
+    (base, signed)
+}
+
+// --- stub registry ------------------------------------------------------------
+
+/// Serve the `/trust-tasks` contract: answer every authorization query for
+/// `authorized_did` with `authorized: true`, everyone else `false`.
+async fn stub_registry(authorized_did: String) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            let authorized_did = authorized_did.clone();
+            tokio::spawn(async move {
+                let mut buf = Vec::new();
+                let mut chunk = [0u8; 4096];
+                // Read headers.
+                let header_end = loop {
+                    let n = socket.read(&mut chunk).await.unwrap_or(0);
+                    if n == 0 {
+                        return;
+                    }
+                    buf.extend_from_slice(&chunk[..n]);
+                    if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                        break pos + 4;
+                    }
+                };
+                let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+                let content_length: usize = headers
+                    .lines()
+                    .find_map(|l| {
+                        l.to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .map(|v| v.trim().parse().unwrap())
+                    })
+                    .unwrap_or(0);
+                while buf.len() < header_end + content_length {
+                    let n = socket.read(&mut chunk).await.unwrap_or(0);
+                    if n == 0 {
+                        return;
+                    }
+                    buf.extend_from_slice(&chunk[..n]);
+                }
+                let request: Value = serde_json::from_slice(&buf[header_end..]).unwrap();
+                let entity = request["payload"]["entity_id"].as_str().unwrap_or_default();
+                let response = json!({
+                    "id": "urn:uuid:stub-reply",
+                    "threadId": request["id"],
+                    "type": "https://trusttasks.org/spec/registry/authorization/0.1#response",
+                    "payload": {
+                        "entity_id": entity,
+                        "authority_id": request["payload"]["authority_id"],
+                        "action": request["payload"]["action"],
+                        "resource": request["payload"]["resource"],
+                        "authorized": entity == authorized_did,
+                        "time_evaluated": "2026-07-16T00:00:00Z",
+                    }
+                });
+                let body = response.to_string();
+                let reply = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(reply.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            });
+        }
+    });
+    format!("http://{addr}")
+}
+
+fn args_for(repo: &Path, range: String, registry_url: String) -> VerifyTrustArgs {
+    VerifyTrustArgs {
+        repo_dir: repo.to_path_buf(),
+        range,
+        signers_file: ".did-signers".into(),
+        registry_url,
+        registry_did: "did:example:registry".into(),
+        authority_did: "did:example:authority".into(),
+        action: "git.commit.sign".into(),
+        resource: "example/repo".into(),
+        json: false,
+    }
+}
+
+const SIGNER: &str = "did:example:signer";
+
+// --- tests ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn signed_and_authorized_commit_passes() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SigningKey::from_bytes(&[9u8; 32]);
+    let (base, signed) = repo_with_signed_commit(dir.path(), &key);
+    let registry = stub_registry(SIGNER.to_string()).await;
+
+    let keys = HashMap::from([(key.verifying_key().to_bytes(), SIGNER.to_string())]);
+    let args = args_for(dir.path(), format!("{base}..{signed}"), registry);
+    let report = verify_with_keys(&args, &keys, BTreeMap::new())
+        .await
+        .unwrap();
+
+    assert_eq!(report.commits.len(), 1);
+    assert_eq!(
+        report.commits[0].status,
+        CommitStatus::Trusted {
+            signer_did: SIGNER.to_string()
+        }
+    );
+    assert!(report.ok);
+}
+
+#[tokio::test]
+async fn signed_but_unauthorized_commit_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SigningKey::from_bytes(&[9u8; 32]);
+    let (base, signed) = repo_with_signed_commit(dir.path(), &key);
+    // The registry authorizes a different DID.
+    let registry = stub_registry("did:example:someone-else".to_string()).await;
+
+    let keys = HashMap::from([(key.verifying_key().to_bytes(), SIGNER.to_string())]);
+    let args = args_for(dir.path(), format!("{base}..{signed}"), registry);
+    let report = verify_with_keys(&args, &keys, BTreeMap::new())
+        .await
+        .unwrap();
+
+    assert!(!report.ok);
+    assert_eq!(
+        report.commits[0].status,
+        CommitStatus::Unauthorized {
+            signer_did: SIGNER.to_string()
+        }
+    );
+}
+
+#[tokio::test]
+async fn unsigned_commit_fails_without_touching_the_registry() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+    git(repo, &["init", "-q", "-b", "main"]);
+    std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+    git(repo, &["add", "a.txt"]);
+    git(repo, &["commit", "-q", "-m", "base"]);
+    let base = git(repo, &["rev-parse", "HEAD"]);
+    std::fs::write(repo.join("a.txt"), "two\n").unwrap();
+    git(repo, &["add", "a.txt"]);
+    git(repo, &["commit", "-q", "-m", "unsigned change"]);
+    let head = git(repo, &["rev-parse", "HEAD"]);
+
+    // Deliberately unreachable registry: no signed commits means no queries.
+    let args = args_for(repo, format!("{base}..{head}"), "http://127.0.0.1:1".into());
+    let report = verify_with_keys(&args, &HashMap::new(), BTreeMap::new())
+        .await
+        .unwrap();
+
+    assert!(!report.ok);
+    assert_eq!(report.commits[0].status, CommitStatus::Unsigned);
+}
+
+#[tokio::test]
+async fn unreachable_registry_fails_closed() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SigningKey::from_bytes(&[9u8; 32]);
+    let (base, signed) = repo_with_signed_commit(dir.path(), &key);
+
+    let keys = HashMap::from([(key.verifying_key().to_bytes(), SIGNER.to_string())]);
+    let args = args_for(
+        dir.path(),
+        format!("{base}..{signed}"),
+        "http://127.0.0.1:1".into(),
+    );
+    let report = verify_with_keys(&args, &keys, BTreeMap::new())
+        .await
+        .unwrap();
+
+    assert!(
+        !report.ok,
+        "a valid signature must not pass without a registry decision"
+    );
+    assert!(matches!(
+        report.commits[0].status,
+        CommitStatus::RegistryUnavailable { .. }
+    ));
+}

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -326,7 +326,7 @@ pub async fn create_did_via_server(
     let mut sign_secret = vta_sdk::did_key::secret_from_key_response(&sign_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
     // Set the secret ID to the DID verification method ID
-    sign_secret.id = format!("{}#key-0", &did);
+    sign_secret.id = format!("{}#key-0", did);
 
     let signing = KeyInfo {
         secret: sign_secret.clone(),
@@ -356,7 +356,7 @@ pub async fn create_did_via_server(
 
     let mut ka_secret = vta_sdk::did_key::secret_from_key_response(&ka_secret_resp)
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
-    ka_secret.id = format!("{}#key-1", &did);
+    ka_secret.id = format!("{}#key-1", did);
 
     let decryption = KeyInfo {
         secret: ka_secret,


### PR DESCRIPTION
## What

Phase 2 of the commit-signature trust check (phase 1 = the transport-agnostic `trql-client`, [affinidi-trust-registry-rs #94](https://github.com/affinidi/affinidi-trust-registry-rs/pull/94)): a new `did-git-sign verify-trust` subcommand designed to run as a CI check on PRs.

```
did-git-sign verify-trust \
  --range origin/main..HEAD \
  --registry-url https://registry.example.com \
  --registry-did did:webvh:...registry \
  --authority did:webvh:...org-authority \
  --resource org/repo        # defaults to $GITHUB_REPOSITORY
```

Per commit in the range:

1. **Cryptographic identity** — parse the `gpgsig` PROTOCOL.sshsig blob (via the `ssh-key` crate, an independent implementation cross-checking our own encoder), match its embedded Ed25519 key against keys published in the DID documents of the repo's **declared signers**, and verify the signature over the exact bytes git signed.
2. **Live trust** — one TRQP authorization query per distinct signer DID (`{entity: signer, authority, action: git.commit.sign, resource}`) through `trql-client` over HTTPS.

The signer index (`.did-signers`, one DID per line) declares **identities, not keys**: keys resolve from DID documents at verify time, so key rotation never touches the repo and revocation is a registry operation that bites on the next run.

**Fails closed at every layer**, each with a distinct verdict (R6.4): `unsigned`, `malformed`, `unknownKey`, `badSignature`, `unauthorized`, `registryUnavailable`. Exit 0 only when every commit is `trusted`. `--json` emits a machine-readable report for the Action layer (phase 3).

## Also in this PR

- **sshsig armor interop fix**: `sign.rs` wrapped base64 at 76 columns; ssh-keygen (and strict PEM parsers like RustCrypto's `ssh-encoding`) use 70. OpenSSH tolerated our width, so signing kept working, but non-OpenSSH verifiers couldn't parse our signatures. Now emits 70; the verifier normalizes armor so **76-column signatures already in git history keep verifying** (pinned by test).
- Two pre-existing clippy 1.97 `-D warnings` errors fixed in `setup_sequence/vta.rs` (kept CI green).

## Dependency note

`trql-client` is a **git dependency on the `feat/trql-client` branch** until affinidi-trust-registry-rs #94 merges and publishes to crates.io — merge #94 first, then a follow-up swaps this to the crates.io version. `trust-tasks-rs` lock bumped 0.2.12 → 0.2.16 (semver-compatible) to unify with it.

## Testing

- 11 unit tests: sshsig split/normalize round-trips, encoder↔decoder cross-check, tampered-payload rejection, legacy 76-column armor, signer-index parsing (rejects non-DIDs loudly), DID-doc key extraction, status composition.
- 4 end-to-end tests: a real git repo with a real signed commit object against a stub registry speaking the `POST /trust-tasks` contract — authorized passes, unauthorized fails, unsigned fails without touching the registry, unreachable registry fails closed. Hermetic against host git config (which on dev machines signs with this very tool).
- `cargo clippy --workspace --all-targets -- -D warnings` clean; full workspace tests green; `cargo doc -p did-git-sign` clean under `-D warnings`. (Pre-existing: `didcomm_integration_test`-style mediator tests unaffected; `openvtc-core` has 7 pre-existing rustdoc errors on main under current rustdoc.)

## Not in scope (phase 3+)

GitHub Action packaging / reusable workflow, bot & merge-commit policy, as-of-commit-time DID resolution (didwebvh versionTime), DIDComm/TSP transports for the registry query (the client seam already supports them).