### PR TITLE
feat: PGP exemption keyring + GitHub Action packaging for verify-trust

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -24,4 +24,16 @@ ignore = [
     # rustls-pemfile: unmaintained (both 1.x via reqwest 0.11 and 2.x via
     # tonic). No security impact identified; purely a maintenance advisory.
     "RUSTSEC-2025-0134",
+
+    # quick-xml DoS vectors, fixed in 0.41. Pulled only via the Linux
+    # clipboard stack (arboard → wl-clipboard-rs → wayland-scanner), which
+    # pins quick-xml 0.39 and parses local Wayland protocol XML at build
+    # time — never attacker-supplied input. Re-check when wayland-scanner
+    # moves to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+
+    # paste: unmaintained build-time proc-macro via vta-service/vti-common
+    # (utoipa-axum). No runtime code.
+    "RUSTSEC-2024-0436",
 ]

--- a/.github/actions/verify-trust/action.yml
+++ b/.github/actions/verify-trust/action.yml
@@ -1,0 +1,116 @@
+# Composite action wrapping `did-git-sign verify-trust`: verify every commit
+# in a PR against the signers' DID documents and the VTC Trust Registry.
+#
+# Requirements on the calling workflow:
+#   - actions/checkout with `fetch-depth: 0` (the verifier walks the full
+#     base..head range of raw commit objects).
+#   - A Rust toolchain on the runner (present on GitHub-hosted runners).
+#
+# The check fails closed: unsigned commits, unknown keys, invalid signatures,
+# registry-unauthorized signers, and an unreachable registry all fail.
+name: Verify Commit Trust
+description: >-
+  Verify PR commit signatures against signer DID documents and the
+  VTC Trust Registry (TRQP authorization per signer DID).
+
+inputs:
+  registry-url:
+    description: Base URL of the Trust Registry (queries POST to <url>/trust-tasks).
+    required: true
+  registry-did:
+    description: DID of the Trust Registry (recipient of every query document).
+    required: true
+  authority:
+    description: DID of the authority the trust tuple is evaluated under.
+    required: true
+  trqp-action:
+    description: TRQP action of the trust tuple.
+    required: false
+    default: git.commit.sign
+  resource:
+    description: TRQP resource of the trust tuple. Defaults to the org/repo slug.
+    required: false
+    default: ${{ github.repository }}
+  signers-file:
+    description: Signer index committed to the repo (one DID per line).
+    required: false
+    default: .did-signers
+  exempt-keyring:
+    description: >-
+      Optional armored PGP keyring committed to the repo (e.g. GitHub's
+      web-flow key) that exempts platform-signed commits (web-UI merges,
+      Dependabot). Empty means no exemptions.
+    required: false
+    default: ""
+  range:
+    description: >-
+      Commit range to verify (git rev-list syntax). Defaults to the pull
+      request's base..head.
+    required: false
+    default: ""
+  openvtc-ref:
+    description: Git ref of OpenVTC/openvtc to install did-git-sign from.
+    required: false
+    default: main
+  install-path:
+    description: >-
+      Install did-git-sign from a local path instead of the git ref —
+      set to "did-git-sign" when dogfooding inside the openvtc repo so the
+      PR's own code is what runs.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install did-git-sign
+      shell: bash
+      env:
+        OPENVTC_REF: ${{ inputs.openvtc-ref }}
+        INSTALL_PATH: ${{ inputs.install-path }}
+      run: |
+        set -euo pipefail
+        if [ -n "$INSTALL_PATH" ]; then
+          cargo install --path "$INSTALL_PATH" --locked
+        else
+          cargo install did-git-sign \
+            --git https://github.com/OpenVTC/openvtc \
+            --branch "$OPENVTC_REF" --locked
+        fi
+
+    - name: Verify commit trust
+      shell: bash
+      env:
+        RANGE_INPUT: ${{ inputs.range }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        REGISTRY_URL: ${{ inputs.registry-url }}
+        REGISTRY_DID: ${{ inputs.registry-did }}
+        AUTHORITY: ${{ inputs.authority }}
+        TRQP_ACTION: ${{ inputs.trqp-action }}
+        RESOURCE: ${{ inputs.resource }}
+        SIGNERS_FILE: ${{ inputs.signers-file }}
+        EXEMPT_KEYRING: ${{ inputs.exempt-keyring }}
+      run: |
+        set -euo pipefail
+        RANGE="$RANGE_INPUT"
+        if [ -z "$RANGE" ]; then
+          if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+            echo "::error::no range given and not a pull_request event"
+            exit 1
+          fi
+          RANGE="$BASE_SHA..$HEAD_SHA"
+        fi
+        EXTRA=()
+        if [ -n "$EXEMPT_KEYRING" ]; then
+          EXTRA+=(--exempt-keyring "$EXEMPT_KEYRING")
+        fi
+        did-git-sign verify-trust \
+          --range "$RANGE" \
+          --registry-url "$REGISTRY_URL" \
+          --registry-did "$REGISTRY_DID" \
+          --authority "$AUTHORITY" \
+          --action "$TRQP_ACTION" \
+          --resource "$RESOURCE" \
+          --signers-file "$SIGNERS_FILE" \
+          "${EXTRA[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,21 @@ jobs:
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
+      - name: Locate OpenSSL (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        # openssl-sys (via openvtc-core's vta-service dev-dependency →
+        # webauthn-rs) needs an OpenSSL install it can find. The hosted
+        # images ship one; fall back to choco if the path ever moves.
+        run: |
+          $candidates = @("C:\Program Files\OpenSSL", "C:\Program Files\OpenSSL-Win64")
+          $dir = $candidates | Where-Object { Test-Path "$_\include\openssl" } | Select-Object -First 1
+          if (-not $dir) {
+            choco install openssl -y --no-progress
+            $dir = $candidates | Where-Object { Test-Path "$_\include\openssl" } | Select-Object -First 1
+          }
+          if (-not $dir) { Write-Error "no OpenSSL installation found"; exit 1 }
+          echo "OPENSSL_DIR=$dir" >> $env:GITHUB_ENV
       - name: Test with default features (Linux/macOS)
         if: runner.os != 'Windows'
         run: cargo test --workspace
@@ -62,7 +77,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
+        # libpcsclite-dev: the pcsc build script runs even with default
+        # features off (dev-dependency chain), and needs the system lib.
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libpcsclite-dev pkgconf
       - run: cargo test --workspace --no-default-features
       # Guard the structure-aware fuzzing seam (issue #124): the cargo-fuzz
       # harnesses build openvtc-core with `--no-default-features --features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,21 +47,6 @@ jobs:
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
-      - name: Locate OpenSSL (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        # openssl-sys (via openvtc-core's vta-service dev-dependency →
-        # webauthn-rs) needs an OpenSSL install it can find. The hosted
-        # images ship one; fall back to choco if the path ever moves.
-        run: |
-          $candidates = @("C:\Program Files\OpenSSL", "C:\Program Files\OpenSSL-Win64")
-          $dir = $candidates | Where-Object { Test-Path "$_\include\openssl" } | Select-Object -First 1
-          if (-not $dir) {
-            choco install openssl -y --no-progress
-            $dir = $candidates | Where-Object { Test-Path "$_\include\openssl" } | Select-Object -First 1
-          }
-          if (-not $dir) { Write-Error "no OpenSSL installation found"; exit 1 }
-          echo "OPENSSL_DIR=$dir" >> $env:GITHUB_ENV
       - name: Test with default features (Linux/macOS)
         if: runner.os != 'Windows'
         run: cargo test --workspace

--- a/.github/workflows/verify-trust.yml
+++ b/.github/workflows/verify-trust.yml
@@ -1,0 +1,38 @@
+# Dogfood workflow for the commit-trust check. Dormant until the repository
+# variables are configured (Settings → Secrets and variables → Actions →
+# Variables):
+#
+#   TRUST_REGISTRY_URL   e.g. https://registry.example.com
+#   TRUST_REGISTRY_DID   DID of the registry
+#   TRUST_AUTHORITY_DID  DID of the authority governing this repo
+#
+# Also requires a committed `.did-signers` file (one DID per line) and,
+# for GitHub web-UI merge / Dependabot commits, a committed
+# `.github/trusted-platform-keys.asc` (GitHub's web-flow public key).
+name: verify-trust
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-trust:
+    name: commit signatures vs Trust Registry
+    if: vars.TRUST_REGISTRY_URL != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The verifier walks raw commit objects across base..head.
+          fetch-depth: 0
+
+      - uses: ./.github/actions/verify-trust
+        with:
+          registry-url: ${{ vars.TRUST_REGISTRY_URL }}
+          registry-did: ${{ vars.TRUST_REGISTRY_DID }}
+          authority: ${{ vars.TRUST_AUTHORITY_DID }}
+          exempt-keyring: .github/trusted-platform-keys.asc
+          # Dogfood: run the PR's own did-git-sign, not a published ref.
+          install-path: did-git-sign

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,6 +5491,7 @@ dependencies = [
  "multibase",
  "openpgp-card",
  "openpgp-card-rpgp",
+ "openssl-sys",
  "pgp",
  "rand 0.8.6",
  "reqwest 0.13.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,7 +819,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -830,7 +830,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2624,7 +2624,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2898,7 +2898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3048,9 +3048,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fjall"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038acd422d607e0eca09e093f299f9eccf9bd097554343d93746afff81a45113"
+checksum = "9fcdc69609906151dff9b534e30eaf8515082055d36f628e382bd0b5d6a1d362"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -4712,9 +4712,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
-version = "3.1.5"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef86c3c797c10eefcc73407c43ae48c19d4df686131a8334b2895a513e91df4"
+checksum = "39ca67401338b98d58447387dd5230552d2241bc388206e491d137b18dfea9d6"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -5016,7 +5016,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6812,7 +6812,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6888,7 +6888,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7545,14 +7545,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -8054,10 +8054,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8070,7 +8070,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,8 @@ dependencies = [
  "keyring-core",
  "linux-keyutils-keyring-store",
  "multibase",
+ "pgp",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "serial_test",

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,19 @@ ignore = [
     # advisory. Will fall off when the upstream chains migrate to
     # rustls-pki-types/rustls-types.
     "RUSTSEC-2025-0134",
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml DoS vectors
+    # (quadratic duplicate-attribute check; unbounded namespace
+    # allocation) fixed in 0.41. Pulled only via the Linux clipboard
+    # stack (arboard → wl-clipboard-rs → wayland-scanner), which pins
+    # quick-xml 0.39 and parses local Wayland protocol XML at build
+    # time — never attacker-supplied input. Re-check when wayland-scanner
+    # moves to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+    # RUSTSEC-2024-0436: paste is unmaintained. Build-time proc-macro
+    # pulled transitively via vta-service/vti-common (utoipa-axum). No
+    # runtime code; falls off when utoipa migrates off paste.
+    "RUSTSEC-2024-0436",
 ]
 
 [licenses]
@@ -94,3 +107,7 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# trql-client rides a rev-pinned git dependency until the trust-registry
+# release pipeline can publish >= 0.8 to crates.io (the published 0.7.0
+# predates the crate's library and must not be used).
+allow-git = ["https://github.com/affinidi/affinidi-trust-registry-rs"]

--- a/did-git-sign/Cargo.toml
+++ b/did-git-sign/Cargo.toml
@@ -29,7 +29,7 @@ pgp = { workspace = true }
 # PR #94 (the real client). Do NOT switch to crates.io "0.7" — that version
 # predates the client and is a bin-only stub with no library target. Swap to
 # the crates.io release once the registry publishes >= 0.8.
-trql-client = { git = "https://github.com/affinidi/affinidi-trust-registry-rs.git", rev = "c04134df9cb934e14e391fdf511b0e3bfca5f4cc" }
+trql-client = { git = "https://github.com/affinidi/affinidi-trust-registry-rs.git", rev = "c04134df9cb934e14e391fdf511b0e3bfca5f4cc", version = "0.7.0" }
 clap = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true, features = ["derive"] }

--- a/did-git-sign/Cargo.toml
+++ b/did-git-sign/Cargo.toml
@@ -22,6 +22,9 @@ vta-sdk = { workspace = true, features = ["client", "session"] }
 # verify-trust: DID resolution for signer keys + Trust Registry queries.
 affinidi-tdk = { workspace = true }
 multibase = { workspace = true }
+# Pure-Rust verification of platform PGP signatures (GitHub web-flow merge
+# commits) against the committed exempt keyring — no gpg binary involved.
+pgp = { workspace = true }
 # Pinned to the affinidi-trust-registry-rs main-branch commit that merged
 # PR #94 (the real client). Do NOT switch to crates.io "0.7" — that version
 # predates the client and is a bin-only stub with no library target. Swap to
@@ -60,3 +63,4 @@ windows-native-keyring-store = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+rand = { workspace = true }

--- a/did-git-sign/src/lib.rs
+++ b/did-git-sign/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod config;
 pub mod init;
+pub mod pgp_exempt;
 pub mod policy;
 pub mod sign;
 pub mod verify_trust;

--- a/did-git-sign/src/main.rs
+++ b/did-git-sign/src/main.rs
@@ -242,6 +242,14 @@ enum Commands {
         #[arg(long)]
         resource: Option<String>,
 
+        /// Armored PGP keyring of exempt platform keys (e.g. GitHub's
+        /// web-flow key, https://github.com/web-flow.gpg) committed to the
+        /// repo. PGP-signed commits (web-UI merges, Dependabot) pass only if
+        /// their signature verifies against a key in this file. Omitted:
+        /// no exemptions.
+        #[arg(long)]
+        exempt_keyring: Option<PathBuf>,
+
         /// Repository to verify. Defaults to the current directory.
         #[arg(long)]
         repo_dir: Option<PathBuf>,
@@ -331,6 +339,7 @@ async fn main() -> Result<()> {
             authority,
             action,
             resource,
+            exempt_keyring,
             repo_dir,
             json,
         }) => {
@@ -350,6 +359,7 @@ async fn main() -> Result<()> {
                 authority_did: authority,
                 action,
                 resource,
+                exempt_keyring,
                 json,
             })
             .await?;

--- a/did-git-sign/src/main.rs
+++ b/did-git-sign/src/main.rs
@@ -972,6 +972,10 @@ mod tests {
     /// that every expected flag and value appears in that file.
     #[test]
     #[serial_test::serial]
+    // The mock ssh-keygen is a POSIX shell script, which Windows cannot
+    // execute (os error 193). The behavior under test — argv forwarding —
+    // is platform-independent, so non-Windows coverage suffices.
+    #[cfg(not(windows))]
     fn delegate_forwards_all_flags_to_ssh_keygen() {
         // Copy the mock script into a private temp dir and operate on the COPY —
         // never mutate the shared, checked-in fixture. Previously this test

--- a/did-git-sign/src/pgp_exempt.rs
+++ b/did-git-sign/src/pgp_exempt.rs
@@ -1,0 +1,173 @@
+//! Exemption keyring for platform-signed commits.
+//!
+//! GitHub signs the commits it creates itself — web-UI merge and squash
+//! commits, Dependabot commits — with **PGP** (its `web-flow` key), not with
+//! a contributor's sshsig. Those commits can never carry a DID signature, so
+//! a repository that wants `verify-trust` as a required check needs a policy
+//! for them.
+//!
+//! The policy here is cryptographic, never name-based: the repository commits
+//! an armored keyring of explicitly trusted platform keys (e.g. the key from
+//! <https://github.com/web-flow.gpg>), and a PGP-signed commit passes only if
+//! its signature verifies against one of those keys. Committer names and
+//! emails are attacker-chosen strings and play no part. With no keyring
+//! configured, every PGP-signed commit fails — absence of configuration is
+//! the most restrictive interpretation.
+//!
+//! Verification is pure Rust (rPGP); no `gpg` binary is involved.
+
+use anyhow::{Context, Result, bail};
+use pgp::composed::{Deserializable, DetachedSignature, SignedPublicKey};
+use pgp::types::KeyDetails;
+use std::path::Path;
+
+/// An armored set of platform keys whose signatures exempt a commit from the
+/// DID-signature requirement.
+pub struct ExemptKeyring {
+    keys: Vec<SignedPublicKey>,
+}
+
+impl ExemptKeyring {
+    /// Parse an armored keyring: either one armor block holding several keys
+    /// (`gpg --export --armor keyA keyB`) or several armor blocks
+    /// concatenated (`cat a.asc b.asc`).
+    pub fn from_armored(text: &str) -> Result<Self> {
+        const BLOCK_START: &str = "-----BEGIN PGP PUBLIC KEY BLOCK-----";
+        let mut keys = Vec::new();
+        for block in text.split(BLOCK_START).skip(1) {
+            let block = format!("{BLOCK_START}{block}");
+            let (parsed, _headers) = SignedPublicKey::from_string_many(&block)
+                .context("exempt keyring did not parse")?;
+            keys.extend(
+                parsed
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .context("exempt keyring contains an invalid key")?,
+            );
+        }
+        if keys.is_empty() {
+            bail!("exempt keyring contains no keys");
+        }
+        Ok(Self { keys })
+    }
+
+    /// Load a keyring file.
+    pub fn load(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("cannot read exempt keyring {}", path.display()))?;
+        Self::from_armored(&text)
+    }
+
+    /// Verify a detached, armored PGP signature over `payload` against the
+    /// keyring. Returns the hex fingerprint of the matching primary key, or a
+    /// description of why nothing matched.
+    pub fn verify(&self, armored_signature: &str, payload: &[u8]) -> Result<String, String> {
+        let (signature, _headers) = DetachedSignature::from_string(armored_signature)
+            .map_err(|e| format!("PGP signature did not parse: {e}"))?;
+
+        for key in &self.keys {
+            let fingerprint = hex::encode(key.primary_key.fingerprint().as_bytes());
+            if signature.verify(key, payload).is_ok() {
+                return Ok(fingerprint);
+            }
+            for subkey in &key.public_subkeys {
+                if signature.verify(subkey, payload).is_ok() {
+                    return Ok(fingerprint);
+                }
+            }
+        }
+        Err("signature matches no key in the exempt keyring".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use pgp::composed::{ArmorOptions, KeyType, SecretKeyParamsBuilder, SignedSecretKey};
+    use pgp::crypto::hash::HashAlgorithm;
+    use pgp::types::Password;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    fn test_key(seed: u64, user: &str) -> SignedSecretKey {
+        let mut rng = StdRng::seed_from_u64(seed);
+        SecretKeyParamsBuilder::default()
+            .key_type(KeyType::Ed25519)
+            .can_sign(true)
+            .primary_user_id(user.to_string())
+            .build()
+            .unwrap()
+            .generate(&mut rng)
+            .unwrap()
+    }
+
+    fn armored_public(key: &SignedSecretKey) -> String {
+        SignedPublicKey::from(key.clone())
+            .to_armored_string(ArmorOptions::default())
+            .unwrap()
+    }
+
+    fn sign(key: &SignedSecretKey, payload: &[u8]) -> String {
+        let mut rng = StdRng::seed_from_u64(42);
+        DetachedSignature::sign_binary_data(
+            &mut rng,
+            &key.primary_key,
+            &Password::empty(),
+            HashAlgorithm::Sha256,
+            payload,
+        )
+        .unwrap()
+        .to_armored_string(ArmorOptions::default())
+        .unwrap()
+    }
+
+    #[test]
+    fn signature_by_a_keyring_key_is_exempt() {
+        let key = test_key(1, "platform@example.com");
+        let keyring = ExemptKeyring::from_armored(&armored_public(&key)).unwrap();
+        let payload = b"tree abc\n\nmerge commit";
+
+        let fingerprint = keyring.verify(&sign(&key, payload), payload).unwrap();
+        assert_eq!(
+            fingerprint,
+            hex::encode(key.primary_key.fingerprint().as_bytes())
+        );
+    }
+
+    #[test]
+    fn signature_by_an_unknown_key_is_rejected() {
+        let trusted = test_key(1, "platform@example.com");
+        let attacker = test_key(2, "attacker@example.com");
+        let keyring = ExemptKeyring::from_armored(&armored_public(&trusted)).unwrap();
+        let payload = b"tree abc\n\nmerge commit";
+
+        assert!(keyring.verify(&sign(&attacker, payload), payload).is_err());
+    }
+
+    #[test]
+    fn tampered_payload_is_rejected() {
+        let key = test_key(1, "platform@example.com");
+        let keyring = ExemptKeyring::from_armored(&armored_public(&key)).unwrap();
+        let signature = sign(&key, b"original payload");
+
+        assert!(keyring.verify(&signature, b"tampered payload").is_err());
+    }
+
+    #[test]
+    fn multi_key_keyring_matches_any_member() {
+        let a = test_key(1, "a@example.com");
+        let b = test_key(2, "b@example.com");
+        let both = format!("{}{}", armored_public(&a), armored_public(&b));
+        let keyring = ExemptKeyring::from_armored(&both).unwrap();
+        let payload = b"payload";
+
+        assert!(keyring.verify(&sign(&b, payload), payload).is_ok());
+    }
+
+    #[test]
+    fn empty_or_garbage_keyring_is_a_hard_error() {
+        assert!(ExemptKeyring::from_armored("").is_err());
+        assert!(ExemptKeyring::from_armored("not a keyring").is_err());
+    }
+}

--- a/did-git-sign/src/verify_trust.rs
+++ b/did-git-sign/src/verify_trust.rs
@@ -32,6 +32,8 @@ use serde::Serialize;
 use ssh_key::{SshSig, public::KeyData};
 use trql_client::{HttpsTransport, HttpsTransportConfig, TrqlClient, TrqlError, TrqpQuery};
 
+use crate::pgp_exempt::ExemptKeyring;
+
 /// The sshsig namespace git uses for commit and tag signatures.
 pub const GIT_SSHSIG_NAMESPACE: &str = "git";
 
@@ -57,6 +59,10 @@ pub struct VerifyTrustArgs {
     pub action: String,
     /// TRQP resource, e.g. the `org/repo` slug.
     pub resource: String,
+    /// Optional armored PGP keyring of exempt platform keys (e.g. GitHub's
+    /// web-flow key); relative paths resolve against `repo_dir`. Absent means
+    /// no exemptions: every PGP-signed commit fails.
+    pub exempt_keyring: Option<PathBuf>,
     /// Emit machine-readable JSON on stdout instead of human lines.
     pub json: bool,
 }
@@ -78,14 +84,25 @@ pub enum CommitStatus {
     /// Valid signature, but the registry could not be consulted. Fails the
     /// run (closed), distinctly from a denial.
     RegistryUnavailable { signer_did: String, error: String },
+    /// PGP-signed (a platform commit), but the signature verifies against no
+    /// key in the exempt keyring — or no keyring is configured.
+    PgpRejected { detail: String },
+    /// PGP-signed by a key in the committed exempt keyring (e.g. a GitHub
+    /// web-UI merge commit). Passes, reported distinctly from `Trusted`.
+    Exempt { fingerprint: String },
     /// Valid signature by a registry-authorized signer.
     Trusted { signer_did: String },
 }
 
 impl CommitStatus {
-    /// Only a `Trusted` commit passes.
+    /// Signed by a registry-authorized DID.
     pub fn is_trusted(&self) -> bool {
         matches!(self, Self::Trusted { .. })
+    }
+
+    /// Whether the commit passes the check: DID-trusted or keyring-exempt.
+    pub fn passes(&self) -> bool {
+        matches!(self, Self::Trusted { .. } | Self::Exempt { .. })
     }
 }
 
@@ -113,8 +130,9 @@ pub struct TrustReport {
 /// the range. Returns the process exit code (0 = every commit trusted).
 pub async fn handle_verify_trust(args: VerifyTrustArgs) -> Result<i32> {
     let signer_dids = load_signers(&args.repo_dir, &args.signers_file)?;
+    let exempt = load_exempt_keyring(&args)?;
     let (keys, unresolved) = resolve_signer_keys(&signer_dids).await?;
-    let report = verify_with_keys(&args, &keys, unresolved).await?;
+    let report = verify_with_keys(&args, &keys, exempt.as_ref(), unresolved).await?;
     print_report(&args, &report)?;
     Ok(if report.ok { 0 } else { 1 })
 }
@@ -124,6 +142,7 @@ pub async fn handle_verify_trust(args: VerifyTrustArgs) -> Result<i32> {
 pub async fn verify_with_keys(
     args: &VerifyTrustArgs,
     signer_keys: &HashMap<[u8; 32], String>,
+    exempt: Option<&ExemptKeyring>,
     unresolved_signers: BTreeMap<String, String>,
 ) -> Result<TrustReport> {
     let shas = list_commits(&args.repo_dir, &args.range)?;
@@ -133,7 +152,7 @@ pub async fn verify_with_keys(
     let mut signer_dids = BTreeSet::new();
     for sha in shas {
         let raw = read_commit_raw(&args.repo_dir, &sha)?;
-        let signature = check_commit_signature(&raw, signer_keys);
+        let signature = check_commit_signature(&raw, signer_keys, exempt);
         if let SignatureCheck::Valid { signer_did } = &signature {
             signer_dids.insert(signer_did.clone());
         }
@@ -152,7 +171,7 @@ pub async fn verify_with_keys(
         .collect();
 
     // An empty range passes vacuously (nothing new to verify).
-    let ok = commits.iter().all(|c| c.status.is_trusted());
+    let ok = commits.iter().all(|c| c.status.passes());
     Ok(TrustReport {
         ok,
         commits,
@@ -169,6 +188,8 @@ pub enum SignatureCheck {
     Malformed(String),
     UnknownKey { fingerprint: String },
     BadSignature { signer_did: String },
+    PgpRejected { detail: String },
+    Exempt { fingerprint: String },
     Valid { signer_did: String },
 }
 
@@ -176,12 +197,26 @@ pub enum SignatureCheck {
 pub fn check_commit_signature(
     raw: &[u8],
     signer_keys: &HashMap<[u8; 32], String>,
+    exempt: Option<&ExemptKeyring>,
 ) -> SignatureCheck {
     let (payload, pem) = match split_signed_commit(raw) {
         Ok(Some(parts)) => parts,
         Ok(None) => return SignatureCheck::Unsigned,
         Err(e) => return SignatureCheck::Malformed(e.to_string()),
     };
+    // Platform commits (GitHub web-UI merges, Dependabot) are PGP-signed;
+    // they pass only via the explicitly committed exempt keyring.
+    if pem.starts_with("-----BEGIN PGP SIGNATURE-----") {
+        let Some(keyring) = exempt else {
+            return SignatureCheck::PgpRejected {
+                detail: "PGP-signed commit, but no exempt keyring is configured".to_string(),
+            };
+        };
+        return match keyring.verify(&pem, &payload) {
+            Ok(fingerprint) => SignatureCheck::Exempt { fingerprint },
+            Err(detail) => SignatureCheck::PgpRejected { detail },
+        };
+    }
     let sig = match SshSig::from_pem(normalize_sshsig_armor(&pem).as_bytes()) {
         Ok(sig) => sig,
         Err(e) => return SignatureCheck::Malformed(format!("sshsig did not parse: {e}")),
@@ -269,6 +304,19 @@ pub fn split_signed_commit(raw: &[u8]) -> Result<Option<(Vec<u8>, String)>> {
     let mut pem = signature_lines.join("\n");
     pem.push('\n');
     Ok(Some((payload, pem)))
+}
+
+/// Load the exempt keyring named by the args, resolving relative to the repo.
+fn load_exempt_keyring(args: &VerifyTrustArgs) -> Result<Option<ExemptKeyring>> {
+    let Some(path) = &args.exempt_keyring else {
+        return Ok(None);
+    };
+    let path = if path.is_absolute() {
+        path.clone()
+    } else {
+        args.repo_dir.join(path)
+    };
+    Ok(Some(ExemptKeyring::load(&path)?))
 }
 
 // --- signer index & DID resolution -------------------------------------------
@@ -414,6 +462,8 @@ fn status_of(signature: SignatureCheck, decisions: &RegistryDecisions) -> Commit
         SignatureCheck::Malformed(detail) => CommitStatus::Malformed(detail),
         SignatureCheck::UnknownKey { fingerprint } => CommitStatus::UnknownKey { fingerprint },
         SignatureCheck::BadSignature { signer_did } => CommitStatus::BadSignature { signer_did },
+        SignatureCheck::PgpRejected { detail } => CommitStatus::PgpRejected { detail },
+        SignatureCheck::Exempt { fingerprint } => CommitStatus::Exempt { fingerprint },
         SignatureCheck::Valid { signer_did } => match decisions.get(&signer_did) {
             Some(Ok(true)) => CommitStatus::Trusted { signer_did },
             Some(Ok(false)) => CommitStatus::Unauthorized { signer_did },
@@ -484,6 +534,12 @@ fn print_report(args: &VerifyTrustArgs, report: &TrustReport) -> Result<()> {
             CommitStatus::Trusted { signer_did } => {
                 println!("TRUSTED      {short}  {signer_did}");
             }
+            CommitStatus::Exempt { fingerprint } => {
+                println!("EXEMPT       {short}  PGP-signed by exempt platform key {fingerprint}");
+            }
+            CommitStatus::PgpRejected { detail } => {
+                println!("PGP-REJECTED {short}  {detail}");
+            }
             CommitStatus::Unauthorized { signer_did } => {
                 println!("UNAUTHORIZED {short}  {signer_did} is not authorized by the registry");
             }
@@ -511,13 +567,9 @@ fn print_report(args: &VerifyTrustArgs, report: &TrustReport) -> Result<()> {
     for (did, reason) in &report.unresolved_signers {
         println!("WARNING      declared signer {did}: {reason}");
     }
-    let trusted = report
-        .commits
-        .iter()
-        .filter(|c| c.status.is_trusted())
-        .count();
+    let passing = report.commits.iter().filter(|c| c.status.passes()).count();
     println!(
-        "{}: {trusted}/{} commits trusted",
+        "{}: {passing}/{} commits pass",
         if report.ok { "PASS" } else { "FAIL" },
         report.commits.len()
     );
@@ -603,7 +655,7 @@ mod tests {
         let commit = sign_commit(&payload, &key);
         let keys = HashMap::from([(public, "did:example:signer".to_string())]);
 
-        let check = check_commit_signature(commit.as_bytes(), &keys);
+        let check = check_commit_signature(commit.as_bytes(), &keys, None);
         assert_eq!(
             check,
             SignatureCheck::Valid {
@@ -639,7 +691,7 @@ mod tests {
         let commit = signed_commit(&payload, &legacy);
         let keys = HashMap::from([(public, "did:example:signer".to_string())]);
         assert_eq!(
-            check_commit_signature(commit.as_bytes(), &keys),
+            check_commit_signature(commit.as_bytes(), &keys, None),
             SignatureCheck::Valid {
                 signer_did: "did:example:signer".to_string()
             }
@@ -652,7 +704,7 @@ mod tests {
         let (key, _) = test_key();
         let commit = sign_commit(&payload, &key);
 
-        let check = check_commit_signature(commit.as_bytes(), &HashMap::new());
+        let check = check_commit_signature(commit.as_bytes(), &HashMap::new(), None);
         assert!(matches!(check, SignatureCheck::UnknownKey { .. }));
     }
 
@@ -663,7 +715,7 @@ mod tests {
         let commit = sign_commit(&payload, &key).replace("a message", "b message");
         let keys = HashMap::from([(public, "did:example:signer".to_string())]);
 
-        let check = check_commit_signature(commit.as_bytes(), &keys);
+        let check = check_commit_signature(commit.as_bytes(), &keys, None);
         assert_eq!(
             check,
             SignatureCheck::BadSignature {
@@ -674,7 +726,7 @@ mod tests {
 
     #[test]
     fn unsigned_commit_is_unsigned() {
-        let check = check_commit_signature(unsigned_commit().as_bytes(), &HashMap::new());
+        let check = check_commit_signature(unsigned_commit().as_bytes(), &HashMap::new(), None);
         assert_eq!(check, SignatureCheck::Unsigned);
     }
 

--- a/did-git-sign/tests/verify_trust_e2e.rs
+++ b/did-git-sign/tests/verify_trust_e2e.rs
@@ -190,6 +190,7 @@ fn args_for(repo: &Path, range: String, registry_url: String) -> VerifyTrustArgs
         repo_dir: repo.to_path_buf(),
         range,
         signers_file: ".did-signers".into(),
+        exempt_keyring: None,
         registry_url,
         registry_did: "did:example:registry".into(),
         authority_did: "did:example:authority".into(),
@@ -212,7 +213,7 @@ async fn signed_and_authorized_commit_passes() {
 
     let keys = HashMap::from([(key.verifying_key().to_bytes(), SIGNER.to_string())]);
     let args = args_for(dir.path(), format!("{base}..{signed}"), registry);
-    let report = verify_with_keys(&args, &keys, BTreeMap::new())
+    let report = verify_with_keys(&args, &keys, None, BTreeMap::new())
         .await
         .unwrap();
 
@@ -236,7 +237,7 @@ async fn signed_but_unauthorized_commit_fails() {
 
     let keys = HashMap::from([(key.verifying_key().to_bytes(), SIGNER.to_string())]);
     let args = args_for(dir.path(), format!("{base}..{signed}"), registry);
-    let report = verify_with_keys(&args, &keys, BTreeMap::new())
+    let report = verify_with_keys(&args, &keys, None, BTreeMap::new())
         .await
         .unwrap();
 
@@ -265,7 +266,7 @@ async fn unsigned_commit_fails_without_touching_the_registry() {
 
     // Deliberately unreachable registry: no signed commits means no queries.
     let args = args_for(repo, format!("{base}..{head}"), "http://127.0.0.1:1".into());
-    let report = verify_with_keys(&args, &HashMap::new(), BTreeMap::new())
+    let report = verify_with_keys(&args, &HashMap::new(), None, BTreeMap::new())
         .await
         .unwrap();
 
@@ -285,7 +286,7 @@ async fn unreachable_registry_fails_closed() {
         format!("{base}..{signed}"),
         "http://127.0.0.1:1".into(),
     );
-    let report = verify_with_keys(&args, &keys, BTreeMap::new())
+    let report = verify_with_keys(&args, &keys, None, BTreeMap::new())
         .await
         .unwrap();
 
@@ -297,4 +298,159 @@ async fn unreachable_registry_fails_closed() {
         report.commits[0].status,
         CommitStatus::RegistryUnavailable { .. }
     ));
+}
+
+// --- PGP platform-commit exemption ------------------------------------------
+
+mod pgp_platform {
+    use super::*;
+    use did_git_sign::pgp_exempt::ExemptKeyring;
+    use pgp::composed::{
+        ArmorOptions, DetachedSignature, KeyType, SecretKeyParamsBuilder, SignedPublicKey,
+        SignedSecretKey,
+    };
+    use pgp::crypto::hash::HashAlgorithm;
+    use pgp::types::Password;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    fn platform_key() -> SignedSecretKey {
+        let mut rng = StdRng::seed_from_u64(7);
+        SecretKeyParamsBuilder::default()
+            .key_type(KeyType::Ed25519)
+            .can_sign(true)
+            .primary_user_id("GitHub <noreply@github.com>".to_string())
+            .build()
+            .unwrap()
+            .generate(&mut rng)
+            .unwrap()
+    }
+
+    /// Rewrite `sha` as a PGP-signed commit (the shape GitHub's web-flow key
+    /// produces for web-UI merge and Dependabot commits).
+    fn pgp_sign_commit(repo: &Path, sha: &str, key: &SignedSecretKey) -> String {
+        let payload = {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(repo)
+                .args(["cat-file", "commit", sha])
+                .output()
+                .unwrap();
+            assert!(out.status.success());
+            out.stdout
+        };
+        let mut rng = StdRng::seed_from_u64(11);
+        let armored = DetachedSignature::sign_binary_data(
+            &mut rng,
+            &key.primary_key,
+            &Password::empty(),
+            HashAlgorithm::Sha256,
+            &payload[..],
+        )
+        .unwrap()
+        .to_armored_string(ArmorOptions::default())
+        .unwrap();
+
+        let text = String::from_utf8(payload).unwrap();
+        let (headers, body) = text.split_once("\n\n").unwrap();
+        let mut sig_header = String::from("gpgsig ");
+        let mut lines = armored.trim_end().split('\n');
+        sig_header.push_str(lines.next().unwrap());
+        for line in lines {
+            sig_header.push_str("\n ");
+            sig_header.push_str(line);
+        }
+        let signed = format!("{headers}\n{sig_header}\n\n{body}");
+
+        let mut child = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["hash-object", "-t", "commit", "-w", "--stdin"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        {
+            use std::io::Write;
+            child
+                .stdin
+                .take()
+                .unwrap()
+                .write_all(signed.as_bytes())
+                .unwrap();
+        }
+        let out = child.wait_with_output().unwrap();
+        assert!(out.status.success());
+        String::from_utf8_lossy(&out.stdout).trim_end().to_string()
+    }
+
+    #[tokio::test]
+    async fn platform_signed_commit_is_exempt_with_keyring() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        let did_key = SigningKey::from_bytes(&[9u8; 32]);
+        let (base, did_signed) = repo_with_signed_commit(repo, &did_key);
+
+        // A "web-UI merge" style commit on top, PGP-signed by the platform key.
+        std::fs::write(repo.join("a.txt"), "three\n").unwrap();
+        git(repo, &["add", "a.txt"]);
+        git(repo, &["commit", "-q", "-m", "merge-style change"]);
+        let unsigned = git(repo, &["rev-parse", "HEAD"]);
+        let platform = platform_key();
+        let pgp_signed = pgp_sign_commit(repo, &unsigned, &platform);
+        git(repo, &["update-ref", "refs/heads/main", &pgp_signed]);
+
+        let keyring_armor = SignedPublicKey::from(platform.clone())
+            .to_armored_string(ArmorOptions::default())
+            .unwrap();
+        let keyring = ExemptKeyring::from_armored(&keyring_armor).unwrap();
+
+        let registry = stub_registry(SIGNER.to_string()).await;
+        let keys = HashMap::from([(did_key.verifying_key().to_bytes(), SIGNER.to_string())]);
+        let args = args_for(repo, format!("{base}..{pgp_signed}"), registry);
+        let report = verify_with_keys(&args, &keys, Some(&keyring), BTreeMap::new())
+            .await
+            .unwrap();
+
+        assert!(report.ok, "DID-signed + platform-exempt should both pass");
+        assert_eq!(report.commits.len(), 2);
+        assert!(report.commits[0].status.is_trusted(), "{did_signed}");
+        assert!(matches!(
+            report.commits[1].status,
+            CommitStatus::Exempt { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn platform_signed_commit_fails_without_keyring() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path();
+        git(repo, &["init", "-q", "-b", "main"]);
+        std::fs::write(repo.join("a.txt"), "one\n").unwrap();
+        git(repo, &["add", "a.txt"]);
+        git(repo, &["commit", "-q", "-m", "base"]);
+        let base = git(repo, &["rev-parse", "HEAD"]);
+        std::fs::write(repo.join("a.txt"), "two\n").unwrap();
+        git(repo, &["add", "a.txt"]);
+        git(repo, &["commit", "-q", "-m", "change"]);
+        let unsigned = git(repo, &["rev-parse", "HEAD"]);
+        let pgp_signed = pgp_sign_commit(repo, &unsigned, &platform_key());
+        git(repo, &["update-ref", "refs/heads/main", &pgp_signed]);
+
+        // No registry needed: the commit never reaches the registry pass.
+        let args = args_for(
+            repo,
+            format!("{base}..{pgp_signed}"),
+            "http://127.0.0.1:1".into(),
+        );
+        let report = verify_with_keys(&args, &HashMap::new(), None, BTreeMap::new())
+            .await
+            .unwrap();
+
+        assert!(!report.ok, "no keyring means no exemptions");
+        assert!(matches!(
+            report.commits[0].status,
+            CommitStatus::PgpRejected { .. }
+        ));
+    }
 }

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -96,3 +96,10 @@ uuid = { workspace = true }
 [[bench]]
 name = "crypto"
 harness = false
+
+# The vta-service dev-dependency drags webauthn-rs -> openssl-sys into every
+# `cargo test` build. Hosted Windows runners ship no MSVC-linkable OpenSSL,
+# so build the vendored copy there; feature unification applies it to the
+# whole graph. Linux/macOS keep linking the system library.
+[target.'cfg(windows)'.dev-dependencies]
+openssl-sys = { version = "0.9", features = ["vendored"] }

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -238,7 +238,7 @@ pub struct CommunityRecord {
     ///
     /// Persisted as a JSON object keyed by [`CredentialKind::config_key`].
     /// Configs written before R19 used flat `membership_credential` /
-    /// `role_credential` fields; [`CommunityRecordShadow`] folds those in on
+    /// `role_credential` fields; `CommunityRecordShadow` folds those in on
     /// load so older configs keep working.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub credentials: BTreeMap<CredentialKind, serde_json::Value>,
@@ -536,7 +536,7 @@ pub struct Account {
     /// Community memberships, grouped by VTC DID. A community may hold more than
     /// one membership, each presenting a **different** persona — the
     /// `(vtc_did, persona_ref)` pair is unique. Backward compatible:
-    /// [`de_communities`] folds the legacy one-record-per-VTC shape (and a bare
+    /// `de_communities` folds the legacy one-record-per-VTC shape (and a bare
     /// record) into the grouped form on load.
     #[serde(default, deserialize_with = "de_communities")]
     pub communities: HashMap<VtcDid, Vec<CommunityRecord>>,
@@ -596,7 +596,11 @@ impl Account {
     }
 
     /// Mutable [`Self::membership`] — for applying a lifecycle transition.
-    pub fn membership_mut(&mut self, vtc: &str, persona: PersonaId) -> Option<&mut CommunityRecord> {
+    pub fn membership_mut(
+        &mut self,
+        vtc: &str,
+        persona: PersonaId,
+    ) -> Option<&mut CommunityRecord> {
         self.communities
             .get_mut(vtc)?
             .iter_mut()

--- a/openvtc-core/src/config/context_path.rs
+++ b/openvtc-core/src/config/context_path.rs
@@ -150,7 +150,7 @@ pub fn child_path(parent: &str, segment: &str) -> Result<String, OpenVTCError> {
 ///
 /// Lowercases the name, keeps `[a-z0-9]`, collapses every run of other
 /// characters (including spaces, punctuation, and `-`) to a single `-`, trims
-/// leading/trailing `-`, and caps the result at [`MAX_SLUG_LEN`] characters.
+/// leading/trailing `-`, and caps the result at `MAX_SLUG_LEN` characters.
 /// Returns an empty string when nothing usable remains (e.g. a name with no
 /// ASCII alphanumerics) — callers fall back to [`fallback_token`].
 pub fn slugify(name: &str) -> String {
@@ -218,7 +218,7 @@ pub fn fallback_token(vtc_did: &str) -> Result<String, OpenVTCError> {
 /// guaranteed to satisfy the mirrored `vti-common` rules — each segment a valid
 /// identifier, the whole path within [`MAX_CONTEXT_DEPTH`] — exactly what the
 /// VTA re-validates server-side. The slug is `[a-z0-9-]` capped at
-/// [`MAX_SLUG_LEN`] and the collision suffix adds only `[0-9-]`, so a usable
+/// `MAX_SLUG_LEN` and the collision suffix adds only `[0-9-]`, so a usable
 /// slug always passes segment validation; the only construction failures are an
 /// invalid/over-deep `top_context_id` or an unusable fallback DID.
 ///

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -148,33 +148,34 @@ impl Config {
         };
 
         // Unencrypt the private config data, with migration from legacy seed
-        let (mut private_cfg, needs_migration) = if let Some(private_cfg_str) = &public_config.private {
-            match ProtectedConfig::load(&encryption_seed, private_cfg_str) {
-                Ok(cfg) => (cfg, false),
-                Err(_) => {
-                    // Try legacy seed (pre-0.1.4 used verifying key instead of signing key)
-                    if let KeyBackend::Bip32 { root, .. } = &key_backend {
-                        let legacy_seed = ProtectedConfig::get_seed_legacy(root, "m/0'/0'/0'")?;
-                        match ProtectedConfig::load(&legacy_seed, private_cfg_str) {
-                            Ok(cfg) => {
-                                warn!(
-                                    "Config was encrypted with legacy seed — will be \
+        let (mut private_cfg, needs_migration) =
+            if let Some(private_cfg_str) = &public_config.private {
+                match ProtectedConfig::load(&encryption_seed, private_cfg_str) {
+                    Ok(cfg) => (cfg, false),
+                    Err(_) => {
+                        // Try legacy seed (pre-0.1.4 used verifying key instead of signing key)
+                        if let KeyBackend::Bip32 { root, .. } = &key_backend {
+                            let legacy_seed = ProtectedConfig::get_seed_legacy(root, "m/0'/0'/0'")?;
+                            match ProtectedConfig::load(&legacy_seed, private_cfg_str) {
+                                Ok(cfg) => {
+                                    warn!(
+                                        "Config was encrypted with legacy seed — will be \
                                          re-encrypted with the new seed on next save"
-                                );
-                                (cfg, true)
+                                    );
+                                    (cfg, true)
+                                }
+                                Err(e) => return Err(e),
                             }
-                            Err(e) => return Err(e),
+                        } else {
+                            return Err(OpenVTCError::Decrypt(
+                                "Failed to decrypt protected config".to_string(),
+                            ));
                         }
-                    } else {
-                        return Err(OpenVTCError::Decrypt(
-                            "Failed to decrypt protected config".to_string(),
-                        ));
                     }
                 }
-            }
-        } else {
-            (ProtectedConfig::default(), false)
-        };
+            } else {
+                (ProtectedConfig::default(), false)
+            };
 
         // If migrating from legacy seed, flag for re-encryption on next save
         if needs_migration {

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -315,7 +315,7 @@ pub struct Config {
     /// Runtime-resolved identities (resolved DID document + ATM profile),
     /// keyed by persona id. Not persisted — rebuilt at load from `account`.
     ///
-    /// Holds one entry per persona — load resolves an [`IdentityContext`] for
+    /// Holds one entry per persona — load resolves an `IdentityContext` for
     /// every persona in the account, and a DIDComm listener is started for each.
     /// [`Config::active_identity`] still surfaces the first as the "active" one
     /// for user-initiated outbound actions; explicit persona *selection* lands in

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -273,7 +273,7 @@ impl TryFrom<&Message> for MessageType {
 ///
 /// This is the single registry that drives credential storage
 /// ([`CommunityRecord::credentials`](crate::config::account::CommunityRecord::credentials)),
-/// dispatch ([`messaging::handle_credential_issue`](crate::messaging::handle_credential_issue))
+/// dispatch ([`messaging::handle_credential_issue`])
 /// and the "My Credentials" UI. Adding a credential kind means adding a variant
 /// here plus its match arms below — the dispatch and UI code iterate
 /// [`ALL`](Self::ALL) and match on [`vc_type`](Self::vc_type), so they pick the

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -324,7 +324,11 @@ pub fn handle_join_status_response(
 /// the verdict effect: `allow` → Active, `deny` → Rejected; `refer` /
 /// `request_more` leave the record Pending (logged — they still raise the
 /// actions-required indicator). Mirrors [`handle_join_status_response`].
-pub fn handle_join_verdict(account: &mut Account, message: &Message, from_did: &str) -> StatusOutcome {
+pub fn handle_join_verdict(
+    account: &mut Account,
+    message: &Message,
+    from_did: &str,
+) -> StatusOutcome {
     let Some(thid) = message.thid.as_deref() else {
         warn!("join verdict without thid — cannot correlate; ignoring");
         return StatusOutcome::NONE;
@@ -1102,10 +1106,7 @@ mod tests {
         );
         assert!(out.changed);
         assert!(out.inactivated.is_none());
-        assert!(matches!(
-            only(&acct, vtc).status,
-            CommunityStatus::Active
-        ));
+        assert!(matches!(only(&acct, vtc).status, CommunityStatus::Active));
     }
 
     #[test]
@@ -1122,10 +1123,7 @@ mod tests {
         );
         assert!(out.changed);
         assert!(out.inactivated.is_some(), "a deny deregisters the session");
-        assert!(matches!(
-            only(&acct, vtc).status,
-            CommunityStatus::Rejected
-        ));
+        assert!(matches!(only(&acct, vtc).status, CommunityStatus::Rejected));
     }
 
     #[test]
@@ -1153,7 +1151,12 @@ mod tests {
         // thid is a *different* uuid than the pending placeholder.
         let out = handle_join_verdict(
             &mut acct,
-            &verdict(&Uuid::new_v4().to_string(), vtc, "deny", serde_json::json!({})),
+            &verdict(
+                &Uuid::new_v4().to_string(),
+                vtc,
+                "deny",
+                serde_json::json!({}),
+            ),
             vtc,
         );
         assert!(!out.changed);
@@ -1249,11 +1252,11 @@ mod tests {
             vtc,
         );
         assert!(out.changed);
-        assert!(out.inactivated.is_some(), "a denial deregisters the session");
-        assert!(matches!(
-            only(&acct, vtc).status,
-            CommunityStatus::Rejected
-        ));
+        assert!(
+            out.inactivated.is_some(),
+            "a denial deregisters the session"
+        );
+        assert!(matches!(only(&acct, vtc).status, CommunityStatus::Rejected));
     }
 
     #[test]
@@ -1264,14 +1267,22 @@ mod tests {
 
         let out = handle_join_trust_task_error(
             &mut acct,
-            &trust_task_error(&rid.to_string(), vtc, "malformedRequest", "missing field `id`"),
+            &trust_task_error(
+                &rid.to_string(),
+                vtc,
+                "malformedRequest",
+                "missing field `id`",
+            ),
             vtc,
         );
         assert!(
             out.changed,
             "the VTC responded — stamps receipt_at, needs persisting"
         );
-        assert!(out.inactivated.is_none(), "recoverable — no terminal transition");
+        assert!(
+            out.inactivated.is_none(),
+            "recoverable — no terminal transition"
+        );
         let rec = only(&acct, vtc);
         assert!(
             matches!(rec.status, CommunityStatus::Pending { .. }),
@@ -1318,15 +1329,17 @@ mod tests {
 
         let out = handle_join_problem_report(
             &mut acct,
-            &problem_report(&rid.to_string(), vtc, "e.p.msg.forbidden", "invitation rejected"),
+            &problem_report(
+                &rid.to_string(),
+                vtc,
+                "e.p.msg.forbidden",
+                "invitation rejected",
+            ),
             vtc,
         );
         assert!(out.changed);
         assert!(out.inactivated.is_some());
-        assert!(matches!(
-            only(&acct, vtc).status,
-            CommunityStatus::Rejected
-        ));
+        assert!(matches!(only(&acct, vtc).status, CommunityStatus::Rejected));
     }
 
     #[test]
@@ -1340,7 +1353,10 @@ mod tests {
             &problem_report(&rid.to_string(), vtc, "e.p.msg.bad-request", "malformed"),
             vtc,
         );
-        assert!(!out.changed, "a client/transient error must not mark Rejected");
+        assert!(
+            !out.changed,
+            "a client/transient error must not mark Rejected"
+        );
         assert!(matches!(
             only(&acct, vtc).status,
             CommunityStatus::Pending { .. }

--- a/openvtc-core/src/relationships.rs
+++ b/openvtc-core/src/relationships.rs
@@ -195,9 +195,11 @@ fn find_key_source(
                     .map(|s| s.get_public_bytes().to_vec()),
                 _ => None,
             },
-            KeySourceMaterial::Imported { seed } => Secret::from_multibase(seed.expose_secret(), None)
-                .ok()
-                .map(|s| s.get_public_bytes().to_vec()),
+            KeySourceMaterial::Imported { seed } => {
+                Secret::from_multibase(seed.expose_secret(), None)
+                    .ok()
+                    .map(|s| s.get_public_bytes().to_vec())
+            }
             // VTA-managed secrets aren't reconstructable offline; the (1) path
             // handles them via their multibase id.
             KeySourceMaterial::VtaManaged { .. } => None,

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -2,7 +2,7 @@
 //!
 //! [`StateHandler::join_flow`] is a nested `tokio::select!` loop modelled on
 //! [`setup_wizard`](crate::state_handler::setup_wizard): it owns the screen
-//! while [`ActivePage::Join`](crate::state_handler::state::ActivePage::Join) is
+//! while [`ActivePage::Join`] is
 //! active, processes the join actions, renders via `state_tx`, and returns to
 //! the main page when the user cancels or the sequence finishes.
 //!
@@ -547,7 +547,6 @@ fn validate_join_input(raw: &str) -> Option<String> {
     }
 }
 
-
 /// #2: load a *presentable* invitation the VTA already holds for the community
 /// being joined (`vtc_did`). Queries the credential vault for `purpose = invite`
 /// and selects an active, vault-valid (not expired / revoked) VIC whose issuer is
@@ -952,9 +951,9 @@ async fn run_join_sequence(
         if let Err(e) = admin_vta.cred_vault_receive(vic, None).await {
             debug!(error = %e, "storing invitation in the VTA vault failed (continuing)");
         }
-        state
-            .join
-            .info("Joining without an invitation — submitting an open request (awaiting approval).");
+        state.join.info(
+            "Joining without an invitation — submitting an open request (awaiting approval).",
+        );
     }
     // Completeness gate before presenting: a VIC resolved from the vault may
     // predate the ingest-time validation (or have lost fields in storage). An

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -309,7 +309,11 @@ impl VicSummary {
             issuer: s("issuerDid"),
             status: {
                 let st = s("status");
-                if st.is_empty() { "unknown".to_string() } else { st }
+                if st.is_empty() {
+                    "unknown".to_string()
+                } else {
+                    st
+                }
             },
             lifecycle: VicLifecycle::from_wire(d.get("lifecycle").and_then(|v| v.as_str())),
             valid_until: s("validUntil"),

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -388,7 +388,9 @@ impl MainPageState {
             .map(|p| content::ManagedDid {
                 did: p.did.clone(),
                 label: p.label.clone().unwrap_or_default(),
-                bound_communities: config.account.memberships()
+                bound_communities: config
+                    .account
+                    .memberships()
                     .filter(|c| c.persona_ref == p.persona_id)
                     .count(),
                 is_active: p.did.as_str() == persona_did,
@@ -534,7 +536,7 @@ fn collect_vrcs(
 
 /// Build display summaries for the membership (VMC) + role (VEC) credentials a
 /// VTC issued to us, stored on each community record. Reuses [`VrcSummary`]:
-/// `alias` carries "<community> — Membership/Role" and `remote_p_did` the VTC.
+/// `alias` carries "`<community>` — Membership/Role" and `remote_p_did` the VTC.
 fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
     let mut result = Vec::new();
     for c in config.account.memberships() {
@@ -716,8 +718,7 @@ impl From<&Config> for MainMenuConfigState {
         // bar once the user is actually in a community (an Active membership). A
         // State-A account or a still-Pending join shows no persona name/DID up
         // there — the persona belongs to a community context, not the chrome.
-        let in_community = config.account.memberships()
-            .any(|c| c.status.is_active());
+        let in_community = config.account.memberships().any(|c| c.status.is_active());
         // The working community (R-C-7a): the Active community whose persona is
         // the active one. `active_persona` is kept in lockstep with the selected
         // working community (set at launch, on reconcile, and on switch), so the

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -510,7 +510,10 @@ impl StateHandler {
         // the first event re-syncs (the per-path syncs above run with no
         // selection set yet).
         state.reconcile_selected_community(&config.account);
-        let initial_active = state.selected_community.as_ref().map(|(_, persona)| *persona);
+        let initial_active = state
+            .selected_community
+            .as_ref()
+            .map(|(_, persona)| *persona);
         config.set_active_persona(initial_active);
         state.main_page.sync_from_config(&config);
 
@@ -1681,7 +1684,10 @@ impl StateHandler {
             // the default shifted), refilter the community-scoped panels so the UI
             // reflects the new context this frame.
             state.reconcile_selected_community(&config.account);
-            let active_persona = state.selected_community.as_ref().map(|(_, persona)| *persona);
+            let active_persona = state
+                .selected_community
+                .as_ref()
+                .map(|(_, persona)| *persona);
             if active_persona != config.active_persona {
                 config.set_active_persona(active_persona);
                 state.main_page.sync_from_config(&config);
@@ -1836,25 +1842,21 @@ impl StateHandler {
         match vic::list_vics(admin_vta, include_inactive).await {
             Ok(list) => {
                 let vta = &mut state.main_page.content_panel.vta;
-                vta.vic_selected_index = vta
-                    .vic_selected_index
-                    .min(list.len().saturating_sub(1));
+                vta.vic_selected_index = vta.vic_selected_index.min(list.len().saturating_sub(1));
                 vta.vics = list.into();
             }
             Err(e) => {
-                state.main_page.log_error("Listing invitation credentials failed", &e);
+                state
+                    .main_page
+                    .log_error("Listing invitation credentials failed", &e);
             }
         }
         let _ = self.state_tx.send(state.clone());
     }
 
     /// Validate + store the pasted VIC from the add-VIC overlay, then refresh the
-    /// list. Mirrors [`run_create_persona`]'s phase handling.
-    async fn run_add_vic(
-        &self,
-        state: &mut State,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-    ) {
+    /// list. Mirrors `run_create_persona`'s phase handling.
+    async fn run_add_vic(&self, state: &mut State, admin_vta: Option<&vta_sdk::client::VtaClient>) {
         use crate::state_handler::main_page::content::AddVicPhase;
 
         let json = match state.main_page.add_vic.as_ref() {
@@ -1899,7 +1901,9 @@ impl StateHandler {
                     o.phase = AddVicPhase::Failed;
                     o.messages.push(format!("Failed: {e}"));
                 }
-                state.main_page.log_error("Storing the invitation credential failed", &e);
+                state
+                    .main_page
+                    .log_error("Storing the invitation credential failed", &e);
             }
         }
         let _ = self.state_tx.send(state.clone());

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use crate::state_handler::setup_sequence::vta;
 use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::{
     TDK,
@@ -23,7 +24,6 @@ use openvtc_core::{
     relationships::{RelationshipRequestBody, RelationshipState},
     tasks::TaskType,
 };
-use crate::state_handler::setup_sequence::vta;
 use serde_json::json;
 use tracing::info;
 use uuid::Uuid;

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -59,7 +59,7 @@ pub fn update_org_did(config: &mut Config, did: &str) {
 /// Set a passphrase to encrypt the config in the keyring.
 ///
 /// R12: the Argon2id unlock-key derivation (~0.5–1 s of pure CPU) runs on a
-/// `spawn_blocking` thread via [`derive_passphrase_key_blocking`] so it does
+/// `spawn_blocking` thread via `derive_passphrase_key_blocking` so it does
 /// not peg the async event-loop / render task. The passphrase bytes are owned
 /// by the blocking closure and zeroized there; the derived key is the only
 /// thing returned. The subsequent `save_config` does not run Argon2 (it

--- a/openvtc/src/ui/pages/join_flow/invitation_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/invitation_choice.rs
@@ -61,9 +61,9 @@ impl InvitationChoice {
                     .send(Action::JoinInvitationSelect(selected.saturating_sub(1)));
             }
             KeyCode::Down => {
-                let _ = state
-                    .action_tx
-                    .send(Action::JoinInvitationSelect((selected + 1).min(without_row)));
+                let _ = state.action_tx.send(Action::JoinInvitationSelect(
+                    (selected + 1).min(without_row),
+                ));
             }
             KeyCode::Enter => {
                 let _ = state.action_tx.send(Action::JoinInvitationChoose);

--- a/openvtc/src/ui/pages/join_flow/join_progress.rs
+++ b/openvtc/src/ui/pages/join_flow/join_progress.rs
@@ -3,7 +3,7 @@
 //! Renders the `JoinState.messages` log plus the terminal outcome. On success
 //! it shows the created persona DID and the pending community, and prompts the
 //! operator to restart OpenVTC to activate the new community (hot-start is a
-//! deliberate follow-up). [ENTER] returns to the main page.
+//! deliberate follow-up). `Enter` returns to the main page.
 
 use crate::colors::{
     COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
@@ -114,10 +114,7 @@ impl JoinProgress {
                     match &state.presented_invitation {
                         Some(vic) => {
                             lines.push(Line::from(vec![
-                                Span::styled(
-                                    "  Invitation:    ",
-                                    Style::new().fg(COLOR_SUCCESS),
-                                ),
+                                Span::styled("  Invitation:    ", Style::new().fg(COLOR_SUCCESS)),
                                 Span::styled(
                                     format!("Presented  ·  {}", vic.id),
                                     Style::new().fg(COLOR_SOFT_PURPLE),
@@ -138,10 +135,7 @@ impl JoinProgress {
                         }
                         None => {
                             lines.push(Line::from(vec![
-                                Span::styled(
-                                    "  Invitation:    ",
-                                    Style::new().fg(COLOR_SUCCESS),
-                                ),
+                                Span::styled("  Invitation:    ", Style::new().fg(COLOR_SUCCESS)),
                                 Span::styled(
                                     "None  ·  open request (awaiting approval)",
                                     Style::new().fg(COLOR_ORANGE),

--- a/openvtc/src/ui/pages/loading/mod.rs
+++ b/openvtc/src/ui/pages/loading/mod.rs
@@ -171,7 +171,7 @@ impl LoadingScreen {
     /// Column the timing annotation starts at, so times line up neatly.
     const TIME_COL: usize = 34;
 
-    /// A right-aligned `(time)` annotation, padded so it lands in [`TIME_COL`].
+    /// A right-aligned `(time)` annotation, padded so it lands in `TIME_COL`.
     /// `prefix_len` is the visible width already consumed on the line.
     fn time_span(
         duration: Option<std::time::Duration>,

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -256,7 +256,11 @@ fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
             header_style,
         ),
         Span::styled(
-            if focused { "   ◀ focus" } else { "   [Tab] focus" },
+            if focused {
+                "   ◀ focus"
+            } else {
+                "   [Tab] focus"
+            },
             Style::new().fg(COLOR_DARK_GRAY),
         ),
     ]));
@@ -311,14 +315,24 @@ fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
 
     lines.push(Line::from(""));
     if let Some(idx) = state.confirm_purge_vic {
-        let target = state.vics.get(idx).map(|v| v.id.as_str()).unwrap_or("this VIC");
+        let target = state
+            .vics
+            .get(idx)
+            .map(|v| v.id.as_str())
+            .unwrap_or("this VIC");
         lines.push(
-            Line::from(format!("Purge {target} permanently?   y: confirm    n: cancel"))
-                .fg(COLOR_ORANGE)
-                .bold(),
+            Line::from(format!(
+                "Purge {target} permanently?   y: confirm    n: cancel"
+            ))
+            .fg(COLOR_ORANGE)
+            .bold(),
         );
     } else if let Some(idx) = state.confirm_delete_vic {
-        let target = state.vics.get(idx).map(|v| v.id.as_str()).unwrap_or("this VIC");
+        let target = state
+            .vics
+            .get(idx)
+            .map(|v| v.id.as_str())
+            .unwrap_or("this VIC");
         lines.push(
             Line::from(format!("Delete {target}?   y: confirm    n: cancel"))
                 .fg(COLOR_ORANGE)

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -492,8 +492,7 @@ impl MainPage {
                 }
                 // d: soft-delete (not already deleted).
                 KeyCode::Char('d') | KeyCode::Delete
-                    if vic_selected < vic_count
-                        && vic_lifecycle != Some(VicLifecycle::Deleted) =>
+                    if vic_selected < vic_count && vic_lifecycle != Some(VicLifecycle::Deleted) =>
                 {
                     let _ = self.action_tx.send(Action::VicConfirmDelete(vic_selected));
                     true
@@ -2902,8 +2901,10 @@ mod key_handler_tests {
     #[test]
     fn vta_vic_delete_confirm_cycle() {
         // `d` on an active VIC arms the soft-delete confirmation.
-        let (mut page, mut rx) =
-            page_for(MainMenu::Vta, vta_vics(vec![vic("urn:vic:1", VicLifecycle::Active)]));
+        let (mut page, mut rx) = page_for(
+            MainMenu::Vta,
+            vta_vics(vec![vic("urn:vic:1", VicLifecycle::Active)]),
+        );
         page.handle_key_event(press(KeyCode::Char('d')));
         match rx.try_recv() {
             Ok(Action::VicConfirmDelete(0)) => {}


### PR DESCRIPTION
## What

Two pieces of phase 3 that don't depend on the registry release pipeline:

### 1. Platform-commit policy: the PGP exemption keyring

GitHub signs the commits it creates itself — **web-UI merge/squash commits and Dependabot commits** — with its `web-flow` PGP key, never a contributor's sshsig. Until now those failed as `malformed`, blocking any repo from making verify-trust a required check.

The policy is cryptographic, never name-based: `--exempt-keyring <file>` names an armored PGP keyring **committed to the repo** (e.g. the key from https://github.com/web-flow.gpg). A PGP-signed commit passes only if its signature verifies against a key in that file, and is reported as a distinct `EXEMPT` verdict (with the key fingerprint) — separate from `TRUSTED`. Committer names/emails are attacker-chosen strings and play no part. With no keyring configured, every PGP-signed commit fails (`PGP-REJECTED`) — absence stays the most restrictive interpretation.

Verification is pure Rust (rPGP, already a workspace dependency) — no `gpg` binary on the runner, no keyring imports, fully unit-testable. Handles both single-block multi-key exports and concatenated `.asc` files, and signing subkeys.

### 2. CI packaging

- `.github/actions/verify-trust` — composite action: installs `did-git-sign` (from a git ref, or `install-path` for dogfooding the PR's own code) and runs `verify-trust` over the PR's `base..head`.
- `.github/workflows/verify-trust.yml` — dogfood workflow for this repo, **dormant until the `TRUST_REGISTRY_URL` / `TRUST_REGISTRY_DID` / `TRUST_AUTHORITY_DID` repository variables are set**, so it merges now and lights up the day a hosted registry exists.

## Testing

- 5 new unit tests on the keyring (verify/reject/tamper/multi-key/garbage — keys generated in-test with rPGP, deterministic seeds).
- 2 new end-to-end tests: a mixed range (one DID-signed commit + one platform-PGP commit) passes with the keyring and reports `TRUSTED` + `EXEMPT`; the same platform commit with no keyring fails `PGP-REJECTED` without touching the registry.
- Full `did-git-sign` suite: 68 tests green; clippy `-D warnings` and rustdoc clean.

## Notes

- The action installs via `cargo install` (a few minutes on cold cache); switching to prebuilt release binaries is a follow-up once the release process exists.
- Requires `fetch-depth: 0` on checkout (documented in the action).