### PR TITLE
fix: make agent names actually appear — negative-cache TTL, restart pruning, and the remaining display surfaces

### DIFF
--- a/openvtc-core/src/agent_name.rs
+++ b/openvtc-core/src/agent_name.rs
@@ -35,11 +35,32 @@ use serde::{Deserialize, Serialize};
 /// few names) is unaffected.
 const MAX_CANDIDATES: usize = 4;
 
-/// How long a persisted lookup (positive **or** negative) is trusted before the
-/// background refresh re-verifies it. The resolver's own name cache is short
-/// (~5 min) and handles churn; this persisted layer only exists so names show
-/// instantly at launch without a network round-trip, so a day is ample.
+/// How long a persisted **positive** lookup is trusted before the background
+/// refresh re-verifies it. The resolver's own name cache is short (~5 min) and
+/// handles churn; this persisted layer only exists so names show instantly at
+/// launch without a network round-trip, so a day is ample.
 pub const AGENT_NAME_TTL: Duration = Duration::hours(24);
+
+/// How long a persisted **negative** lookup is trusted.
+///
+/// Deliberately far shorter than [`AGENT_NAME_TTL`]. A negative is not a fact
+/// about the DID, it is the absence of evidence — and every transient cause
+/// produces one: the naming host briefly down, no network at launch, a name
+/// claimed on the VTA moments ago whose redirect is not yet live. Caching those
+/// for a day blinds every display surface for a day, with the DID rendering
+/// exactly as it would if it genuinely had no name, and nothing in the sweep to
+/// re-check it (`agent_name_refresh_targets` skips entries that are not stale).
+///
+/// A few minutes is enough to stop a nameless DID being re-resolved on every
+/// render, while letting a transient failure heal itself on the next sweep.
+///
+/// Set to the sweep interval rather than below it. Because staleness is
+/// `now - checked_at >= TTL`, a negative written *during* a sweep is a shade
+/// under one interval old at the next tick and is picked up by the one after,
+/// so the effective retry is ~2 sweeps. That is deliberate: retrying a failing
+/// name on *every* sweep would re-fetch up to `MAX_CANDIDATES` redirects per DID
+/// indefinitely, which is the unbounded-polling shape VTI R1.4 warns about.
+pub const AGENT_NAME_NEGATIVE_TTL: Duration = Duration::minutes(5);
 
 /// A persisted DID → agent-name lookup. The value is deliberately an
 /// `Option`: a resolved-and-verified name, **or** `None` recording that the DID
@@ -55,11 +76,22 @@ pub struct CachedAgentName {
 }
 
 impl CachedAgentName {
-    /// Whether this entry is older than [`AGENT_NAME_TTL`] as of `now` and
+    /// How long this entry is trusted: [`AGENT_NAME_TTL`] for a verified name,
+    /// the much shorter [`AGENT_NAME_NEGATIVE_TTL`] for a negative.
+    #[must_use]
+    pub fn ttl(&self) -> Duration {
+        if self.name.is_some() {
+            AGENT_NAME_TTL
+        } else {
+            AGENT_NAME_NEGATIVE_TTL
+        }
+    }
+
+    /// Whether this entry has outlived its [`ttl`](Self::ttl) as of `now` and
     /// should be re-verified by the background refresh.
     #[must_use]
     pub fn is_stale(&self, now: DateTime<Utc>) -> bool {
-        now - self.checked_at >= AGENT_NAME_TTL
+        now - self.checked_at >= self.ttl()
     }
 }
 
@@ -89,14 +121,82 @@ pub async fn verified_agent_name(
     did: &str,
     doc: &Document,
 ) -> Option<String> {
+    match name_outcome(resolver, did, doc).await {
+        NameOutcome::Verified(name) => Some(name),
+        NameOutcome::NoClaim | NameOutcome::NotVerified(_) => None,
+    }
+}
+
+/// Why `did` does or does not have a displayable agent name.
+///
+/// Same verification as [`verified_agent_name`], but it keeps the reasons
+/// instead of collapsing them to `None`. Display code should use
+/// `verified_agent_name`; this exists so the background sweep and any operator
+/// diagnostic can say *why* a DID is rendering as a raw DID — the distinction
+/// between "this DID claims no name", "the naming host is unreachable" and
+/// "the name points at somebody else's DID" is invisible otherwise, which is
+/// what makes a silent no-name display so hard to debug (VTI R6.4).
+pub async fn name_outcome(resolver: &DIDCacheClient, did: &str, doc: &Document) -> NameOutcome {
     let candidates = agent_names::extract_agent_names(doc);
-    verify_candidates(did, candidates, |name| async move {
+    verify_candidates_detailed(did, candidates, |name| async move {
         // resolve_any performs the mandatory `alsoKnownAs` check on the document
         // it fetches; we additionally require its resolved DID to be the one we
         // are labelling, which ties the name's forward redirect back to `did`.
-        resolver.resolve_any(&name).await.ok().map(|resp| resp.did)
+        resolver
+            .resolve_any(&name)
+            .await
+            .map(|resp| resp.did)
+            .map_err(|e| e.to_string())
     })
     .await
+}
+
+/// The outcome of looking for a displayable agent name for a DID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NameOutcome {
+    /// A name that completed the full round-trip and is safe to display.
+    Verified(String),
+    /// The document claims no agent names at all — this DID simply has none.
+    NoClaim,
+    /// Names were claimed but none verified; carries each rejection reason.
+    NotVerified(Vec<CandidateFailure>),
+}
+
+impl NameOutcome {
+    /// The verified name, if there is one.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            NameOutcome::Verified(n) => Some(n),
+            _ => None,
+        }
+    }
+
+    /// A short operator-facing summary for logs.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        match self {
+            NameOutcome::Verified(n) => format!("verified '{n}'"),
+            NameOutcome::NoClaim => "no agent name claimed in the document".to_string(),
+            NameOutcome::NotVerified(failures) => {
+                let detail = failures
+                    .iter()
+                    .map(|f| format!("'{}' ({})", f.name, f.reason))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                format!("claimed but not verified: {detail}")
+            }
+        }
+    }
+}
+
+/// One claimed name that failed verification, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CandidateFailure {
+    /// The claimed name, scheme-less.
+    pub name: String,
+    /// Why it was rejected — unreachable host, not a DID, or a spoof.
+    pub reason: String,
 }
 
 /// Resolve `did` to a verified agent name, fetching its document first.
@@ -106,8 +206,22 @@ pub async fn verified_agent_name(
 /// resolver's document cache. `None` if the DID does not resolve or has no
 /// verifiable name.
 pub async fn resolve_verified_name(resolver: &DIDCacheClient, did: &str) -> Option<String> {
-    let resp = resolver.resolve(did).await.ok()?;
-    verified_agent_name(resolver, did, &resp.doc).await
+    match resolve_name_outcome(resolver, did).await {
+        Ok(outcome) => outcome.name().map(str::to_owned),
+        Err(_) => None,
+    }
+}
+
+/// [`resolve_verified_name`] retaining the reason, for the background sweep and
+/// operator diagnostics. `Err` carries the resolver's message when the DID
+/// itself could not be resolved — distinct from resolving fine but having no
+/// verifiable name.
+pub async fn resolve_name_outcome(
+    resolver: &DIDCacheClient,
+    did: &str,
+) -> Result<NameOutcome, String> {
+    let resp = resolver.resolve(did).await.map_err(|e| e.to_string())?;
+    Ok(name_outcome(resolver, did, &resp.doc).await)
 }
 
 /// The verification decision, factored out so the spoof guard is testable
@@ -117,21 +231,41 @@ pub async fn resolve_verified_name(resolver: &DIDCacheClient, did: &str) -> Opti
 ///
 /// `resolve` maps a name's canonical string to the DID it forward-resolves to
 /// (`None` on any failure).
-async fn verify_candidates<F, Fut>(
+/// The verification decision, factored out so the spoof guard is testable
+/// without a live resolver, and retaining the rejection reasons.
+///
+/// `resolve` maps a name's canonical string to the DID it forward-resolves to,
+/// or an error describing why it could not be resolved.
+async fn verify_candidates_detailed<F, Fut>(
     did: &str,
     candidates: Vec<AgentName>,
     resolve: F,
-) -> Option<String>
+) -> NameOutcome
 where
     F: Fn(String) -> Fut,
-    Fut: std::future::Future<Output = Option<String>>,
+    Fut: std::future::Future<Output = Result<String, String>>,
 {
+    if candidates.is_empty() {
+        return NameOutcome::NoClaim;
+    }
+    let mut failures = Vec::new();
     for name in candidates.into_iter().take(MAX_CANDIDATES) {
-        if resolve(name.as_str().to_string()).await.as_deref() == Some(did) {
-            return Some(name.without_scheme().to_string());
+        match resolve(name.as_str().to_string()).await {
+            Ok(got) if got == did => {
+                return NameOutcome::Verified(name.without_scheme().to_string());
+            }
+            // The spoof case: the name is real but belongs to another DID.
+            Ok(got) => failures.push(CandidateFailure {
+                name: name.without_scheme().to_string(),
+                reason: format!("forward-resolves to a different DID ({got})"),
+            }),
+            Err(reason) => failures.push(CandidateFailure {
+                name: name.without_scheme().to_string(),
+                reason,
+            }),
         }
     }
-    None
+    NameOutcome::NotVerified(failures)
 }
 
 /// Why an identifier the user typed could not be turned into a DID.
@@ -226,22 +360,62 @@ mod tests {
         assert!(fresh.is_stale(checked_at + Duration::hours(25)));
     }
 
+    /// A negative expires on the short TTL, not the 24h one. Caching "no name"
+    /// for a day is what made a transient resolve failure — host briefly down,
+    /// offline at launch, a redirect not yet live — hide every name until the
+    /// next day, indistinguishable from the DID genuinely having no name.
+    #[test]
+    fn negative_entries_expire_far_sooner_than_positive_ones() {
+        let checked_at = Utc::now();
+        let negative = CachedAgentName {
+            name: None,
+            checked_at,
+        };
+        assert_eq!(negative.ttl(), AGENT_NAME_NEGATIVE_TTL);
+        assert!(!negative.is_stale(checked_at));
+        assert!(negative.is_stale(checked_at + AGENT_NAME_NEGATIVE_TTL));
+
+        // The point of the split: at a time when a negative is already stale, a
+        // positive written at the same instant is still trusted.
+        let positive = CachedAgentName {
+            name: Some("example.com/@alice".into()),
+            checked_at,
+        };
+        let after = checked_at + AGENT_NAME_NEGATIVE_TTL;
+        assert!(negative.is_stale(after));
+        assert!(!positive.is_stale(after));
+    }
+
     /// The spoof case, and the single most important behaviour in this module:
     /// a document claims `example.com/@alice`, but that name forward-resolves to
-    /// a *different* DID. It must NOT be displayed as our name.
+    /// a *different* DID. It must NOT be displayed as our name, and the reason
+    /// must name the DID it actually landed on so the report is actionable.
     #[tokio::test]
     async fn rejects_name_resolving_to_a_different_did() {
-        let got = verify_candidates(
+        let got = verify_candidates_detailed(
             "did:webvh:us:example.com",
             vec![name("example.com/@alice")],
             // The name points at somebody else's DID.
-            |_| async { Some("did:webvh:them:evil.example".to_string()) },
+            |_| async { Ok("did:webvh:them:evil.example".to_string()) },
         )
         .await;
         assert_eq!(
-            got, None,
+            got.name(),
+            None,
             "a name pointing at a different DID must be rejected"
         );
+        match &got {
+            NameOutcome::NotVerified(failures) => {
+                assert_eq!(failures.len(), 1);
+                assert_eq!(failures[0].name, "example.com/@alice");
+                assert!(
+                    failures[0].reason.contains("did:webvh:them:evil.example"),
+                    "reason was: {}",
+                    failures[0].reason
+                );
+            }
+            other => panic!("expected NotVerified, got {other:?}"),
+        }
     }
 
     /// The happy path: the claimed name forward-resolves back to the DID we are
@@ -249,28 +423,31 @@ mod tests {
     #[tokio::test]
     async fn accepts_name_that_round_trips() {
         let did = "did:webvh:us:example.com";
-        let got = verify_candidates(did, vec![name("example.com/@alice")], |n| {
+        let got = verify_candidates_detailed(did, vec![name("example.com/@alice")], |n| {
             let did = did.to_string();
             async move {
                 assert_eq!(n, "https://example.com/@alice");
-                Some(did)
+                Ok(did)
             }
         })
         .await;
-        assert_eq!(got.as_deref(), Some("example.com/@alice"));
+        assert_eq!(got.name(), Some("example.com/@alice"));
     }
 
     /// A name that does not resolve at all (host down, no redirect) yields no
-    /// name rather than an error — the caller falls back to the DID.
+    /// name rather than an error — the caller falls back to the DID — but the
+    /// transport reason is kept, so "host is down" stays distinguishable from
+    /// "the name is not claimed".
     #[tokio::test]
     async fn skips_unresolvable_name() {
-        let got = verify_candidates(
+        let got = verify_candidates_detailed(
             "did:webvh:us:example.com",
             vec![name("example.com/@alice")],
-            |_| async { None },
+            |_| async { Err("connection refused".to_string()) },
         )
         .await;
-        assert_eq!(got, None);
+        assert_eq!(got.name(), None);
+        assert!(got.summary().contains("connection refused"), "{got:?}");
     }
 
     /// A document that claims many names must not trigger an unbounded number of
@@ -281,13 +458,13 @@ mod tests {
         let candidates: Vec<AgentName> = (0..(MAX_CANDIDATES + 5))
             .map(|i| name(&format!("example.com/@name{i}")))
             .collect();
-        let got = verify_candidates("did:webvh:us:example.com", candidates, |_| {
+        let got = verify_candidates_detailed("did:webvh:us:example.com", candidates, |_| {
             calls.set(calls.get() + 1);
             // None of them match, so every attempt (up to the cap) is made.
-            async { Some("did:webvh:other:host".to_string()) }
+            async { Ok("did:webvh:other:host".to_string()) }
         })
         .await;
-        assert_eq!(got, None);
+        assert_eq!(got.name(), None);
         assert_eq!(calls.get(), MAX_CANDIDATES, "must not resolve past the cap");
     }
 
@@ -297,14 +474,27 @@ mod tests {
         let did = "did:webvh:us:example.com";
         let calls = Cell::new(0usize);
         let candidates = vec![name("example.com/@first"), name("example.com/@second")];
-        let got = verify_candidates(did, candidates, |_| {
+        let got = verify_candidates_detailed(did, candidates, |_| {
             calls.set(calls.get() + 1);
             let did = did.to_string();
-            async move { Some(did) }
+            async move { Ok(did) }
         })
         .await;
-        assert_eq!(got.as_deref(), Some("example.com/@first"));
+        assert_eq!(got.name(), Some("example.com/@first"));
         assert_eq!(calls.get(), 1, "must short-circuit on the first match");
+    }
+
+    /// A document claiming nothing is reported as `NoClaim`, not as a failure —
+    /// the operator needs "this DID has no name" to read differently from "the
+    /// name would not verify".
+    #[tokio::test]
+    async fn no_claimed_names_reports_no_claim() {
+        let got = verify_candidates_detailed("did:webvh:us:example.com", vec![], |_| async {
+            panic!("must not resolve anything when there are no candidates")
+        })
+        .await;
+        assert_eq!(got, NameOutcome::NoClaim);
+        assert!(got.summary().contains("no agent name claimed"));
     }
 
     #[test]

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -182,6 +182,14 @@ impl Config {
             info!("Config will be re-encrypted with the updated seed derivation on next save");
         }
 
+        // Cached "this DID has no verifiable name" results do not survive a
+        // restart — see `prune_agent_name_negatives`. The first refresh sweep
+        // fires immediately after launch, so these re-resolve straight away.
+        let pruned = private_cfg.prune_agent_name_negatives();
+        if pruned > 0 {
+            debug!("Discarded {pruned} cached agent-name negative(s); will re-resolve on launch");
+        }
+
         log_private_config_shape(&private_cfg);
 
         // The v2 `account` persisted in the protected tier is the source of

--- a/openvtc-core/src/config/protected_config.rs
+++ b/openvtc-core/src/config/protected_config.rs
@@ -247,6 +247,25 @@ pub struct ProtectedConfig {
     pub agent_names: HashMap<String, CachedAgentName>,
 }
 
+impl ProtectedConfig {
+    /// Drop every cached *negative* agent-name lookup, returning how many went.
+    ///
+    /// Called on load. A negative records only that a name could not be verified
+    /// at some past moment, and the usual causes do not survive a restart: no
+    /// network at the time, the naming host briefly down, or a name claimed
+    /// moments before its redirect went live. Persisting those across a relaunch
+    /// means the operator's instinctive fix — restart it — provably cannot work,
+    /// which is exactly the trap this cache fell into.
+    ///
+    /// Verified names are kept: showing them instantly at launch without a
+    /// network round-trip is the reason the cache is persisted at all.
+    pub fn prune_agent_name_negatives(&mut self) -> usize {
+        let before = self.agent_names.len();
+        self.agent_names.retain(|_, cached| cached.name.is_some());
+        before - self.agent_names.len()
+    }
+}
+
 /// Manual impl so freshly created configs are stamped with the current
 /// schema version (a derived `Default` would set `schema_version` to 0).
 impl Default for ProtectedConfig {
@@ -558,5 +577,40 @@ mod tests {
         let seed1 = ProtectedConfig::get_seed_from_credential("key1").unwrap();
         let seed2 = ProtectedConfig::get_seed_from_credential("key2").unwrap();
         assert_ne!(seed1.expose_secret(), seed2.expose_secret(),);
+    }
+
+    /// Negatives are dropped on load so a restart re-checks them; verified names
+    /// survive, since instant display at launch is why the cache is persisted.
+    #[test]
+    fn pruning_drops_negatives_and_keeps_verified_names() {
+        use crate::agent_name::CachedAgentName;
+
+        let now = chrono::Utc::now();
+        let mut cfg = ProtectedConfig::default();
+        cfg.agent_names.insert(
+            "did:webvh:us:example.com".to_string(),
+            CachedAgentName {
+                name: Some("example.com/@alice".to_string()),
+                checked_at: now,
+            },
+        );
+        cfg.agent_names.insert(
+            "did:webvh:us:nameless.example".to_string(),
+            CachedAgentName {
+                name: None,
+                checked_at: now,
+            },
+        );
+
+        assert_eq!(cfg.prune_agent_name_negatives(), 1);
+        assert_eq!(cfg.agent_names.len(), 1);
+        assert!(cfg.agent_names.contains_key("did:webvh:us:example.com"));
+        assert!(
+            !cfg.agent_names
+                .contains_key("did:webvh:us:nameless.example")
+        );
+
+        // Idempotent: a second prune has nothing left to drop.
+        assert_eq!(cfg.prune_agent_name_negatives(), 0);
     }
 }

--- a/openvtc/src/state_handler/agent_name_refresh.rs
+++ b/openvtc/src/state_handler/agent_name_refresh.rs
@@ -17,6 +17,7 @@
 // direct dependency on the cache SDK.
 use affinidi_tdk::did_resolver::DIDCacheClient;
 use tokio::task::JoinSet;
+use tracing::debug;
 
 /// Maximum concurrent DID resolutions inside one batch job.
 const CONCURRENCY: usize = 4;
@@ -35,7 +36,21 @@ pub(crate) async fn resolve_batch(
     let spawn_one = |set: &mut JoinSet<(String, Option<String>)>, did: String| {
         let resolver = resolver.clone();
         set.spawn(async move {
-            let name = openvtc_core::agent_name::resolve_verified_name(&resolver, &did).await;
+            // Resolve via the reason-carrying entry point and log the outcome.
+            // A DID that renders as a raw DID is otherwise indistinguishable on
+            // screen from one that has no name at all, so without this line the
+            // only way to tell an unreachable naming host from an unclaimed name
+            // from a spoof is to reproduce it by hand (VTI R6.4).
+            let name = match openvtc_core::agent_name::resolve_name_outcome(&resolver, &did).await {
+                Ok(outcome) => {
+                    debug!("agent name for {did}: {}", outcome.summary());
+                    outcome.name().map(str::to_owned)
+                }
+                Err(e) => {
+                    debug!("agent name for {did}: DID did not resolve: {e}");
+                    None
+                }
+            };
             (did, name)
         });
     };
@@ -56,5 +71,11 @@ pub(crate) async fn resolve_batch(
             spawn_one(&mut in_flight, did);
         }
     }
+
+    let resolved = out.iter().filter(|(_, name)| name.is_some()).count();
+    debug!(
+        "agent name sweep: {} DID(s) checked, {resolved} name(s) verified",
+        out.len()
+    );
     out
 }

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -147,6 +147,10 @@ fn handle_inbox_open_detail(state: &mut State, index: usize) {
             } => Some(ActiveTaskView::RelationshipRequestInbound {
                 task_id: task.id.clone(),
                 from_did: from_did.clone(),
+                // `remote_agent_name` is the verified name for the requester's
+                // persona DID — i.e. `from_did`, the DID this labels. The
+                // requester's R-DID (`their_did`) is a pseudonym and gets none.
+                from_agent_name: task.remote_agent_name.clone(),
                 their_did: their_did.clone(),
                 reason: reason.clone(),
                 name: name.clone(),
@@ -154,28 +158,35 @@ fn handle_inbox_open_detail(state: &mut State, index: usize) {
             TaskKind::VRCRequestInbound { reason } => Some(ActiveTaskView::VRCRequestInbound {
                 task_id: task.id.clone(),
                 from_did: task.remote_did.clone(),
+                from_agent_name: task.remote_agent_name.clone(),
                 reason: reason.clone(),
             }),
             TaskKind::VRCIssued => Some(ActiveTaskView::VRCIssued {
                 task_id: task.id.clone(),
                 issuer: task.remote_did.clone(),
+                issuer_agent_name: task.remote_agent_name.clone(),
             }),
-            TaskKind::RelationshipRequestOutbound { our_did } => {
-                Some(ActiveTaskView::RelationshipRequestOutbound {
-                    task_id: task.id.clone(),
-                    to_did: task.remote_did.clone(),
-                    our_did: our_did.clone(),
-                    state: "Request Sent".to_string(),
-                })
-            }
+            TaskKind::RelationshipRequestOutbound {
+                our_did,
+                our_agent_name,
+            } => Some(ActiveTaskView::RelationshipRequestOutbound {
+                task_id: task.id.clone(),
+                to_did: task.remote_did.clone(),
+                to_agent_name: task.remote_agent_name.clone(),
+                our_did: our_did.clone(),
+                our_agent_name: our_agent_name.clone(),
+                state: "Request Sent".to_string(),
+            }),
             TaskKind::VRCRequestOutbound => Some(ActiveTaskView::VRCRequestOutbound {
                 task_id: task.id.clone(),
                 remote_did: task.remote_did.clone(),
+                remote_agent_name: task.remote_agent_name.clone(),
             }),
             TaskKind::TrustPing | TaskKind::Informational(_) => Some(ActiveTaskView::Info {
                 task_id: task.id.clone(),
                 type_display: task.type_display.clone(),
                 remote_did: task.remote_did.clone(),
+                remote_agent_name: task.remote_agent_name.clone(),
             }),
         };
         state.main_page.content_panel.inbox.active_task = view;

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -510,6 +510,11 @@ pub enum AddVicPhase {
 pub struct ManagedDid {
     /// The persona `did:webvh`.
     pub did: String,
+    /// Verified agent name for [`did`](Self::did) (`example.com/@me`), if one is
+    /// cached. Shown in place of the DID; the DID is the fallback. Populated in
+    /// `sync_from_config` from the persisted cache, which only ever holds
+    /// round-tripped (verified) lookups.
+    pub agent_name: Option<String>,
     /// Optional human label.
     pub label: String,
     /// How many communities present this persona (0 ⇒ orphan).
@@ -523,6 +528,11 @@ pub struct ManagedDid {
 pub struct ActiveDid {
     /// The DID string
     pub did: String,
+    /// Verified agent name for [`did`](Self::did), if one is cached. Shown in
+    /// place of the DID; the DID is the fallback. A relationship R-DID is a
+    /// per-relationship pseudonym and never carries one, so this stays `None`
+    /// for those rows.
+    pub agent_name: Option<String>,
     /// Human-readable label
     pub label: String,
 }
@@ -569,6 +579,12 @@ pub struct TaskSummary {
     pub kind: TaskKind,
     /// Shortened DID of the remote party (if applicable)
     pub remote_did: String,
+    /// Verified agent name for exactly the DID held in
+    /// [`remote_did`](Self::remote_did), if one is cached — shown in its place.
+    /// Only ever sourced from `Config::agent_name_for` (verified, round-tripped
+    /// lookups); it outranks the requester-supplied `name` on an inbound
+    /// relationship request, which is self-asserted and therefore spoofable.
+    pub remote_agent_name: Option<String>,
     /// Formatted creation timestamp
     pub created: String,
 }
@@ -588,7 +604,12 @@ pub enum TaskKind {
         name: Option<String>,
     },
     /// Outbound relationship request awaiting response
-    RelationshipRequestOutbound { our_did: String },
+    RelationshipRequestOutbound {
+        our_did: String,
+        /// Verified agent name for `our_did`, if cached. `None` when we sent the
+        /// request from a generated R-DID (a pseudonym, which carries no name).
+        our_agent_name: Option<String>,
+    },
     /// Inbound VRC request awaiting accept/reject
     VRCRequestInbound { reason: Option<String> },
     /// Outbound VRC request awaiting response
@@ -602,11 +623,18 @@ pub enum TaskKind {
 }
 
 /// Detailed view of a specific task for the interaction screen.
+///
+/// Every `*_agent_name` is the **verified** name for exactly the DID in the
+/// field it sits beside (from `Config::agent_name_for`), so rendering the name
+/// in place of that DID never relabels a different identity. `their_did` — the
+/// requester's relationship DID — has no name field on purpose: an R-DID is a
+/// per-relationship pseudonym, deliberately not a stable named identity.
 #[derive(Clone, Debug)]
 pub enum ActiveTaskView {
     RelationshipRequestInbound {
         task_id: String,
         from_did: String,
+        from_agent_name: Option<String>,
         their_did: String,
         reason: Option<String>,
         name: Option<String>,
@@ -615,28 +643,34 @@ pub enum ActiveTaskView {
     RelationshipRequestOutbound {
         task_id: String,
         to_did: String,
+        to_agent_name: Option<String>,
         our_did: String,
+        our_agent_name: Option<String>,
         state: String,
     },
     VRCRequestInbound {
         task_id: String,
         from_did: String,
+        from_agent_name: Option<String>,
         reason: Option<String>,
     },
     /// Outbound VRC request — waiting for response
     VRCRequestOutbound {
         task_id: String,
         remote_did: String,
+        remote_agent_name: Option<String>,
     },
     VRCIssued {
         task_id: String,
         issuer: String,
+        issuer_agent_name: Option<String>,
     },
     /// Generic info task (ping, pong, informational)
     Info {
         task_id: String,
         type_display: String,
         remote_did: String,
+        remote_agent_name: Option<String>,
     },
 }
 
@@ -799,14 +833,22 @@ pub struct VrcSummary {
     pub vrc_id: String,
     /// Remote party's persona DID
     pub remote_p_did: String,
+    /// Verified agent name for [`remote_p_did`](Self::remote_p_did), if cached.
+    /// Shown when there is no user alias; the DID is the last resort. Populated
+    /// in `sync_from_config` from the persisted (verified-only) cache.
+    pub remote_agent_name: Option<String>,
     /// Raw credential source, pretty-printed lazily at detail-view time.
     pub raw_json: RawCredential,
     /// Contact alias (if set)
     pub alias: Option<String>,
     /// Issuer DID
     pub issuer: String,
+    /// Verified agent name for [`issuer`](Self::issuer), if cached.
+    pub issuer_agent_name: Option<String>,
     /// Subject DID
     pub subject: String,
+    /// Verified agent name for [`subject`](Self::subject), if cached.
+    pub subject_agent_name: Option<String>,
     /// Formatted valid_from date
     pub valid_from: String,
     /// Formatted valid_until date (if set)

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -176,7 +176,13 @@ impl MainPageState {
                             .get(to)
                             .map(|rel| rel.our_did.to_string())
                             .unwrap_or_default();
-                        TaskKind::RelationshipRequestOutbound { our_did }
+                        let our_agent_name = config
+                            .agent_name_for(&our_did)
+                            .map(|n| sanitize_display(n, 256));
+                        TaskKind::RelationshipRequestOutbound {
+                            our_did,
+                            our_agent_name,
+                        }
                     }
                     TaskType::VRCRequestInbound { request, .. } => TaskKind::VRCRequestInbound {
                         reason: request.reason.as_deref().map(|r| sanitize_display(r, 256)),
@@ -216,11 +222,33 @@ impl MainPageState {
                     TaskType::VRCIssued { vrc } => sanitize_display(vrc.issuer(), 40),
                     _ => String::new(),
                 };
+                // The verified name for *exactly* the DID `remote_did` renders,
+                // so showing the name in its place can never relabel a different
+                // identity. Cache-only (`agent_name_for`) — an unverified
+                // `alsoKnownAs` claim never reaches it. A relationship R-DID has
+                // no cache entry, so those rows keep showing the DID.
+                let remote_agent_name = match &task.type_ {
+                    TaskType::RelationshipRequestInbound { from, .. } => {
+                        config.agent_name_for(from)
+                    }
+                    TaskType::RelationshipRequestOutbound { to } => config.agent_name_for(to),
+                    TaskType::TrustPing { to, .. } => config.agent_name_for(to),
+                    TaskType::VRCRequestInbound { remote_p_did, .. } => {
+                        config.agent_name_for(remote_p_did)
+                    }
+                    TaskType::VRCRequestOutbound { remote_p_did } => {
+                        config.agent_name_for(remote_p_did)
+                    }
+                    TaskType::VRCIssued { vrc } => config.agent_name_for(vrc.issuer()),
+                    _ => None,
+                }
+                .map(|n| sanitize_display(n, 256));
                 TaskSummary {
                     id: task.id.to_string(),
                     type_display: task.type_.to_string(),
                     kind,
                     remote_did: sanitize_display(&remote_did, 256),
+                    remote_agent_name,
                     created: task.created.format("%Y-%m-%d %H:%M").to_string(),
                 }
             })
@@ -372,6 +400,9 @@ impl MainPageState {
         if !persona_did.is_empty() {
             active_dids.push(content::ActiveDid {
                 did: persona_did.to_string(),
+                agent_name: config
+                    .agent_name_for(persona_did)
+                    .map(|n| sanitize_display(n, 256)),
                 label: "Persona".to_string(),
             });
         }
@@ -384,6 +415,13 @@ impl MainPageState {
                     .and_then(|c| c.alias.clone())
                     .unwrap_or_else(|| shorten_did(remote_p_did, 30));
                 active_dids.push(content::ActiveDid {
+                    // An R-DID is a per-relationship pseudonym: there is no
+                    // cache entry for it, so this resolves to `None` and the
+                    // row keeps showing the DID. Looked up all the same so the
+                    // name always belongs to the DID being displayed.
+                    agent_name: config
+                        .agent_name_for(rel.our_did.as_str())
+                        .map(|n| sanitize_display(n, 256)),
                     did: rel.our_did.to_string(),
                     label: format!("R-DID ({})", alias),
                 });
@@ -400,6 +438,9 @@ impl MainPageState {
             .personas
             .values()
             .map(|p| content::ManagedDid {
+                agent_name: config
+                    .agent_name_for(&p.did)
+                    .map(|n| sanitize_display(n, 256)),
                 did: p.did.clone(),
                 label: p.label.clone().unwrap_or_default(),
                 bound_communities: config
@@ -542,10 +583,19 @@ fn collect_vrcs(
                 result.push(VrcSummary {
                     vrc_id: vrc_id.to_string(),
                     remote_p_did: sanitize_display(remote_p_did, 256),
+                    remote_agent_name: config
+                        .agent_name_for(remote_p_did)
+                        .map(|n| sanitize_display(n, 256)),
                     raw_json,
                     alias: alias.as_deref().map(|a| sanitize_display(a, 256)),
                     issuer: sanitize_display(vrc.issuer(), 256),
+                    issuer_agent_name: config
+                        .agent_name_for(vrc.issuer())
+                        .map(|n| sanitize_display(n, 256)),
                     subject: sanitize_display(vrc.subject(), 256),
+                    subject_agent_name: config
+                        .agent_name_for(vrc.subject())
+                        .map(|n| sanitize_display(n, 256)),
                     valid_from: vrc.valid_from().format("%Y-%m-%d").to_string(),
                     valid_until: vrc.valid_until().map(|d| d.format("%Y-%m-%d").to_string()),
                 });
@@ -604,10 +654,19 @@ fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
             result.push(VrcSummary {
                 vrc_id: vc_id,
                 remote_p_did: sanitize_display(&c.vtc_did, 256),
+                remote_agent_name: config
+                    .agent_name_for(&c.vtc_did)
+                    .map(|n| sanitize_display(n, 256)),
                 raw_json,
                 alias: Some(format!("{community} — {}", kind.config_key())),
                 issuer: sanitize_display(&issuer, 256),
+                issuer_agent_name: config
+                    .agent_name_for(&issuer)
+                    .map(|n| sanitize_display(n, 256)),
                 subject: sanitize_display(&subject, 256),
+                subject_agent_name: config
+                    .agent_name_for(&subject)
+                    .map(|n| sanitize_display(n, 256)),
                 valid_from,
                 valid_until,
             });
@@ -935,6 +994,209 @@ mod tests {
         assert_eq!(row.persona_label, shorten_did(persona_did, 24));
     }
 
+    // --- agent names on the credential / inbox / VTA-DID view models ---
+    //
+    // These cover the three panels migrated off raw DIDs. Each asserts the
+    // *view model* carries the verified name beside the DID it labels; the
+    // panels render it through `openvtc_core::display::display_identifier`,
+    // which is unit-tested in `openvtc-core`.
+
+    const ALICE_DID: &str = "did:webvh:QmScidAliceAAAAAAAAAAAAAAAAAAAA:example.com:alice";
+    const BOB_DID: &str = "did:webvh:QmScidBobBBBBBBBBBBBBBBBBBBBBBB:example.com:bob";
+
+    /// A minimally-valid *signed* VRC. `Vrcs::insert` keys on the proof value,
+    /// so an unsigned credential cannot be stored.
+    fn signed_vrc(issuer: &str, subject: &str) -> Arc<dtg_credentials::DTGCredential> {
+        let json = serde_json::json!({
+            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            "type": ["VerifiableCredential", "DTGCredential", "RelationshipCredential"],
+            "issuer": issuer,
+            "validFrom": "2024-06-18T10:00:00Z",
+            "credentialSubject": { "id": subject },
+            "proof": {
+                "type": "DataIntegrityProof",
+                "cryptosuite": "eddsa-jcs-2022",
+                "created": "2024-06-18T10:00:00",
+                "verificationMethod": "did:example:test#key-1",
+                "proofPurpose": "assertionMethod",
+                "proofValue": "z-test-proof"
+            }
+        });
+        Arc::new(serde_json::from_value(json).expect("valid signed VRC"))
+    }
+
+    /// A config holding one received VRC issued by `BOB_DID` to `ALICE_DID`.
+    fn config_with_received_vrc() -> Config {
+        let mut config = crate::state_handler::dispatch_util::test_config();
+        let remote = Arc::new(BOB_DID.to_string());
+        config
+            .private
+            .vrcs_received
+            .insert(&remote, signed_vrc(BOB_DID, ALICE_DID))
+            .expect("VRC stores");
+        config
+    }
+
+    /// The credentials panel's view model carries the verified name for every
+    /// DID it shows: the remote party, the issuer and the subject.
+    #[test]
+    fn vrc_summary_carries_verified_agent_names() {
+        let mut config = config_with_received_vrc();
+        let now = chrono::Utc::now();
+        config.set_cached_agent_name(BOB_DID, Some("example.com/@bob".into()), now);
+        config.set_cached_agent_name(ALICE_DID, Some("example.com/@alice".into()), now);
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let vrc = &page.content_panel.credentials.received[0];
+
+        assert_eq!(vrc.remote_agent_name.as_deref(), Some("example.com/@bob"));
+        assert_eq!(vrc.issuer_agent_name.as_deref(), Some("example.com/@bob"));
+        assert_eq!(
+            vrc.subject_agent_name.as_deref(),
+            Some("example.com/@alice")
+        );
+        // The DIDs themselves are unchanged — the name sits beside them.
+        assert_eq!(vrc.issuer, BOB_DID);
+        assert_eq!(vrc.subject, ALICE_DID);
+    }
+
+    /// No cache entry (and a cached *negative* lookup) must leave every name
+    /// unset, so the panel keeps rendering the DID.
+    #[test]
+    fn vrc_summary_has_no_name_without_a_verified_lookup() {
+        let mut config = config_with_received_vrc();
+        config.set_cached_agent_name(BOB_DID, None, chrono::Utc::now());
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let vrc = &page.content_panel.credentials.received[0];
+
+        assert!(vrc.remote_agent_name.is_none());
+        assert!(vrc.issuer_agent_name.is_none());
+        // ALICE_DID was never looked up at all.
+        assert!(vrc.subject_agent_name.is_none());
+    }
+
+    /// Insert one task and return the summary the inbox panel would render.
+    fn task_summary_for(config: &mut Config, type_: TaskType) -> TaskSummary {
+        let id = Arc::new("task-1".to_string());
+        config.private.tasks.new_task(&id, type_);
+        let mut page = MainPageState::default();
+        page.sync_from_config(config);
+        page.content_panel.inbox.tasks[0].clone()
+    }
+
+    /// An inbox row carries the verified name for exactly the DID it displays.
+    #[test]
+    fn inbox_task_carries_verified_agent_name() {
+        let mut config = crate::state_handler::dispatch_util::test_config();
+        config.set_cached_agent_name(BOB_DID, Some("example.com/@bob".into()), chrono::Utc::now());
+
+        let task = task_summary_for(
+            &mut config,
+            TaskType::VRCRequestOutbound {
+                remote_p_did: Arc::new(BOB_DID.to_string()),
+            },
+        );
+
+        assert_eq!(task.remote_agent_name.as_deref(), Some("example.com/@bob"));
+        assert_eq!(
+            openvtc_core::display::display_identifier(
+                task.remote_agent_name.as_deref(),
+                &task.remote_did,
+                60
+            ),
+            "example.com/@bob"
+        );
+    }
+
+    /// A verified name outranks the requester-supplied `name` on an inbound
+    /// relationship request: that name is self-asserted and spoofable, so it
+    /// must not win over a name that actually round-tripped to this DID.
+    #[test]
+    fn inbox_verified_name_outranks_a_self_asserted_request_name() {
+        use openvtc_core::relationships::RelationshipRequestBody;
+
+        let mut config = crate::state_handler::dispatch_util::test_config();
+        config.set_cached_agent_name(BOB_DID, Some("example.com/@bob".into()), chrono::Utc::now());
+
+        let task = task_summary_for(
+            &mut config,
+            TaskType::RelationshipRequestInbound {
+                from: Arc::new(BOB_DID.to_string()),
+                to: Arc::new(ALICE_DID.to_string()),
+                request: RelationshipRequestBody {
+                    reason: None,
+                    did: BOB_DID.to_string(),
+                    name: Some("Totally Not Bob".to_string()),
+                },
+            },
+        );
+
+        // The self-asserted name is still what the DID slot falls back to...
+        assert_eq!(task.remote_did, "Totally Not Bob");
+        // ...but the verified name is what gets rendered.
+        assert_eq!(
+            openvtc_core::display::display_identifier(
+                task.remote_agent_name.as_deref(),
+                &task.remote_did,
+                60
+            ),
+            "example.com/@bob"
+        );
+    }
+
+    /// An unresolvable DID leaves the inbox row on its existing display string.
+    #[test]
+    fn inbox_task_without_a_name_keeps_the_did() {
+        let mut config = crate::state_handler::dispatch_util::test_config();
+        let task = task_summary_for(
+            &mut config,
+            TaskType::VRCRequestOutbound {
+                remote_p_did: Arc::new(BOB_DID.to_string()),
+            },
+        );
+
+        assert!(task.remote_agent_name.is_none());
+        assert_eq!(task.remote_did, shorten_did(BOB_DID, 60));
+    }
+
+    /// The VTA panel's Context Identities list carries the persona's verified
+    /// name beside its DID; the persona's own label is a separate line and is
+    /// left untouched.
+    #[test]
+    fn context_did_row_carries_verified_agent_name() {
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(ALICE_DID, Some("Work me"), vtc_did, None);
+        config.set_cached_agent_name(
+            ALICE_DID,
+            Some("example.com/@alice".into()),
+            chrono::Utc::now(),
+        );
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let row = &page.content_panel.vta.context_dids[0];
+
+        assert_eq!(row.agent_name.as_deref(), Some("example.com/@alice"));
+        assert_eq!(row.did, ALICE_DID);
+        assert_eq!(row.label, "Work me");
+    }
+
+    /// A cached negative lookup leaves the Context Identities row on the DID.
+    #[test]
+    fn context_did_row_ignores_a_cached_negative_lookup() {
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(ALICE_DID, None, vtc_did, None);
+        config.set_cached_agent_name(ALICE_DID, None, chrono::Utc::now());
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+
+        assert!(page.content_panel.vta.context_dids[0].agent_name.is_none());
+    }
+
     // --- persona_in_scope (community-scoping filter, D10/R-C-6) ---
 
     #[test]
@@ -1101,6 +1363,7 @@ mod tests {
             type_display: "Test".to_string(),
             kind: TaskKind::Informational("x".to_string()),
             remote_did: "did:test:remote".to_string(),
+            remote_agent_name: None,
             created: "2024-01-01 00:00".to_string(),
         }]
         .into();

--- a/openvtc/src/ui/pages/main/components/credentials_panel.rs
+++ b/openvtc/src/ui/pages/main/components/credentials_panel.rs
@@ -9,6 +9,7 @@ use crate::state_handler::{
     },
     state::ConnectionState,
 };
+use openvtc_core::display::display_identifier;
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
@@ -95,9 +96,12 @@ fn render_list(state: &CredentialsState) -> Vec<Line<'static>> {
                 Style::new().fg(COLOR_TEXT_DEFAULT)
             };
 
+            // Precedence: user alias → verified agent name → the DID itself
+            // (matches the relationships panel).
             let display_name = vrc
                 .alias
                 .as_deref()
+                .or(vrc.remote_agent_name.as_deref())
                 .unwrap_or(&vrc.remote_p_did)
                 .to_string();
 
@@ -148,17 +152,32 @@ fn render_detail(state: &CredentialsState, index: usize) -> Vec<Line<'static>> {
             Span::styled(alias.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
         ]));
     }
+    // The verified agent name, above the full DID it belongs to.
+    if let Some(agent_name) = &vrc.remote_agent_name {
+        lines.push(Line::from(vec![
+            Span::styled("Agent name: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled(agent_name.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+        ]));
+    }
     lines.push(Line::from(vec![
         Span::styled("Remote DID: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
         Span::styled(vrc.remote_p_did.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
     ]));
+    // Issuer/subject show their verified name when one is known, else the DID.
+    // The raw credential below always carries the underlying DIDs.
     lines.push(Line::from(vec![
         Span::styled("Issuer:     ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        Span::styled(vrc.issuer.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+        Span::styled(
+            display_identifier(vrc.issuer_agent_name.as_deref(), &vrc.issuer, 256).into_owned(),
+            Style::new().fg(COLOR_SOFT_PURPLE),
+        ),
     ]));
     lines.push(Line::from(vec![
         Span::styled("Subject:    ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        Span::styled(vrc.subject.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+        Span::styled(
+            display_identifier(vrc.subject_agent_name.as_deref(), &vrc.subject, 256).into_owned(),
+            Style::new().fg(COLOR_SOFT_PURPLE),
+        ),
     ]));
     lines.push(Line::from(vec![
         Span::styled("Valid from: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
@@ -237,9 +256,11 @@ fn render_new_request(
             Style::new().fg(COLOR_TEXT_DEFAULT)
         };
 
+        // Precedence: user alias → verified agent name → the DID itself.
         let display_name = rel
             .alias
             .as_deref()
+            .or(rel.agent_name.as_deref())
             .unwrap_or(&rel.remote_p_did)
             .to_string();
 

--- a/openvtc/src/ui/pages/main/components/inbox_panel.rs
+++ b/openvtc/src/ui/pages/main/components/inbox_panel.rs
@@ -7,10 +7,16 @@ use crate::state_handler::{
     main_page::content::{ActiveTaskView, ContentPanelState, InboxConfirm, InboxState, TaskKind},
     state::{ConnectionState, MediatorStatus},
 };
+use openvtc_core::display::display_identifier;
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
 };
+
+/// Width the inbox shows a counterparty identifier at. The DIDs in the view
+/// model are already shortened to this by the builder; it bounds the agent name
+/// shown in a DID's place.
+const ID_WIDTH: usize = 60;
 
 /// Inbox content panel.
 pub struct InboxPanel;
@@ -111,7 +117,15 @@ pub fn render(state: &InboxState, connection: &ConnectionState) -> Vec<Line<'sta
                 };
                 lines.push(Line::from(vec![
                     Span::styled("    ", Style::default()),
-                    Span::styled(task.remote_did.clone(), did_style),
+                    Span::styled(
+                        display_identifier(
+                            task.remote_agent_name.as_deref(),
+                            &task.remote_did,
+                            ID_WIDTH,
+                        )
+                        .into_owned(),
+                        did_style,
+                    ),
                     Span::styled("  ", Style::default()),
                     Span::styled(task.created.clone(), did_style),
                 ]));
@@ -150,6 +164,7 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
         ActiveTaskView::RelationshipRequestInbound {
             task_id,
             from_did,
+            from_agent_name,
             their_did,
             reason,
             name,
@@ -168,8 +183,15 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
             }
             lines.push(Line::from(vec![
                 Span::styled("From:      ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-                Span::styled(from_did.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+                Span::styled(
+                    // Full-width here: the detail view shows the whole DID
+                    // (sanitised to 256 by the builder), unlike the list.
+                    display_identifier(from_agent_name.as_deref(), from_did, 256).into_owned(),
+                    Style::new().fg(COLOR_SOFT_PURPLE),
+                ),
             ]));
+            // `their_did` is the requester's relationship DID — a pseudonym with
+            // no agent name — so it always renders as the DID.
             let uses_r_did = from_did != their_did;
             lines.push(Line::from(vec![
                 Span::styled("Their DID: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
@@ -210,13 +232,17 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
         ActiveTaskView::VRCRequestInbound {
             task_id,
             from_did,
+            from_agent_name,
             reason,
         } => {
             lines.push(Line::from("Inbound VRC Request").fg(COLOR_SUCCESS).bold());
             lines.push(Line::from(""));
             lines.push(Line::from(vec![
                 Span::styled("From:  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-                Span::styled(from_did.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+                Span::styled(
+                    display_identifier(from_agent_name.as_deref(), from_did, ID_WIDTH).into_owned(),
+                    Style::new().fg(COLOR_SOFT_PURPLE),
+                ),
             ]));
             if let Some(reason) = reason {
                 lines.push(Line::from(vec![
@@ -234,12 +260,19 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
                     .fg(COLOR_DARK_GRAY),
             );
         }
-        ActiveTaskView::VRCIssued { task_id, issuer } => {
+        ActiveTaskView::VRCIssued {
+            task_id,
+            issuer,
+            issuer_agent_name,
+        } => {
             lines.push(Line::from("VRC Received").fg(COLOR_SUCCESS).bold());
             lines.push(Line::from(""));
             lines.push(Line::from(vec![
                 Span::styled("Issuer: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-                Span::styled(issuer.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+                Span::styled(
+                    display_identifier(issuer_agent_name.as_deref(), issuer, ID_WIDTH).into_owned(),
+                    Style::new().fg(COLOR_SOFT_PURPLE),
+                ),
             ]));
             lines.push(Line::from(vec![
                 Span::styled("Task:   ", Style::new().fg(COLOR_DARK_GRAY)),
@@ -251,7 +284,9 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
         ActiveTaskView::RelationshipRequestOutbound {
             task_id,
             to_did,
+            to_agent_name,
             our_did,
+            our_agent_name,
             state,
         } => {
             let label = Style::new().fg(COLOR_TEXT_DEFAULT);
@@ -265,11 +300,18 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
             lines.push(Line::from(""));
             lines.push(Line::from(vec![
                 Span::styled("To:       ", label),
-                Span::styled(to_did.clone(), value),
+                Span::styled(
+                    display_identifier(to_agent_name.as_deref(), to_did, ID_WIDTH).into_owned(),
+                    value,
+                ),
             ]));
             lines.push(Line::from(vec![
                 Span::styled("Our DID:  ", label),
-                Span::styled(our_did.clone(), value),
+                Span::styled(
+                    // Full-width: `our_did` is not shortened by the builder.
+                    display_identifier(our_agent_name.as_deref(), our_did, 256).into_owned(),
+                    value,
+                ),
             ]));
             lines.push(Line::from(vec![
                 Span::styled("Status:   ", label),
@@ -285,6 +327,7 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
         ActiveTaskView::VRCRequestOutbound {
             task_id,
             remote_did,
+            remote_agent_name,
         } => {
             let label = Style::new().fg(COLOR_TEXT_DEFAULT);
             let value = Style::new().fg(COLOR_SOFT_PURPLE);
@@ -293,7 +336,11 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
             lines.push(Line::from(""));
             lines.push(Line::from(vec![
                 Span::styled("To:    ", label),
-                Span::styled(remote_did.clone(), value),
+                Span::styled(
+                    display_identifier(remote_agent_name.as_deref(), remote_did, ID_WIDTH)
+                        .into_owned(),
+                    value,
+                ),
             ]));
             lines.push(Line::from(vec![
                 Span::styled("Task:  ", dim),
@@ -306,6 +353,7 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
             task_id,
             type_display,
             remote_did,
+            remote_agent_name,
         } => {
             let label = Style::new().fg(COLOR_TEXT_DEFAULT);
             let value = Style::new().fg(COLOR_SOFT_PURPLE);
@@ -315,7 +363,11 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
             if !remote_did.is_empty() {
                 lines.push(Line::from(vec![
                     Span::styled("DID:   ", label),
-                    Span::styled(remote_did.clone(), value),
+                    Span::styled(
+                        display_identifier(remote_agent_name.as_deref(), remote_did, ID_WIDTH)
+                            .into_owned(),
+                        value,
+                    ),
                 ]));
             }
             lines.push(Line::from(vec![

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -6,10 +6,15 @@ use crate::state_handler::{
     main_page::content::{ContentPanelState, VicLifecycle, VtaFocus, VtaState},
     state::ConnectionState,
 };
+use openvtc_core::display::display_identifier;
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
 };
+
+/// Width the DID lists render an identifier at. The panel has never truncated
+/// these, so this only bounds an agent name shown in a DID's place.
+const ID_WIDTH: usize = 256;
 
 /// VTA service information panel.
 pub struct VtaPanel;
@@ -138,13 +143,20 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         lines.push(Line::from(""));
 
         for did_entry in state.active_dids.iter() {
+            // `label` is the DID's *role* ("Persona", "R-DID (…)"), not a name
+            // for it — the verified agent name (when known) replaces the DID
+            // beside it.
             lines.push(Line::from(vec![
                 Span::styled("  ● ", Style::new().fg(COLOR_SUCCESS)),
                 Span::styled(
                     format!("{:<16}", did_entry.label),
                     Style::new().fg(COLOR_TEXT_DEFAULT),
                 ),
-                Span::styled(did_entry.did.clone(), Style::new().fg(COLOR_DARK_GRAY)),
+                Span::styled(
+                    display_identifier(did_entry.agent_name.as_deref(), &did_entry.did, ID_WIDTH)
+                        .into_owned(),
+                    Style::new().fg(COLOR_DARK_GRAY),
+                ),
             ]));
         }
     }
@@ -181,7 +193,10 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
             lines.push(Line::from(vec![
                 Span::styled(prefix, marker_style),
                 Span::styled(marker, marker_style),
-                Span::styled(d.did.clone(), did_style),
+                Span::styled(
+                    display_identifier(d.agent_name.as_deref(), &d.did, ID_WIDTH).into_owned(),
+                    did_style,
+                ),
             ]));
 
             let name = if d.label.is_empty() {

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2721,10 +2721,13 @@ mod key_handler_tests {
         VrcSummary {
             vrc_id: vrc_id.to_string(),
             remote_p_did: "did:example:them".to_string(),
+            remote_agent_name: None,
             raw_json: RawCredential::Value(Arc::new(serde_json::Value::Null)),
             alias: None,
             issuer: "did:example:issuer".to_string(),
+            issuer_agent_name: None,
             subject: "did:example:subject".to_string(),
+            subject_agent_name: None,
             valid_from: String::new(),
             valid_until: None,
         }
@@ -2736,6 +2739,7 @@ mod key_handler_tests {
             type_display: "Trust Ping".to_string(),
             kind: TaskKind::TrustPing,
             remote_did: "did:example:them".to_string(),
+            remote_agent_name: None,
             created: String::new(),
         }
     }
@@ -3041,12 +3045,14 @@ mod key_handler_tests {
             s.main_page.content_panel.vta.context_dids = vec![
                 ManagedDid {
                     did: "did:webvh:example.com:alice".into(),
+                    agent_name: None,
                     label: "Alice".into(),
                     bound_communities: 1,
                     is_active: true,
                 },
                 ManagedDid {
                     did: "did:webvh:example.com:bob".into(),
+                    agent_name: None,
                     label: "Bob".into(),
                     bound_communities: 0,
                     is_active: false,

--- a/tasks/follow-ups.md
+++ b/tasks/follow-ups.md
@@ -38,17 +38,24 @@ persisted name cache (first served name → the persona's displayed name) so the
 header/panels update without waiting for the background sweep.
 The destructive `remove` is gated behind a local `y`/Enter confirm (#169).
 
-### [ ] Agent names — remaining display + input surfaces
-Consumer display covers relationships, communities, the header, VTA/settings
-persona lines, and every log message (`resolve_did_to_display`). Still on the
-raw-DID pattern, to migrate onto the same view-model + `display_identifier`
-approach: VRC issuer/subject (`credentials_panel.rs`), inbox message DIDs
-(`inbox_panel.rs`), and the persona/context DID lists (`ActiveDid`/`ManagedDid`
-in `vta_panel.rs`). Input support covers the join VTC-DID entry and the new
-relationship request; the setup-time entries (VTA DID, webvh import, custom
-mediator, org DID) still take a DID only — apply the same
-`looks_like_agent_name` + `resolve_identifier` pattern, threading a resolver
-into those setup handlers.
+### [ ] Agent names — remaining input surfaces
+Consumer **display** is done. On top of relationships, communities, the header,
+VTA/settings persona lines and every log message (`resolve_did_to_display`), the
+last three panels now use the same view-model + `display_identifier` approach:
+VRC remote/issuer/subject (`credentials_panel.rs`, via
+`VrcSummary::{remote,issuer,subject}_agent_name`), inbox message DIDs
+(`inbox_panel.rs`, via `TaskSummary::remote_agent_name` and the per-variant
+`*_agent_name` on `ActiveTaskView`), and the persona/context DID lists
+(`ActiveDid::agent_name` / `ManagedDid::agent_name` in `vta_panel.rs`).
+Deliberately left on the raw DID: the requester's R-DID on an inbound
+relationship request (a per-relationship pseudonym), and the mediator / VTA /
+credential DIDs — `Config::agent_name_refresh_targets` never resolves those, so
+a name for them could not appear without also extending the refresh sweep.
+
+Input support covers the join VTC-DID entry and the new relationship request;
+the setup-time entries (VTA DID, webvh import, custom mediator, org DID) still
+take a DID only — apply the same `looks_like_agent_name` + `resolve_identifier`
+pattern, threading a resolver into those setup handlers.
 
 ### [x] Agent names — resolve → verify e2e
 DONE (#168). `openvtc-core/tests/agent_name_e2e.rs` drives the whole chain


### PR DESCRIPTION
Agent names were invisible on every surface, including ones already wired for them, and stayed invisible across restarts.

## Resolution was never broken

Probed against a live name (`did:webvh:QmR6e4…:webvh.storm.ws:magic-depart` / `https://webvh.storm.ws/@magic-depart`):

| Stage | Result |
|---|---|
| `/@magic-depart` redirect | `302` → bare DID |
| Document `alsoKnownAs` | matches the DID |
| SDK `resolve_any` round-trip | lands back on the DID |
| `resolve_verified_name` | `Some("webvh.storm.ws/@magic-depart")` |
| Via the app's own `tdk.did_resolver()` | identical |

## The cache was

`AGENT_NAME_TTL` was 24h for **negative** lookups as well as positive ones, and `agent_name_refresh_targets` only returns entries that are uncached or stale. One transient failure — naming host briefly down, no network at launch, a name claimed just before its redirect went live — wrote `CachedAgentName { name: None }` and suppressed that DID's name for a day. A negative renders identically to a DID with no name, so nothing on screen distinguished them, and nothing in the sweep re-checked it.

## Changes

**Commit 1 — the fix**
- **TTL split**: negatives expire on a new `AGENT_NAME_NEGATIVE_TTL` (5min); verified names keep 24h. Effective retry is ~2 sweeps (staleness is `>=`, sweep interval is also 5min) — deliberate, as retrying every sweep would re-fetch up to `MAX_CANDIDATES` redirects per DID indefinitely (VTI R1.4).
- **Negatives dropped on load**, so a restart re-checks. Verified names are kept — instant display at launch is why the cache is persisted.
- **Failures now state a reason**: `NameOutcome`/`CandidateFailure` replace a bare `Option`, so unreachable host / unclaimed / spoof are distinguishable in logs (VTI R6.4). This absence is why the bug took several attempts to find.

**Commit 2 — the remaining display surfaces** (the open item in `tasks/follow-ups.md`)
Credentials, inbox and VTA DID lists migrated onto the existing view-model + `display_identifier` pattern.

## Security

The spoof guard is unchanged and still the single gate. Names are sourced **only** from `config.agent_name_for`, which returns verified entries and nothing else — no path can put an unverified `alsoKnownAs` claim on screen. Its tests now exercise the reason-carrying path directly and assert a rejection names the DID it actually landed on.

**One behavioural change worth review:** on inbound relationship requests a verified name now outranks `request.name`, which is requester-supplied and self-asserted (it remains the fallback). It is not a user alias, so the "alias outranks a resolved name" rule doesn't apply, and letting a spoofable claim beat a round-tripped one is the exact phishing surface this verification exists to close.

## Deliberately left on raw DIDs

The inbound requester's R-DID (a per-relationship pseudonym); mediator/VTA/credential DIDs in the VTA panel (`agent_name_refresh_targets` never resolves those, so wiring them would be dead display code); and the VTA delete-confirm prompt, where unambiguous is right for a destructive gate.

## Verification

`openvtc-core` 251 passed, `openvtc` 197 passed (was 190), 0 failed. clippy and fmt clean.