### PR TITLE
chore(openvtc-core): dedup capabilities wire code to the shared crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5506,6 +5506,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "trust-tasks-capability-client",
  "trust-tasks-rs",
  "url",
  "uuid",
@@ -5798,7 +5799,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -8614,6 +8615,20 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "trust-tasks-rs",
+]
+
+[[package]]
+name = "trust-tasks-capability-client"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdd2a1c83c4b1b74d2bd335ff2e45cdcb1bf4e17eddbf24761dd4a471a79cf8"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "trust-tasks-rs",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ tokio-util = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 trust-tasks-rs = "0.2"
+trust-tasks-capability-client = "0.1"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -54,6 +54,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 trust-tasks-rs.workspace = true
+trust-tasks-capability-client.workspace = true
 url.workspace = true
 uuid.workspace = true
 x25519-dalek.workspace = true

--- a/openvtc-core/src/capabilities.rs
+++ b/openvtc-core/src/capabilities.rs
@@ -1,17 +1,13 @@
-//! Client side of the `governance/capability/*` Trust Task family: query and
-//! manage a community's pluggable capabilities from the TUI.
+//! Capability Trust Task client for the TUI: query and manage a community's
+//! pluggable capabilities.
 //!
-//! The community's governance host is the VTC itself (its registry serves the
-//! capability surface), reached over DIDComm via the mediator: requests are
-//! `TrustTask` documents packed inside the `trust-tasks-didcomm` binding
-//! envelope, replies arrive asynchronously and are correlated by the
-//! document's `threadId` (== the request document id).
-//!
-//! Writes (`enable`/`disable`) carry an `eddsa-jcs-2022` Data-Integrity proof
-//! signed with the persona's signing key, bound to the document `issuer`.
-//! NOTE: v1 signs directly in the client; routing the approval through the
-//! delegated-execution consent flow is the planned upgrade
-//! (`trust-task-delegation-architecture.md`).
+//! The wire layer — document builders, envelope parsing, and reply
+//! classification — lives in the shared [`trust_tasks_capability_client`]
+//! crate (re-exported below) so this client and the community service's hook
+//! producer cannot drift on the contract. Only the two pieces that are
+//! genuinely openvtc-specific stay here: signing with the persona key
+//! ([`sign_document`]) and sending over the profile's mediator
+//! ([`send_capability_document`]).
 
 use std::sync::Arc;
 
@@ -27,114 +23,22 @@ use uuid::Uuid;
 use crate::errors::OpenVTCError;
 use crate::pack_and_send;
 
-/// The `trust-tasks-didcomm` binding envelope type (the message type the
-/// registry's DIDComm Trust Task handler listens for). Kept in sync with
-/// `trust_tasks_didcomm::ENVELOPE_TYPE`; hardcoded here to avoid pulling the
-/// whole binding crate for one constant.
-pub const TRUST_TASK_ENVELOPE_TYPE: &str = "https://trusttasks.org/binding/didcomm/0.1/envelope";
-
-/// Type URIs of the governance capability family.
-pub const CAPABILITY_LIST_TYPE: &str = "https://trusttasks.org/spec/governance/capability/list/0.1";
-pub const CAPABILITY_ENABLE_TYPE: &str =
-    "https://trusttasks.org/spec/governance/capability/enable/0.1";
-pub const CAPABILITY_DISABLE_TYPE: &str =
-    "https://trusttasks.org/spec/governance/capability/disable/0.1";
-
-/// One capability as rendered by the panel.
-#[derive(Debug, Clone, PartialEq)]
-pub struct CapabilitySummary {
-    pub slug: String,
-    pub title: Option<String>,
-    pub version: String,
-    pub enabled: bool,
-    pub enabled_at: Option<String>,
-    pub delegate: Option<String>,
-    /// The full manifest for the detail view.
-    pub manifest: Value,
-}
-
-/// What a correlated capability reply means for the panel.
-#[derive(Debug, Clone, PartialEq)]
-pub enum CapabilityReply {
-    /// A `list` response: the community's capabilities.
-    Listing(Vec<CapabilitySummary>),
-    /// An `enable`/`disable` response acknowledging the toggle.
-    Toggled { capability: String, enabled: bool },
-    /// A `trust-task-error` document; the code is the machine-readable
-    /// trust-task error code, the message its human detail.
-    Rejected {
-        code: String,
-        message: Option<String>,
-    },
-}
-
-/// Build the `governance/capability/list` request document (status `all`, so
-/// the panel can offer enabling what's available).
-pub fn build_list_document(persona_did: &str, vtc_did: &str) -> TrustTask<Value> {
-    build_document(
-        persona_did,
-        vtc_did,
-        CAPABILITY_LIST_TYPE,
-        serde_json::json!({ "status": "all" }),
-    )
-}
-
-/// Build the `enable` or `disable` request document.
-///
-/// For `enable`, `config.authority` defaults to the community's own DID: per
-/// the governance model the community *is* the authority its capability
-/// records are issued under.
-pub fn build_toggle_document(
-    persona_did: &str,
-    vtc_did: &str,
-    slug: &str,
-    version: &str,
-    enable: bool,
-) -> TrustTask<Value> {
-    if enable {
-        build_document(
-            persona_did,
-            vtc_did,
-            CAPABILITY_ENABLE_TYPE,
-            serde_json::json!({
-                "capability": slug,
-                "version": version,
-                "config": { "authority": vtc_did },
-            }),
-        )
-    } else {
-        build_document(
-            persona_did,
-            vtc_did,
-            CAPABILITY_DISABLE_TYPE,
-            serde_json::json!({ "capability": slug }),
-        )
-    }
-}
-
-fn build_document(
-    persona_did: &str,
-    vtc_did: &str,
-    type_uri: &str,
-    payload: Value,
-) -> TrustTask<Value> {
-    let mut doc = TrustTask::new(
-        format!("urn:uuid:{}", Uuid::new_v4()),
-        type_uri
-            .parse()
-            .unwrap_or_else(|_| unreachable!("static capability type URIs are valid")),
-        payload,
-    );
-    doc.issuer = Some(persona_did.to_string());
-    doc.recipient = Some(vtc_did.to_string());
-    doc.issued_at = Some(chrono::Utc::now());
-    doc
-}
+// The wire layer, shared with the community service (vtc-service hooks).
+pub use trust_tasks_capability_client::{
+    CAPABILITY_DISABLE_TYPE, CAPABILITY_ENABLE_TYPE, CAPABILITY_LIST_TYPE, CapabilityReply,
+    CapabilitySummary, TRUST_TASK_ENVELOPE_TYPE, build_list_document, build_toggle_document,
+    parse_capability_reply, parse_envelope_reply,
+};
 
 /// Attach an `eddsa-jcs-2022` Data-Integrity proof over `doc` (minus the
-/// `proof` member, mirroring the verifier's canonical form), signed with the
-/// persona's signing secret. The verification method is the secret's key id,
-/// which must belong to the document `issuer` (the host enforces the binding).
+/// `proof` member) signed with the persona's signing key, bound to the
+/// document `issuer`. Signing is kept local rather than in the shared crate:
+/// each consumer signs with its own signer and its own error type, so the
+/// wire crate stays crypto-free.
+///
+/// NOTE: v1 signs directly in the client; routing the approval through the
+/// delegated-execution consent flow is the planned upgrade
+/// (`trust-task-delegation-architecture.md`).
 pub async fn sign_document(
     doc: &mut TrustTask<Value>,
     signing_secret: &Secret,
@@ -157,9 +61,9 @@ pub async fn sign_document(
 }
 
 /// Pack `doc` in the DIDComm Trust Task envelope and send it to the VTC via
-/// the mediator. Returns the document id — the `threadId` the reply will
-/// carry. Sending is fire-and-forget: `Ok` means handed to the transport,
-/// never that the host received it; the caller owns a reply timeout.
+/// the mediator. Returns the document id — the `threadId` the reply carries.
+/// Sending is fire-and-forget: `Ok` means handed to the transport, never that
+/// the host received it; the caller owns a reply timeout.
 pub async fn send_capability_document(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
@@ -183,96 +87,6 @@ pub async fn send_capability_document(
     Ok(doc.id.clone())
 }
 
-/// Parse a raw DIDComm envelope body into `(threadId, reply)` — the entry
-/// point for inbound dispatch, which holds only `serde_json::Value`.
-pub fn parse_envelope_reply(body: &Value) -> Option<(String, CapabilityReply)> {
-    let doc: TrustTask<Value> = serde_json::from_value(body.clone()).ok()?;
-    let thid = doc.thread_id.clone()?;
-    let reply = parse_capability_reply(&doc)?;
-    Some((thid, reply))
-}
-
-/// Interpret an inbound Trust Task envelope body as a capability reply.
-/// Returns `None` when the document is not part of this family (someone
-/// else's trust task riding the same envelope type).
-pub fn parse_capability_reply(doc: &TrustTask<Value>) -> Option<CapabilityReply> {
-    let slug = doc.type_uri.slug();
-    if slug == "trust-task-error" {
-        // Only classified as ours by the caller's threadId correlation.
-        let code = doc
-            .payload
-            .get("code")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown")
-            .to_string();
-        let message = doc
-            .payload
-            .get("message")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        return Some(CapabilityReply::Rejected { code, message });
-    }
-    if !doc.type_uri.is_response() {
-        return None;
-    }
-    match slug {
-        "governance/capability/list" => {
-            let entries = doc
-                .payload
-                .get("capabilities")
-                .and_then(Value::as_array)
-                .map(|entries| entries.iter().filter_map(summary_of).collect())
-                .unwrap_or_default();
-            Some(CapabilityReply::Listing(entries))
-        }
-        "governance/capability/enable" | "governance/capability/disable" => {
-            Some(CapabilityReply::Toggled {
-                capability: doc
-                    .payload
-                    .get("capability")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-                enabled: doc
-                    .payload
-                    .get("enabled")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false),
-            })
-        }
-        _ => None,
-    }
-}
-
-fn summary_of(entry: &Value) -> Option<CapabilitySummary> {
-    let manifest = entry.get("manifest")?.clone();
-    Some(CapabilitySummary {
-        slug: manifest.get("capability")?.as_str()?.to_string(),
-        title: manifest
-            .get("title")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        version: manifest
-            .get("version")
-            .and_then(Value::as_str)
-            .unwrap_or("?")
-            .to_string(),
-        enabled: entry
-            .get("enabled")
-            .and_then(Value::as_bool)
-            .unwrap_or(false),
-        enabled_at: entry
-            .get("enabledAt")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        delegate: entry
-            .get("delegate")
-            .and_then(Value::as_str)
-            .map(str::to_string),
-        manifest,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
@@ -280,96 +94,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn list_document_is_addressed_and_typed() {
-        let doc = build_list_document("did:example:me", "did:example:vtc");
-        assert_eq!(doc.issuer.as_deref(), Some("did:example:me"));
-        assert_eq!(doc.recipient.as_deref(), Some("did:example:vtc"));
-        assert_eq!(doc.type_uri.slug(), "governance/capability/list");
-        assert_eq!(doc.payload["status"], "all");
-    }
+    fn re_exported_builders_are_addressed() {
+        let list = build_list_document("did:example:me", "did:example:vtc");
+        assert_eq!(list.recipient.as_deref(), Some("did:example:vtc"));
+        assert_eq!(list.type_uri.slug(), "governance/capability/list");
 
-    #[test]
-    fn enable_defaults_authority_to_the_community() {
-        let doc = build_toggle_document(
+        let enable = build_toggle_document(
             "did:example:me",
             "did:example:vtc",
             "git-trust",
             "0.1",
             true,
         );
-        assert_eq!(doc.payload["config"]["authority"], "did:example:vtc");
-        assert_eq!(doc.payload["capability"], "git-trust");
-        let doc = build_toggle_document(
-            "did:example:me",
-            "did:example:vtc",
-            "git-trust",
-            "0.1",
-            false,
-        );
-        assert_eq!(doc.type_uri.slug(), "governance/capability/disable");
-        assert!(doc.payload.get("config").is_none());
-    }
-
-    #[test]
-    fn parses_a_listing_reply() {
-        let request = build_list_document("did:example:me", "did:example:vtc");
-        let reply = request.respond_with(
-            "urn:uuid:r".to_string(),
-            serde_json::json!({
-                "capabilities": [{
-                    "manifest": {
-                        "capability": "git-trust", "version": "0.1",
-                        "title": "Git Commit Trust", "specs": ["git-trust/*"]
-                    },
-                    "enabled": true,
-                    "enabledAt": "2026-07-17T00:00:00Z"
-                }]
-            }),
-        );
-        let Some(CapabilityReply::Listing(items)) = parse_capability_reply(&reply) else {
-            panic!("expected listing");
-        };
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].slug, "git-trust");
-        assert!(items[0].enabled);
-        assert_eq!(items[0].title.as_deref(), Some("Git Commit Trust"));
-    }
-
-    #[test]
-    fn parses_error_and_toggle_replies_and_ignores_foreign_tasks() {
-        let request = build_toggle_document("did:example:me", "did:example:vtc", "x", "0.1", true);
-        let err = request.reject_with(
-            "urn:uuid:e".to_string(),
-            trust_tasks_rs::RejectReason::PermissionDenied {
-                reason: "nope".to_string(),
-            },
-        );
-        let err_value: TrustTask<Value> =
-            serde_json::from_value(serde_json::to_value(&err).unwrap()).unwrap();
-        assert!(matches!(
-            parse_capability_reply(&err_value),
-            Some(CapabilityReply::Rejected { .. })
-        ));
-
-        let ok = request.respond_with(
-            "urn:uuid:t".to_string(),
-            serde_json::json!({ "capability": "x", "enabled": true }),
-        );
-        assert_eq!(
-            parse_capability_reply(&ok),
-            Some(CapabilityReply::Toggled {
-                capability: "x".to_string(),
-                enabled: true
-            })
-        );
-
-        let foreign = TrustTask::new(
-            "urn:uuid:f".to_string(),
-            "https://trusttasks.org/spec/registry/authorization/0.1#response"
-                .parse()
-                .unwrap(),
-            serde_json::json!({}),
-        );
-        assert_eq!(parse_capability_reply(&foreign), None);
+        assert_eq!(enable.payload["config"]["authority"], "did:example:vtc");
     }
 }


### PR DESCRIPTION
Second of the two dedup swaps (`trust-tasks-capability-client 0.1.0` is now on crates.io).

`openvtc-core::capabilities` drops its hand-maintained copy of the capability wire layer and re-exports it from the shared crate: `build_list_document`, `build_toggle_document`, `parse_envelope_reply`, `parse_capability_reply`, `CapabilitySummary`, `CapabilityReply`, and the type-URI constants. Every TUI call site (`openvtc_core::capabilities::…`) resolves through the re-export unchanged.

The two genuinely openvtc-specific functions stay local, because they're not wire code:
- `sign_document` — signs with the persona key and openvtc's own error type (the shared crate is deliberately crypto-free; each consumer signs its own way).
- `send_capability_document` — the mediator transport via `pack_and_send`.

Net: ~180 lines of duplicated builders/parsers/types deleted, replaced by one re-export line and the two locals.

Verified: full workspace tests green, clippy clean under `-D warnings`. DCO — n/a (openvtc doesn't enforce it), but signed anyway.