### PR TITLE
feat: accept an agent name wherever a peer identifier is entered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,37 @@ entry point that now delegates to the library.
 If the library appears to be missing a capability, prefer opening an issue
 or extending the library over reimplementing it locally.
 
+## Agent names (DID shortcuts)
+
+An **agent name** is a human-memorable shortcut that resolves to a DID —
+a URL whose path begins with `/@` (`example.com/@alice`). OpenVTC consumes
+them; `openvtc-core/src/agent_name.rs` is the single entry point.
+
+Rules, all enforced there:
+
+- **Always use the `agent-names` crate** for parsing, canonicalisation, and
+  `alsoKnownAs` matching — never hand-roll them. Canonicalisation is
+  unspecified by the spec, so two implementations that normalise differently
+  disagree about whether a name verifies. Same discipline as the `didwebvh-rs`
+  rule above.
+- **Never display an unverified name.** A name is shown only after a full
+  round-trip: it forward-resolves (`DIDCacheClient::resolve_any`, which does the
+  mandatory `alsoKnownAs` check) *and* lands back on the DID being labelled.
+  `agent_name::verified_agent_name` is the gate; an unverified claim renders as
+  the plain DID. Displaying a name straight from a document's `alsoKnownAs`
+  would turn the TUI into a phishing surface — anyone can claim
+  `bigbank.com/@support` in their own document.
+- **Never persist a name in place of a DID.** A name is a mutable web redirect;
+  storing one would let a redirect silently repoint a saved identity. On input,
+  `agent_name::resolve_identifier` turns a name into a DID and the DID is what
+  gets persisted.
+
+Resolution needs the resolver's `agent-names` feature, enabled via the direct
+`affinidi-did-resolver-cache-sdk` dependency in the root `Cargo.toml`. The
+management side (claiming / parking / resuming a name for your own persona) goes
+through the VTA's `did-management/agent-name` Trust Tasks — see
+`tasks/follow-ups.md`.
+
 ## Cross-service networking & integration discipline
 
 OpenVTC tooling drives the live VTA/VTC/webvh services over the network, so

--- a/docs/design/tui-architecture.md
+++ b/docs/design/tui-architecture.md
@@ -75,6 +75,7 @@ the real work is decomposed into focused modules (declared at `mod.rs:50`):
 | `message_dispatch.rs` | Inbound DIDComm orchestration: `process_inbound_message` (async I/O only). |
 | `background_dispatch.rs` | Off-loop network dispatch plumbing (see §4). |
 | `save_coalesce.rs` | Coalesced, off-runtime `Config` persistence (see §4). |
+| `agent_name_refresh.rs` | Off-loop batch resolution of agent names (DID→name), applied via background-dispatch (see §4). |
 | `inbox_actions.rs`, `relationship_actions.rs`, `credential_actions.rs`, `settings_actions.rs` | Per-panel business logic — each exposes a `dispatch(...)` entry point the matching `Action` arm calls. |
 | `didcomm.rs` | `DIDCommService` integration: service start, listener config/ids, the `DIDCommEvent` enum, lifecycle logging. |
 | `main_page/` | Maps `Config` → display state (`sync_from_config`), menu/content models. |
@@ -116,6 +117,15 @@ single `spawn_blocking` save, with at most one in flight. Durability-critical
 points (Exit, passphrase/protection change) force-flush synchronously. The
 startup load uses the same shape: a spawned task streams progress back into the
 loading-screen `select!`.
+
+**Agent-name refresh** ([`agent_name_refresh.rs`](../../openvtc/src/state_handler/agent_name_refresh.rs)) —
+a concrete instance of the background-dispatch pattern. A 5-minute interval arm
+collects the DIDs whose agent name is uncached or stale
+(`Config::agent_name_refresh_targets`) and hands the whole list to **one**
+background job on the `DispatchDomain::AgentName` domain (one job, not one per
+DID: the busy-guard is per-domain). Inside the job the DIDs resolve with bounded
+concurrency (a sliding window of 4). The job does I/O only; `apply_outcome` folds
+the verified `(did, name)` results into `Config::agent_names` on the loop thread.
 
 ## 5. Recipes
 

--- a/docs/openvtc-config-data-structure.md
+++ b/docs/openvtc-config-data-structure.md
@@ -133,6 +133,16 @@ cryptographic key derived from the `m/1'/0'/0'` derivation path.
 | `tasks`         | `Tasks`         | Task management data.                         |
 | `vrcs_issued`   | `Vrcs`          | Verifiable relationship credentials issued.   |
 | `vrcs_received` | `Vrcs`          | Verifiable relationship credentials received. |
+| `agent_names`   | `HashMap<String, CachedAgentName>` | Verified agent-name lookups, keyed by DID (see below). |
+
+The **`agent_names`** map is an additive, `#[serde(default)]` cache of verified
+agent-name lookups (`example.com/@alice`) so a DID's human-memorable name shows
+at launch without a network round-trip. Each `CachedAgentName` holds the
+verified `name` (`None` records a DID with no verifiable name — a cached
+negative) and a `checked_at` timestamp; a background sweep re-verifies entries
+older than 24h. One map covers every displayed DID (personas, communities,
+relationships, contacts). Only verified names are stored — see
+`openvtc-core/src/agent_name.rs`.
 
 #### Protected Config Categories
 

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -152,6 +152,30 @@ impl StateHandler {
                             let Some(vtc_did) = validate_join_input(&vtc_did) else {
                                 continue;
                             };
+                            // Accept an agent name (`example.com/@acme`) in place
+                            // of the VTC DID. Only resolve when the input actually
+                            // looks like a name, so pasting a DID keeps its
+                            // existing (no-extra-round-trip) path; the resolved
+                            // DID is what everything downstream persists.
+                            let vtc_did = if openvtc_core::agent_name::looks_like_agent_name(
+                                &vtc_did,
+                            ) {
+                                match openvtc_core::agent_name::resolve_identifier(
+                                    tdk.did_resolver(),
+                                    &vtc_did,
+                                )
+                                .await
+                                {
+                                    Ok(did) => did,
+                                    Err(e) => {
+                                        state.join.fail(e.to_string());
+                                        let _ = self.state_tx.send(state.clone());
+                                        continue;
+                                    }
+                                }
+                            } else {
+                                vtc_did
+                            };
                             // Idempotency is now per-persona (R-B-9): a community may
                             // be joined as more than one persona, so the duplicate
                             // check happens once the identity is chosen (in the

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -1101,6 +1101,19 @@ async fn prepare_submit(
     generate_r_did: bool,
     admin_vta: Option<&vta_sdk::client::VtaClient>,
 ) -> Result<RelationshipJob> {
+    // Accept an agent name (`example.com/@bob`) in place of the DID. Resolve it
+    // up front so every downstream key (dedup, contact, the provisional record)
+    // is the DID, never the mutable name. A plain DID is left untouched — no
+    // extra round-trip — and validated by the `did:` check below.
+    let resolved_did;
+    let did = if openvtc_core::agent_name::looks_like_agent_name(did) {
+        resolved_did = openvtc_core::agent_name::resolve_identifier(tdk.did_resolver(), did)
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        resolved_did.as_str()
+    } else {
+        did
+    };
     // Validate DID format.
     if !did.starts_with("did:") {
         anyhow::bail!("Invalid DID: must start with 'did:'");

--- a/openvtc/src/ui/pages/join_flow/vtc_enter_did.rs
+++ b/openvtc/src/ui/pages/join_flow/vtc_enter_did.rs
@@ -89,7 +89,7 @@ impl VtcEnterDid {
                 ),
                 Line::default(),
                 Line::styled(
-                    "Enter the community's DID:",
+                    "Enter the community's DID or agent name:",
                     Style::new().fg(COLOR_BORDER).bold(),
                 ),
             ]),
@@ -106,9 +106,13 @@ impl VtcEnterDid {
         render_input(input, frame, input_col);
 
         let mut lines = vec![
-            Line::styled("Example:", Style::new().fg(COLOR_ORANGE).bold()),
+            Line::styled("Examples:", Style::new().fg(COLOR_ORANGE).bold()),
             Line::styled(
                 "  • did:webvh:QmRoot…:community.example.com",
+                Style::new().fg(COLOR_ORANGE).italic(),
+            ),
+            Line::styled(
+                "  • community.example.com/@acme",
                 Style::new().fg(COLOR_ORANGE).italic(),
             ),
             Line::default(),

--- a/openvtc/src/ui/pages/main/components/relationships_panel.rs
+++ b/openvtc/src/ui/pages/main/components/relationships_panel.rs
@@ -452,6 +452,9 @@ fn render_form(
 
     lines.push(Line::from(""));
     lines.push(
+        Line::from("DID accepts an agent name too, e.g. example.com/@bob").fg(COLOR_DARK_GRAY),
+    );
+    lines.push(
         Line::from("Tab: next field  Space: toggle R-DID  Enter (on R-DID): submit  Esc: cancel")
             .fg(COLOR_DARK_GRAY),
     );


### PR DESCRIPTION
Fourth in the agent-names sequence (after #163 deps, #164 core, #165 display).
Adds input: the two flows where a user types someone else's identifier now
accept an agent name (`example.com/@acme`) in place of a DID.

## Changes

- The **join flow's VTC-DID entry** and the **new-relationship-request** DID
  field both resolve a name to a DID via `agent_name::resolve_identifier` and
  persist the **DID**, never the name — a name is a mutable web redirect, so
  storing one would let a redirect silently repoint a saved identity.
- Resolution runs **only when the input looks like a name**
  (`looks_like_agent_name`), so pasting a DID keeps its existing path with no
  extra round-trip. A failure surfaces the distinct `IdentifierError` message
  (not-found vs not-claimed vs unreachable), and the entry screens' example text
  now shows both forms.
- **Docs**: CLAUDE.md gains an "Agent names" section (the three rules the module
  enforces — use the crate's canonicalisation, never display an unverified name,
  never persist a name for a DID); the config-structure and TUI-architecture docs
  describe the `agent_names` cache and the off-loop refresh job.

The setup-time DID entries (VTA, webvh import, custom mediator, org DID) still
take a DID only — infrastructure DIDs are rarely agent names, and it would mean
threading a resolver through several one-time setup handlers. Left as a follow-up
alongside the display surfaces that remain on the raw-DID pattern.

## Verification

506 tests (fmt, clippy --all-targets clean).