### PR TITLE
refactor: make community and credential detail read in names, not identifiers

### DIFF
--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -861,6 +861,24 @@ pub struct VrcSummary {
     pub valid_from: String,
     /// Formatted valid_until date (if set)
     pub valid_until: Option<String>,
+    /// What this credential asserts — "Membership", "Role" — when known.
+    ///
+    /// Previously only reachable by parsing it back out of [`alias`](Self::alias),
+    /// which packed `"<community> — <kind>"` into one string.
+    pub kind: Option<String>,
+    /// Whether the subject is one of this account's own personas, so the detail
+    /// view can say which side is you rather than leaving two names to compare.
+    pub subject_is_self: bool,
+    /// The validity window in human form, with a relative note — e.g.
+    /// `"22 Jul 2026 → 21 Aug 2026 · 29 days left"`.
+    ///
+    /// Composed where `chrono` and the current time are already at hand, so the
+    /// renderer stays free of date arithmetic.
+    pub validity: String,
+    /// One-word validity state for the header line: `valid`, `expired`, or
+    /// `not yet valid`. Derived from the window only — this is **not** a
+    /// revocation check, which needs the issuer's status list.
+    pub status: String,
 }
 
 // ****************************************************************************

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -602,6 +602,26 @@ fn collect_vrcs(
                     subject_agent_name: config
                         .agent_name_for(vrc.subject())
                         .map(|n| sanitize_display(n, 256)),
+                    validity: {
+                        let (v, _) = format_validity_from_dates(
+                            vrc.valid_from(),
+                            vrc.valid_until(),
+                            chrono::Utc::now(),
+                        );
+                        v
+                    },
+                    status: {
+                        let (_, s) = format_validity_from_dates(
+                            vrc.valid_from(),
+                            vrc.valid_until(),
+                            chrono::Utc::now(),
+                        );
+                        s
+                    },
+                    // A peer-to-peer VRC carries no membership/role kind; the
+                    // credential's own `type` is visible in the raw JSON.
+                    kind: None,
+                    subject_is_self: config.is_persona_did(vrc.subject()),
                     valid_from: vrc.valid_from().format("%Y-%m-%d").to_string(),
                     valid_until: vrc.valid_until().map(|d| d.format("%Y-%m-%d").to_string()),
                 });
@@ -617,9 +637,13 @@ fn collect_vrcs(
 fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
     let mut result = Vec::new();
     for c in config.account.memberships() {
+        // Explicit name, then the community's verified agent name, then the DID.
+        // Falling straight from the display name to a 64-char truncation was
+        // what put a DID sliced mid-string on the credential's Contact line.
         let community = c
             .display_name
             .clone()
+            .or_else(|| config.agent_name_for(&c.vtc_did).map(str::to_owned))
             .unwrap_or_else(|| sanitize_display(&c.vtc_did, 64));
         for kind in openvtc_core::CredentialKind::ALL {
             let Some(vc) = c.credentials.get(kind) else {
@@ -657,6 +681,8 @@ fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
             // already-parsed JSON value by Arc pointer (a `serde_json::Value`
             // pretty-prints identically whether done now or later).
             let raw_json = content::RawCredential::Value(Arc::new(vc.clone()));
+            let (validity, status) =
+                format_validity(&valid_from, valid_until.as_deref(), chrono::Utc::now());
             result.push(VrcSummary {
                 vrc_id: vc_id,
                 remote_p_did: sanitize_display(&c.vtc_did, 256),
@@ -664,7 +690,7 @@ fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
                     .agent_name_for(&c.vtc_did)
                     .map(|n| sanitize_display(n, 256)),
                 raw_json,
-                alias: Some(format!("{community} — {}", kind.config_key())),
+                alias: Some(community.clone()),
                 issuer: sanitize_display(&issuer, 256),
                 issuer_agent_name: config
                     .agent_name_for(&issuer)
@@ -673,12 +699,94 @@ fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
                 subject_agent_name: config
                     .agent_name_for(&subject)
                     .map(|n| sanitize_display(n, 256)),
+                validity,
+                status,
+                kind: Some(kind.config_key().to_string()),
+                subject_is_self: config.is_persona_did(&subject),
                 valid_from,
                 valid_until,
             });
         }
     }
     result
+}
+
+/// Render a credential's validity window for people rather than machines.
+///
+/// Returns `(validity, status)` — e.g. `("22 Jul 2026 → 21 Aug 2026 · 29 days
+/// left", "valid")`. The raw `validFrom`/`validUntil` are RFC 3339 timestamps;
+/// read literally they answer "is this still good?" only after mental
+/// arithmetic, which is the question the detail view exists to answer.
+///
+/// `status` reflects the **window only**. A credential can be inside its window
+/// and still be revoked; that needs the issuer's status list, which is not
+/// consulted here — so this never claims more than it checked.
+///
+/// Unparseable timestamps fall back to the raw strings rather than being hidden.
+fn format_validity(
+    valid_from: &str,
+    valid_until: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> (String, String) {
+    use chrono::DateTime;
+
+    let fmt = |s: &str| -> Option<DateTime<chrono::Utc>> {
+        DateTime::parse_from_rfc3339(s)
+            .ok()
+            .map(|d| d.with_timezone(&chrono::Utc))
+    };
+    let human = |d: DateTime<chrono::Utc>| d.format("%-d %b %Y").to_string();
+
+    let from = fmt(valid_from);
+    let until = valid_until.and_then(fmt);
+
+    let from_text = from.map_or_else(|| valid_from.to_string(), human);
+
+    let Some(until_text) = until.map(human) else {
+        // No expiry: the window is open-ended, so the only state is whether it
+        // has started.
+        let status = match from {
+            Some(f) if f > now => "not yet valid",
+            _ => "valid",
+        };
+        return (format!("from {from_text}"), status.to_string());
+    };
+
+    let (status, note) = match (from, until) {
+        (Some(f), _) if f > now => ("not yet valid", "starts in the future".to_string()),
+        (_, Some(u)) if u <= now => ("expired", "expired".to_string()),
+        (_, Some(u)) => {
+            let days = (u - now).num_days();
+            let note = match days {
+                0 => "expires today".to_string(),
+                1 => "1 day left".to_string(),
+                d => format!("{d} days left"),
+            };
+            ("valid", note)
+        }
+        _ => ("valid", String::new()),
+    };
+
+    let validity = if note.is_empty() {
+        format!("{from_text} → {until_text}")
+    } else {
+        format!("{from_text} → {until_text}  ·  {note}")
+    };
+    (validity, status.to_string())
+}
+
+/// [`format_validity`] for callers that already hold parsed dates, so a
+/// timestamp is not formatted only to be parsed straight back.
+fn format_validity_from_dates(
+    valid_from: chrono::DateTime<chrono::Utc>,
+    valid_until: Option<chrono::DateTime<chrono::Utc>>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> (String, String) {
+    format_validity(
+        &valid_from.to_rfc3339(),
+        valid_until.map(|d| d.to_rfc3339()).as_deref(),
+        now,
+    )
 }
 
 /// Returns true for unicode codepoints that can spoof or mangle TUI
@@ -963,12 +1071,71 @@ mod tests {
         assert_eq!(row.display_name, "example.com/@acme");
     }
 
-    /// The expanded troubleshooting block carries the names *alongside* the
-    /// DIDs. The DIDs stay: that block is what you read and copy when
-    /// diagnosing, so the name is added on its own row rather than replacing
-    /// the identifier it labels.
+    /// The point of the summary line: "is this still good, and for how long"
+    /// answered without the reader doing date arithmetic on RFC 3339 stamps.
     #[test]
-    fn community_detail_carries_agent_names_beside_the_dids() {
+    fn validity_reads_in_human_terms_with_a_relative_note() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-07-23T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let (validity, status) =
+            format_validity("2026-07-22T01:36:31Z", Some("2026-08-21T01:36:31Z"), now);
+        assert_eq!(status, "valid");
+        assert!(validity.contains("22 Jul 2026"), "{validity}");
+        assert!(validity.contains("21 Aug 2026"), "{validity}");
+        assert!(validity.contains("29 days left"), "{validity}");
+    }
+
+    /// An elapsed window reads as expired rather than as a countdown.
+    #[test]
+    fn validity_reports_an_expired_window() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-09-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let (validity, status) =
+            format_validity("2026-07-22T01:36:31Z", Some("2026-08-21T01:36:31Z"), now);
+        assert_eq!(status, "expired");
+        assert!(validity.contains("expired"), "{validity}");
+    }
+
+    /// A window that has not opened yet is neither valid nor expired.
+    #[test]
+    fn validity_reports_a_future_window() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-07-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let (_, status) =
+            format_validity("2026-07-22T01:36:31Z", Some("2026-08-21T01:36:31Z"), now);
+        assert_eq!(status, "not yet valid");
+    }
+
+    /// No `validUntil` means open-ended — it must not render as expired, and
+    /// must not invent an end date.
+    #[test]
+    fn validity_handles_an_open_ended_credential() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-07-23T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let (validity, status) = format_validity("2026-07-22T01:36:31Z", None, now);
+        assert_eq!(status, "valid");
+        assert!(validity.starts_with("from "), "{validity}");
+        assert!(!validity.contains('→'), "no end date to show: {validity}");
+    }
+
+    /// An unparseable timestamp is shown as-is rather than dropped — a
+    /// credential with an odd date should still display something truthful.
+    #[test]
+    fn validity_falls_back_to_the_raw_string() {
+        let now = chrono::Utc::now();
+        let (validity, _) = format_validity("not-a-date", None, now);
+        assert!(validity.contains("not-a-date"), "{validity}");
+    }
+
+    /// The detail block's identity rows resolve to a verified agent name, with
+    /// the DID kept in the view model as the fallback the renderer uses when
+    /// there is no name.
+    #[test]
+    fn community_detail_carries_agent_names_for_its_identity_rows() {
         let persona_did = "did:webvh:QmScidPersonaAAAAAAAAAAAAAAAAAAA:example.com:persona";
         let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
         let mut config = config_with_membership(persona_did, None, vtc_did, None);

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -11,6 +11,11 @@ use ratatui::{
     text::{Line, Span},
 };
 
+/// Width for identifier rows in the expanded detail block. Generous, because a
+/// DID shown here is what you copy when diagnosing — truncating it would defeat
+/// the purpose of the block.
+const ID_WIDTH: usize = 256;
+
 /// Communities overview content panel (R-C-1..R-C-8).
 pub struct CommunitiesPanel;
 
@@ -140,17 +145,29 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
                     Span::styled(v, value),
                 ])
             };
-            // Verified agent name above the DID it belongs to, never instead of
-            // it: this block exists for troubleshooting, so the DID has to stay
-            // readable. Same shape as the settings Context block.
-            if let Some(name) = &c.persona_agent_name {
-                lines.push(kv("Persona name:", name.clone()));
-            }
-            lines.push(kv("Persona DID:", c.persona_did.clone()));
-            if let Some(name) = &c.vtc_agent_name {
-                lines.push(kv("VTC name:", name.clone()));
-            }
-            lines.push(kv("VTC DID:", c.vtc_did.clone()));
+            // The identifier row shows the verified agent name when there is
+            // one, and the DID when there is not — so the label is "Persona",
+            // not "Persona DID": it names the party, and the DID is simply what
+            // it falls back to. Two rows per identity (name above DID) read as
+            // two different things to someone scanning the block.
+            lines.push(kv(
+                "Persona:",
+                openvtc_core::display::display_identifier(
+                    c.persona_agent_name.as_deref(),
+                    &c.persona_did,
+                    ID_WIDTH,
+                )
+                .into_owned(),
+            ));
+            lines.push(kv(
+                "VTC:",
+                openvtc_core::display::display_identifier(
+                    c.vtc_agent_name.as_deref(),
+                    &c.vtc_did,
+                    ID_WIDTH,
+                )
+                .into_owned(),
+            ));
             if !c.sub_context_id.is_empty() {
                 lines.push(kv("Sub-context:", c.sub_context_id.clone()));
             }

--- a/openvtc/src/ui/pages/main/components/credentials_panel.rs
+++ b/openvtc/src/ui/pages/main/components/credentials_panel.rs
@@ -146,51 +146,64 @@ fn render_detail(state: &CredentialsState, index: usize) -> Vec<Line<'static>> {
     lines.push(Line::from("Credential Details").fg(COLOR_SUCCESS).bold());
     lines.push(Line::from(""));
 
-    if let Some(alias) = &vrc.alias {
-        lines.push(Line::from(vec![
-            Span::styled("Contact:    ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled(alias.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
-        ]));
-    }
-    // The verified agent name, above the full DID it belongs to.
-    if let Some(agent_name) = &vrc.remote_agent_name {
-        lines.push(Line::from(vec![
-            Span::styled("Agent name: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled(agent_name.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
-        ]));
-    }
+    // Headline: what this credential asserts, and whether it is currently in
+    // its validity window.
+    let kind = vrc.kind.clone().unwrap_or_else(|| "Credential".to_string());
+    let status_style = if vrc.status == "valid" {
+        Style::new().fg(COLOR_SUCCESS)
+    } else {
+        Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED)
+    };
     lines.push(Line::from(vec![
-        Span::styled("Remote DID: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        Span::styled(vrc.remote_p_did.clone(), Style::new().fg(COLOR_SOFT_PURPLE)),
+        Span::styled(kind, Style::new().fg(COLOR_TEXT_DEFAULT).bold()),
+        Span::styled("  ·  ", Style::new().fg(COLOR_DARK_GRAY)),
+        Span::styled(vrc.status.clone(), status_style),
     ]));
-    // Issuer/subject show their verified name when one is known, else the DID.
-    // The raw credential below always carries the underlying DIDs.
+    lines.push(Line::from(""));
+
+    // Who issued it and who it is about. `Contact`/`Agent name`/`Remote DID`
+    // used to sit alongside these naming the *same* party three more ways; the
+    // full DIDs are in the raw credential below, so the summary keeps names.
+    let party = |alias: Option<&str>, name: Option<&str>, did: &str| -> String {
+        let resolved = display_identifier(name, did, 256).into_owned();
+        match alias {
+            // An explicit alias outranks a resolved name, but both are useful
+            // here: the alias is what you call them, the name is verifiable.
+            Some(a) if a != resolved => format!("{a}  ·  {resolved}"),
+            _ => resolved,
+        }
+    };
+
     lines.push(Line::from(vec![
-        Span::styled("Issuer:     ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        Span::styled("Issued by   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
         Span::styled(
-            display_identifier(vrc.issuer_agent_name.as_deref(), &vrc.issuer, 256).into_owned(),
+            party(
+                vrc.alias.as_deref(),
+                vrc.issuer_agent_name.as_deref(),
+                &vrc.issuer,
+            ),
             Style::new().fg(COLOR_SOFT_PURPLE),
         ),
     ]));
-    lines.push(Line::from(vec![
-        Span::styled("Subject:    ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+
+    let mut about = vec![
+        Span::styled("About       ", Style::new().fg(COLOR_TEXT_DEFAULT)),
         Span::styled(
             display_identifier(vrc.subject_agent_name.as_deref(), &vrc.subject, 256).into_owned(),
             Style::new().fg(COLOR_SOFT_PURPLE),
         ),
-    ]));
-    lines.push(Line::from(vec![
-        Span::styled("Valid from: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        Span::styled(vrc.valid_from.clone(), Style::new().fg(COLOR_TEXT_DEFAULT)),
-    ]));
-    if let Some(until) = &vrc.valid_until {
-        lines.push(Line::from(vec![
-            Span::styled("Valid until: ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled(until.clone(), Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]));
+    ];
+    if vrc.subject_is_self {
+        about.push(Span::styled("  (you)", Style::new().fg(COLOR_DARK_GRAY)));
     }
+    lines.push(Line::from(about));
+
     lines.push(Line::from(vec![
-        Span::styled("VRC ID:     ", Style::new().fg(COLOR_DARK_GRAY)),
+        Span::styled("Valid       ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        Span::styled(vrc.validity.clone(), Style::new().fg(COLOR_TEXT_DEFAULT)),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("ID          ", Style::new().fg(COLOR_DARK_GRAY)),
         Span::styled(vrc.vrc_id.clone(), Style::new().fg(COLOR_DARK_GRAY)),
     ]));
 

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2859,6 +2859,10 @@ mod key_handler_tests {
             subject_agent_name: None,
             valid_from: String::new(),
             valid_until: None,
+            kind: None,
+            subject_is_self: false,
+            validity: String::new(),
+            status: "valid".to_string(),
         }
     }
 


### PR DESCRIPTION
Both screens showed the same party several times over, in a form that had to be decoded before it meant anything.

## Credential detail

For a membership credential, `Contact`, `Agent name`, `Remote DID` and `Issuer` were **four renderings of one party** — the issuing community. And `Contact` was the worst of them: it packed `"<community> — <kind>"` into one string, with the community falling straight from its display name to a 64-char truncation, producing a DID sliced mid-string:

```
Contact:    did:webvh:QmXi1PZD4NEvcvjfErAzVoCGtBFEv7dhXZQJHvcFY4U83F:webvh.s — Membership
Agent name: webvh.storm.ws/@first-vtc
Remote DID: did:webvh:QmXi1PZD4NEvcvjfErAzVoCGtBFEv7dhXZQJHvcFY4U83F:webvh.storm.ws:first-vtc
Issuer:     webvh.storm.ws/@first-vtc
Subject:    webvh.storm.ws/@magic-depart
Valid from: 2026-07-22T01:36:31Z
Valid until: 2026-08-21T01:36:31Z
```

Now:

```
Membership  ·  valid

Issued by   Alice  ·  webvh.storm.ws/@first-vtc
About       webvh.storm.ws/@magic-depart  (you)
Valid       22 Jul 2026 → 21 Aug 2026  ·  29 days left
ID          urn:uuid:5541d7db-…
```

**Nothing is lost.** Every DID is already in the raw credential immediately below, which remains the source of truth for identifiers.

- `kind` and `subject_is_self` become real fields instead of being recovered by parsing `alias` back apart.
- The community name falls back to its **verified agent name** before the truncated DID — the direct cause of the mangled line.
- `format_validity` turns the RFC 3339 window into a human range plus a relative note, because "is this still good?" was a mental subtraction.

Its `status` deliberately reflects the **window only**. A credential can be inside its window and still be revoked; that needs the issuer's status list, which is not consulted here — so it never claims more than it checked.

## Community detail

`Persona DID:` / `VTC DID:` become `Persona:` / `VTC:`, showing the verified name and falling back to the DID. The label names the party; the DID is what it degrades to.

This replaces the name-above-DID pair added in #176 — two rows per identity read as two different things to someone scanning the block.

## Verification

`openvtc` 215 passed (was 210 — 5 new tests on the validity formatter: relative countdown, expired, not-yet-valid, open-ended, and unparseable-date fallback), `openvtc-core` 251 passed, 0 failed. clippy and fmt clean.