### PR TITLE
feat: confirm before releasing an agent name

### DIFF
--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -414,7 +414,14 @@ pub enum Action {
     /// Park (`disable`) or resume (`enable`) the selected name, then refresh.
     AgentNameManagerToggle,
 
-    /// Remove (release) the selected name, then refresh.
+    /// Arm the remove confirmation for the selected name (destructive).
+    AgentNameManagerConfirmRemove,
+
+    /// Cancel a pending remove confirmation.
+    AgentNameManagerCancelRemove,
+
+    /// Remove (release) the selected name, then refresh. Sent only after the
+    /// confirmation is armed and the operator presses `y`/Enter.
     AgentNameManagerRemove,
 
     /// Close the agent-name manager overlay.

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -227,6 +227,10 @@ pub struct AgentNameManagerState {
     pub phase: AgentNameManagerPhase,
     /// Transient status / error line.
     pub message: Option<String>,
+    /// Armed remove confirmation: `Some(row)` while awaiting `y`/Enter to
+    /// release that name (a destructive op — the name becomes free for anyone to
+    /// reclaim). Any other key cancels. `None` when nothing is armed.
+    pub confirm_remove: Option<usize>,
 }
 
 /// One agent-name registry row shown in the manager overlay.

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -2282,6 +2282,9 @@ impl StateHandler {
         if let Some(o) = state.main_page.agent_names.as_mut() {
             o.phase = AgentNameManagerPhase::Working;
             o.message = Some(status.to_string());
+            // The confirm (if any) has served its purpose — the mutation is now
+            // running; don't leave it armed over the refreshed list.
+            o.confirm_remove = None;
         }
         let _ = self.state_tx.send(state.clone());
         Some(admin_vta)
@@ -3084,6 +3087,21 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
                 }
             }
         }
+        Action::AgentNameManagerConfirmRemove => {
+            // Arm the confirm on the selected row (only when there is one and the
+            // overlay is idle). The network remove runs on `AgentNameManagerRemove`.
+            if let Some(o) = state.main_page.agent_names.as_mut()
+                && o.phase == main_page::content::AgentNameManagerPhase::Ready
+                && !o.names.is_empty()
+            {
+                o.confirm_remove = Some(o.selected);
+            }
+        }
+        Action::AgentNameManagerCancelRemove => {
+            if let Some(o) = state.main_page.agent_names.as_mut() {
+                o.confirm_remove = None;
+            }
+        }
         Action::AgentNameManagerClose => {
             state.main_page.agent_names = None;
         }
@@ -3287,6 +3305,52 @@ mod tests {
             }),
         );
         assert_eq!(resolve_did_to_display(&config, did), "Alice");
+    }
+
+    /// The remove-confirm arm/cancel transitions on the agent-name overlay:
+    /// `ConfirmRemove` arms the selected row (only when Ready and non-empty),
+    /// `CancelRemove` clears it.
+    #[test]
+    fn agent_name_remove_confirm_arms_and_cancels() {
+        use crate::state_handler::main_page::content::{
+            AgentNameManagerPhase, AgentNameManagerState, AgentNameRow,
+        };
+        let mut state = State::default();
+        state.main_page.agent_names = Some(AgentNameManagerState {
+            phase: AgentNameManagerPhase::Ready,
+            names: vec![
+                AgentNameRow {
+                    name: "alice".into(),
+                    enabled: true,
+                },
+                AgentNameRow {
+                    name: "alias".into(),
+                    enabled: false,
+                },
+            ],
+            selected: 1,
+            ..Default::default()
+        });
+
+        assert!(handle_nav_action(
+            &mut state,
+            &Action::AgentNameManagerConfirmRemove
+        ));
+        assert_eq!(
+            state.main_page.agent_names.as_ref().unwrap().confirm_remove,
+            Some(1),
+            "arms the selected row"
+        );
+
+        assert!(handle_nav_action(
+            &mut state,
+            &Action::AgentNameManagerCancelRemove
+        ));
+        assert_eq!(
+            state.main_page.agent_names.as_ref().unwrap().confirm_remove,
+            None,
+            "cancel clears the arm"
+        );
     }
 
     /// Drive `handle_nav_action` directly over a fresh `State`. Because the

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -749,6 +749,19 @@ impl MainPage {
         let Some(overlay) = self.props.main_page.agent_names.as_ref() else {
             return;
         };
+        // A remove is armed: it owns all input — only y/Enter confirms (releasing
+        // the name, which anyone can then reclaim); anything else backs out.
+        if overlay.confirm_remove.is_some() {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Enter => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerRemove);
+                }
+                _ => {
+                    let _ = self.action_tx.send(Action::AgentNameManagerCancelRemove);
+                }
+            }
+            return;
+        }
         match overlay.phase {
             AgentNameManagerPhase::Ready => match key.code {
                 KeyCode::Enter => {
@@ -763,13 +776,13 @@ impl MainPage {
                 KeyCode::Down => {
                     let _ = self.action_tx.send(Action::AgentNameManagerSelect(true));
                 }
-                // Space parks/resumes; `d`/Delete removes — both act on the
-                // selected row and only when there is one.
+                // Space parks/resumes; `d`/Delete arms the remove confirm — both
+                // act on the selected row and only when there is one.
                 KeyCode::Char(' ') if !overlay.names.is_empty() => {
                     let _ = self.action_tx.send(Action::AgentNameManagerToggle);
                 }
                 KeyCode::Char('d') | KeyCode::Delete if !overlay.names.is_empty() => {
-                    let _ = self.action_tx.send(Action::AgentNameManagerRemove);
+                    let _ = self.action_tx.send(Action::AgentNameManagerConfirmRemove);
                 }
                 _ => {
                     let _ = self.action_tx.send(Action::AgentNameManagerInput(key));
@@ -2465,16 +2478,31 @@ impl MainPage {
         }
 
         lines.push(Line::default());
-        let hint = match overlay.phase {
-            AgentNameManagerPhase::Working | AgentNameManagerPhase::Loading => "working…",
-            AgentNameManagerPhase::Ready => {
-                "⏎ claim   ↑/↓ select   space park/resume   d remove   esc close"
-            }
-        };
-        lines.push(Line::from(Span::styled(
-            hint,
-            Style::new().fg(COLOR_BORDER),
-        )));
+        // An armed remove confirmation overrides the normal hint with a warning.
+        let armed = overlay
+            .confirm_remove
+            .and_then(|i| overlay.names.get(i))
+            .map(|row| row.name.as_str());
+        if let Some(name) = armed {
+            lines.push(
+                Line::from(format!(
+                    "Release @{name}? It becomes free for anyone to reclaim.   y: confirm    n: cancel"
+                ))
+                .fg(COLOR_ORANGE)
+                .bold(),
+            );
+        } else {
+            let hint = match overlay.phase {
+                AgentNameManagerPhase::Working | AgentNameManagerPhase::Loading => "working…",
+                AgentNameManagerPhase::Ready => {
+                    "⏎ claim   ↑/↓ select   space park/resume   d remove   esc close"
+                }
+            };
+            lines.push(Line::from(Span::styled(
+                hint,
+                Style::new().fg(COLOR_BORDER),
+            )));
+        }
 
         frame.render_widget(Paragraph::new(lines).block(block), popup_area);
     }
@@ -3061,9 +3089,13 @@ mod key_handler_tests {
         page.handle_key_event(press(KeyCode::Char(' ')));
         assert!(matches!(rx.try_recv(), Ok(Action::AgentNameManagerToggle)));
 
+        // `d` arms the remove confirmation; it does not remove directly.
         let (mut page, mut rx) = open();
         page.handle_key_event(press(KeyCode::Char('d')));
-        assert!(matches!(rx.try_recv(), Ok(Action::AgentNameManagerRemove)));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::AgentNameManagerConfirmRemove)
+        ));
 
         let (mut page, mut rx) = open();
         page.handle_key_event(press(KeyCode::Esc));
@@ -3075,6 +3107,51 @@ mod key_handler_tests {
         assert!(matches!(
             rx.try_recv(),
             Ok(Action::AgentNameManagerInput(_))
+        ));
+    }
+
+    #[test]
+    fn agent_name_manager_remove_confirm_gate() {
+        use crate::state_handler::main_page::content::{
+            AgentNameManagerPhase, AgentNameManagerState, AgentNameRow,
+        };
+        // An armed remove: y/Enter confirms, anything else cancels — and no
+        // other Ready-phase key acts while it is armed.
+        let armed = || {
+            page_for(MainMenu::Vta, |s| {
+                s.main_page.agent_names = Some(AgentNameManagerState {
+                    phase: AgentNameManagerPhase::Ready,
+                    names: vec![AgentNameRow {
+                        name: "alice".into(),
+                        enabled: true,
+                    }],
+                    confirm_remove: Some(0),
+                    ..Default::default()
+                });
+            })
+        };
+
+        let (mut page, mut rx) = armed();
+        page.handle_key_event(press(KeyCode::Char('y')));
+        assert!(matches!(rx.try_recv(), Ok(Action::AgentNameManagerRemove)));
+
+        let (mut page, mut rx) = armed();
+        page.handle_key_event(press(KeyCode::Enter));
+        assert!(matches!(rx.try_recv(), Ok(Action::AgentNameManagerRemove)));
+
+        let (mut page, mut rx) = armed();
+        page.handle_key_event(press(KeyCode::Esc));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::AgentNameManagerCancelRemove)
+        ));
+
+        // A stray key while armed cancels rather than editing the input.
+        let (mut page, mut rx) = armed();
+        page.handle_key_event(press(KeyCode::Char('x')));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::AgentNameManagerCancelRemove)
         ));
     }
 


### PR DESCRIPTION
Closes the last agent-names follow-up. Removing an agent name releases it for
anyone to reclaim — the one destructive op in the manager overlay, and it
previously fired the instant you pressed `d`. This gates it behind a
confirmation, mirroring the DID-delete `y/Enter` gate.

## Change

- `d` now **arms** a confirm on the selected row instead of removing. The overlay
  shows *"Release @name? It becomes free for anyone to reclaim.  y: confirm  n:
  cancel"*, and while armed it owns all input — only `y`/Enter proceeds to the
  actual `remove`; anything else backs out.
- The arm is cleared when the mutation starts (so it never lingers over the
  refreshed list) and by cancel.
- New `confirm_remove: Option<usize>` on the overlay state, plus
  `AgentNameManagerConfirmRemove` / `AgentNameManagerCancelRemove` actions
  (pure-state arm/cancel in the nav reducer).

Park / resume / claim are unchanged — they are recoverable and need no gate.

## Verification

519 tests (fmt, clippy --all-targets clean): the key map (`d` arms, y/Enter
confirms, a stray key cancels), the Working-phase lock, and the arm/cancel nav
transitions are covered.