### PR TITLE
fix: say why an agent-name trust-task result failed to decode

### DIFF
--- a/openvtc/src/state_handler/agent_name_manage.rs
+++ b/openvtc/src/state_handler/agent_name_manage.rs
@@ -15,7 +15,8 @@
 //! `remove` releases a name for anyone to reclaim; `disable` keeps it reserved
 //! but stops it resolving. Both report `enabled: false`.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use serde::de::DeserializeOwned;
 use vta_sdk::client::VtaClient;
 use vta_sdk::protocols::did_management::agent_name::{
     AgentNameCheckResultBody, AgentNameEntry, AgentNameListResultBody, AgentNameResultBody,
@@ -25,6 +26,32 @@ use vta_sdk::trust_tasks;
 /// Trust-task round-trips can involve a webvh publish (sign + host write), so
 /// allow more headroom than a plain read.
 const AGENT_NAME_TT_TIMEOUT: u64 = 60;
+
+/// How much of an unexpected payload to quote back in an error.
+///
+/// Enough to see the shape — which keys are present, how they are cased — but
+/// bounded, since this text reaches a one-line status message in the UI.
+const PAYLOAD_EXCERPT_LIMIT: usize = 300;
+
+/// Decode a trust-task payload, saying *why* it failed when it does.
+///
+/// `serde_json` names the exact field that was missing or mistyped, and the
+/// payload shows what the VTA actually sent. Reporting neither — as a bare
+/// `.context("decoding …")` does — produces "decoding agent-name list result",
+/// which cannot be acted on: it looks identical whether the field is absent,
+/// null, snake_cased, or the whole contract has drifted. That distinction is
+/// the operator's only lead (VTI R6.4), and the mismatch it points at is
+/// usually a version skew between this client and the VTA.
+fn decode_payload<T: DeserializeOwned>(value: serde_json::Value, what: &str) -> Result<T> {
+    serde_json::from_value(value.clone()).map_err(|e| {
+        let mut excerpt = value.to_string();
+        if excerpt.chars().count() > PAYLOAD_EXCERPT_LIMIT {
+            excerpt = excerpt.chars().take(PAYLOAD_EXCERPT_LIMIT).collect();
+            excerpt.push('…');
+        }
+        anyhow!("decoding {what}: {e}. VTA sent: {excerpt}")
+    })
+}
 
 /// The host a `did:webvh` is served from (`example.com`, or `example.com:8443`
 /// for a custom port) — the authority half of any agent name on it. Derived via
@@ -111,8 +138,7 @@ pub(crate) async fn list_names(vta: &VtaClient, did: &str) -> Result<Vec<AgentNa
         )
         .await
         .context("agent-name list task failed")?;
-    let body: AgentNameListResultBody =
-        serde_json::from_value(value).context("decoding agent-name list result")?;
+    let body: AgentNameListResultBody = decode_payload(value, "agent-name list result")?;
     Ok(body.names)
 }
 
@@ -131,7 +157,7 @@ pub(crate) async fn check_name(
         )
         .await
         .context("agent-name check task failed")?;
-    serde_json::from_value(value).context("decoding agent-name check result")
+    decode_payload(value, "agent-name check result")
 }
 
 /// Shared submit for the four mutating verbs, which share the `{ did, name }`
@@ -150,7 +176,7 @@ async fn dispatch(
         .dispatch_trust_task(type_uri, payload, AGENT_NAME_TT_TIMEOUT)
         .await
         .with_context(|| format!("agent-name task {type_uri} failed"))?;
-    serde_json::from_value(value).context("decoding agent-name result")
+    decode_payload(value, "agent-name result")
 }
 
 #[cfg(test)]
@@ -177,5 +203,72 @@ mod tests {
     #[test]
     fn derive_host_rejects_a_non_webvh_did() {
         assert_eq!(derive_host("did:key:z6Mk"), None);
+    }
+
+    #[test]
+    fn decode_payload_passes_a_well_formed_result_through() {
+        let value = serde_json::json!({
+            "did": "did:webvh:QmScid:example.com",
+            "names": [{ "name": "alice", "enabled": true, "createdAt": 1_700_000_000u64 }],
+        });
+        let body: AgentNameListResultBody =
+            decode_payload(value, "agent-name list result").expect("should decode");
+        assert_eq!(body.names.len(), 1);
+        assert_eq!(body.names[0].name, "alice");
+    }
+
+    /// The failure that sent an operator hunting: the message must name the
+    /// missing field and quote what actually arrived, not just say "decoding
+    /// agent-name list result".
+    #[test]
+    fn decode_payload_names_the_missing_field_and_quotes_the_payload() {
+        // `names` omitted — what a server that drops empty collections sends.
+        let value = serde_json::json!({ "did": "did:webvh:QmScid:example.com" });
+        let err = decode_payload::<AgentNameListResultBody>(value, "agent-name list result")
+            .expect_err("must not decode");
+        let msg = format!("{err:#}");
+
+        assert!(msg.contains("agent-name list result"), "{msg}");
+        assert!(
+            msg.contains("names"),
+            "must name the offending field: {msg}"
+        );
+        assert!(
+            msg.contains("VTA sent:") && msg.contains("did:webvh:QmScid:example.com"),
+            "must quote the payload: {msg}"
+        );
+    }
+
+    /// Casing drift is the other likely cause, and reads very differently from a
+    /// missing field — so the reported reason has to tell them apart.
+    #[test]
+    fn decode_payload_surfaces_casing_drift() {
+        let value = serde_json::json!({
+            "did": "did:webvh:QmScid:example.com",
+            // snake_case, where the contract is camelCase `createdAt`.
+            "names": [{ "name": "alice", "enabled": true, "created_at": 1_700_000_000u64 }],
+        });
+        let err = decode_payload::<AgentNameListResultBody>(value, "agent-name list result")
+            .expect_err("must not decode");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("createdAt"),
+            "must name the expected key: {msg}"
+        );
+    }
+
+    /// The excerpt is bounded — this text lands in a one-line status message.
+    #[test]
+    fn decode_payload_truncates_a_large_payload() {
+        let value = serde_json::json!({ "did": "x".repeat(2_000) });
+        let err = decode_payload::<AgentNameListResultBody>(value, "agent-name list result")
+            .expect_err("must not decode");
+        let msg = format!("{err:#}");
+        assert!(msg.contains('…'), "should be elided: {msg}");
+        assert!(
+            msg.len() < 600,
+            "excerpt must stay bounded, got {}",
+            msg.len()
+        );
     }
 }

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -2143,7 +2143,7 @@ impl StateHandler {
             Err(e) => self.set_agent_name_message(
                 state,
                 AgentNameManagerPhase::Ready,
-                format!("Could not load agent names: {e}"),
+                format!("Could not load agent names: {e:#}"),
             ),
         }
     }
@@ -2204,7 +2204,7 @@ impl StateHandler {
             Err(e) => self.set_agent_name_message(
                 state,
                 AgentNameManagerPhase::Ready,
-                format!("Could not claim @{name}: {e}"),
+                format!("Could not claim @{name}: {e:#}"),
             ),
         }
     }
@@ -2246,7 +2246,7 @@ impl StateHandler {
             Err(e) => self.set_agent_name_message(
                 state,
                 AgentNameManagerPhase::Ready,
-                format!("Could not {} @{name}: {e}", verb.to_lowercase()),
+                format!("Could not {} @{name}: {e:#}", verb.to_lowercase()),
             ),
         }
     }
@@ -2279,7 +2279,7 @@ impl StateHandler {
             Err(e) => self.set_agent_name_message(
                 state,
                 AgentNameManagerPhase::Ready,
-                format!("Could not remove @{name}: {e}"),
+                format!("Could not remove @{name}: {e:#}"),
             ),
         }
     }
@@ -2320,7 +2320,7 @@ impl StateHandler {
             Err(e) => self.set_agent_name_message(
                 state,
                 AgentNameManagerPhase::Ready,
-                format!("Applied, but could not reload the list: {e}"),
+                format!("Applied, but could not reload the list: {e:#}"),
             ),
         }
     }


### PR DESCRIPTION
Opening the agent-name manager reports:

> Could not load agent names: decoding agent-name list result

…and nothing else. Two layers each discarded the part that identifies the fault.

1. `list_names` decoded with `.context("decoding agent-name list result")`, which **replaces** `serde_json`'s message — the one naming the exact field that was missing or mistyped — with a fixed string.
2. The UI rendered it with `{e}`, which on an `anyhow::Error` prints only the outermost context, dropping any cause that survived.

So the message reads identically whether `names` was absent, null, snake_cased, or the contract drifted entirely.

## Change

`decode_payload` reports the serde error **and** a bounded excerpt of what the VTA actually sent; the manager's five status messages render `{e:#}` so the cause chain reaches the operator (VTI R6.4).

Before / after:

```
Could not load agent names: decoding agent-name list result
Could not load agent names: decoding agent-name list result: missing field `names`. VTA sent: {"did":"did:webvh:QmXi1PZD4…"}
```

## Deliberately not made lenient

Defaulting a missing `names` to empty would turn a contract mismatch into a silent "No agent names yet" — the exact failure mode that made the negative-cache bug in #175 so hard to find. The strict type is right; what was missing is a diagnosis.

If this turns out to be real drift, the fix belongs in the shared `vta-sdk` type, not a tolerant client-side mirror.

## Note

`dispatch_trust_task` already surfaces VTA *rejections* as `Err` (`extract_trust_task_payload` errors when there is no `payload`), so this path means the VTA returned a **success payload of an unexpected shape** — not an authorization failure. Worth keeping in mind when reading the new message.

## Verification

`openvtc` 205 passed (was 201 — 4 new tests), `openvtc-core` 251 passed, 0 failed. clippy and fmt clean.