### PR TITLE
chore(deps): take vta-sdk 0.19.19 for the canonical spec/vtc join types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.19",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -872,7 +872,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2780,7 +2780,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5295,7 +5295,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5751,7 +5751,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.19",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5806,7 +5806,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.19",
  "vta-service",
  "wiremock",
  "x25519-dalek",
@@ -5844,7 +5844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6558,7 +6558,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7205,7 +7205,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7281,7 +7281,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7926,7 +7926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8412,7 +8412,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8425,7 +8425,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9348,7 +9348,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.19",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.19",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9393,9 +9393,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.17"
+version = "0.19.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6453a67174e5456b42a0a986a2477507e28465c61c32bfa4da3ca08a60848496"
+checksum = "aa4dadface2af16f9146338c6b3e6771381f43d29e2e7829d08ac4f66c4ab66f"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9507,7 +9507,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.19",
  "vti-common",
  "vti-secrets",
  "vti-webauthn",
@@ -9555,7 +9555,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.17",
+ "vta-sdk 0.19.19",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9968,7 +9968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -1236,7 +1236,7 @@ mod tests {
             "https://trusttasks.org/spec/trust-task-error/0.2"
         ));
         assert!(!is_trust_task_error_type(
-            "https://trusttasks.org/openvtc/vtc/spec/join-requests/submit/1.0"
+            "https://trusttasks.org/spec/vtc/join-requests/submit/0.1"
         ));
     }
 


### PR DESCRIPTION
**Step 3 of 3** — completes the cross-repo VTC Trust Task migration.

| step | what | where |
|---|---|---|
| 1 | router *accepts* the canonical prefix | #171 (merged) |
| 2 | the VTC *emits* it; SDK constants move | [VTI#733](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/733) (merged) |
| 3 | openvtc *dispatches* it | this PR |

### Why a third step was needed

Routing and dispatch are **separate gates**. #171 fixed the router regex, but `message_dispatch` compares `message.typ` against `vta_sdk::protocols::join_requests` **constants** — which only carry the canonical values from 0.19.19 onward. Without this bump, a migrated VTC's replies would pass the router and then **fall through the type match**: handled, then silently ignored.

Because dispatch is constant-keyed rather than literal-keyed, this is essentially a lockfile change. `JOIN_REQUEST_SUBMIT_TYPE` and friends now resolve to `spec/vtc/join-requests/{verb}/0.1`.

### Deliberately unchanged

- **`legacy_vtc_trust_tasks_still_route`** keeps its `openvtc/vtc` literals. That test *is* the rollout guarantee — an unmigrated VTC must stay reachable, which is why #171 accepted both prefixes.
- **The two `*_RECEIPT_TYPE` constants** remain on the `openvtc` authority upstream: a receipt is a fire-and-forget ack, and the registry publishes no receipt task.
- **The transitive `vta-sdk 0.18.21`** (via `did-git-sign`) is untouched — unrelated to the ceremony.

One sample URI in a `messaging.rs` negative assertion moves to the canonical form, since that's what now appears on the wire.

### Verification

`cargo test --workspace`: **523 passed, 0 failed**. `cargo clippy --workspace --all-targets -D warnings` clean. `cargo fmt --all --check` clean.

⚠️ Worth knowing: **the join-ceremony e2e tests are `#[ignore]`d as slow, so a plain `cargo test` does not exercise the thing this PR changes.** I ran them explicitly — all three round-trips pass against the canonical constants:

```
test join_submit_and_approval_activates ... ok
test join_submit_and_rejection_inactivates ... ok
test member_self_remove_round_trip ... ok
```

Worth considering whether those should run in CI, given they're the only coverage of the cross-repo wire contract.
