### PR TITLE
feat: per-community Capabilities panel (governance/capability/*)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5798,7 +5798,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",

--- a/openvtc-core/src/capabilities.rs
+++ b/openvtc-core/src/capabilities.rs
@@ -1,0 +1,375 @@
+//! Client side of the `governance/capability/*` Trust Task family: query and
+//! manage a community's pluggable capabilities from the TUI.
+//!
+//! The community's governance host is the VTC itself (its registry serves the
+//! capability surface), reached over DIDComm via the mediator: requests are
+//! `TrustTask` documents packed inside the `trust-tasks-didcomm` binding
+//! envelope, replies arrive asynchronously and are correlated by the
+//! document's `threadId` (== the request document id).
+//!
+//! Writes (`enable`/`disable`) carry an `eddsa-jcs-2022` Data-Integrity proof
+//! signed with the persona's signing key, bound to the document `issuer`.
+//! NOTE: v1 signs directly in the client; routing the approval through the
+//! delegated-execution consent flow is the planned upgrade
+//! (`trust-task-delegation-architecture.md`).
+
+use std::sync::Arc;
+
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
+use affinidi_tdk::didcomm::Message;
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+use serde_json::Value;
+use trust_tasks_rs::TrustTask;
+use uuid::Uuid;
+
+use crate::errors::OpenVTCError;
+use crate::pack_and_send;
+
+/// The `trust-tasks-didcomm` binding envelope type (the message type the
+/// registry's DIDComm Trust Task handler listens for). Kept in sync with
+/// `trust_tasks_didcomm::ENVELOPE_TYPE`; hardcoded here to avoid pulling the
+/// whole binding crate for one constant.
+pub const TRUST_TASK_ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
+
+/// Type URIs of the governance capability family.
+pub const CAPABILITY_LIST_TYPE: &str = "https://trusttasks.org/spec/governance/capability/list/0.1";
+pub const CAPABILITY_ENABLE_TYPE: &str =
+    "https://trusttasks.org/spec/governance/capability/enable/0.1";
+pub const CAPABILITY_DISABLE_TYPE: &str =
+    "https://trusttasks.org/spec/governance/capability/disable/0.1";
+
+/// One capability as rendered by the panel.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CapabilitySummary {
+    pub slug: String,
+    pub title: Option<String>,
+    pub version: String,
+    pub enabled: bool,
+    pub enabled_at: Option<String>,
+    pub delegate: Option<String>,
+    /// The full manifest for the detail view.
+    pub manifest: Value,
+}
+
+/// What a correlated capability reply means for the panel.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CapabilityReply {
+    /// A `list` response: the community's capabilities.
+    Listing(Vec<CapabilitySummary>),
+    /// An `enable`/`disable` response acknowledging the toggle.
+    Toggled { capability: String, enabled: bool },
+    /// A `trust-task-error` document; the code is the machine-readable
+    /// trust-task error code, the message its human detail.
+    Rejected {
+        code: String,
+        message: Option<String>,
+    },
+}
+
+/// Build the `governance/capability/list` request document (status `all`, so
+/// the panel can offer enabling what's available).
+pub fn build_list_document(persona_did: &str, vtc_did: &str) -> TrustTask<Value> {
+    build_document(
+        persona_did,
+        vtc_did,
+        CAPABILITY_LIST_TYPE,
+        serde_json::json!({ "status": "all" }),
+    )
+}
+
+/// Build the `enable` or `disable` request document.
+///
+/// For `enable`, `config.authority` defaults to the community's own DID: per
+/// the governance model the community *is* the authority its capability
+/// records are issued under.
+pub fn build_toggle_document(
+    persona_did: &str,
+    vtc_did: &str,
+    slug: &str,
+    version: &str,
+    enable: bool,
+) -> TrustTask<Value> {
+    if enable {
+        build_document(
+            persona_did,
+            vtc_did,
+            CAPABILITY_ENABLE_TYPE,
+            serde_json::json!({
+                "capability": slug,
+                "version": version,
+                "config": { "authority": vtc_did },
+            }),
+        )
+    } else {
+        build_document(
+            persona_did,
+            vtc_did,
+            CAPABILITY_DISABLE_TYPE,
+            serde_json::json!({ "capability": slug }),
+        )
+    }
+}
+
+fn build_document(
+    persona_did: &str,
+    vtc_did: &str,
+    type_uri: &str,
+    payload: Value,
+) -> TrustTask<Value> {
+    let mut doc = TrustTask::new(
+        format!("urn:uuid:{}", Uuid::new_v4()),
+        type_uri
+            .parse()
+            .unwrap_or_else(|_| unreachable!("static capability type URIs are valid")),
+        payload,
+    );
+    doc.issuer = Some(persona_did.to_string());
+    doc.recipient = Some(vtc_did.to_string());
+    doc.issued_at = Some(chrono::Utc::now());
+    doc
+}
+
+/// Attach an `eddsa-jcs-2022` Data-Integrity proof over `doc` (minus the
+/// `proof` member, mirroring the verifier's canonical form), signed with the
+/// persona's signing secret. The verification method is the secret's key id,
+/// which must belong to the document `issuer` (the host enforces the binding).
+pub async fn sign_document(
+    doc: &mut TrustTask<Value>,
+    signing_secret: &Secret,
+) -> Result<(), OpenVTCError> {
+    let mut doc_value = serde_json::to_value(&*doc)
+        .map_err(|e| OpenVTCError::Config(format!("serialise capability document: {e}")))?;
+    if let Some(obj) = doc_value.as_object_mut() {
+        obj.remove("proof");
+    }
+    let proof = DataIntegrityProof::sign(&doc_value, signing_secret, SignOptions::default())
+        .await
+        .map_err(|e| OpenVTCError::Config(format!("sign capability document: {e}")))?;
+    let proof_value = serde_json::to_value(&proof)
+        .map_err(|e| OpenVTCError::Config(format!("serialise proof: {e}")))?;
+    doc.proof = Some(
+        serde_json::from_value(proof_value)
+            .map_err(|e| OpenVTCError::Config(format!("convert proof: {e}")))?,
+    );
+    Ok(())
+}
+
+/// Pack `doc` in the DIDComm Trust Task envelope and send it to the VTC via
+/// the mediator. Returns the document id — the `threadId` the reply will
+/// carry. Sending is fire-and-forget: `Ok` means handed to the transport,
+/// never that the host received it; the caller owns a reply timeout.
+pub async fn send_capability_document(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    persona_did: &str,
+    vtc_did: &str,
+    mediator: &str,
+    doc: &TrustTask<Value>,
+) -> Result<String, OpenVTCError> {
+    let body = serde_json::to_value(doc)
+        .map_err(|e| OpenVTCError::Config(format!("serialise capability document: {e}")))?;
+    let message = Message::build(
+        format!("urn:uuid:{}", Uuid::new_v4()),
+        TRUST_TASK_ENVELOPE_TYPE.to_string(),
+        body,
+    )
+    .from(persona_did.to_string())
+    .to(vtc_did.to_string())
+    .thid(doc.id.clone())
+    .finalize();
+    pack_and_send(atm, profile, &message, persona_did, vtc_did, mediator).await?;
+    Ok(doc.id.clone())
+}
+
+/// Parse a raw DIDComm envelope body into `(threadId, reply)` — the entry
+/// point for inbound dispatch, which holds only `serde_json::Value`.
+pub fn parse_envelope_reply(body: &Value) -> Option<(String, CapabilityReply)> {
+    let doc: TrustTask<Value> = serde_json::from_value(body.clone()).ok()?;
+    let thid = doc.thread_id.clone()?;
+    let reply = parse_capability_reply(&doc)?;
+    Some((thid, reply))
+}
+
+/// Interpret an inbound Trust Task envelope body as a capability reply.
+/// Returns `None` when the document is not part of this family (someone
+/// else's trust task riding the same envelope type).
+pub fn parse_capability_reply(doc: &TrustTask<Value>) -> Option<CapabilityReply> {
+    let slug = doc.type_uri.slug();
+    if slug == "trust-task-error" {
+        // Only classified as ours by the caller's threadId correlation.
+        let code = doc
+            .payload
+            .get("code")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let message = doc
+            .payload
+            .get("message")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        return Some(CapabilityReply::Rejected { code, message });
+    }
+    if !doc.type_uri.is_response() {
+        return None;
+    }
+    match slug {
+        "governance/capability/list" => {
+            let entries = doc
+                .payload
+                .get("capabilities")
+                .and_then(Value::as_array)
+                .map(|entries| entries.iter().filter_map(summary_of).collect())
+                .unwrap_or_default();
+            Some(CapabilityReply::Listing(entries))
+        }
+        "governance/capability/enable" | "governance/capability/disable" => {
+            Some(CapabilityReply::Toggled {
+                capability: doc
+                    .payload
+                    .get("capability")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                enabled: doc
+                    .payload
+                    .get("enabled")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn summary_of(entry: &Value) -> Option<CapabilitySummary> {
+    let manifest = entry.get("manifest")?.clone();
+    Some(CapabilitySummary {
+        slug: manifest.get("capability")?.as_str()?.to_string(),
+        title: manifest
+            .get("title")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        version: manifest
+            .get("version")
+            .and_then(Value::as_str)
+            .unwrap_or("?")
+            .to_string(),
+        enabled: entry
+            .get("enabled")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        enabled_at: entry
+            .get("enabledAt")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        delegate: entry
+            .get("delegate")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        manifest,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    #[test]
+    fn list_document_is_addressed_and_typed() {
+        let doc = build_list_document("did:example:me", "did:example:vtc");
+        assert_eq!(doc.issuer.as_deref(), Some("did:example:me"));
+        assert_eq!(doc.recipient.as_deref(), Some("did:example:vtc"));
+        assert_eq!(doc.type_uri.slug(), "governance/capability/list");
+        assert_eq!(doc.payload["status"], "all");
+    }
+
+    #[test]
+    fn enable_defaults_authority_to_the_community() {
+        let doc = build_toggle_document(
+            "did:example:me",
+            "did:example:vtc",
+            "git-trust",
+            "0.1",
+            true,
+        );
+        assert_eq!(doc.payload["config"]["authority"], "did:example:vtc");
+        assert_eq!(doc.payload["capability"], "git-trust");
+        let doc = build_toggle_document(
+            "did:example:me",
+            "did:example:vtc",
+            "git-trust",
+            "0.1",
+            false,
+        );
+        assert_eq!(doc.type_uri.slug(), "governance/capability/disable");
+        assert!(doc.payload.get("config").is_none());
+    }
+
+    #[test]
+    fn parses_a_listing_reply() {
+        let request = build_list_document("did:example:me", "did:example:vtc");
+        let reply = request.respond_with(
+            "urn:uuid:r".to_string(),
+            serde_json::json!({
+                "capabilities": [{
+                    "manifest": {
+                        "capability": "git-trust", "version": "0.1",
+                        "title": "Git Commit Trust", "specs": ["git-trust/*"]
+                    },
+                    "enabled": true,
+                    "enabledAt": "2026-07-17T00:00:00Z"
+                }]
+            }),
+        );
+        let Some(CapabilityReply::Listing(items)) = parse_capability_reply(&reply) else {
+            panic!("expected listing");
+        };
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].slug, "git-trust");
+        assert!(items[0].enabled);
+        assert_eq!(items[0].title.as_deref(), Some("Git Commit Trust"));
+    }
+
+    #[test]
+    fn parses_error_and_toggle_replies_and_ignores_foreign_tasks() {
+        let request = build_toggle_document("did:example:me", "did:example:vtc", "x", "0.1", true);
+        let err = request.reject_with(
+            "urn:uuid:e".to_string(),
+            trust_tasks_rs::RejectReason::PermissionDenied {
+                reason: "nope".to_string(),
+            },
+        );
+        let err_value: TrustTask<Value> =
+            serde_json::from_value(serde_json::to_value(&err).unwrap()).unwrap();
+        assert!(matches!(
+            parse_capability_reply(&err_value),
+            Some(CapabilityReply::Rejected { .. })
+        ));
+
+        let ok = request.respond_with(
+            "urn:uuid:t".to_string(),
+            serde_json::json!({ "capability": "x", "enabled": true }),
+        );
+        assert_eq!(
+            parse_capability_reply(&ok),
+            Some(CapabilityReply::Toggled {
+                capability: "x".to_string(),
+                enabled: true
+            })
+        );
+
+        let foreign = TrustTask::new(
+            "urn:uuid:f".to_string(),
+            "https://trusttasks.org/spec/registry/authorization/0.1#response"
+                .parse()
+                .unwrap(),
+            serde_json::json!({}),
+        );
+        assert_eq!(parse_capability_reply(&foreign), None);
+    }
+}

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, sync::Arc};
 
 pub mod bip32;
+pub mod capabilities;
 pub mod config;
 pub mod display;
 pub mod errors;

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -261,6 +261,24 @@ pub enum Action {
     /// send it to the community's VTC over DIDComm (`members/vmc/1.0`). Indexed
     /// into the Communities display list.
     IssueMemberVmc(usize),
+    /// Open the capabilities view for the community at display index `usize`
+    /// and fire the `governance/capability/list` query.
+    CapabilitiesOpen(usize),
+    /// Re-fire the list query for the open capabilities view.
+    CapabilitiesRefresh,
+    /// Close the capabilities view (back to the Communities list).
+    CapabilitiesClose,
+    /// Move the capabilities selection up / down.
+    CapabilitiesUp,
+    CapabilitiesDown,
+    /// Toggle the manifest detail view for the selected capability.
+    CapabilitiesDetail,
+    /// Arm enable/disable confirmation for the selected capability.
+    CapabilitiesToggleArm,
+    /// Cancel an armed enable/disable confirmation.
+    CapabilitiesToggleCancel,
+    /// Commit the armed enable/disable (signs and sends the governance write).
+    CapabilitiesToggleCommit,
 
     /// Cancel the join flow and return to the main page.
     JoinCancel,

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -66,6 +66,76 @@ pub struct ContentPanelState {
     pub logs: LogsState,
     /// Communities overview panel state
     pub communities: CommunitiesState,
+    /// Per-community capabilities view (opened from Communities with `c`).
+    pub capabilities: CapabilitiesState,
+}
+
+// ****************************************************************************
+// Capabilities State
+// ****************************************************************************
+
+/// Load phase of the capabilities view. The reply arrives asynchronously
+/// over DIDComm; `Loading` carries the send instant so the loop's sweep can
+/// fail the query closed after the reply window.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CapabilitiesPhase {
+    Loading,
+    Loaded,
+    Failed(String),
+}
+
+/// The capabilities view for one selected community. `None` in
+/// [`CapabilitiesState::view`] means the Communities panel renders normally.
+#[derive(Clone, Debug)]
+pub struct CapabilitiesView {
+    /// Community (VTC) whose capabilities are shown.
+    pub vtc_did: String,
+    /// Persona the queries are sent as.
+    pub persona: openvtc_core::config::account::PersonaId,
+    /// Display name for the header.
+    pub community_name: String,
+    pub phase: CapabilitiesPhase,
+    pub items: Vec<openvtc_core::capabilities::CapabilitySummary>,
+    pub selected: usize,
+    /// Detail view open for the selected capability.
+    pub detail: bool,
+    /// When `Some(index)`, an enable/disable of that capability awaits
+    /// `y`/`⏎` confirmation.
+    pub confirm_toggle: Option<usize>,
+    /// threadId of the in-flight request (list or toggle).
+    pub pending_thid: Option<String>,
+    /// When the in-flight request was sent (reply-timeout sweep).
+    pub sent_at: Option<std::time::Instant>,
+    /// Transient status message.
+    pub status_message: Option<String>,
+}
+
+impl CapabilitiesView {
+    pub fn new(
+        vtc_did: String,
+        persona: openvtc_core::config::account::PersonaId,
+        community_name: String,
+    ) -> Self {
+        Self {
+            vtc_did,
+            persona,
+            community_name,
+            phase: CapabilitiesPhase::Loading,
+            items: Vec::new(),
+            selected: 0,
+            detail: false,
+            confirm_toggle: None,
+            pending_thid: None,
+            sent_at: None,
+            status_message: None,
+        }
+    }
+}
+
+/// Wrapper so `ContentPanelState` stays `Default`-derivable.
+#[derive(Clone, Debug, Default)]
+pub struct CapabilitiesState {
+    pub view: Option<CapabilitiesView>,
 }
 
 // ****************************************************************************

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -77,6 +77,81 @@ pub(crate) async fn issue_member_vmc_for(
     .await
 }
 
+/// Send a `governance/capability/list` query for `vtc_did` as `persona_id`.
+/// Returns the request document id (the reply's `threadId`).
+pub(crate) async fn capabilities_list_for(
+    config: &Config,
+    tdk: &TDK,
+    vtc_did: &str,
+    persona_id: openvtc_core::config::account::PersonaId,
+) -> Result<String, openvtc_core::errors::OpenVTCError> {
+    use openvtc_core::errors::OpenVTCError;
+    let id = config
+        .identities
+        .get(&persona_id)
+        .ok_or_else(|| OpenVTCError::Config("persona identity unavailable".into()))?;
+    let persona_did = id.persona_did().to_string();
+    let profile = id.profile().clone();
+    let mediator = id.mediator_did.clone().unwrap_or_default();
+    let atm = tdk
+        .atm
+        .as_ref()
+        .ok_or_else(|| OpenVTCError::Config("messaging (ATM) unavailable".into()))?;
+    let doc = openvtc_core::capabilities::build_list_document(&persona_did, vtc_did);
+    openvtc_core::capabilities::send_capability_document(
+        atm,
+        &profile,
+        &persona_did,
+        vtc_did,
+        &mediator,
+        &doc,
+    )
+    .await
+}
+
+/// Sign and send a `governance/capability/enable|disable` write for
+/// `vtc_did` as `persona_id`. Returns the request document id.
+pub(crate) async fn capability_toggle_for(
+    config: &Config,
+    tdk: &TDK,
+    vtc_did: &str,
+    persona_id: openvtc_core::config::account::PersonaId,
+    slug: &str,
+    version: &str,
+    enable: bool,
+) -> Result<String, openvtc_core::errors::OpenVTCError> {
+    use openvtc_core::errors::OpenVTCError;
+    let id = config
+        .identities
+        .get(&persona_id)
+        .ok_or_else(|| OpenVTCError::Config("persona identity unavailable".into()))?;
+    let persona_did = id.persona_did().to_string();
+    let profile = id.profile().clone();
+    let mediator = id.mediator_did.clone().unwrap_or_default();
+    let atm = tdk
+        .atm
+        .as_ref()
+        .ok_or_else(|| OpenVTCError::Config("messaging (ATM) unavailable".into()))?;
+    let keys = config.get_persona_keys_for(persona_id, tdk).await?;
+    let mut doc = openvtc_core::capabilities::build_toggle_document(
+        &persona_did,
+        vtc_did,
+        slug,
+        version,
+        enable,
+    );
+    openvtc_core::capabilities::sign_document(&mut doc, &keys.signing.secret).await?;
+    openvtc_core::capabilities::send_capability_document(
+        atm,
+        &profile,
+        &persona_did,
+        vtc_did,
+        &mediator,
+        &doc,
+    )
+    .await
+}
+
 /// Process an inbound DIDComm message.
 ///
 /// Auto-processes messages that don't need human input (pong, accept, finalize, reject).
@@ -90,6 +165,7 @@ pub async fn process_inbound_message(
     seen: &mut SeenMessages,
     message: &Message,
     inactivated: &mut Vec<(VtcDid, openvtc_core::config::account::PersonaId)>,
+    capability_replies: &mut Vec<(String, openvtc_core::capabilities::CapabilityReply)>,
 ) -> Result<bool, anyhow::Error> {
     // Drop messages outside the replay / freshness window before doing
     // any state-mutating work. Saves us from acting on stale captures
@@ -158,6 +234,18 @@ pub async fn process_inbound_message(
             size = body_size,
             "rejecting oversized message body ({} bytes)", body_size
         );
+        return Ok(false);
+    }
+
+    // Trust Task envelope replies (governance/capability/*): parse the body
+    // document, classify it, and hand it to the state loop keyed by the
+    // document's `threadId` (== our request id). Foreign trust tasks riding
+    // the same envelope type are ignored here.
+    if message.typ == openvtc_core::capabilities::TRUST_TASK_ENVELOPE_TYPE {
+        if let Some((thid, reply)) = openvtc_core::capabilities::parse_envelope_reply(&message.body)
+        {
+            capability_replies.push((thid, reply));
+        }
         return Ok(false);
     }
 

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -665,6 +665,9 @@ impl StateHandler {
         // immediately, so a Pending that aged out while the app was closed expires
         // on launch; thereafter it sweeps hourly.
         let mut pending_expiry_tick = tokio::time::interval(std::time::Duration::from_secs(3600));
+        // Reply-window sweep for the capabilities view (cheap no-op when the
+        // view is closed or idle).
+        let mut capabilities_sweep = tokio::time::interval(std::time::Duration::from_secs(5));
 
         let result = loop {
             tokio::select! {
@@ -864,6 +867,111 @@ impl StateHandler {
                             }
                         }
                     },
+                    Action::CapabilitiesOpen(i) => {
+                        let target = config
+                            .account
+                            .communities_for_display(state.main_page.content_panel.communities.show_archived)
+                            .get(i)
+                            .filter(|c| c.status.is_active())
+                            .map(|c| {
+                                (
+                                    c.vtc_did.clone(),
+                                    c.persona_ref,
+                                    c.display_name.clone().unwrap_or_else(|| c.vtc_did.clone()),
+                                )
+                            });
+                        if let Some((vtc, persona_id, name)) = target {
+                            let mut view = crate::state_handler::main_page::content::CapabilitiesView::new(
+                                vtc.clone(),
+                                persona_id,
+                                name,
+                            );
+                            match message_dispatch::capabilities_list_for(&config, &tdk, &vtc, persona_id).await {
+                                Ok(thid) => {
+                                    view.pending_thid = Some(thid);
+                                    view.sent_at = Some(std::time::Instant::now());
+                                }
+                                Err(e) => {
+                                    state.main_page.log_error("Capability query failed", &e);
+                                    view.phase =
+                                        crate::state_handler::main_page::content::CapabilitiesPhase::Failed(
+                                            format!("could not send the query: {e}"),
+                                        );
+                                }
+                            }
+                            state.main_page.content_panel.capabilities.view = Some(view);
+                        }
+                    }
+                    Action::CapabilitiesRefresh => {
+                        let target = state
+                            .main_page
+                            .content_panel
+                            .capabilities
+                            .view
+                            .as_ref()
+                            .map(|v| (v.vtc_did.clone(), v.persona));
+                        if let Some((vtc, persona_id)) = target
+                            && let Some(view) = state.main_page.content_panel.capabilities.view.as_mut()
+                        {
+                            view.phase = crate::state_handler::main_page::content::CapabilitiesPhase::Loading;
+                            view.status_message = None;
+                            match message_dispatch::capabilities_list_for(&config, &tdk, &vtc, persona_id).await {
+                                Ok(thid) => {
+                                    view.pending_thid = Some(thid);
+                                    view.sent_at = Some(std::time::Instant::now());
+                                }
+                                Err(e) => {
+                                    view.phase =
+                                        crate::state_handler::main_page::content::CapabilitiesPhase::Failed(
+                                            format!("could not send the query: {e}"),
+                                        );
+                                }
+                            }
+                        }
+                    }
+                    Action::CapabilitiesToggleCommit => {
+                        let target = state
+                            .main_page
+                            .content_panel
+                            .capabilities
+                            .view
+                            .as_ref()
+                            .and_then(|v| {
+                                let i = v.confirm_toggle?;
+                                let item = v.items.get(i)?;
+                                Some((
+                                    v.vtc_did.clone(),
+                                    v.persona,
+                                    item.slug.clone(),
+                                    item.version.clone(),
+                                    !item.enabled,
+                                ))
+                            });
+                        if let Some((vtc, persona_id, slug, version, enable)) = target
+                            && let Some(view) = state.main_page.content_panel.capabilities.view.as_mut()
+                        {
+                            view.confirm_toggle = None;
+                            match message_dispatch::capability_toggle_for(
+                                &config, &tdk, &vtc, persona_id, &slug, &version, enable,
+                            )
+                            .await
+                            {
+                                Ok(thid) => {
+                                    view.pending_thid = Some(thid);
+                                    view.sent_at = Some(std::time::Instant::now());
+                                    view.status_message = Some(format!(
+                                        "{} {slug}… awaiting the community's reply",
+                                        if enable { "enabling" } else { "disabling" }
+                                    ));
+                                }
+                                Err(e) => {
+                                    view.status_message =
+                                        Some(format!("couldn't send the change: {e}"));
+                                    tracing::error!("capability toggle failed: {e}");
+                                }
+                            }
+                        }
+                    }
                     Action::IssueMemberVmc(i) => {
                         // Issue this membership's reciprocal VMC (member -> community)
                         // and send it to the VTC over DIDComm (members/vmc/1.0).
@@ -1372,6 +1480,7 @@ impl StateHandler {
                             let msg_thid = message.thid.clone().unwrap_or_else(|| "none".into());
 
                             let mut inactivated = Vec::new();
+                            let mut capability_replies = Vec::new();
                             match message_dispatch::process_inbound_message(
                                 &mut config,
                                 &tdk,
@@ -1379,6 +1488,7 @@ impl StateHandler {
                                 &mut seen_messages,
                                 &message,
                                 &mut inactivated,
+                                &mut capability_replies,
                             )
                             .await
                             {
@@ -1437,6 +1547,7 @@ impl StateHandler {
                                     debug!("message dispatch error: {e}");
                                 }
                             }
+                            apply_capability_replies(&mut state, capability_replies);
                         }
                         didcomm::DIDCommEvent::TrustPingReceived { from, listener_id, message_id } => {
                             let sender = from.as_deref().unwrap_or("unknown");
@@ -1608,6 +1719,27 @@ impl StateHandler {
                 // loop stays responsive. At most one save is in flight; a mark
                 // that lands while a save runs is re-scheduled on completion.
                 // When nothing is scheduled the arm parks forever (no busy-wait).
+                _ = capabilities_sweep.tick() => {
+                    // R4.3: a capability query has a defined reply window. The
+                    // send was fire-and-forget; if no correlated reply arrived,
+                    // fail the view closed with a distinct, actionable message.
+                    if let Some(view) = state.main_page.content_panel.capabilities.view.as_mut()
+                        && view.pending_thid.is_some()
+                        && view.sent_at.is_some_and(|t| t.elapsed() > std::time::Duration::from_secs(30))
+                    {
+                        view.pending_thid = None;
+                        view.sent_at = None;
+                        if matches!(view.phase, crate::state_handler::main_page::content::CapabilitiesPhase::Loading) {
+                            view.phase = crate::state_handler::main_page::content::CapabilitiesPhase::Failed(
+                                "no reply within 30s — the community's governance host may be offline".to_string(),
+                            );
+                        } else {
+                            view.status_message = Some(
+                                "no reply to the change within 30s — refresh (r) to re-check".to_string(),
+                            );
+                        }
+                    }
+                }
                 _ = pending_expiry_tick.tick() => {
                     // R-B-7: expire Pending joins unanswered for 7 days, raising
                     // actions-required, and tear down each one's now-dead session
@@ -2315,6 +2447,68 @@ enum DegradedOutcome {
     Joined(DegradedJoinContext),
 }
 
+/// Apply correlated `governance/capability/*` replies to the open
+/// capabilities view. Uncorrelated replies (view closed, or thid from an
+/// older query) are dropped — the reply is stale by definition.
+fn apply_capability_replies(
+    state: &mut State,
+    replies: Vec<(String, openvtc_core::capabilities::CapabilityReply)>,
+) {
+    use crate::state_handler::main_page::content::CapabilitiesPhase;
+    use openvtc_core::capabilities::CapabilityReply;
+    if replies.is_empty() {
+        return;
+    }
+    let Some(view) = state.main_page.content_panel.capabilities.view.as_mut() else {
+        return;
+    };
+    for (thid, reply) in replies {
+        if view.pending_thid.as_deref() != Some(thid.as_str()) {
+            continue;
+        }
+        view.pending_thid = None;
+        view.sent_at = None;
+        match reply {
+            CapabilityReply::Listing(items) => {
+                view.selected = view.selected.min(items.len().saturating_sub(1));
+                view.items = items;
+                view.phase = CapabilitiesPhase::Loaded;
+            }
+            CapabilityReply::Toggled {
+                capability,
+                enabled,
+            } => {
+                if let Some(item) = view.items.iter_mut().find(|i| i.slug == capability) {
+                    item.enabled = enabled;
+                }
+                view.status_message = Some(format!(
+                    "{capability} is now {}",
+                    if enabled { "enabled" } else { "disabled" }
+                ));
+                view.phase = CapabilitiesPhase::Loaded;
+            }
+            CapabilityReply::Rejected { code, message } => {
+                let detail = message.map(|m| format!(" — {m}")).unwrap_or_default();
+                match view.phase {
+                    CapabilitiesPhase::Loaded => {
+                        // A rejected toggle: keep the listing, surface the code.
+                        view.status_message =
+                            Some(format!("the community rejected the change: {code}{detail}"));
+                    }
+                    _ => {
+                        view.phase = CapabilitiesPhase::Failed(match code.as_str() {
+                            "unsupportedType" => {
+                                "this community does not offer capability management".to_string()
+                            }
+                            _ => format!("the community rejected the query: {code}{detail}"),
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Apply a pure navigation action to `state`, shared by the runtime loop and the
 /// degraded loop so both modes route the same nav set from exactly one place.
 ///
@@ -2355,6 +2549,40 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
                 state.main_page.content_panel.selected = false;
             }
         },
+        Action::CapabilitiesClose => {
+            state.main_page.content_panel.capabilities.view = None;
+        }
+        Action::CapabilitiesUp => {
+            if let Some(view) = state.main_page.content_panel.capabilities.view.as_mut() {
+                view.selected = view.selected.saturating_sub(1);
+                view.confirm_toggle = None;
+            }
+        }
+        Action::CapabilitiesDown => {
+            if let Some(view) = state.main_page.content_panel.capabilities.view.as_mut() {
+                if view.selected + 1 < view.items.len() {
+                    view.selected += 1;
+                }
+                view.confirm_toggle = None;
+            }
+        }
+        Action::CapabilitiesDetail => {
+            if let Some(view) = state.main_page.content_panel.capabilities.view.as_mut() {
+                view.detail = !view.detail;
+            }
+        }
+        Action::CapabilitiesToggleArm => {
+            if let Some(view) = state.main_page.content_panel.capabilities.view.as_mut()
+                && !view.items.is_empty()
+            {
+                view.confirm_toggle = Some(view.selected);
+            }
+        }
+        Action::CapabilitiesToggleCancel => {
+            if let Some(view) = state.main_page.content_panel.capabilities.view.as_mut() {
+                view.confirm_toggle = None;
+            }
+        }
         Action::CommunitySelect(i) => {
             state.main_page.content_panel.communities.selected_index = *i;
         }

--- a/openvtc/src/ui/pages/main/components/capabilities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/capabilities_panel.rs
@@ -1,0 +1,237 @@
+//! Capabilities panel — the per-community `governance/capability/*` view,
+//! opened from the Communities panel with `c`.
+
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use serde_json::Value;
+
+use crate::colors::{
+    COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+};
+use crate::state_handler::main_page::content::{CapabilitiesPhase, ContentPanelState};
+use crate::state_handler::state::ConnectionState;
+
+use super::panel::Panel;
+
+pub struct CapabilitiesPanel;
+
+impl Panel for CapabilitiesPanel {
+    fn render(
+        &self,
+        state: &ContentPanelState,
+        _connection: &ConnectionState,
+    ) -> Vec<Line<'static>> {
+        let Some(view) = &state.capabilities.view else {
+            return vec![Line::from("no capabilities view open")];
+        };
+        let mut lines = Vec::new();
+
+        let enabled_count = view.items.iter().filter(|i| i.enabled).count();
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("  Capabilities — {}", view.community_name),
+                Style::default().fg(COLOR_TEXT_DEFAULT).bold(),
+            ),
+            Span::styled(
+                if matches!(view.phase, CapabilitiesPhase::Loaded) {
+                    format!("    ● {enabled_count} enabled")
+                } else {
+                    String::new()
+                },
+                Style::default().fg(COLOR_SUCCESS),
+            ),
+        ]));
+        lines.push(Line::from(""));
+
+        match &view.phase {
+            CapabilitiesPhase::Loading => {
+                lines.push(Line::from(Span::styled(
+                    "    querying the community's governance host…",
+                    Style::default().fg(COLOR_DARK_GRAY),
+                )));
+            }
+            CapabilitiesPhase::Failed(detail) => {
+                lines.push(Line::from(Span::styled(
+                    format!("    {detail}"),
+                    Style::default().fg(COLOR_ORANGE),
+                )));
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    "    r retry   Esc back",
+                    Style::default().fg(COLOR_DARK_GRAY),
+                )));
+                return lines;
+            }
+            CapabilitiesPhase::Loaded if view.items.is_empty() => {
+                lines.push(Line::from(Span::styled(
+                    "    this community has no capabilities available",
+                    Style::default().fg(COLOR_DARK_GRAY),
+                )));
+            }
+            CapabilitiesPhase::Loaded => {
+                for (i, item) in view.items.iter().enumerate() {
+                    let selected = i == view.selected;
+                    let (glyph, glyph_style) = if item.enabled {
+                        ("●", Style::default().fg(COLOR_SUCCESS))
+                    } else if item.delegate.is_some() {
+                        ("◈", Style::default().fg(COLOR_SOFT_PURPLE))
+                    } else {
+                        ("○", Style::default().fg(COLOR_DARK_GRAY))
+                    };
+                    let title = item.title.clone().unwrap_or_else(|| item.slug.clone());
+                    let name_style = if selected {
+                        Style::default().fg(COLOR_SUCCESS).bold()
+                    } else if item.enabled {
+                        Style::default().fg(COLOR_TEXT_DEFAULT)
+                    } else {
+                        Style::default().fg(COLOR_DARK_GRAY)
+                    };
+                    let mut spans = vec![
+                        Span::raw(if selected { "    ▸ " } else { "      " }),
+                        Span::styled(format!("{glyph} "), glyph_style),
+                        Span::styled(format!("{title:<24}"), name_style),
+                        Span::styled(
+                            format!("{}@{}", item.slug, item.version),
+                            Style::default().fg(COLOR_DARK_GRAY),
+                        ),
+                    ];
+                    if item.enabled {
+                        if let Some(at) = &item.enabled_at {
+                            spans.push(Span::styled(
+                                format!("   enabled {}", &at[..at.len().min(10)]),
+                                Style::default().fg(COLOR_DARK_GRAY),
+                            ));
+                        }
+                    } else {
+                        spans.push(Span::styled(
+                            "   available",
+                            Style::default().fg(COLOR_DARK_GRAY),
+                        ));
+                    }
+                    lines.push(Line::from(spans));
+
+                    if selected {
+                        if view.detail {
+                            render_manifest(&mut lines, item);
+                        } else {
+                            render_summary(&mut lines, item);
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(idx) = view.confirm_toggle
+            && let Some(item) = view.items.get(idx)
+        {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                    format!(
+                        "    {} {}? This is a signed governance write. y/⏎ confirm · any other key cancels",
+                        if item.enabled { "Disable" } else { "Enable" },
+                        item.slug,
+                    ),
+                    Style::default().fg(COLOR_ORANGE).bold(),
+                )));
+        }
+
+        if let Some(status) = &view.status_message {
+            lines.push(Line::from(""));
+            super::status::push_status(&mut lines, status, "");
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "    ↑/↓ navigate   ⏎ details   e enable/disable   r refresh   Esc back",
+            Style::default().fg(COLOR_DARK_GRAY),
+        )));
+        lines
+    }
+}
+
+fn kv(lines: &mut Vec<Line<'static>>, key: &str, value: String) {
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!("        {key:<13}"),
+            Style::default().fg(COLOR_DARK_GRAY),
+        ),
+        Span::styled(value, Style::default().fg(COLOR_TEXT_DEFAULT)),
+    ]));
+}
+
+/// The collapsed (non-detail) summary under the selected row.
+fn render_summary(
+    lines: &mut Vec<Line<'static>>,
+    item: &openvtc_core::capabilities::CapabilitySummary,
+) {
+    let manifest = &item.manifest;
+    if let Some(actions) = manifest
+        .get("vocabulary")
+        .and_then(|v| v.get("actions"))
+        .and_then(Value::as_array)
+    {
+        let actions: Vec<&str> = actions.iter().filter_map(Value::as_str).collect();
+        kv(lines, "registry", actions.join(", "));
+    }
+    if let Some(delegate) = &item.delegate {
+        kv(lines, "served by", delegate.clone());
+    }
+    if let Some(description) = manifest.get("description").and_then(Value::as_str) {
+        kv(lines, "about", description.to_string());
+    }
+}
+
+/// The full manifest, rendered when the detail view (⏎) is open.
+fn render_manifest(
+    lines: &mut Vec<Line<'static>>,
+    item: &openvtc_core::capabilities::CapabilitySummary,
+) {
+    let manifest = &item.manifest;
+    if let Some(description) = manifest.get("description").and_then(Value::as_str) {
+        kv(lines, "about", description.to_string());
+    }
+    if let Some(specs) = manifest.get("specs").and_then(Value::as_array) {
+        let specs: Vec<&str> = specs.iter().filter_map(Value::as_str).collect();
+        kv(lines, "serves", specs.join(", "));
+    }
+    if let Some(vocabulary) = manifest.get("vocabulary") {
+        if let Some(actions) = vocabulary.get("actions").and_then(Value::as_array) {
+            let actions: Vec<&str> = actions.iter().filter_map(Value::as_str).collect();
+            kv(lines, "actions", actions.join(", "));
+        }
+        if let Some(pattern) = vocabulary.get("resourcePattern").and_then(Value::as_str) {
+            kv(lines, "resources", pattern.to_string());
+        }
+    }
+    if let Some(roles) = manifest.get("roles").and_then(Value::as_object) {
+        for (op, who) in roles {
+            let who: Vec<&str> = who
+                .as_array()
+                .map(|a| a.iter().filter_map(Value::as_str).collect())
+                .unwrap_or_default();
+            kv(lines, &format!("role: {op}"), who.join(", "));
+        }
+    }
+    if let Some(hooks) = manifest.get("lifecycleHooks").and_then(Value::as_array) {
+        let hooks: Vec<&str> = hooks.iter().filter_map(Value::as_str).collect();
+        if !hooks.is_empty() {
+            kv(lines, "hooks", hooks.join(", "));
+        }
+    }
+    if let Some(adapters) = manifest.get("externalAdapters").and_then(Value::as_array) {
+        for adapter in adapters {
+            let kind = adapter.get("kind").and_then(Value::as_str).unwrap_or("?");
+            let reference = adapter.get("ref").and_then(Value::as_str).unwrap_or("?");
+            kv(lines, "adapter", format!("{kind} · {reference}"));
+        }
+    }
+    if let Some(config_schema) = manifest.get("configSchema").and_then(Value::as_str) {
+        kv(lines, "config", config_schema.to_string());
+    }
+    if let Some(delegate) = &item.delegate {
+        kv(lines, "served by", delegate.clone());
+    }
+    if let Some(at) = &item.enabled_at {
+        kv(lines, "enabled at", at.clone());
+    }
+}

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -207,7 +207,7 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         };
         lines.push(
             Line::from(format!(
-                "↑/↓ navigate   ⏎ open   f: ★   a: acknowledge   m: issue VMC   \
+                "↑/↓ navigate   ⏎ open   f: ★   a: acknowledge   m: issue VMC   c: capabilities   \
                  l: leave   c: cancel   x: archive   d: delete   j: join   {archived_hint}"
             ))
             .fg(COLOR_DARK_GRAY),

--- a/openvtc/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc/src/ui/pages/main/components/content_panel.rs
@@ -65,7 +65,13 @@ impl ContentPanelState {
         };
 
         let panel: Option<Box<dyn Panel>> = match menu.selected_menu {
-            MainMenu::Communities => Some(Box::new(CommunitiesPanel)),
+            MainMenu::Communities => {
+                if self.capabilities.view.is_some() {
+                    Some(Box::new(super::capabilities_panel::CapabilitiesPanel))
+                } else {
+                    Some(Box::new(CommunitiesPanel))
+                }
+            }
             MainMenu::Inbox => Some(Box::new(InboxPanel)),
             MainMenu::Relationships => Some(Box::new(RelationshipsPanel)),
             MainMenu::Credentials => Some(Box::new(CredentialsPanel)),

--- a/openvtc/src/ui/pages/main/components/mod.rs
+++ b/openvtc/src/ui/pages/main/components/mod.rs
@@ -1,6 +1,7 @@
 /// The main page is made up of two main panels side by side:
 /// LEFT: Menu Panel
 /// RIGHT: Content Panel
+pub mod capabilities_panel;
 pub mod communities_panel;
 pub mod content_panel;
 pub mod credentials_panel;

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -510,7 +510,53 @@ impl MainPage {
     /// Communities overview keys (R-A-5 Stage 4): `j` starts the join flow
     /// (incl. from the empty state), ↑/↓ move the selection, `d`/Del removes the
     /// selected community. Returns true if consumed.
+    /// Keys for the per-community capabilities view.
+    fn handle_capabilities_key(
+        &mut self,
+        key: KeyEvent,
+        view: &crate::state_handler::main_page::content::CapabilitiesView,
+    ) -> bool {
+        // Toggle confirmation pending: y/⏎ commits, anything else cancels.
+        if view.confirm_toggle.is_some() {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    let _ = self.action_tx.send(Action::CapabilitiesToggleCommit);
+                }
+                _ => {
+                    let _ = self.action_tx.send(Action::CapabilitiesToggleCancel);
+                }
+            }
+            return true;
+        }
+        match key.code {
+            KeyCode::Esc => {
+                let _ = self.action_tx.send(Action::CapabilitiesClose);
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                let _ = self.action_tx.send(Action::CapabilitiesUp);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let _ = self.action_tx.send(Action::CapabilitiesDown);
+            }
+            KeyCode::Enter => {
+                let _ = self.action_tx.send(Action::CapabilitiesDetail);
+            }
+            KeyCode::Char('r') => {
+                let _ = self.action_tx.send(Action::CapabilitiesRefresh);
+            }
+            KeyCode::Char('e') => {
+                let _ = self.action_tx.send(Action::CapabilitiesToggleArm);
+            }
+            _ => return false,
+        }
+        true
+    }
+
     fn handle_communities_key(&mut self, key: KeyEvent) -> bool {
+        // Capabilities view open: it owns the keys until closed (Esc).
+        if let Some(view) = self.props.main_page.content_panel.capabilities.view.clone() {
+            return self.handle_capabilities_key(key, &view);
+        }
         let comms = &self.props.main_page.content_panel.communities;
         let count = comms.items.len();
         let selected = comms.selected_index;
@@ -599,6 +645,11 @@ impl MainPage {
                 // Issue this membership's reciprocal VMC back to the community and
                 // send it to the VTC (members/vmc/1.0). Active-only.
                 let _ = self.action_tx.send(Action::IssueMemberVmc(selected));
+                true
+            }
+            KeyCode::Char('c') if sel_active => {
+                // Open the community's capabilities view (governance/capability/*).
+                let _ = self.action_tx.send(Action::CapabilitiesOpen(selected));
                 true
             }
             // Cancel is pending-only: a Pending join can be withdrawn (arming on
@@ -2560,13 +2611,15 @@ mod key_handler_tests {
             Ok(Action::IssueMemberVmc(0)) => {}
             _ => panic!("expected IssueMemberVmc(0)"),
         }
-        // Active row: `c` (cancel pending join) does nothing.
+        // Active row: `c` opens the community's capabilities view (the
+        // cancel-pending-join meaning of `c` is Pending-only; the two are
+        // disjoint by status).
         let (mut page, mut rx) = active();
         page.handle_key_event(press(KeyCode::Char('c')));
-        assert!(
-            rx.try_recv().is_err(),
-            "cancel is gated off for Active rows"
-        );
+        match rx.try_recv() {
+            Ok(Action::CapabilitiesOpen(0)) => {}
+            _ => panic!("expected CapabilitiesOpen(0) for Active rows"),
+        }
         let (mut page, mut rx) = active();
         page.handle_key_event(press(KeyCode::Char('d')));
         assert!(


### PR DESCRIPTION
## What

The VTC-side UX for capability modules (design: `design-docs/vtc-capability-modules.md` §4.5; specs: dtgwg #119/#120; host: affinidi-trust-registry-rs #97/#98). UX shape as agreed: **per-community entry (`c` on an Active community), read + manage in v1**.

### The flow

- `c` on a selected Active community swaps the content panel to its capabilities, live-queried via a `governance/capability/list` Trust Task (status `all`) to the community's DID over DIDComm — async reply correlated by `threadId`, **30s fail-closed reply window** swept by the state loop (R4.3).
- List rows: `●` enabled / `○` available / `◈` companion-delegated, `slug@version`, enablement date; selected-row summary expansion; `⏎` opens the full **manifest detail** (vocabulary, roles, lifecycle hooks, adapters, config schema) — the generic manifest-driven view, so capabilities without compiled panels are fully browsable.
- **Distinct failure states** (R6.4): in-flight, host-unreachable timeout, "community does not offer capability management" (`unsupportedType` — a pre-capability VTC is expected, not an error), and `permissionDenied`.
- `e` arms enable/disable with the standard orange y/⏎ confirm gate; the write is a `governance/capability/enable|disable` document carrying an `eddsa-jcs-2022` Data-Integrity proof signed with the persona's signing key. Enable defaults `config.authority` to the community's own DID — per governance decision D-B, **the community is the authority**. Toggle replies update the row in place; rejections surface the machine-readable trust-task code.

### Noted shortcut (as agreed)

v1 signs the governance write directly with the persona key in the client. The delegated-execution consent flow (device-approved, digest-bound) is the planned upgrade and is called out in the module docs.

### Key-binding note

`c` was previously only "cancel pending join" (Pending rows). Capabilities is **Active-only**, so the meanings are disjoint by row status — the key-gating test now pins both behaviors.

## Testing

172 workspace tests green (4 new openvtc-core unit tests on document building/signing/reply parsing; the key-gating test updated to pin the new `c` semantics). fmt + clippy under CI's `-D warnings` profile clean.
