### PR TITLE
chore: pin trql-client git dep to the merged registry commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3798,7 +3798,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5543,7 +5543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6181,7 +6181,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6219,7 +6219,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8600,7 +8600,7 @@ dependencies = [
 [[package]]
 name = "trql-client"
 version = "0.7.0"
-source = "git+https://github.com/affinidi/affinidi-trust-registry-rs.git?branch=feat%2Ftrql-client#1eb572b1d05afbe9040ab55448aaccba0673132a"
+source = "git+https://github.com/affinidi/affinidi-trust-registry-rs.git?rev=c04134df9cb934e14e391fdf511b0e3bfca5f4cc#c04134df9cb934e14e391fdf511b0e3bfca5f4cc"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9550,7 +9550,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/did-git-sign/Cargo.toml
+++ b/did-git-sign/Cargo.toml
@@ -22,9 +22,11 @@ vta-sdk = { workspace = true, features = ["client", "session"] }
 # verify-trust: DID resolution for signer keys + Trust Registry queries.
 affinidi-tdk = { workspace = true }
 multibase = { workspace = true }
-# Pinned to the feat/trql-client branch until affinidi-trust-registry-rs
-# PR #94 merges and the crate is published to crates.io.
-trql-client = { git = "https://github.com/affinidi/affinidi-trust-registry-rs.git", branch = "feat/trql-client" }
+# Pinned to the affinidi-trust-registry-rs main-branch commit that merged
+# PR #94 (the real client). Do NOT switch to crates.io "0.7" — that version
+# predates the client and is a bin-only stub with no library target. Swap to
+# the crates.io release once the registry publishes >= 0.8.
+trql-client = { git = "https://github.com/affinidi/affinidi-trust-registry-rs.git", rev = "c04134df9cb934e14e391fdf511b0e3bfca5f4cc" }
 clap = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Re-points the `trql-client` git dependency from `branch = "feat/trql-client"` (now deletable on the registry repo) to the immutable merge commit of [affinidi-trust-registry-rs #94](https://github.com/affinidi/affinidi-trust-registry-rs/pull/94) on `main`. Once this merges, that branch can be deleted without breaking openvtc resolution.

**Why not crates.io:** `trql-client 0.7.0` on crates.io was published 2026-07-09 — *before* the client existed — and is a bin-only `Hello, world!` stub with no library target. The registry workspace needs a version bump (→ 0.8.0) and its release pipeline fixed (trusted-publishing token fetch has been failing since ~July 13) before a crates.io swap is possible; a follow-up PR will do that swap.

Verified: `cargo check` + full `did-git-sign` test suite green on the pinned rev (15 tests).