### PR TITLE
fix: show verified agent names on the communities screen

### DIFF
--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -435,8 +435,14 @@ impl MainPageState {
         let now = chrono::Utc::now();
         for c in config.account.communities_for_display(show_archived) {
             let persona = config.account.personas.get(&c.persona_ref);
+            // Precedence follows `resolve_did_to_display`: the user's own label
+            // wins (explicit, and unspoofable by definition), then a verified
+            // agent name, then the truncated DID. The name is read from the
+            // cache, which only ever holds round-tripped lookups — an
+            // unverified `alsoKnownAs` claim never reaches it.
             let persona_label = persona
                 .and_then(|p| p.label.clone())
+                .or_else(|| persona.and_then(|p| config.agent_name_for(&p.did).map(str::to_owned)))
                 .or_else(|| persona.map(|p| shorten_did(&p.did, 24)))
                 .unwrap_or_default();
             let request_id = match &c.status {
@@ -449,6 +455,7 @@ impl MainPageState {
                 display_name: c
                     .display_name
                     .clone()
+                    .or_else(|| config.agent_name_for(&c.vtc_did).map(str::to_owned))
                     .unwrap_or_else(|| shorten_did(&c.vtc_did, 40)),
                 status_label: community_status_label(&c.status),
                 persona_label,
@@ -800,6 +807,133 @@ impl MainPanel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- community row labelling (agent names) ---
+
+    /// Build a config holding one Active membership: persona `persona_did`
+    /// presented to community `vtc_did`. `persona_label` and `display_name` are
+    /// the explicitly-set names, either of which may be absent.
+    fn config_with_membership(
+        persona_did: &str,
+        persona_label: Option<&str>,
+        vtc_did: &str,
+        display_name: Option<&str>,
+    ) -> Config {
+        use openvtc_core::config::account::{CommunityRecord, CommunityStatus, PersonaRecord};
+
+        let mut config = crate::state_handler::dispatch_util::test_config();
+        let persona_id = PersonaId::new();
+        config.account.personas.insert(
+            persona_id,
+            PersonaRecord {
+                persona_id,
+                did: persona_did.to_string(),
+                did_document: None,
+                key_refs: vec![],
+                mediator_did: None,
+                origin_context_id: String::new(),
+                created_at: chrono::Utc::now(),
+                label: persona_label.map(str::to_owned),
+            },
+        );
+        config.account.communities.insert(
+            vtc_did.to_string(),
+            vec![CommunityRecord {
+                vtc_did: vtc_did.to_string(),
+                display_name: display_name.map(str::to_owned),
+                sub_context_id: String::new(),
+                persona_ref: persona_id,
+                status: CommunityStatus::Active,
+                favourite: false,
+                archived: false,
+                acknowledged: true,
+                member_since: None,
+                requested_at: None,
+                receipt_at: None,
+                relationships: Default::default(),
+                tasks: Default::default(),
+                vrcs_issued: Default::default(),
+                vrcs_received: Default::default(),
+                credentials: std::collections::BTreeMap::new(),
+            }],
+        );
+        config
+    }
+
+    /// With no explicit label and no cached name, both halves of the row fall
+    /// back to a truncated DID — the pre-existing behaviour, which must not
+    /// change for an account that has no agent names.
+    #[test]
+    fn community_row_falls_back_to_truncated_dids() {
+        let persona_did = "did:webvh:QmScidPersonaAAAAAAAAAAAAAAAAAAA:example.com:persona";
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let config = config_with_membership(persona_did, None, vtc_did, None);
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let row = &page.content_panel.communities.items[0];
+
+        assert_eq!(row.persona_label, shorten_did(persona_did, 24));
+        assert_eq!(row.display_name, shorten_did(vtc_did, 40));
+    }
+
+    /// A verified agent name in the cache labels both the presented persona and
+    /// the community, in place of the truncated DID. This is the regression the
+    /// panel previously had: it never consulted the cache at all, so an enabled
+    /// name could not appear on the communities screen.
+    #[test]
+    fn community_row_prefers_a_verified_agent_name_over_a_truncated_did() {
+        let persona_did = "did:webvh:QmScidPersonaAAAAAAAAAAAAAAAAAAA:example.com:persona";
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(persona_did, None, vtc_did, None);
+        let now = chrono::Utc::now();
+        config.set_cached_agent_name(persona_did, Some("example.com/@alice".into()), now);
+        config.set_cached_agent_name(vtc_did, Some("example.com/@acme".into()), now);
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let row = &page.content_panel.communities.items[0];
+
+        assert_eq!(row.persona_label, "example.com/@alice");
+        assert_eq!(row.display_name, "example.com/@acme");
+    }
+
+    /// The user's own label still wins over an agent name — it is an explicit
+    /// labelling choice and unspoofable, matching `resolve_did_to_display`'s
+    /// documented precedence. Same for a community's resolved display name.
+    #[test]
+    fn community_row_keeps_explicit_labels_ahead_of_an_agent_name() {
+        let persona_did = "did:webvh:QmScidPersonaAAAAAAAAAAAAAAAAAAA:example.com:persona";
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config =
+            config_with_membership(persona_did, Some("Work me"), vtc_did, Some("Acme Co"));
+        let now = chrono::Utc::now();
+        config.set_cached_agent_name(persona_did, Some("example.com/@alice".into()), now);
+        config.set_cached_agent_name(vtc_did, Some("example.com/@acme".into()), now);
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let row = &page.content_panel.communities.items[0];
+
+        assert_eq!(row.persona_label, "Work me");
+        assert_eq!(row.display_name, "Acme Co");
+    }
+
+    /// A cached *negative* lookup (the DID has no verifiable name) must not
+    /// render as a name — the row falls back to the truncated DID.
+    #[test]
+    fn community_row_ignores_a_cached_negative_lookup() {
+        let persona_did = "did:webvh:QmScidPersonaAAAAAAAAAAAAAAAAAAA:example.com:persona";
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(persona_did, None, vtc_did, None);
+        config.set_cached_agent_name(persona_did, None, chrono::Utc::now());
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let row = &page.content_panel.communities.items[0];
+
+        assert_eq!(row.persona_label, shorten_did(persona_did, 24));
+    }
 
     // --- persona_in_scope (community-scoping filter, D10/R-C-6) ---
 

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1122,11 +1122,17 @@ impl StateHandler {
                             .into_iter()
                             .filter(|c| c.status.is_active())
                             .map(|c| {
-                                let persona_label = config
-                                    .account
-                                    .personas
-                                    .get(&c.persona_ref)
+                                // Same precedence as the communities panel:
+                                // user label, then verified agent name, then
+                                // the truncated DID.
+                                let persona = config.account.personas.get(&c.persona_ref);
+                                let persona_label = persona
                                     .and_then(|p| p.label.clone())
+                                    .or_else(|| {
+                                        persona.and_then(|p| {
+                                            config.agent_name_for(&p.did).map(str::to_owned)
+                                        })
+                                    })
                                     .unwrap_or_default();
                                 main_page::content::SwitcherItem {
                                     vtc_did: c.vtc_did.clone(),
@@ -1134,6 +1140,9 @@ impl StateHandler {
                                     display_name: c
                                         .display_name
                                         .clone()
+                                        .or_else(|| {
+                                            config.agent_name_for(&c.vtc_did).map(str::to_owned)
+                                        })
                                         .unwrap_or_else(|| main_page::shorten_did(&c.vtc_did, 40)),
                                     persona_label,
                                     is_current: current.as_ref()


### PR DESCRIPTION
## The bug

A verified agent name could not appear on the communities screen. Claim a name on a persona, enable it, and the row still rendered a truncated DID:

```
  did:webvh:QmXi1PZD4NEvcvjfErAzVoCGtBF...
  ▸ ★ as did:webvh:QmXi1PZD4NEvcvjfErAzVoCGtBFEv7dhXZQJHvcFY4U83F:webvh.storm.ws:first-vtc
       Active  ·  since 2026-07-22
```

Nothing was wrong with the enable. `AgentNameVerb::claims_name()` covers `Set | Enable`, so the VTA republishes the `alsoKnownAs` claim, and `list_agent_names` reads the control plane live. The panel simply never looked the name up.

Both halves of a membership row were built from static fields in `sync_from_config`:

```rust
let persona_label = persona
    .and_then(|p| p.label.clone())
    .or_else(|| persona.map(|p| shorten_did(&p.did, 24)))
    .unwrap_or_default();
…
display_name: c.display_name.clone().unwrap_or_else(|| shorten_did(&c.vtc_did, 40)),
```

Neither consults `config.agent_name_for`, and neither routes through `resolve_did_to_display` — the helper that already documents the intended precedence (**user alias → verified agent name → truncated DID**). The helper exists; this screen bypassed it.

## The fix

Consult the cache in the slot that renders a truncated DID today, on both surfaces that list memberships — the communities panel and the Ctrl+K switcher — so the two cannot disagree about what a membership is called.

Deliberately **additive**: any row that already had an explicit name (the user's persona label, or the community's resolved `display_name`) is unchanged. Nothing that displayed a name before displays a different one now; only rows that were showing a truncated DID can change.

No plumbing was needed. `agent_name_refresh_targets` already seeds the cache with both persona DIDs and community VTC DIDs, and `background_dispatch` already calls `sync_from_config` when a displayed name changes.

## Why this doesn't widen the phishing surface

The repo rule is *never display an unverified name*. This change doesn't relax it: the cache is only written from `resolve_verified_name`, which gates on the full three-stage round-trip (`verified_agent_name`), so an unverified `alsoKnownAs` claim never reaches the screen. A cached **negative** (`Some(CachedAgentName { name: None })`) renders as the truncated DID, not as a name — covered by a test.

## Tests

Four new tests in `main_page::tests`:

- `community_row_falls_back_to_truncated_dids` — pins the pre-existing behaviour for an account with no names
- `community_row_prefers_a_verified_agent_name_over_a_truncated_did` — the regression itself
- `community_row_keeps_explicit_labels_ahead_of_an_agent_name` — precedence
- `community_row_ignores_a_cached_negative_lookup` — a negative is not a name

`cargo test --workspace`: all suites pass, 0 failed. `cargo clippy --all-targets` clean, `cargo fmt` applied.

## One open call for the reviewer

I kept the community's `display_name` **ahead** of the agent name. That field is documented as "resolved from the VTC DID document" — self-asserted by the community — whereas an agent name is round-trip verified, so by the anti-phishing logic in CLAUDE.md the verified name arguably ought to outrank it.

I left the order alone because reordering changes what already-labelled communities display, which is beyond "make the name visible". Happy to swap it — one line in each of the two call sites.

## Not in scope

- The expanded troubleshooting block under a selected row still prints full DIDs verbatim (`communities_panel.rs:143-146`). That is the point of that block.
- Separately observed while debugging: `refresh_agent_names` writes the name it caches as a hand-built `format!("{host}/@{name}")`, and caches `None` when `derive_host` fails — a sticky negative from a *successful* enable, since it also stamps `checked_at = now` and so survives the 24h TTL. Both are worth their own issue; neither is touched here.
