### PR TITLE
Pin VGI verify-trust action to @v0.1.1

### DIFF
--- a/.github/workflows/verify-trust.yml
+++ b/.github/workflows/verify-trust.yml
@@ -32,8 +32,7 @@ jobs:
           # The verifier walks raw commit objects across base..head.
           fetch-depth: 0
 
-      # Pin to a VGI release tag (e.g. @v0.1.0) once one is published.
-      - uses: OpenVTC/verifiable-git-infrastructure/.github/actions/verify-trust@main
+      - uses: OpenVTC/verifiable-git-infrastructure/.github/actions/verify-trust@v0.1.1
         with:
           range: origin/${{ github.base_ref }}..HEAD
           registry-url: ${{ vars.TRUST_REGISTRY_URL }}


### PR DESCRIPTION
Follow-up to #159. The dogfood workflow referenced `OpenVTC/verifiable-git-infrastructure/.github/actions/verify-trust@main` as a placeholder before a VGI release existed.

VGI **v0.1.1** is now published — with the prebuilt binaries the action downloads — so this pins to the release tag `@v0.1.1` for a reproducible, non-moving reference.

No behavior change: the check is still dormant until `TRUST_REGISTRY_URL` etc. are configured.