### PR TITLE
feat: show verified agent names wherever DIDs are displayed

### DIFF
--- a/openvtc-core/src/display.rs
+++ b/openvtc-core/src/display.rs
@@ -39,6 +39,24 @@ pub fn truncate_did_centered(did: &str, max_len: usize) -> Cow<'_, str> {
     Cow::Owned(format!("{start}...{end}"))
 }
 
+/// Pick what to show for an identifier: a verified agent name when one is
+/// known, otherwise the tail-truncated DID.
+///
+/// A name (`example.com/@alice`) is short and human-memorable, so it is shown
+/// whole (only truncated in the rare case it exceeds `max_len`); the DID is the
+/// fallback. The shared primitive for name-or-DID surfaces — those without a
+/// user alias in front. Surfaces that also honour a user alias (relationships,
+/// contacts) layer that check ahead of this, since an explicit alias outranks a
+/// resolved name. The `name` passed here must already be **verified** (see
+/// [`crate::agent_name`]); this function does no checking, it only formats.
+#[must_use]
+pub fn display_identifier<'a>(name: Option<&'a str>, did: &'a str, max_len: usize) -> Cow<'a, str> {
+    match name {
+        Some(name) => truncate_did(name, max_len),
+        None => truncate_did(did, max_len),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,5 +98,34 @@ mod tests {
         assert!(out.starts_with("did:web"));
         assert!(out.contains("..."));
         assert!(out.ends_with("path"));
+    }
+
+    #[test]
+    fn display_identifier_prefers_the_name() {
+        let did = "did:webvh:abcdef0123456789:example.com:alice";
+        assert_eq!(
+            display_identifier(Some("example.com/@alice"), did, 40),
+            "example.com/@alice"
+        );
+    }
+
+    #[test]
+    fn display_identifier_falls_back_to_truncated_did() {
+        let did = "did:webvh:abcdef0123456789:example.com:alice";
+        let out = display_identifier(None, did, 20);
+        assert!(out.starts_with("did:webvh"));
+        assert!(out.ends_with("..."));
+    }
+
+    #[test]
+    fn display_identifier_truncates_an_overlong_name() {
+        let did = "did:web:x";
+        let out = display_identifier(
+            Some("verylonghost.example.com/@a-very-long-handle"),
+            did,
+            20,
+        );
+        assert_eq!(out.len(), 20);
+        assert!(out.ends_with("..."));
     }
 }

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -293,6 +293,9 @@ pub struct VtaState {
     pub context_name: Option<String>,
     /// Persona DID
     pub persona_did: String,
+    /// Verified agent name for the persona DID (`example.com/@me`), if cached —
+    /// shown above the DID in the panel.
+    pub persona_agent_name: Option<String>,
     /// Mediator DID
     pub mediator_did: String,
     /// VTA service URL
@@ -640,6 +643,10 @@ pub struct RelationshipSummary {
     pub remote_p_did: String,
     /// Contact alias (if set)
     pub alias: Option<String>,
+    /// Verified agent name for the remote persona DID (`example.com/@bob`), if
+    /// one is cached. Shown when there is no user alias; the DID is the last
+    /// resort. Populated in `sync_from_config` from the persisted cache.
+    pub agent_name: Option<String>,
     /// Human-readable state (e.g., "Established", "Request Sent")
     pub state: String,
     /// Our DID used in this relationship
@@ -783,6 +790,8 @@ pub struct SettingsState {
     pub org_did: String,
     /// Persona DID (read-only display)
     pub persona_did: String,
+    /// Verified agent name for the persona DID, if cached.
+    pub persona_agent_name: Option<String>,
     /// How the config is protected (Token/Encrypted/Plaintext)
     pub protection_type: String,
     /// Currently selected setting index

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -284,6 +284,9 @@ impl MainPageState {
                 RelationshipSummary {
                     remote_p_did: sanitize_display(remote_p_did, 256),
                     alias: alias.as_deref().map(|a| sanitize_display(a, 256)),
+                    agent_name: config
+                        .agent_name_for(remote_p_did)
+                        .map(|n| sanitize_display(n, 256)),
                     state: rel.state.to_string(),
                     our_did: rel.our_did.to_string(),
                     remote_did: sanitize_display(&rel.remote_did, 256),
@@ -317,9 +320,15 @@ impl MainPageState {
         self.content_panel.settings.mediator_did = config.mediator_did().to_string();
         self.content_panel.settings.org_did = config.account.org_did.clone();
         self.content_panel.settings.persona_did = config.persona_did().to_string();
+        self.content_panel.settings.persona_agent_name = config
+            .agent_name_for(config.persona_did())
+            .map(str::to_owned);
         self.content_panel.settings.did_git_sign = detect_did_git_sign_info(config.persona_did());
         // Sync VTA info
         self.content_panel.vta.persona_did = config.persona_did().to_string();
+        self.content_panel.vta.persona_agent_name = config
+            .agent_name_for(config.persona_did())
+            .map(str::to_owned);
         self.content_panel.vta.mediator_did = config.mediator_did().to_string();
         match &config.key_backend {
             KeyBackend::Vta {
@@ -701,6 +710,9 @@ pub(crate) fn shorten_did(did: &str, max_width: usize) -> String {
 pub struct MainMenuConfigState {
     pub name: String,
     pub did: Arc<String>,
+    /// Verified agent name for the active persona DID, if cached — shown in the
+    /// header in place of the truncated DID.
+    pub agent_name: Option<String>,
     /// Display name of the working (active) community, shown top-left (R-C-7a).
     /// Empty when there is no active community.
     pub community: String,
@@ -740,17 +752,23 @@ impl From<&Config> for MainMenuConfigState {
                     })
             })
             .unwrap_or_default();
+        let did = if in_community {
+            config.persona_did_arc()
+        } else {
+            Arc::new(String::new())
+        };
         MainMenuConfigState {
             name: if in_community {
                 config.public.friendly_name.clone()
             } else {
                 String::new()
             },
-            did: if in_community {
-                config.persona_did_arc()
+            agent_name: if in_community {
+                config.agent_name_for(&did).map(str::to_owned)
             } else {
-                Arc::new(String::new())
+                None
             },
+            did,
             community,
         }
     }

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -25,15 +25,23 @@ pub(crate) fn log_did(did: &str) -> std::borrow::Cow<'_, str> {
 
 /// Resolve a DID to a human-readable display name.
 ///
-/// Tries: contact alias by DID → R-DID relationship → persona contact alias → truncated DID.
+/// Precedence: **user alias → verified agent name → truncated DID.** The user's
+/// own alias wins — it is unspoofable by definition and an explicit labelling
+/// choice; a verified agent name (`example.com/@alice`, already round-tripped
+/// before caching) comes next; the truncated DID is the last resort. The same
+/// order applies when a remote R-DID resolves through to its persona DID.
 pub(crate) fn resolve_did_to_display(config: &openvtc_core::config::Config, did: &str) -> String {
-    // Direct contact lookup
+    // 1. User alias on the DID directly.
     if let Some(contact) = config.private.contacts.find_contact(did)
         && let Some(alias) = &contact.alias
     {
         return alias.clone();
     }
-    // R-DID → persona DID → contact alias
+    // 2. Verified agent name for the DID.
+    if let Some(name) = config.agent_name_for(did) {
+        return name.to_string();
+    }
+    // 3. R-DID → persona DID → its alias / agent name / truncation.
     let did_arc = std::sync::Arc::new(did.to_string());
     if let Some(rel) = config.private.relationships.find_by_remote_did(&did_arc) {
         let p_did = rel.remote_p_did.to_string();
@@ -41,6 +49,9 @@ pub(crate) fn resolve_did_to_display(config: &openvtc_core::config::Config, did:
             && let Some(alias) = &contact.alias
         {
             return alias.clone();
+        }
+        if let Some(name) = config.agent_name_for(&p_did) {
+            return name.to_string();
         }
         return log_did(&p_did).into_owned();
     }
@@ -225,6 +236,8 @@ impl StateHandler {
                     // working community name) populate from the full Config once
                     // load_step2 completes.
                     did: std::sync::Arc::new(String::new()),
+                    // The account isn't decrypted yet, so no name is available.
+                    agent_name: None,
                     community: String::new(),
                 };
                 state.connection.status = state::MediatorStatus::Initializing("Starting...".into());
@@ -2887,6 +2900,38 @@ fn build_trust_pong(
 mod tests {
     use super::*;
     use crate::state_handler::main_page::menu::MainMenu;
+
+    /// `resolve_did_to_display` precedence: a verified agent name is shown when
+    /// present, but a user alias overrides it, and an unknown DID falls back to
+    /// the truncated form.
+    #[test]
+    fn resolve_did_to_display_prefers_alias_then_agent_name() {
+        use crate::state_handler::dispatch_util::test_config;
+
+        let did = "did:webvh:example.com:alice";
+        let mut config = test_config();
+
+        // No alias, no cached name → truncated DID.
+        assert_eq!(
+            resolve_did_to_display(&config, did),
+            openvtc_core::display::truncate_did(did, 30)
+        );
+
+        // A verified agent name is now shown.
+        config.set_cached_agent_name(did, Some("example.com/@alice".into()), chrono::Utc::now());
+        assert_eq!(resolve_did_to_display(&config, did), "example.com/@alice");
+
+        // A user alias on the same DID overrides the agent name.
+        let key = std::sync::Arc::new(did.to_string());
+        config.private.contacts.contacts.insert(
+            key.clone(),
+            std::sync::Arc::new(openvtc_core::config::protected_config::Contact {
+                did: key,
+                alias: Some("Alice".to_string()),
+            }),
+        );
+        assert_eq!(resolve_did_to_display(&config, did), "Alice");
+    }
 
     /// Drive `handle_nav_action` directly over a fresh `State`. Because the
     /// reducer is the single code path both the runtime loop and the degraded

--- a/openvtc/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc/src/ui/pages/main/components/content_panel.rs
@@ -214,6 +214,14 @@ fn render_status_help(
 
     let hint_style = Style::new().fg(COLOR_DARK_GRAY);
 
+    // Verified agent name, above the DID it belongs to.
+    if let Some(agent_name) = &settings.persona_agent_name {
+        lines.push(Line::from(vec![
+            Span::styled("  Agent name:   ", label_style),
+            Span::styled(agent_name.clone(), value_style),
+        ]));
+    }
+
     // Persona DID (full) with copy hotkey
     lines.push(Line::from(vec![
         Span::styled("  Persona DID:  ", label_style),

--- a/openvtc/src/ui/pages/main/components/relationships_panel.rs
+++ b/openvtc/src/ui/pages/main/components/relationships_panel.rs
@@ -82,9 +82,11 @@ fn render_list(state: &RelationshipsState) -> Vec<Line<'static>> {
                 Style::new().fg(COLOR_TEXT_DEFAULT)
             };
 
+            // Precedence: user alias → verified agent name → the DID itself.
             let display_name = rel
                 .alias
                 .as_deref()
+                .or(rel.agent_name.as_deref())
                 .unwrap_or(&rel.remote_p_did)
                 .to_string();
 
@@ -142,6 +144,13 @@ fn render_detail(
         lines.push(Line::from(vec![
             Span::styled("Alias:        ", Style::new().fg(COLOR_TEXT_DEFAULT)),
             Span::styled(alias.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+        ]));
+    }
+    // The verified agent name, above the full DID it belongs to.
+    if let Some(agent_name) = &rel.agent_name {
+        lines.push(Line::from(vec![
+            Span::styled("Agent name:   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled(agent_name.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
         ]));
     }
     lines.push(Line::from(vec![

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -62,6 +62,12 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
             ),
         ]));
     } else {
+        if let Some(agent_name) = &state.persona_agent_name {
+            lines.push(Line::from(vec![
+                Span::styled("  Agent name:    ", label_style),
+                Span::styled(agent_name.clone(), value_style),
+            ]));
+        }
         lines.push(Line::from(vec![
             Span::styled("  Persona DID:   ", label_style),
             Span::styled(state.persona_did.clone(), value_style),

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2050,9 +2050,14 @@ impl ComponentRender<()> for MainPage {
         frame.render_widget(
             Paragraph::new(vec![
                 Line::from(self.props.main_page.config.name.to_string()).fg(COLOR_SUCCESS),
-                Line::from(
-                    truncate_did_centered(&self.props.main_page.config.did, 30).into_owned(),
-                )
+                Line::from(match &self.props.main_page.config.agent_name {
+                    // A verified agent name is short and human-readable — show it
+                    // whole in place of the truncated DID.
+                    Some(name) => name.clone(),
+                    None => {
+                        truncate_did_centered(&self.props.main_page.config.did, 30).into_owned()
+                    }
+                })
                 .fg(COLOR_TEXT_DEFAULT),
             ])
             .alignment(Alignment::Right),
@@ -2497,6 +2502,7 @@ mod key_handler_tests {
         RelationshipSummary {
             remote_p_did: remote_p_did.to_string(),
             alias: None,
+            agent_name: None,
             state: "Established".to_string(),
             our_did: "did:example:me".to_string(),
             remote_did: "did:example:them".to_string(),


### PR DESCRIPTION
Third in the agent-names sequence (after #163 deps, #164 core). Wires the
verified names from #164 into the UI. Where a DID has a verified agent name
(`example.com/@alice`), it now shows the name; the DID stays reachable in detail
views, never fully replaced.

## Changes

- **Core primitive** `display::display_identifier(name, did, max_len)` — name
  when present, tail-truncated DID otherwise; the shared name-or-DID formatter.
- **TUI chokepoint** `resolve_did_to_display` (which every ping / VRC /
  relationship log line already flows through) gains the precedence
  **user alias → verified agent name → truncated DID**. The user's own alias
  wins (unspoofable, explicit); the agent name was round-tripped before caching;
  the DID is the last resort. Same order when a remote R-DID resolves through to
  its persona DID.
- **Panels** — the name is threaded through the view models (populated once in
  `sync_from_config`, so panels stay pure) and rendered at the most-viewed sites:
  relationships (rows show alias → name → DID; detail gains an "Agent name" line
  above the full P-DID), the header (active persona's name replaces its truncated
  DID), and the VTA / Settings persona lines. Communities already surface their
  name via `CommunityRecord.display_name` (populated at join in #164).

The DID is never hidden in a detail view — a name is a mutable web redirect, so
the identity it stands for must always be inspectable. Lower-frequency surfaces
(VRC issuer/subject, inbox message DIDs, the persona/context DID lists) can adopt
the same pattern later; the primitive and precedence are in place.

## Verification

506 tests (fmt, clippy --all-targets clean): the primitive's name/DID/overlong
cases and the chokepoint's alias-beats-name-beats-DID precedence are covered.