### PR TITLE
docs: record cross-service networking discipline in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,22 @@ entry point that now delegates to the library.
 
 If the library appears to be missing a capability, prefer opening an issue
 or extending the library over reimplementing it locally.
+
+## Cross-service networking & integration discipline
+
+OpenVTC tooling drives the live VTA/VTC/webvh services over the network, so
+it inherits the ecosystem's integration rules. Read the doc set in
+`../design-docs/` before adding or changing any service call:
+
+- **`vti-stack-development-guide.md`** — binding rules; paste its pre-merge
+  checklist into PRs. Most relevant to a CLI/tooling repo: **R1.2** (every
+  outbound client has finite timeouts — a hung service must produce an error,
+  not a hung command), **R1.4** (polling loops are bounded and backed off),
+  **R6.4** (error text must let the operator tell network-unreachable from
+  auth-rejected from contract-mismatch — never one fixed hint for all
+  failures), and **R3.6** (verify endpoint paths/shapes against the current
+  services rather than assuming they haven't moved).
+- **`vti-networking-remediation-plan.md`** — the confirmed-defect backlog
+  across the ecosystem; check it before debugging an integration failure —
+  the cause may already be catalogued.
+- **`vti-architectural-direction.md`** — design-level rationale.


### PR DESCRIPTION
## What

Adds a **Cross-service networking & integration discipline** section to `CLAUDE.md`.

OpenVTC tooling drives the live VTA/VTC/webvh services over the network, so it inherits the ecosystem's integration rules. The new section points at the `../design-docs/` set and pins the four rules that bite a CLI/tooling repo hardest:

- **R1.2** — every outbound client has finite timeouts; a hung service must produce an error, not a hung command.
- **R1.4** — polling loops are bounded and backed off.
- **R6.4** — error text must let the operator tell network-unreachable from auth-rejected from contract-mismatch.
- **R3.6** — verify endpoint paths/shapes against the current services rather than assuming they haven't moved.

All three referenced docs (`vti-stack-development-guide.md`, `vti-networking-remediation-plan.md`, `vti-architectural-direction.md`) were confirmed present in `../design-docs/`.

## Note on scope

This branch originally also carried a workspace-wide `cargo fmt` sweep from an older working tree. While preparing it, `main` advanced 9 commits (#152–#160) and that formatting had already landed upstream — `cargo fmt --all` is now a no-op on `main`. The sweep was dropped; this PR is docs-only.

## Test plan

Documentation only — no code, no behavior change. `cargo fmt --all --check` is clean on the branch.