### PR TITLE
test(agent-names): end-to-end resolve → verify against a mock host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -872,7 +872,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1014,6 +1014,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2427,6 +2437,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "decoded-char"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,7 +2780,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3047,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3704,6 +3732,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -5261,7 +5295,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5396,6 +5430,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5764,6 +5808,7 @@ dependencies = [
  "uuid",
  "vta-sdk 0.19.17",
  "vta-service",
+ "wiremock",
  "x25519-dalek",
  "zeroize",
 ]
@@ -5799,7 +5844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6513,7 +6558,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7160,7 +7205,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7236,7 +7281,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7881,7 +7926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8367,7 +8412,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8380,7 +8425,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9923,7 +9968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10305,6 +10350,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper 1.11.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -95,6 +95,10 @@ reqwest = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util = { workspace = true }
+# Mock HTTP server for the agent-name resolve→verify e2e: it serves the
+# `/@name` → 302 → DID redirect the `HttpRedirectResolver` follows, so the whole
+# chain is exercised without a live host.
+wiremock = "0.6"
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 

--- a/openvtc-core/tests/agent_name_e2e.rs
+++ b/openvtc-core/tests/agent_name_e2e.rs
@@ -1,0 +1,148 @@
+//! End-to-end resolve → verify for agent names, against a mock host.
+//!
+//! The consumer-side unit tests cover the decision logic in isolation (the spoof
+//! guard with an injected resolver, error classification). These drive the whole
+//! chain through a real [`DIDCacheClient`]: the `/@name` → 302 → DID redirect is
+//! served by a wiremock server the resolver actually fetches, and the DID's
+//! document is seeded into the cache so the mandatory `alsoKnownAs` verification
+//! runs against a document we control — no live host, fully deterministic.
+//!
+//! Scheme note: over a plain-HTTP mock the agent name must carry an explicit
+//! `http://`. A scheme-less name canonicalises to `https`, which would not hit
+//! the mock — so both the input and the document's `alsoKnownAs` use the mock's
+//! own `http://127.0.0.1:PORT` origin.
+
+use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+use affinidi_tdk::did_common::{Document, DocumentBuilder};
+use agent_names::HttpRedirectResolver;
+use openvtc_core::agent_name::{
+    IdentifierError, resolve_identifier, resolve_verified_name, verified_agent_name,
+};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+/// Two immutable `did:key`s so the seeded documents need no network resolution
+/// and the "resolves to a different DID" spoof case has a concrete other DID.
+const DID: &str = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const OTHER_DID: &str = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH";
+
+/// A `DIDCacheClient` whose only agent-name backend is a redirect resolver
+/// relaxed for the loopback mock (plain HTTP + private addresses).
+async fn client() -> DIDCacheClient {
+    let mut client = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+        .await
+        .expect("build DID cache client");
+    client.set_agent_name_resolvers(vec![Box::new(
+        HttpRedirectResolver::new()
+            .allow_insecure_http(true)
+            .allow_private_addresses(true),
+    )]);
+    client
+}
+
+/// Seed `did`'s document into the cache, claiming `also_known_as`, so DID
+/// resolution returns a document we control (no network).
+async fn seed(client: &mut DIDCacheClient, did: &str, also_known_as: &[&str]) {
+    let doc: Document = DocumentBuilder::new(did)
+        .unwrap()
+        .also_known_as_many(also_known_as.iter().copied())
+        .build();
+    client.add_did_document(did, doc).await;
+}
+
+/// Start a mock host that 302-redirects `GET /@{local}` to `did`.
+async fn redirect_host(local: &str, did: &str) -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/@{local}")))
+        .respond_with(ResponseTemplate::new(302).insert_header("location", did))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// The happy path, both directions: a name that redirects to `DID`, whose
+/// document claims the name back, resolves as input *and* is returned for
+/// display.
+#[tokio::test]
+async fn verified_name_resolves_and_displays() {
+    let host = redirect_host("alice", DID).await;
+    let name = format!("{}/@alice", host.uri()); // http://127.0.0.1:PORT/@alice
+    let mut client = client().await;
+    seed(&mut client, DID, &[&name]).await;
+
+    // Input direction: a typed agent name resolves to the DID.
+    let did = resolve_identifier(&client, &name)
+        .await
+        .expect("agent name resolves to a DID");
+    assert_eq!(did, DID, "resolve_identifier returns the DID, not the name");
+
+    // Display direction: the DID resolves back to the verified name (scheme-less).
+    let shown = resolve_verified_name(&client, DID).await;
+    assert_eq!(
+        shown.as_deref(),
+        Some(name.trim_start_matches("http://")),
+        "resolve_verified_name returns the scheme-less name"
+    );
+}
+
+/// The spoofing case, and the single most important guarantee: a document that
+/// claims a name which actually redirects to a *different* DID must not be
+/// displayed under that name.
+#[tokio::test]
+async fn name_pointing_at_a_different_did_is_rejected() {
+    // The name redirects to OTHER_DID...
+    let host = redirect_host("mallory", OTHER_DID).await;
+    let name = format!("{}/@mallory", host.uri());
+    let mut client = client().await;
+    // ...but DID's document falsely claims that name.
+    seed(&mut client, DID, &[&name]).await;
+    // OTHER_DID's own document does not claim the name, so nothing legitimises it.
+    seed(&mut client, OTHER_DID, &[]).await;
+
+    let doc = client.resolve(DID).await.unwrap().doc;
+    let shown = verified_agent_name(&client, DID, &doc).await;
+    assert_eq!(
+        shown, None,
+        "a name resolving to a different DID must be rejected, not displayed"
+    );
+}
+
+/// A document that claims no names yields no display name (the common case for a
+/// DID with no agent name).
+#[tokio::test]
+async fn did_without_a_claimed_name_has_no_display_name() {
+    let mut client = client().await;
+    seed(&mut client, DID, &[]).await;
+    assert_eq!(resolve_verified_name(&client, DID).await, None);
+}
+
+/// A name that redirects to a DID whose document does **not** claim it back
+/// fails the mandatory `alsoKnownAs` check — surfaced as an agent-name error on
+/// input, distinct from a network failure.
+#[tokio::test]
+async fn name_not_claimed_back_fails_to_resolve() {
+    let host = redirect_host("alice", DID).await;
+    let name = format!("{}/@alice", host.uri());
+    let mut client = client().await;
+    // DID resolves, but claims nothing — the reverse binding is missing.
+    seed(&mut client, DID, &[]).await;
+
+    match resolve_identifier(&client, &name).await {
+        Err(IdentifierError::AgentName { .. }) => {}
+        other => panic!("expected an AgentName error for an unclaimed name, got {other:?}"),
+    }
+}
+
+/// A plain DID passes straight through `resolve_identifier` unchanged.
+#[tokio::test]
+async fn a_plain_did_passes_through() {
+    let mut client = client().await;
+    seed(&mut client, DID, &[]).await;
+    let did = resolve_identifier(&client, DID)
+        .await
+        .expect("a resolvable DID passes through");
+    assert_eq!(did, DID);
+}


### PR DESCRIPTION
Closes the deferred agent-names e2e follow-up. A deterministic end-to-end test
for the whole resolve → verify chain, with **no live host**: a wiremock server
serves the `/@name` → 302 → DID redirect the `HttpRedirectResolver` actually
follows, and the DID's document is seeded into the cache so the mandatory
`alsoKnownAs` verification runs against a document the test controls.

Five cases, driven through a real `DIDCacheClient` and OpenVTC's own
`resolve_identifier` / `resolve_verified_name` / `verified_agent_name`:

- **happy path, both directions** — a name that redirects to a DID whose
  document claims it back resolves as input *and* is returned (scheme-less) for
  display;
- **the spoof case** — a document claiming a name that redirects to a *different*
  DID is rejected. This is the single most important guarantee, and it is now
  proven end-to-end (previously only with an injected resolver);
- a DID that claims no name has no display name;
- a name the target does not claim back fails with a distinct `AgentName` error
  (not a network error);
- a plain DID passes straight through.

Scheme detail baked into the setup: over a plain-HTTP mock the name must carry an
explicit `http://` (a scheme-less name canonicalises to `https` and would miss
the mock), so both the input and the seeded `alsoKnownAs` use the mock's origin.

Adds `wiremock` as an `openvtc-core` dev-dependency. **Test-only; no production
change.**