### PR TITLE
feat: manage a persona's agent names from the VTA panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.17",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -872,7 +872,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2752,7 +2752,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3047,7 +3047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5261,7 +5261,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5707,7 +5707,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.17",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5762,7 +5762,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.17",
  "vta-service",
  "x25519-dalek",
  "zeroize",
@@ -5799,7 +5799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6513,7 +6513,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7160,7 +7160,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7236,7 +7236,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7881,7 +7881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8367,7 +8367,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8380,7 +8380,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9303,7 +9303,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.19",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.17",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9348,9 +9348,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.15"
+version = "0.19.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965e2b5dbac71f50c3da28c01e83ec68e6da097fc4e0ba4c20989818ab455121"
+checksum = "6453a67174e5456b42a0a986a2477507e28465c61c32bfa4da3ca08a60848496"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9462,7 +9462,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.17",
  "vti-common",
  "vti-secrets",
  "vti-webauthn",
@@ -9510,7 +9510,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.15",
+ "vta-sdk 0.19.17",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9923,7 +9923,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -396,6 +396,30 @@ pub enum Action {
     /// Close the create-persona overlay.
     CreatePersonaClose,
 
+    // ── Agent-name manager (VTA panel, per persona) ─────────────────────────
+    /// Open the "manage agent names" overlay for the persona at the given index
+    /// in the VTA panel's context-identity list, and load its registry.
+    StartAgentNameManager(usize),
+
+    /// Forward a key event to the new-name input (editing keys only; Enter/Esc
+    /// and row actions are handled by the panel).
+    AgentNameManagerInput(crossterm::event::KeyEvent),
+
+    /// Move the selected row up (`false`) or down (`true`).
+    AgentNameManagerSelect(bool),
+
+    /// Claim the name in the input (`set`), then refresh the registry.
+    AgentNameManagerClaim,
+
+    /// Park (`disable`) or resume (`enable`) the selected name, then refresh.
+    AgentNameManagerToggle,
+
+    /// Remove (release) the selected name, then refresh.
+    AgentNameManagerRemove,
+
+    /// Close the agent-name manager overlay.
+    AgentNameManagerClose,
+
     // ── VIC manager (VTA panel, Invitation Credentials list) ────────────────
     /// (Re)load the VIC list from the vault (async). Sent when the operator
     /// focuses the VIC list so the panel is populated without polling.

--- a/openvtc/src/state_handler/agent_name_manage.rs
+++ b/openvtc/src/state_handler/agent_name_manage.rs
@@ -1,0 +1,181 @@
+//! Managing agent names on the account's own personas.
+//!
+//! The consumer side ([`openvtc_core::agent_name`]) *reads* agent names. This
+//! module *writes* them: bind (`set`), release (`remove`), park (`disable`) and
+//! resume (`enable`) a name on a persona the VTA hosts, plus `list` (the
+//! authoritative registry, parked names included) and `check` (availability).
+//!
+//! Every verb is a VTA Trust Task (`spec/vta/webvh/agent-name/{op}/1.0`),
+//! submitted through [`VtaClient::dispatch_trust_task`]. The VTA is the party
+//! with authority over the account's webvh DIDs — it created them and holds
+//! their update keys — so it resolves the DID's current document, edits
+//! `alsoKnownAs`, signs a new version, and calls the hosting server. OpenVTC
+//! only names the persona DID and the name; it never signs here.
+//!
+//! `remove` releases a name for anyone to reclaim; `disable` keeps it reserved
+//! but stops it resolving. Both report `enabled: false`.
+
+use anyhow::{Context, Result};
+use vta_sdk::client::VtaClient;
+use vta_sdk::protocols::did_management::agent_name::{
+    AgentNameCheckResultBody, AgentNameEntry, AgentNameListResultBody, AgentNameResultBody,
+};
+use vta_sdk::trust_tasks;
+
+/// Trust-task round-trips can involve a webvh publish (sign + host write), so
+/// allow more headroom than a plain read.
+const AGENT_NAME_TT_TIMEOUT: u64 = 60;
+
+/// The host a `did:webvh` is served from (`example.com`, or `example.com:8443`
+/// for a custom port) — the authority half of any agent name on it. Derived via
+/// `didwebvh-rs` per the repo's did:webvh rule; `None` if the DID does not
+/// parse. Used only to build the scheme-less name (`host/@local`) for the local
+/// display cache; the VTA derives the domain itself for the actual operations.
+pub(crate) fn derive_host(did: &str) -> Option<String> {
+    let url = didwebvh_rs::url::WebVHURL::parse_did_url(did).ok()?;
+    Some(match url.port {
+        Some(port) => format!("{}:{port}", url.domain),
+        None => url.domain,
+    })
+}
+
+/// Bind (or refresh) `name` on `did`. The resulting document claims the name;
+/// it resolves once the host serves the new version.
+pub(crate) async fn set_name(
+    vta: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<AgentNameResultBody> {
+    dispatch(
+        vta,
+        trust_tasks::TASK_WEBVH_AGENT_NAME_SET_1_0,
+        did,
+        Some(name),
+    )
+    .await
+}
+
+/// Release `name` from `did` — it stops resolving and is free for anyone to
+/// reclaim. Destructive.
+pub(crate) async fn remove_name(
+    vta: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<AgentNameResultBody> {
+    dispatch(
+        vta,
+        trust_tasks::TASK_WEBVH_AGENT_NAME_REMOVE_1_0,
+        did,
+        Some(name),
+    )
+    .await
+}
+
+/// Resume serving a parked `name` on `did`.
+pub(crate) async fn enable_name(
+    vta: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<AgentNameResultBody> {
+    dispatch(
+        vta,
+        trust_tasks::TASK_WEBVH_AGENT_NAME_ENABLE_1_0,
+        did,
+        Some(name),
+    )
+    .await
+}
+
+/// Park `name` on `did` — it stops resolving but stays reserved to this DID.
+pub(crate) async fn disable_name(
+    vta: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<AgentNameResultBody> {
+    dispatch(
+        vta,
+        trust_tasks::TASK_WEBVH_AGENT_NAME_DISABLE_1_0,
+        did,
+        Some(name),
+    )
+    .await
+}
+
+/// The DID's agent-name registry as the host holds it — parked names included.
+pub(crate) async fn list_names(vta: &VtaClient, did: &str) -> Result<Vec<AgentNameEntry>> {
+    let value = vta
+        .dispatch_trust_task(
+            trust_tasks::TASK_WEBVH_AGENT_NAME_LIST_1_0,
+            serde_json::json!({ "did": did }),
+            AGENT_NAME_TT_TIMEOUT,
+        )
+        .await
+        .context("agent-name list task failed")?;
+    let body: AgentNameListResultBody =
+        serde_json::from_value(value).context("decoding agent-name list result")?;
+    Ok(body.names)
+}
+
+/// Whether `name` is free to claim on `did`'s host. `available` is `false` for a
+/// reserved name too — `reserved` distinguishes the two.
+pub(crate) async fn check_name(
+    vta: &VtaClient,
+    did: &str,
+    name: &str,
+) -> Result<AgentNameCheckResultBody> {
+    let value = vta
+        .dispatch_trust_task(
+            trust_tasks::TASK_WEBVH_AGENT_NAME_CHECK_1_0,
+            serde_json::json!({ "did": did, "name": name }),
+            AGENT_NAME_TT_TIMEOUT,
+        )
+        .await
+        .context("agent-name check task failed")?;
+    serde_json::from_value(value).context("decoding agent-name check result")
+}
+
+/// Shared submit for the four mutating verbs, which share the `{ did, name }`
+/// body and `AgentNameResultBody` shape.
+async fn dispatch(
+    vta: &VtaClient,
+    type_uri: &str,
+    did: &str,
+    name: Option<&str>,
+) -> Result<AgentNameResultBody> {
+    let mut payload = serde_json::json!({ "did": did });
+    if let Some(name) = name {
+        payload["name"] = serde_json::Value::String(name.to_string());
+    }
+    let value = vta
+        .dispatch_trust_task(type_uri, payload, AGENT_NAME_TT_TIMEOUT)
+        .await
+        .with_context(|| format!("agent-name task {type_uri} failed"))?;
+    serde_json::from_value(value).context("decoding agent-name result")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_host_pulls_the_domain_from_a_webvh_did() {
+        assert_eq!(
+            derive_host("did:webvh:QmScid:example.com").as_deref(),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn derive_host_includes_a_custom_port() {
+        // did:webvh encodes ports as %3A within the path segment.
+        assert_eq!(
+            derive_host("did:webvh:QmScid:example.com%3A8443").as_deref(),
+            Some("example.com:8443")
+        );
+    }
+
+    #[test]
+    fn derive_host_rejects_a_non_webvh_did() {
+        assert_eq!(derive_host("did:key:z6Mk"), None);
+    }
+}

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -202,6 +202,54 @@ pub struct CreatePersonaState {
     pub copied: bool,
 }
 
+/// "Manage agent names" overlay for a persona. `Some` while open; floats over
+/// the main page. Lists the persona's names (parked ones included), and claims /
+/// parks / resumes / removes them via the VTA's agent-name Trust Tasks. The
+/// registry is authoritative — it is (re)fetched after every mutation, so what
+/// the overlay shows is what the host actually holds.
+#[derive(Clone, Debug, Default)]
+pub struct AgentNameManagerState {
+    /// The persona whose names are being managed.
+    pub persona_did: String,
+    /// The persona's label, for the overlay title.
+    pub persona_label: String,
+    /// The persona's domain-derived host (`example.com`), so the overlay can
+    /// show the full name a local part will bind to. Empty if underivable.
+    pub host: String,
+    /// Current registry entries (name, enabled/parked, created-at). Empty until
+    /// the first list completes.
+    pub names: Vec<AgentNameRow>,
+    /// Selected row in [`names`](Self::names), for park/resume/remove.
+    pub selected: usize,
+    /// New-name input (local part), used to claim a name.
+    pub input: tui_input::Input,
+    /// What the overlay is doing right now (input locked while `Working`).
+    pub phase: AgentNameManagerPhase,
+    /// Transient status / error line.
+    pub message: Option<String>,
+}
+
+/// One agent-name registry row shown in the manager overlay.
+#[derive(Clone, Debug)]
+pub struct AgentNameRow {
+    /// Local part, without the `@`.
+    pub name: String,
+    /// Whether it currently resolves (`false` = parked, still reserved).
+    pub enabled: bool,
+}
+
+/// What the [`AgentNameManagerState`] overlay is doing.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum AgentNameManagerPhase {
+    /// Fetching the registry (initial open or post-mutation refresh).
+    #[default]
+    Loading,
+    /// Idle — showing the list, accepting input and row actions.
+    Ready,
+    /// A mutation or check is running; input and actions are locked.
+    Working,
+}
+
 /// Step of the [`CreatePersonaState`] overlay.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum CreatePersonaPhase {

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -73,6 +73,11 @@ pub struct MainPageState {
     /// [`create_persona`](Self::create_persona)) because it floats over the panel.
     pub add_vic: Option<content::AddVicState>,
 
+    /// "Manage agent names" overlay for a persona. `Some` while open; `None`
+    /// (default) when closed. Page-level (like [`create_persona`](Self::create_persona)),
+    /// reachable from the VTA panel's persona/context-identity lists.
+    pub agent_names: Option<content::AgentNameManagerState>,
+
     /// Activity log entries shown in the bottom panel (newest last).
     ///
     /// Entries are wrapped in `Arc` so cloning `MainPageState` (which happens

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -59,6 +59,7 @@ pub(crate) fn resolve_did_to_display(config: &openvtc_core::config::Config, did:
 }
 
 pub mod actions;
+mod agent_name_manage;
 mod agent_name_refresh;
 mod background_dispatch;
 mod create_persona;
@@ -1257,6 +1258,37 @@ impl StateHandler {
                         )
                         .await;
                     },
+                    Action::StartAgentNameManager(index) => {
+                        self.run_agent_name_open(&mut state, admin_vta.as_ref(), index)
+                            .await;
+                    },
+                    Action::AgentNameManagerClaim => {
+                        self.run_agent_name_claim(
+                            &mut state,
+                            &mut config,
+                            &mut save,
+                            admin_vta.as_ref(),
+                        )
+                        .await;
+                    },
+                    Action::AgentNameManagerToggle => {
+                        self.run_agent_name_toggle(
+                            &mut state,
+                            &mut config,
+                            &mut save,
+                            admin_vta.as_ref(),
+                        )
+                        .await;
+                    },
+                    Action::AgentNameManagerRemove => {
+                        self.run_agent_name_remove(
+                            &mut state,
+                            &mut config,
+                            &mut save,
+                            admin_vta.as_ref(),
+                        )
+                        .await;
+                    },
                     Action::VicRefresh => {
                         self.refresh_vics(&mut state, admin_vta.as_ref()).await;
                     },
@@ -2003,6 +2035,308 @@ impl StateHandler {
         let _ = self.state_tx.send(state.clone());
     }
 
+    /// Open the agent-name manager for the persona at `index` in the VTA panel's
+    /// context-identity list, and load its registry. Runs inline (modal): the
+    /// overlay shows "Loading…" while the list task round-trips.
+    async fn run_agent_name_open(
+        &self,
+        state: &mut State,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+        index: usize,
+    ) {
+        use crate::state_handler::main_page::content::{
+            AgentNameManagerPhase, AgentNameManagerState,
+        };
+
+        let Some(persona) = state
+            .main_page
+            .content_panel
+            .vta
+            .context_dids
+            .get(index)
+            .cloned()
+        else {
+            return;
+        };
+        state.main_page.agent_names = Some(AgentNameManagerState {
+            persona_did: persona.did.clone(),
+            persona_label: persona.label.clone(),
+            host: agent_name_manage::derive_host(&persona.did).unwrap_or_default(),
+            phase: AgentNameManagerPhase::Loading,
+            ..Default::default()
+        });
+        let _ = self.state_tx.send(state.clone());
+
+        let Some(admin_vta) = admin_vta else {
+            self.set_agent_name_message(
+                state,
+                AgentNameManagerPhase::Ready,
+                "VTA session unavailable — cannot manage agent names right now.",
+            );
+            return;
+        };
+        match agent_name_manage::list_names(admin_vta, &persona.did).await {
+            Ok(names) => self.apply_agent_name_list(state, names, AgentNameManagerPhase::Ready),
+            Err(e) => self.set_agent_name_message(
+                state,
+                AgentNameManagerPhase::Ready,
+                format!("Could not load agent names: {e}"),
+            ),
+        }
+    }
+
+    /// Claim the name in the overlay's input (`set`), then refresh the registry.
+    async fn run_agent_name_claim(
+        &self,
+        state: &mut State,
+        config: &mut Config,
+        save: &mut save_coalesce::SaveScheduler,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+    ) {
+        use crate::state_handler::main_page::content::AgentNameManagerPhase;
+
+        let (persona_did, name) = match state.main_page.agent_names.as_ref() {
+            Some(o) if o.phase == AgentNameManagerPhase::Ready => {
+                (o.persona_did.clone(), o.input.value().trim().to_string())
+            }
+            _ => return,
+        };
+        if name.is_empty() {
+            self.set_agent_name_message(state, AgentNameManagerPhase::Ready, "Enter a name first.");
+            return;
+        }
+        let Some(admin_vta) =
+            self.begin_agent_name_work(state, admin_vta, &format!("Claiming @{name}…"))
+        else {
+            return;
+        };
+        // Fast-path rejection: a reserved or already-taken name fails the check
+        // before any publish, with a clearer reason than the set error. A check
+        // failure is non-fatal — fall through to `set`, which is authoritative
+        // (and closes the check→set race if someone claims it in between).
+        if let Ok(avail) = agent_name_manage::check_name(admin_vta, &persona_did, &name).await
+            && !avail.available
+        {
+            let why = if avail.reserved {
+                "a reserved name"
+            } else {
+                "already taken on this domain"
+            };
+            self.set_agent_name_message(
+                state,
+                AgentNameManagerPhase::Ready,
+                format!("@{name} is {why} ({}).", avail.domain),
+            );
+            return;
+        }
+        match agent_name_manage::set_name(admin_vta, &persona_did, &name).await {
+            Ok(_) => {
+                if let Some(o) = state.main_page.agent_names.as_mut() {
+                    o.input.reset();
+                }
+                state.main_page.log(format!("Claimed agent name @{name}"));
+                self.refresh_agent_names(state, config, save, admin_vta, &persona_did)
+                    .await;
+            }
+            Err(e) => self.set_agent_name_message(
+                state,
+                AgentNameManagerPhase::Ready,
+                format!("Could not claim @{name}: {e}"),
+            ),
+        }
+    }
+
+    /// Park (`disable`) or resume (`enable`) the selected name, then refresh.
+    async fn run_agent_name_toggle(
+        &self,
+        state: &mut State,
+        config: &mut Config,
+        save: &mut save_coalesce::SaveScheduler,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+    ) {
+        use crate::state_handler::main_page::content::AgentNameManagerPhase;
+
+        let (persona_did, name, enabled) = match self.selected_agent_name(state) {
+            Some(v) => v,
+            None => return,
+        };
+        let verb = if enabled { "Parking" } else { "Resuming" };
+        let Some(admin_vta) =
+            self.begin_agent_name_work(state, admin_vta, &format!("{verb} @{name}…"))
+        else {
+            return;
+        };
+        let result = if enabled {
+            agent_name_manage::disable_name(admin_vta, &persona_did, &name).await
+        } else {
+            agent_name_manage::enable_name(admin_vta, &persona_did, &name).await
+        };
+        match result {
+            Ok(_) => {
+                state.main_page.log(format!(
+                    "{} agent name @{name}",
+                    if enabled { "Parked" } else { "Resumed" }
+                ));
+                self.refresh_agent_names(state, config, save, admin_vta, &persona_did)
+                    .await;
+            }
+            Err(e) => self.set_agent_name_message(
+                state,
+                AgentNameManagerPhase::Ready,
+                format!("Could not {} @{name}: {e}", verb.to_lowercase()),
+            ),
+        }
+    }
+
+    /// Remove (release) the selected name, then refresh.
+    async fn run_agent_name_remove(
+        &self,
+        state: &mut State,
+        config: &mut Config,
+        save: &mut save_coalesce::SaveScheduler,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+    ) {
+        use crate::state_handler::main_page::content::AgentNameManagerPhase;
+
+        let (persona_did, name, _enabled) = match self.selected_agent_name(state) {
+            Some(v) => v,
+            None => return,
+        };
+        let Some(admin_vta) =
+            self.begin_agent_name_work(state, admin_vta, &format!("Removing @{name}…"))
+        else {
+            return;
+        };
+        match agent_name_manage::remove_name(admin_vta, &persona_did, &name).await {
+            Ok(_) => {
+                state.main_page.log(format!("Removed agent name @{name}"));
+                self.refresh_agent_names(state, config, save, admin_vta, &persona_did)
+                    .await;
+            }
+            Err(e) => self.set_agent_name_message(
+                state,
+                AgentNameManagerPhase::Ready,
+                format!("Could not remove @{name}: {e}"),
+            ),
+        }
+    }
+
+    /// Re-list the registry after a mutation and reconcile the persisted
+    /// name cache: the persona's displayed name becomes its first *enabled*
+    /// entry (or `None` when it has none), so the header/panels reflect the
+    /// change without waiting for the background sweep.
+    async fn refresh_agent_names(
+        &self,
+        state: &mut State,
+        config: &mut Config,
+        save: &mut save_coalesce::SaveScheduler,
+        admin_vta: &vta_sdk::client::VtaClient,
+        persona_did: &str,
+    ) {
+        use crate::state_handler::main_page::content::AgentNameManagerPhase;
+
+        let host = state
+            .main_page
+            .agent_names
+            .as_ref()
+            .map(|o| o.host.clone())
+            .unwrap_or_default();
+        match agent_name_manage::list_names(admin_vta, persona_did).await {
+            Ok(names) => {
+                // First served name → the persona's displayed name.
+                let cached = names
+                    .iter()
+                    .find(|n| n.enabled)
+                    .filter(|_| !host.is_empty())
+                    .map(|n| format!("{host}/@{}", n.name));
+                config.set_cached_agent_name(persona_did, cached, chrono::Utc::now());
+                save.mark_dirty();
+                state.main_page.sync_from_config(config);
+                self.apply_agent_name_list(state, names, AgentNameManagerPhase::Ready);
+            }
+            Err(e) => self.set_agent_name_message(
+                state,
+                AgentNameManagerPhase::Ready,
+                format!("Applied, but could not reload the list: {e}"),
+            ),
+        }
+    }
+
+    /// Enter the `Working` phase with a status line, returning the VTA client, or
+    /// surface "VTA unavailable" and return `None`.
+    fn begin_agent_name_work<'a>(
+        &self,
+        state: &mut State,
+        admin_vta: Option<&'a vta_sdk::client::VtaClient>,
+        status: &str,
+    ) -> Option<&'a vta_sdk::client::VtaClient> {
+        use crate::state_handler::main_page::content::AgentNameManagerPhase;
+        let Some(admin_vta) = admin_vta else {
+            self.set_agent_name_message(
+                state,
+                AgentNameManagerPhase::Ready,
+                "VTA session unavailable — cannot manage agent names right now.",
+            );
+            return None;
+        };
+        if let Some(o) = state.main_page.agent_names.as_mut() {
+            o.phase = AgentNameManagerPhase::Working;
+            o.message = Some(status.to_string());
+        }
+        let _ = self.state_tx.send(state.clone());
+        Some(admin_vta)
+    }
+
+    /// The `(persona_did, name, enabled)` of the overlay's selected row, if the
+    /// overlay is open, `Ready`, and has a selection.
+    fn selected_agent_name(&self, state: &State) -> Option<(String, String, bool)> {
+        use crate::state_handler::main_page::content::AgentNameManagerPhase;
+        let o = state.main_page.agent_names.as_ref()?;
+        if o.phase != AgentNameManagerPhase::Ready {
+            return None;
+        }
+        let row = o.names.get(o.selected)?;
+        Some((o.persona_did.clone(), row.name.clone(), row.enabled))
+    }
+
+    /// Replace the overlay's rows and phase from a fresh registry listing,
+    /// clamping the selection into range.
+    fn apply_agent_name_list(
+        &self,
+        state: &mut State,
+        names: Vec<vta_sdk::protocols::did_management::agent_name::AgentNameEntry>,
+        phase: crate::state_handler::main_page::content::AgentNameManagerPhase,
+    ) {
+        use crate::state_handler::main_page::content::AgentNameRow;
+        if let Some(o) = state.main_page.agent_names.as_mut() {
+            o.names = names
+                .into_iter()
+                .map(|e| AgentNameRow {
+                    name: e.name,
+                    enabled: e.enabled,
+                })
+                .collect();
+            o.selected = o.selected.min(o.names.len().saturating_sub(1));
+            o.phase = phase;
+            o.message = None;
+        }
+        let _ = self.state_tx.send(state.clone());
+    }
+
+    /// Set the overlay's status line and phase (no-op if the overlay is closed).
+    fn set_agent_name_message(
+        &self,
+        state: &mut State,
+        phase: crate::state_handler::main_page::content::AgentNameManagerPhase,
+        message: impl Into<String>,
+    ) {
+        if let Some(o) = state.main_page.agent_names.as_mut() {
+            o.phase = phase;
+            o.message = Some(message.into());
+        }
+        let _ = self.state_tx.send(state.clone());
+    }
+
     /// (Re)load the VIC list from the VTA credential vault into the VTA panel,
     /// honouring the "show inactive" toggle. Best-effort: a query failure logs
     /// and leaves the previous list in place. Called when the operator focuses
@@ -2730,6 +3064,28 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
         }
         Action::CreatePersonaClose => {
             state.main_page.create_persona = None;
+        }
+        Action::AgentNameManagerInput(key) => {
+            use tui_input::backend::crossterm::EventHandler;
+            if let Some(o) = state.main_page.agent_names.as_mut()
+                && o.phase == main_page::content::AgentNameManagerPhase::Ready
+            {
+                o.input.handle_event(&crossterm::event::Event::Key(*key));
+            }
+        }
+        Action::AgentNameManagerSelect(down) => {
+            if let Some(o) = state.main_page.agent_names.as_mut()
+                && !o.names.is_empty()
+            {
+                if *down {
+                    o.selected = (o.selected + 1).min(o.names.len() - 1);
+                } else {
+                    o.selected = o.selected.saturating_sub(1);
+                }
+            }
+        }
+        Action::AgentNameManagerClose => {
+            state.main_page.agent_names = None;
         }
         _ => return false,
     }

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -228,8 +228,10 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
             );
         } else {
             lines.push(
-                Line::from("↑/↓ select   n: new persona   d: remove selected orphan")
-                    .fg(COLOR_DARK_GRAY),
+                Line::from(
+                    "↑/↓ select   n: new persona   g: agent names   d: remove selected orphan",
+                )
+                .fg(COLOR_DARK_GRAY),
             );
         }
     } else {

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -1,6 +1,6 @@
 use crate::colors::{
-    COLOR_BORDER, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
-    COLOR_WARNING_ACCESSIBLE_RED,
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
+    COLOR_TEXT_DEFAULT, COLOR_WARNING_ACCESSIBLE_RED,
 };
 use crate::{
     state_handler::{
@@ -120,6 +120,12 @@ impl Component for MainPage {
         // Create-persona overlay: while open it owns all input.
         if self.props.main_page.create_persona.is_some() {
             self.handle_create_persona_key(key);
+            return;
+        }
+
+        // Agent-name manager overlay: while open it owns all input.
+        if self.props.main_page.agent_names.is_some() {
+            self.handle_agent_name_manager_key(key);
             return;
         }
 
@@ -457,6 +463,13 @@ impl MainPage {
                     }
                     true
                 }
+                KeyCode::Char('g') if did_selected < did_count => {
+                    // Manage this persona's agent names (claim / park / remove).
+                    let _ = self
+                        .action_tx
+                        .send(Action::StartAgentNameManager(did_selected));
+                    true
+                }
                 _ => false,
             },
             VtaFocus::Vics => match key.code {
@@ -723,6 +736,47 @@ impl MainPage {
             CreatePersonaPhase::Failed => {
                 let _ = self.action_tx.send(Action::CreatePersonaClose);
             }
+        }
+    }
+
+    /// Agent-name manager overlay keys. `Ready` phase: Enter claims the typed
+    /// name, ↑/↓ move the row selection, Space parks/resumes the selected name,
+    /// `d`/Delete removes it, Esc closes, other keys edit the input. `Loading`
+    /// and `Working` swallow input (a mutation is in flight). Called only while
+    /// the overlay is open, where it owns all input.
+    fn handle_agent_name_manager_key(&mut self, key: KeyEvent) {
+        use crate::state_handler::main_page::content::AgentNameManagerPhase;
+        let Some(overlay) = self.props.main_page.agent_names.as_ref() else {
+            return;
+        };
+        match overlay.phase {
+            AgentNameManagerPhase::Ready => match key.code {
+                KeyCode::Enter => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerClaim);
+                }
+                KeyCode::Esc => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerClose);
+                }
+                KeyCode::Up => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerSelect(false));
+                }
+                KeyCode::Down => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerSelect(true));
+                }
+                // Space parks/resumes; `d`/Delete removes — both act on the
+                // selected row and only when there is one.
+                KeyCode::Char(' ') if !overlay.names.is_empty() => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerToggle);
+                }
+                KeyCode::Char('d') | KeyCode::Delete if !overlay.names.is_empty() => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerRemove);
+                }
+                _ => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerInput(key));
+                }
+            },
+            // A list load or mutation is in flight: lock input.
+            AgentNameManagerPhase::Loading | AgentNameManagerPhase::Working => {}
         }
     }
 
@@ -2130,6 +2184,10 @@ impl ComponentRender<()> for MainPage {
         if let Some(overlay) = self.props.main_page.add_vic.as_ref() {
             self.render_add_vic_overlay(frame, overlay);
         }
+        // Agent-name manager overlay floats over everything when open.
+        if let Some(overlay) = self.props.main_page.agent_names.as_ref() {
+            self.render_agent_name_manager_overlay(frame, overlay);
+        }
     }
 }
 
@@ -2299,6 +2357,124 @@ impl MainPage {
                 )));
             }
         }
+
+        frame.render_widget(Paragraph::new(lines).block(block), popup_area);
+    }
+
+    /// Render the agent-name manager popup: the persona's registry (served and
+    /// parked names), a claim input, and the row actions. Mirrors the
+    /// create-persona overlay's centering.
+    fn render_agent_name_manager_overlay(
+        &self,
+        frame: &mut Frame,
+        overlay: &crate::state_handler::main_page::content::AgentNameManagerState,
+    ) {
+        use crate::state_handler::main_page::content::AgentNameManagerPhase;
+        use ratatui::{
+            layout::{Constraint, Flex},
+            style::Style,
+            widgets::{Block, Clear, Padding},
+        };
+
+        let area = frame.area();
+        let popup_width = 68u16.min(area.width.saturating_sub(4));
+        let popup_height = 16u16.min(area.height.saturating_sub(2)).max(9);
+
+        let [popup_area] = Layout::vertical([Constraint::Length(popup_height)])
+            .flex(Flex::Center)
+            .areas(area);
+        let [popup_area] = Layout::horizontal([Constraint::Length(popup_width)])
+            .flex(Flex::Center)
+            .areas(popup_area);
+
+        frame.render_widget(Clear, popup_area);
+
+        let title = if overlay.persona_label.is_empty() {
+            " Agent names ".to_string()
+        } else {
+            format!(" Agent names — {} ", overlay.persona_label)
+        };
+        let block = Block::bordered()
+            .title(title)
+            .title_style(Style::new().fg(COLOR_ORANGE).bold())
+            .border_style(Style::new().fg(COLOR_ORANGE))
+            .padding(Padding::uniform(1));
+
+        let mut lines: Vec<Line> = Vec::new();
+        match overlay.phase {
+            AgentNameManagerPhase::Loading => {
+                lines.push(Line::from(Span::styled(
+                    "Loading agent names…",
+                    Style::new().fg(COLOR_TEXT_DEFAULT),
+                )));
+            }
+            AgentNameManagerPhase::Ready | AgentNameManagerPhase::Working => {
+                if overlay.names.is_empty() {
+                    lines.push(Line::from(Span::styled(
+                        "No agent names yet.",
+                        Style::new().fg(COLOR_DARK_GRAY),
+                    )));
+                } else {
+                    for (i, row) in overlay.names.iter().enumerate() {
+                        let marker = if i == overlay.selected { "▸ " } else { "  " };
+                        let host = if overlay.host.is_empty() {
+                            "@".to_string()
+                        } else {
+                            format!("{}/@", overlay.host)
+                        };
+                        let status = if row.enabled { "served" } else { "parked" };
+                        let status_style = if row.enabled {
+                            Style::new().fg(COLOR_SUCCESS)
+                        } else {
+                            Style::new().fg(COLOR_DARK_GRAY)
+                        };
+                        let name_style = if i == overlay.selected {
+                            Style::new().fg(COLOR_SUCCESS).bold()
+                        } else {
+                            Style::new().fg(COLOR_TEXT_DEFAULT)
+                        };
+                        lines.push(Line::from(vec![
+                            Span::styled(format!("{marker}{host}{}", row.name), name_style),
+                            Span::styled(format!("   [{status}]"), status_style),
+                        ]));
+                    }
+                }
+                lines.push(Line::default());
+                // The claim input.
+                let prefix = if overlay.host.is_empty() {
+                    "@".to_string()
+                } else {
+                    format!("{}/@", overlay.host)
+                };
+                lines.push(Line::from(vec![
+                    Span::styled("Claim: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+                    Span::styled(
+                        format!("{prefix}{}", overlay.input.value()),
+                        Style::new().fg(COLOR_SOFT_PURPLE).bold(),
+                    ),
+                ]));
+            }
+        }
+
+        if let Some(msg) = &overlay.message {
+            lines.push(Line::default());
+            lines.push(Line::from(Span::styled(
+                msg.clone(),
+                Style::new().fg(COLOR_ORANGE),
+            )));
+        }
+
+        lines.push(Line::default());
+        let hint = match overlay.phase {
+            AgentNameManagerPhase::Working | AgentNameManagerPhase::Loading => "working…",
+            AgentNameManagerPhase::Ready => {
+                "⏎ claim   ↑/↓ select   space park/resume   d remove   esc close"
+            }
+        };
+        lines.push(Line::from(Span::styled(
+            hint,
+            Style::new().fg(COLOR_BORDER),
+        )));
 
         frame.render_widget(Paragraph::new(lines).block(block), popup_area);
     }
@@ -2828,6 +3004,96 @@ mod key_handler_tests {
             Ok(Action::StartCreatePersona) => {}
             _ => panic!("expected StartCreatePersona"),
         }
+    }
+
+    #[test]
+    fn vta_g_opens_agent_name_manager_for_selected_persona() {
+        use crate::state_handler::main_page::content::ManagedDid;
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
+            s.main_page.content_panel.vta.context_dids = vec![
+                ManagedDid {
+                    did: "did:webvh:example.com:alice".into(),
+                    label: "Alice".into(),
+                    bound_communities: 1,
+                    is_active: true,
+                },
+                ManagedDid {
+                    did: "did:webvh:example.com:bob".into(),
+                    label: "Bob".into(),
+                    bound_communities: 0,
+                    is_active: false,
+                },
+            ]
+            .into();
+            s.main_page.content_panel.vta.did_selected_index = 1;
+        });
+        page.handle_key_event(press(KeyCode::Char('g')));
+        match rx.try_recv() {
+            Ok(Action::StartAgentNameManager(1)) => {}
+            _ => panic!("expected StartAgentNameManager(1)"),
+        }
+    }
+
+    #[test]
+    fn agent_name_manager_ready_keys_map_to_actions() {
+        use crate::state_handler::main_page::content::{
+            AgentNameManagerPhase, AgentNameManagerState, AgentNameRow,
+        };
+        let open = || {
+            page_for(MainMenu::Vta, |s| {
+                s.main_page.agent_names = Some(AgentNameManagerState {
+                    persona_did: "did:webvh:example.com:alice".into(),
+                    phase: AgentNameManagerPhase::Ready,
+                    names: vec![AgentNameRow {
+                        name: "alice".into(),
+                        enabled: true,
+                    }],
+                    ..Default::default()
+                });
+            })
+        };
+
+        let (mut page, mut rx) = open();
+        page.handle_key_event(press(KeyCode::Enter));
+        assert!(matches!(rx.try_recv(), Ok(Action::AgentNameManagerClaim)));
+
+        let (mut page, mut rx) = open();
+        page.handle_key_event(press(KeyCode::Char(' ')));
+        assert!(matches!(rx.try_recv(), Ok(Action::AgentNameManagerToggle)));
+
+        let (mut page, mut rx) = open();
+        page.handle_key_event(press(KeyCode::Char('d')));
+        assert!(matches!(rx.try_recv(), Ok(Action::AgentNameManagerRemove)));
+
+        let (mut page, mut rx) = open();
+        page.handle_key_event(press(KeyCode::Esc));
+        assert!(matches!(rx.try_recv(), Ok(Action::AgentNameManagerClose)));
+
+        // A plain character edits the input rather than triggering an action.
+        let (mut page, mut rx) = open();
+        page.handle_key_event(press(KeyCode::Char('x')));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::AgentNameManagerInput(_))
+        ));
+    }
+
+    #[test]
+    fn agent_name_manager_working_swallows_input() {
+        use crate::state_handler::main_page::content::{
+            AgentNameManagerPhase, AgentNameManagerState,
+        };
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
+            s.main_page.agent_names = Some(AgentNameManagerState {
+                phase: AgentNameManagerPhase::Working,
+                ..Default::default()
+            });
+        });
+        page.handle_key_event(press(KeyCode::Enter));
+        assert!(
+            rx.try_recv().is_err(),
+            "input is locked while a mutation is in flight"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Last in the agent-names sequence (after #163 deps, #164 core, #165 display, #166
input). The management half: bind, park, resume and release a name on your own
persona. The consumer PRs only read names; this writes them.

## Changes

- `agent_name_manage.rs` wraps the six VTA agent-name verbs (`set` / `remove` /
  `enable` / `disable` / `list` / `check`) over `VtaClient::dispatch_trust_task`.
  The VTA holds the account's webvh update keys, so it edits `alsoKnownAs`, signs
  the new version and calls the host; OpenVTC only names the DID and the name,
  never signs. Needs the vta-sdk bump 0.19.15 → 0.19.17 (where set/remove/list/
  check landed) — the only dependency change here.
- **UX**: the VTA panel's context-identity list gains `g`, opening a per-persona
  manager overlay. It lists the registry as the host holds it — served **and**
  parked names, which are invisible to plain resolution — and offers claim (with
  a `check` availability pre-check that rejects a reserved or taken name before
  any publish), park/resume (space), and remove (`d`). Modal + inline-await,
  mirroring the create-persona overlay; the registry is re-fetched after every
  mutation so what shows is what the host actually holds.
- A successful mutation reconciles the persisted name cache — the persona's first
  served name becomes its displayed name (host derived via didwebvh-rs) — so the
  header and panels update immediately rather than waiting for the background
  sweep.

## Follow-up

`remove` releases a name for anyone to reclaim; the VTA classifies it destructive
but OpenVTC sends it without a local confirm gate. A `y/Enter` gate (like
DID-delete) is worth adding.

## Verification

512 tests (fmt, clippy --all-targets clean): the `g` trigger, the overlay key
map, the Working-phase input lock, and host derivation (including the %3A
custom-port case) are covered.