### PR TITLE
feat: agent-name resolution, verification, and off-loop refresh cache

### DIFF
--- a/openvtc-core/src/agent_name.rs
+++ b/openvtc-core/src/agent_name.rs
@@ -1,0 +1,323 @@
+//! Agent names — human-memorable shortcuts that resolve to DIDs.
+//!
+//! An agent name is a URL whose path begins with `/@`
+//! (`example.com/@alice`). It is **not** a DID method; it is a shortcut layer
+//! in front of DID resolution. Resolution is three stages and the third is
+//! mandatory:
+//!
+//! 1. the name URL redirects to a DID,
+//! 2. the DID resolves to a document,
+//! 3. **the document must claim the name back via `alsoKnownAs`.**
+//!
+//! Stage 1 is served by the name's own web server, so on its own it proves
+//! nothing — anyone can publish a redirect at somebody else's DID. Stage 3 is
+//! what makes the binding real: only the DID's controller can add an
+//! `alsoKnownAs` entry. This module never surfaces a name that has not
+//! completed all three, so a hostile DID cannot make the UI display it under a
+//! name it does not actually own.
+//!
+//! All parsing, canonicalisation and `alsoKnownAs` matching delegates to the
+//! [`agent_names`] crate. Canonicalisation is unspecified by the agent-name
+//! spec, so two implementations that normalise differently disagree about
+//! whether a name verifies — hand-rolling any of it is how the two sides drift.
+//! This is the same rule the crate states for `didwebvh-rs`.
+
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, errors::DIDCacheError};
+use affinidi_tdk::did_common::Document;
+use agent_names::AgentName;
+
+/// How many `alsoKnownAs` candidates we are willing to round-trip per document
+/// before giving up. A document that claims a name makes us do one network
+/// resolve per candidate; a hostile document could list hundreds, so we cap it.
+/// The first candidate that verifies wins, so a well-formed document (one or a
+/// few names) is unaffected.
+const MAX_CANDIDATES: usize = 4;
+
+/// Cheap syntactic test — no network. A string containing the `/@` marker is
+/// treated as an agent name; everything else is a DID (or nonsense) for the
+/// resolver to judge.
+#[must_use]
+pub fn looks_like_agent_name(input: &str) -> bool {
+    AgentName::looks_like_agent_name(input)
+}
+
+/// Resolve `did` to a **verified** agent name for display, or `None`.
+///
+/// Returns `Some(name)` only when a name the document claims round-trips: the
+/// name resolves forward (via [`DIDCacheClient::resolve_any`], which performs
+/// the mandatory `alsoKnownAs` check on the document *it* fetches) **and** that
+/// forward resolution lands on the same `did` we are labelling. The returned
+/// string is the scheme-less spelling (`example.com/@alice`).
+///
+/// Anything short of that — the name points at a different DID (a spoof), the
+/// name no longer redirects, the host is unreachable — yields `None`, and the
+/// caller falls back to showing the DID. A name is a mutable web redirect; the
+/// verification is what stops the UI from becoming a phishing surface, so a
+/// failure to verify is deliberately indistinguishable here from "no name".
+pub async fn verified_agent_name(
+    resolver: &DIDCacheClient,
+    did: &str,
+    doc: &Document,
+) -> Option<String> {
+    let candidates = agent_names::extract_agent_names(doc);
+    verify_candidates(did, candidates, |name| async move {
+        // resolve_any performs the mandatory `alsoKnownAs` check on the document
+        // it fetches; we additionally require its resolved DID to be the one we
+        // are labelling, which ties the name's forward redirect back to `did`.
+        resolver.resolve_any(&name).await.ok().map(|resp| resp.did)
+    })
+    .await
+}
+
+/// The verification decision, factored out so the spoof guard is testable
+/// without a live resolver: accept the first candidate whose forward resolution
+/// lands on `did`; a candidate resolving to a *different* DID (a spoof) or not
+/// resolving at all is skipped. Capped at [`MAX_CANDIDATES`].
+///
+/// `resolve` maps a name's canonical string to the DID it forward-resolves to
+/// (`None` on any failure).
+async fn verify_candidates<F, Fut>(
+    did: &str,
+    candidates: Vec<AgentName>,
+    resolve: F,
+) -> Option<String>
+where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = Option<String>>,
+{
+    for name in candidates.into_iter().take(MAX_CANDIDATES) {
+        if resolve(name.as_str().to_string()).await.as_deref() == Some(did) {
+            return Some(name.without_scheme().to_string());
+        }
+    }
+    None
+}
+
+/// Why an identifier the user typed could not be turned into a DID.
+///
+/// The variants exist so the operator can tell the failure modes apart, rather
+/// than getting one fixed hint for every failure. `resolve_any` collapses the
+/// underlying [`agent_names::AgentNameError`] into a string, so [`Self::AgentName`]
+/// carries that already-descriptive message (e.g. "did not redirect (HTTP 404)"
+/// vs "is not authorized by DID" vs "resolves to the non-public address")
+/// rather than re-deriving a typed variant by string-matching.
+#[derive(Debug, thiserror::Error)]
+pub enum IdentifierError {
+    /// An agent name failed to resolve or verify. The message distinguishes the
+    /// cause (not-found / not-a-DID / not-claimed-back / blocked address).
+    #[error("agent name '{input}' could not be resolved: {detail}")]
+    AgentName { input: String, detail: String },
+
+    /// The resolver could not reach the network (timeout or transport failure).
+    #[error("could not reach the network resolving '{input}'")]
+    Unreachable { input: String },
+
+    /// It was not an agent name, and it is not a resolvable DID either.
+    #[error("'{input}' is not a resolvable DID")]
+    InvalidDid { input: String },
+}
+
+/// Resolve user input that may be a DID **or** an agent name to a DID string.
+///
+/// A DID is passed straight through the resolver; an agent name goes through
+/// the full three-stage resolve-and-verify. On success the caller should
+/// persist the returned **DID**, never the name — a name is a mutable web
+/// redirect, and persisting one would let a redirect change silently repoint a
+/// saved identity.
+pub async fn resolve_identifier(
+    resolver: &DIDCacheClient,
+    input: &str,
+) -> Result<String, IdentifierError> {
+    let input = input.trim();
+    match resolver.resolve_any(input).await {
+        Ok(resp) => Ok(resp.did),
+        Err(e) => Err(classify(input, e)),
+    }
+}
+
+/// Map a [`DIDCacheError`] onto the operator-facing [`IdentifierError`], using
+/// whether the input looked like a name to disambiguate the parse/DID buckets.
+fn classify(input: &str, err: DIDCacheError) -> IdentifierError {
+    let input = input.to_string();
+    match err {
+        // `AgentNameError` is gated behind the cache-sdk's `agent-names`
+        // feature, which this workspace always enables (see the root
+        // `Cargo.toml`), so the variant is always present in our build.
+        DIDCacheError::AgentNameError(detail) => IdentifierError::AgentName { input, detail },
+        DIDCacheError::NetworkTimeout | DIDCacheError::TransportError(_) => {
+            IdentifierError::Unreachable { input }
+        }
+        // A DID-parse / method / config failure. If the user typed a name, the
+        // name-shaped failure is the useful framing; otherwise it is a bad DID.
+        other => {
+            if looks_like_agent_name(&input) {
+                IdentifierError::AgentName {
+                    input,
+                    detail: other.to_string(),
+                }
+            } else {
+                IdentifierError::InvalidDid { input }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::cell::Cell;
+
+    fn name(s: &str) -> AgentName {
+        AgentName::parse(s).expect("valid agent name in test")
+    }
+
+    /// The spoof case, and the single most important behaviour in this module:
+    /// a document claims `example.com/@alice`, but that name forward-resolves to
+    /// a *different* DID. It must NOT be displayed as our name.
+    #[tokio::test]
+    async fn rejects_name_resolving_to_a_different_did() {
+        let got = verify_candidates(
+            "did:webvh:us:example.com",
+            vec![name("example.com/@alice")],
+            // The name points at somebody else's DID.
+            |_| async { Some("did:webvh:them:evil.example".to_string()) },
+        )
+        .await;
+        assert_eq!(
+            got, None,
+            "a name pointing at a different DID must be rejected"
+        );
+    }
+
+    /// The happy path: the claimed name forward-resolves back to the DID we are
+    /// labelling. Returned scheme-less.
+    #[tokio::test]
+    async fn accepts_name_that_round_trips() {
+        let did = "did:webvh:us:example.com";
+        let got = verify_candidates(did, vec![name("example.com/@alice")], |n| {
+            let did = did.to_string();
+            async move {
+                assert_eq!(n, "https://example.com/@alice");
+                Some(did)
+            }
+        })
+        .await;
+        assert_eq!(got.as_deref(), Some("example.com/@alice"));
+    }
+
+    /// A name that does not resolve at all (host down, no redirect) yields no
+    /// name rather than an error — the caller falls back to the DID.
+    #[tokio::test]
+    async fn skips_unresolvable_name() {
+        let got = verify_candidates(
+            "did:webvh:us:example.com",
+            vec![name("example.com/@alice")],
+            |_| async { None },
+        )
+        .await;
+        assert_eq!(got, None);
+    }
+
+    /// A document that claims many names must not trigger an unbounded number of
+    /// network resolves; verification stops at MAX_CANDIDATES.
+    #[tokio::test]
+    async fn caps_the_number_of_candidates_verified() {
+        let calls = Cell::new(0usize);
+        let candidates: Vec<AgentName> = (0..(MAX_CANDIDATES + 5))
+            .map(|i| name(&format!("example.com/@name{i}")))
+            .collect();
+        let got = verify_candidates("did:webvh:us:example.com", candidates, |_| {
+            calls.set(calls.get() + 1);
+            // None of them match, so every attempt (up to the cap) is made.
+            async { Some("did:webvh:other:host".to_string()) }
+        })
+        .await;
+        assert_eq!(got, None);
+        assert_eq!(calls.get(), MAX_CANDIDATES, "must not resolve past the cap");
+    }
+
+    /// The first verifying candidate wins; later ones are not resolved.
+    #[tokio::test]
+    async fn stops_at_first_verified_candidate() {
+        let did = "did:webvh:us:example.com";
+        let calls = Cell::new(0usize);
+        let candidates = vec![name("example.com/@first"), name("example.com/@second")];
+        let got = verify_candidates(did, candidates, |_| {
+            calls.set(calls.get() + 1);
+            let did = did.to_string();
+            async move { Some(did) }
+        })
+        .await;
+        assert_eq!(got.as_deref(), Some("example.com/@first"));
+        assert_eq!(calls.get(), 1, "must short-circuit on the first match");
+    }
+
+    #[test]
+    fn recognises_agent_names() {
+        assert!(looks_like_agent_name("example.com/@alice"));
+        assert!(looks_like_agent_name("https://connect.me/@bob"));
+        assert!(looks_like_agent_name(
+            "firstperson.network/@drummond/h2hsummit"
+        ));
+    }
+
+    #[test]
+    fn rejects_non_agent_names() {
+        assert!(!looks_like_agent_name("did:webvh:QmScid:example.com"));
+        assert!(!looks_like_agent_name("did:web:example.com"));
+        // An email is not an agent name — the marker is `/@`, not `@`.
+        assert!(!looks_like_agent_name("alice@example.com"));
+        // A bare handle with no host is not resolvable and not an agent name.
+        assert!(!looks_like_agent_name("@alice"));
+        assert!(!looks_like_agent_name(""));
+    }
+
+    /// A non-name, non-DID string that the resolver rejects with a DID-parse
+    /// error surfaces as `InvalidDid`, not as an agent-name failure.
+    #[test]
+    fn classify_non_name_did_error_is_invalid_did() {
+        let err = classify("not-a-did", DIDCacheError::DIDError("bad".into()));
+        assert!(matches!(err, IdentifierError::InvalidDid { .. }));
+    }
+
+    /// The same DID-parse error, when the input *looked* like a name, is framed
+    /// as an agent-name failure so the operator gets the name-shaped hint.
+    #[test]
+    fn classify_name_shaped_parse_error_is_agent_name() {
+        let err = classify("example.com/@alice", DIDCacheError::DIDError("bad".into()));
+        assert!(matches!(err, IdentifierError::AgentName { .. }));
+    }
+
+    /// Network failures are their own bucket regardless of input shape, so the
+    /// operator can tell "the host is down" from "the name isn't claimed".
+    #[test]
+    fn classify_network_errors_are_unreachable() {
+        assert!(matches!(
+            classify("example.com/@alice", DIDCacheError::NetworkTimeout),
+            IdentifierError::Unreachable { .. }
+        ));
+        assert!(matches!(
+            classify("did:web:x", DIDCacheError::TransportError("refused".into())),
+            IdentifierError::Unreachable { .. }
+        ));
+    }
+
+    /// The agent-name resolver's descriptive message is preserved verbatim, so
+    /// distinct causes (not-found vs not-claimed vs blocked) reach the user.
+    #[test]
+    fn classify_agent_name_error_preserves_detail() {
+        let err = classify(
+            "example.com/@alice",
+            DIDCacheError::AgentNameError(
+                "Agent name 'example.com/@alice' did not redirect (HTTP 404)".into(),
+            ),
+        );
+        match err {
+            IdentifierError::AgentName { detail, .. } => {
+                assert!(detail.contains("did not redirect"), "detail was: {detail}");
+            }
+            other => panic!("expected AgentName, got {other:?}"),
+        }
+    }
+}

--- a/openvtc-core/src/agent_name.rs
+++ b/openvtc-core/src/agent_name.rs
@@ -25,6 +25,8 @@
 use affinidi_did_resolver_cache_sdk::{DIDCacheClient, errors::DIDCacheError};
 use affinidi_tdk::did_common::Document;
 use agent_names::AgentName;
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
 
 /// How many `alsoKnownAs` candidates we are willing to round-trip per document
 /// before giving up. A document that claims a name makes us do one network
@@ -32,6 +34,34 @@ use agent_names::AgentName;
 /// The first candidate that verifies wins, so a well-formed document (one or a
 /// few names) is unaffected.
 const MAX_CANDIDATES: usize = 4;
+
+/// How long a persisted lookup (positive **or** negative) is trusted before the
+/// background refresh re-verifies it. The resolver's own name cache is short
+/// (~5 min) and handles churn; this persisted layer only exists so names show
+/// instantly at launch without a network round-trip, so a day is ample.
+pub const AGENT_NAME_TTL: Duration = Duration::hours(24);
+
+/// A persisted DID → agent-name lookup. The value is deliberately an
+/// `Option`: a resolved-and-verified name, **or** `None` recording that the DID
+/// currently has no verifiable name — a negative result worth caching so the UI
+/// does not re-resolve a nameless DID on every render.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CachedAgentName {
+    /// The verified name (scheme-less, `example.com/@alice`), or `None` if the
+    /// DID has no verifiable name.
+    pub name: Option<String>,
+    /// When this was last verified, for staleness (`AGENT_NAME_TTL`).
+    pub checked_at: DateTime<Utc>,
+}
+
+impl CachedAgentName {
+    /// Whether this entry is older than [`AGENT_NAME_TTL`] as of `now` and
+    /// should be re-verified by the background refresh.
+    #[must_use]
+    pub fn is_stale(&self, now: DateTime<Utc>) -> bool {
+        now - self.checked_at >= AGENT_NAME_TTL
+    }
+}
 
 /// Cheap syntactic test — no network. A string containing the `/@` marker is
 /// treated as an agent name; everything else is a DID (or nonsense) for the
@@ -67,6 +97,17 @@ pub async fn verified_agent_name(
         resolver.resolve_any(&name).await.ok().map(|resp| resp.did)
     })
     .await
+}
+
+/// Resolve `did` to a verified agent name, fetching its document first.
+///
+/// The batch refresh has only DIDs to work from, not documents, so this wraps
+/// [`verified_agent_name`] with the leading `resolve(did)`. Both hops reuse the
+/// resolver's document cache. `None` if the DID does not resolve or has no
+/// verifiable name.
+pub async fn resolve_verified_name(resolver: &DIDCacheClient, did: &str) -> Option<String> {
+    let resp = resolver.resolve(did).await.ok()?;
+    verified_agent_name(resolver, did, &resp.doc).await
 }
 
 /// The verification decision, factored out so the spoof guard is testable
@@ -170,6 +211,19 @@ mod tests {
 
     fn name(s: &str) -> AgentName {
         AgentName::parse(s).expect("valid agent name in test")
+    }
+
+    #[test]
+    fn cache_entry_staleness_tracks_the_ttl() {
+        let checked_at = Utc::now();
+        let fresh = CachedAgentName {
+            name: Some("example.com/@alice".into()),
+            checked_at,
+        };
+        assert!(!fresh.is_stale(checked_at));
+        assert!(!fresh.is_stale(checked_at + Duration::hours(23)));
+        assert!(fresh.is_stale(checked_at + AGENT_NAME_TTL));
+        assert!(fresh.is_stale(checked_at + Duration::hours(25)));
     }
 
     /// The spoof case, and the single most important behaviour in this module:

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -436,6 +436,71 @@ impl Config {
             .unwrap_or_else(|| "Persona".to_string())
     }
 
+    /// The verified agent name cached for `did`, if one is known.
+    ///
+    /// Returns `Some` only for a positive lookup; a cached *negative* result
+    /// (the DID has no verifiable name) reads as `None`, same as an uncached
+    /// DID. Callers that need to distinguish the two consult
+    /// [`ProtectedConfig::agent_names`](crate::config::protected_config::ProtectedConfig)
+    /// directly.
+    #[must_use]
+    pub fn agent_name_for(&self, did: &str) -> Option<&str> {
+        self.private
+            .agent_names
+            .get(did)
+            .and_then(|c| c.name.as_deref())
+    }
+
+    /// Record a verified agent-name lookup (positive or negative) for `did`,
+    /// stamped `now`. Overwrites any prior entry.
+    pub fn set_cached_agent_name(
+        &mut self,
+        did: &str,
+        name: Option<String>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) {
+        self.private.agent_names.insert(
+            did.to_string(),
+            crate::agent_name::CachedAgentName {
+                name,
+                checked_at: now,
+            },
+        );
+    }
+
+    /// Every DID the UI displays that needs an agent-name lookup — those with no
+    /// cache entry or a stale one (`now` past [`AGENT_NAME_TTL`]).
+    ///
+    /// Covers persona DIDs, community VTC DIDs, relationship remote-persona DIDs
+    /// and contact DIDs. De-duplicated; the same DID appearing in several places
+    /// is resolved once. Fed to the background batch refresh.
+    ///
+    /// [`AGENT_NAME_TTL`]: crate::agent_name::AGENT_NAME_TTL
+    #[must_use]
+    pub fn agent_name_refresh_targets(&self, now: chrono::DateTime<chrono::Utc>) -> Vec<String> {
+        let mut dids: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for persona in self.account.personas.values() {
+            dids.insert(persona.did.clone());
+        }
+        for community in self.account.memberships() {
+            dids.insert(community.vtc_did.clone());
+        }
+        for rel in self.private.relationships.relationships.values() {
+            dids.insert(rel.remote_p_did.to_string());
+        }
+        for contact in self.private.contacts.contacts.keys() {
+            dids.insert(contact.to_string());
+        }
+        dids.into_iter()
+            .filter(|did| {
+                self.private
+                    .agent_names
+                    .get(did)
+                    .is_none_or(|cached| cached.is_stale(now))
+            })
+            .collect()
+    }
+
     /// Set the active persona's mediator DID, updating both the persisted
     /// `account` record and the runtime `IdentityContext` so subsequent reads
     /// (and the next save) see the new value. No-op if no identity is active.
@@ -751,6 +816,51 @@ mod tests {
             }),
             mediator_did: None,
         }
+    }
+
+    /// A persona DID with no cache entry is a refresh target; once a lookup is
+    /// recorded it drops out until it goes stale, and a positive lookup reads
+    /// back through `agent_name_for` while a negative one does not.
+    #[test]
+    fn agent_name_targets_and_cache_roundtrip() {
+        use crate::config::account::{PersonaId, PersonaRecord};
+        use chrono::Utc;
+
+        let now = Utc::now();
+        let mut config = test_config(BTreeMap::new());
+        let pid = PersonaId::new();
+        let did = "did:webvh:example.com:alice".to_string();
+        config.account.personas.insert(
+            pid,
+            PersonaRecord {
+                persona_id: pid,
+                did: did.clone(),
+                did_document: None,
+                key_refs: vec![],
+                mediator_did: None,
+                origin_context_id: "openvtc/alice".into(),
+                created_at: now,
+                label: None,
+            },
+        );
+
+        // Uncached → a target.
+        assert_eq!(config.agent_name_refresh_targets(now), vec![did.clone()]);
+
+        // A positive lookup: no longer a target, readable via `agent_name_for`.
+        config.set_cached_agent_name(&did, Some("example.com/@alice".into()), now);
+        assert!(config.agent_name_refresh_targets(now).is_empty());
+        assert_eq!(config.agent_name_for(&did), Some("example.com/@alice"));
+
+        // A negative lookup on a second DID: still not a target, but no name.
+        let did2 = "did:webvh:example.com:bob".to_string();
+        config.set_cached_agent_name(&did2, None, now);
+        assert!(config.agent_name_for(&did2).is_none());
+        assert!(!config.agent_name_refresh_targets(now).contains(&did2));
+
+        // Once stale, the entry becomes a target again.
+        let later = now + crate::agent_name::AGENT_NAME_TTL;
+        assert!(config.agent_name_refresh_targets(later).contains(&did));
     }
 
     /// A State-A (account-bootstrap, R-A-5) config carries an account but no

--- a/openvtc-core/src/config/protected_config.rs
+++ b/openvtc-core/src/config/protected_config.rs
@@ -5,6 +5,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
+    agent_name::CachedAgentName,
     config::account::Account,
     config::secured_config::{unlock_code_decrypt, unlock_code_encrypt},
     errors::OpenVTCError,
@@ -233,6 +234,17 @@ pub struct ProtectedConfig {
     /// VRCs received
     /// key = remote P-DID
     pub vrcs_received: Vrcs,
+
+    /// Verified agent-name lookups, keyed by DID. Additive persisted cache so a
+    /// DID's human-memorable name (`example.com/@alice`) shows at launch without
+    /// a network round-trip; the background refresh re-verifies stale entries.
+    /// One map covers every DID the UI shows (personas, communities,
+    /// relationships, contacts). `#[serde(default)]` keeps older configs loading
+    /// without a schema bump. Keyed by a plain `String` DID — unlike the
+    /// contact/relationship maps, these keys are not shared with any object, so
+    /// there is nothing to `Arc`. See [`crate::agent_name`].
+    #[serde(default)]
+    pub agent_names: HashMap<String, CachedAgentName>,
 }
 
 /// Manual impl so freshly created configs are stamped with the current
@@ -247,6 +259,7 @@ impl Default for ProtectedConfig {
             tasks: Tasks::default(),
             vrcs_issued: Vrcs::default(),
             vrcs_received: Vrcs::default(),
+            agent_names: HashMap::default(),
         }
     }
 }
@@ -372,6 +385,26 @@ mod tests {
         assert!(ProtectedConfig::parse(&bytes).is_ok());
         assert!(ProtectedConfig::parse(b"not json at all").is_err());
         assert!(ProtectedConfig::parse(&[]).is_err());
+    }
+
+    /// A config written before the `agent_names` field existed has no such key;
+    /// `#[serde(default)]` must load it as an empty map rather than failing, so
+    /// the feature stays additive with no schema bump.
+    #[test]
+    fn parse_tolerates_config_without_agent_names() {
+        // Derive an "old config" by serialising a current one and dropping the
+        // `agent_names` key, so the fixture tracks the real struct shape rather
+        // than a hand-written approximation of it.
+        let mut value = serde_json::to_value(ProtectedConfig::default()).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("agent_names")
+            .expect("current config serialises agent_names");
+        let bytes = serde_json::to_vec(&value).unwrap();
+
+        let parsed = ProtectedConfig::parse(&bytes).expect("legacy config must load");
+        assert!(parsed.agent_names.is_empty());
     }
 
     fn test_seed() -> SecretBox<Vec<u8>> {

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -13,6 +13,7 @@ use affinidi_tdk::{
 use serde::{Deserialize, Serialize};
 use std::{fmt, sync::Arc};
 
+pub mod agent_name;
 pub mod bip32;
 pub mod capabilities;
 pub mod config;

--- a/openvtc/src/state_handler/agent_name_refresh.rs
+++ b/openvtc/src/state_handler/agent_name_refresh.rs
@@ -1,0 +1,60 @@
+//! Off-loop batch resolution of agent names.
+//!
+//! The runtime loop collects the DIDs whose names are uncached or stale
+//! ([`Config::agent_name_refresh_targets`](openvtc_core::config::Config::agent_name_refresh_targets))
+//! and hands the whole list to [`resolve_batch`] as a single background job. One
+//! job (not one per DID) because the background-dispatch busy-guard is
+//! per-domain: per-DID jobs on the shared `AgentName` domain would serialise.
+//!
+//! Inside the job the DIDs resolve concurrently but **bounded** — a sliding
+//! window of at most [`CONCURRENCY`] in flight — so a large account does not
+//! open an unbounded fan of connections at the resolver (VTI R1.4). The job does
+//! I/O only; its `(did, name)` results are applied to the config on the loop
+//! thread by `background_dispatch::apply_outcome`, preserving the single-mutator
+//! invariant.
+
+// The resolver type, re-exported by the TDK facade so this crate needs no
+// direct dependency on the cache SDK.
+use affinidi_tdk::did_resolver::DIDCacheClient;
+use tokio::task::JoinSet;
+
+/// Maximum concurrent DID resolutions inside one batch job.
+const CONCURRENCY: usize = 4;
+
+/// Resolve each DID to a verified agent name (or `None`), bounded to
+/// [`CONCURRENCY`] in flight. The result pairs each input DID with its verified
+/// name; order is not preserved (the caller keys by DID).
+pub(crate) async fn resolve_batch(
+    resolver: DIDCacheClient,
+    dids: Vec<String>,
+) -> Vec<(String, Option<String>)> {
+    let mut out = Vec::with_capacity(dids.len());
+    let mut pending = dids.into_iter();
+    let mut in_flight: JoinSet<(String, Option<String>)> = JoinSet::new();
+
+    let spawn_one = |set: &mut JoinSet<(String, Option<String>)>, did: String| {
+        let resolver = resolver.clone();
+        set.spawn(async move {
+            let name = openvtc_core::agent_name::resolve_verified_name(&resolver, &did).await;
+            (did, name)
+        });
+    };
+
+    // Prime the window, then keep it full: each completion spawns the next DID.
+    for _ in 0..CONCURRENCY {
+        if let Some(did) = pending.next() {
+            spawn_one(&mut in_flight, did);
+        }
+    }
+    while let Some(joined) = in_flight.join_next().await {
+        // A resolution task does not panic (its body is fallible-by-Option), so
+        // a JoinError would be a cancellation; drop it and keep going.
+        if let Ok(pair) = joined {
+            out.push(pair);
+        }
+        if let Some(did) = pending.next() {
+            spawn_one(&mut in_flight, did);
+        }
+    }
+    out
+}

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -66,6 +66,10 @@ pub(crate) enum DispatchDomain {
     Inbox,
     /// Context-DID deletion: `delete_did_webvh` at the VTA + listener teardown.
     Did,
+    /// Agent-name refresh: a batch DID→name verification sweep. One job resolves
+    /// many DIDs (the busy-guard is per-domain, so per-DID jobs would serialise),
+    /// each a network round-trip; read-only, off the loop.
+    AgentName,
 }
 
 impl DispatchDomain {
@@ -76,6 +80,7 @@ impl DispatchDomain {
             DispatchDomain::Relationship => "Relationship action",
             DispatchDomain::Inbox => "Inbox action",
             DispatchDomain::Did => "Identity deletion",
+            DispatchDomain::AgentName => "Agent name refresh",
         }
     }
 }
@@ -140,6 +145,10 @@ pub(crate) enum DispatchOutcome {
     /// A context-DID deletion finished (VTA delete + listener teardown done in
     /// the task; local cleanup + save applied here).
     Did(DidDeleteOutcome),
+    /// A batch agent-name refresh finished. Carries `(did, resolved_name)` for
+    /// each DID resolved — `resolved_name` is `None` for a DID with no
+    /// verifiable name (a cached negative). Applied on the loop thread.
+    AgentName(Vec<(String, Option<String>)>),
     /// A spawned dispatch job panicked (or was cancelled) and so never produced a
     /// real outcome. Synthesised by [`spawn_dispatch`] from the `JoinError` so the
     /// domain's busy-flag is still cleared (a panicking job that sent nothing would
@@ -156,6 +165,7 @@ impl DispatchOutcome {
             DispatchOutcome::Relationship(_) => DispatchDomain::Relationship,
             DispatchOutcome::Inbox(_) => DispatchDomain::Inbox,
             DispatchOutcome::Did(_) => DispatchDomain::Did,
+            DispatchOutcome::AgentName(_) => DispatchDomain::AgentName,
             DispatchOutcome::Panicked(domain) => *domain,
         }
     }
@@ -236,6 +246,37 @@ pub(crate) fn apply_outcome(
         DispatchOutcome::Relationship(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Inbox(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Did(outcome) => outcome.apply(state, config, save),
+        DispatchOutcome::AgentName(results) => {
+            // Fold each verified (or negatively-verified) lookup into the
+            // persisted cache on the loop thread — the single mutator.
+            //
+            // Two independent "did anything change?" tests, to avoid needless
+            // work: persist when a mapping is genuinely new or its name changed
+            // (a checked-at-only bump is not worth a save), and rebuild the UI
+            // only when a *displayed* name changed. A DID going from uncached to
+            // "no name" is worth persisting (so we don't re-resolve it every
+            // launch) but changes nothing on screen.
+            let now = chrono::Utc::now();
+            let mut cache_changed = false;
+            let mut display_changed = false;
+            for (did, name) in results {
+                let had_entry = config.private.agent_names.contains_key(&did);
+                let prior_name = config.agent_name_for(&did).map(str::to_owned);
+                if prior_name != name {
+                    display_changed = true;
+                }
+                if !had_entry || prior_name != name {
+                    cache_changed = true;
+                }
+                config.set_cached_agent_name(&did, name, now);
+            }
+            if cache_changed {
+                save.mark_dirty();
+            }
+            if display_changed {
+                state.main_page.sync_from_config(config);
+            }
+        }
         DispatchOutcome::Panicked(domain) => {
             // The job panicked and produced no real outcome. Surface a generic
             // failure so the user isn't left staring at a stuck "in progress"; the
@@ -501,5 +542,71 @@ mod tests {
         // Releasing now would deliver the outcome, but the loop already exited;
         // the point is proven. Drop the sender to avoid an unused warning.
         let _ = release_tx;
+    }
+
+    /// Applying an agent-name batch outcome writes the verified names into the
+    /// config, frees the `AgentName` domain, marks the config dirty on a real
+    /// change, and leaves it clean when nothing changed.
+    #[test]
+    fn apply_agent_name_outcome_updates_cache_and_frees_domain() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
+        let mut in_flight = InFlight::default();
+        assert!(in_flight.try_begin(DispatchDomain::AgentName));
+
+        // A new positive lookup and a new negative lookup.
+        apply_outcome(
+            &mut state,
+            &mut config,
+            &mut save,
+            &mut in_flight,
+            DispatchOutcome::AgentName(vec![
+                (
+                    "did:webvh:example.com:alice".to_string(),
+                    Some("example.com/@alice".to_string()),
+                ),
+                ("did:webvh:example.com:nameless".to_string(), None),
+            ]),
+        );
+
+        assert!(
+            !in_flight.is_busy(DispatchDomain::AgentName),
+            "the batch's domain must be freed after apply"
+        );
+        assert_eq!(
+            config.agent_name_for("did:webvh:example.com:alice"),
+            Some("example.com/@alice")
+        );
+        assert!(
+            config
+                .agent_name_for("did:webvh:example.com:nameless")
+                .is_none()
+        );
+        assert!(
+            save.is_pending(),
+            "a new mapping must mark the config dirty"
+        );
+
+        // Re-applying the identical results changes nothing: no new dirty mark.
+        let mut save2 = crate::state_handler::save_coalesce::SaveScheduler::new("test");
+        assert!(in_flight.try_begin(DispatchDomain::AgentName));
+        apply_outcome(
+            &mut state,
+            &mut config,
+            &mut save2,
+            &mut in_flight,
+            DispatchOutcome::AgentName(vec![
+                (
+                    "did:webvh:example.com:alice".to_string(),
+                    Some("example.com/@alice".to_string()),
+                ),
+                ("did:webvh:example.com:nameless".to_string(), None),
+            ]),
+        );
+        assert!(
+            !save2.is_pending(),
+            "an unchanged sweep must not re-dirty the config"
+        );
     }
 }

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -673,14 +673,15 @@ async fn run_join_sequence(
         return;
     };
 
-    // 2. Resolve a display name for the community (best-effort).
-    let display_name = match tdk.did_resolver().resolve(&vtc_did).await {
-        Ok(resolved) => resolved_display_name(&resolved.doc),
-        Err(e) => {
-            debug!("VTC DID resolve failed (continuing without name): {e}");
-            None
-        }
-    };
+    // 2. Resolve the community's verified agent name for display (best-effort).
+    // A verified name (`example.com/@acme`) is the community's human-readable
+    // handle; `None` when it has no verifiable name, so the sub-context
+    // derivation falls back to the DID-derived token (D9). The lookup is also
+    // seeded into the persisted cache so the communities list shows it without
+    // waiting for the background sweep.
+    let display_name =
+        openvtc_core::agent_name::resolve_verified_name(tdk.did_resolver(), &vtc_did).await;
+    config.set_cached_agent_name(&vtc_did, display_name.clone(), chrono::Utc::now());
     state.join.display_name = display_name.clone();
 
     let top_context_id = config.account.top_context_id.clone();
@@ -1119,16 +1120,6 @@ where
         () = sequence => None,
         Ok(interrupted) = interrupt_rx.recv() => Some(interrupted),
     }
-}
-
-/// Best-effort display name from a resolved VTC DID document. Prefers a
-/// non-empty `name`-like service/alias if present; falls back to `None` so the
-/// sub-context derivation uses the DID-derived token (D9).
-fn resolved_display_name(_doc: &affinidi_tdk::did_common::Document) -> Option<String> {
-    // The DID-core document has no canonical human name field; community naming
-    // (whois/metadata) is a later enrichment. Returning `None` keeps the
-    // derivation deterministic (DID-token slug) until that lands.
-    None
 }
 
 #[cfg(test)]

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -48,6 +48,7 @@ pub(crate) fn resolve_did_to_display(config: &openvtc_core::config::Config, did:
 }
 
 pub mod actions;
+mod agent_name_refresh;
 mod background_dispatch;
 mod create_persona;
 mod credential_actions;
@@ -668,6 +669,13 @@ impl StateHandler {
         // Reply-window sweep for the capabilities view (cheap no-op when the
         // view is closed or idle).
         let mut capabilities_sweep = tokio::time::interval(std::time::Duration::from_secs(5));
+        // Agent-name refresh sweep. The first tick fires immediately so names
+        // resolve shortly after launch; thereafter it picks up newly-added DIDs
+        // (a fresh relationship/contact) and re-verifies stale entries every few
+        // minutes. Cheap when there is nothing to do — it only spawns a job when
+        // `agent_name_refresh_targets` finds uncached/stale DIDs, and the resolver
+        // caches keep repeat sweeps quiet.
+        let mut agent_name_tick = tokio::time::interval(std::time::Duration::from_secs(300));
 
         let result = loop {
             tokio::select! {
@@ -1765,6 +1773,28 @@ impl StateHandler {
                             if expired.len() == 1 { "" } else { "s" },
                         ));
                         let _ = self.state_tx.send(state.clone());
+                    }
+                },
+                _ = agent_name_tick.tick() => {
+                    // Collect DIDs whose agent name is uncached or stale and, if
+                    // any, resolve them in one background job (read-only I/O).
+                    // Results are folded into the persisted cache on the loop
+                    // thread by `apply_outcome`. The busy-guard drops the tick if
+                    // a prior sweep is still running, so ticks never pile up.
+                    let targets = config.agent_name_refresh_targets(chrono::Utc::now());
+                    if !targets.is_empty()
+                        && in_flight.try_begin(background_dispatch::DispatchDomain::AgentName)
+                    {
+                        let resolver = tdk.did_resolver().clone();
+                        background_dispatch::spawn_dispatch(
+                            dispatch_tx.clone(),
+                            background_dispatch::DispatchDomain::AgentName,
+                            async move {
+                                let results =
+                                    agent_name_refresh::resolve_batch(resolver, targets).await;
+                                background_dispatch::DispatchOutcome::AgentName(results)
+                            },
+                        );
                     }
                 },
                 _ = save.wait_deadline() => {


### PR DESCRIPTION
Second in the agent-names sequence (after #163, the dependency prerequisite).
Adds the consumer-side core — how OpenVTC resolves, verifies, caches and
refreshes agent names — with no UI yet (that's the next PR).

## What an agent name is

A human-memorable DID shortcut: a URL whose path starts with `/@`
(`example.com/@alice`). Resolution is three stages and stage 3 is mandatory:
the name redirects to a DID, the DID resolves to a document, and **the document
must claim the name back via `alsoKnownAs`**. Displaying a name straight from
`alsoKnownAs` would be a phishing surface — anyone can claim
`bigbank.com/@support` in their own document — so nothing here surfaces a name
that has not round-tripped.

## Core (`openvtc-core/src/agent_name.rs`)

- `looks_like_agent_name` — the cheap `/@`-marker test, no network.
- `verified_agent_name(resolver, did, doc)` — DID → displayable name. Returns a
  name only when one the document claims forward-resolves (via `resolve_any`,
  which performs the mandatory `alsoKnownAs` check) **and** lands back on the DID
  being labelled. A name pointing at a different DID is a spoof and is rejected.
- `resolve_verified_name` / `resolve_identifier` — the DID→name and
  (DID-or-name)→DID entry points the later PRs use.
- All parsing/canonicalisation/matching delegates to the `agent-names` crate
  (canonicalisation is unspecified by the spec; hand-rolling it is how two sides
  drift). `IdentifierError` keeps the failure buckets distinct so the operator
  can tell not-found from not-claimed from unreachable (CLAUDE.md R6.4).

## Persisted cache + off-loop refresh

- `ProtectedConfig.agent_names: HashMap<String, CachedAgentName>` — additive,
  `#[serde(default)]`, so older configs load with no schema bump. Stores a
  verified name **or** a cached negative, with a 24h staleness stamp.
- A 5-minute interval collects uncached/stale DIDs (personas, communities,
  relationships, contacts) and resolves them in one background job with bounded
  concurrency, following the existing background-dispatch pattern — the loop
  never blocks, and the single-mutator invariant holds (results applied on the
  loop thread).
- Join now fills `CommunityRecord.display_name` from a real verified lookup,
  replacing a stub that always returned `None`.

## Verification

502 tests (fmt, clippy --all-targets clean). The spoof guard — rejecting a name
that resolves to a different DID — is factored out and unit-tested without
network, alongside serde-default tolerance, staleness, target collection, and the
apply-outcome dirty/sync decision. Full round-trip against a live host is a noted
follow-up (the `resolve_any` wiring is a thin pass-through).