### PR TITLE
chore(deps): take vta-sdk 0.19.20 for the canonical members/self-remove type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -872,7 +872,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2780,7 +2780,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5295,7 +5295,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5751,7 +5751,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5806,7 +5806,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "vta-service",
  "wiremock",
  "x25519-dalek",
@@ -5844,7 +5844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6558,7 +6558,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7205,7 +7205,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7281,7 +7281,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7926,7 +7926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8412,7 +8412,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8425,7 +8425,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9348,7 +9348,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.19",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "vti-common",
  "x25519-dalek",
 ]
@@ -9393,9 +9393,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.19"
+version = "0.19.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4dadface2af16f9146338c6b3e6771381f43d29e2e7829d08ac4f66c4ab66f"
+checksum = "89bfd9bbf74ea936a57729e01a1c69e14f74d06d22b70aa3872798dc723e6804"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9507,7 +9507,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "vta-cli-common",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "vti-common",
  "vti-secrets",
  "vti-webauthn",
@@ -9555,7 +9555,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.19",
+ "vta-sdk 0.19.20",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9968,7 +9968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Completes the VTC Trust Task migration on the openvtc side.

### Why this is a separate bump from #172

`members/self-remove` was deliberately **held back** from the join-requests move ([VTI#733](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/733)). Changing only its DIDComm constant there would have left its REST mount on the old authority — splitting one task across two registries. The VTC's manifest census (`retired_tasks_are_not_bound`) caught exactly that and refused it.

The whole members family then moved together in [VTI#743](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/743), so `MEMBER_SELF_REMOVE_TYPE` now resolves to `spec/vtc/members/self-remove/0.1`.

### Lockfile-only

Same reason as the 0.19.19 bump: dispatch is keyed on the SDK **constants**, not URI literals, and the router already accepts the canonical prefix (#171). Nothing in openvtc's source changes.

### Verification

`cargo test --workspace`: **523 passed, 0 failed**. `cargo clippy --workspace --all-targets -D warnings` clean. `cargo fmt --all --check` clean.

⚠️ As with #172 — the join-ceremony e2e tests are `#[ignore]`d as slow, so **a plain `cargo test` does not exercise what this PR changes**. Run explicitly:

```
$ cargo test -p openvtc-core --test join_lifecycle_e2e -- --ignored
test member_self_remove_round_trip ... ok
test join_submit_and_approval_activates ... ok
test join_submit_and_rejection_inactivates ... ok
```

All three pass against the canonical constants.
