### PR TITLE
fix: name the party on the remaining user-facing DID surfaces

### DIFF
--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -81,7 +81,7 @@ pub fn remove_vrc(config: &mut Config, vrc_id: &str) -> Result<()> {
 
 use crate::state_handler::{
     actions::CredentialAction,
-    dispatch_util, log_did,
+    dispatch_util,
     main_page::content::{CredentialTab, CredentialsMode},
     save_coalesce::SaveScheduler,
     state::State,
@@ -156,17 +156,17 @@ async fn handle_submit_request(
     match send_vrc_request(config, tdk, service, relationship_p_did, reason).await {
         Ok(()) => {
             state.main_page.content_panel.credentials.mode = CredentialsMode::List;
+            // Names the party, like every other user-facing status line.
+            let display_name =
+                crate::state_handler::resolve_did_to_display(config, relationship_p_did);
             dispatch_util::save_and_sync(
                 &mut state.main_page,
                 config,
                 save,
                 dispatch_util::Persist::SaveAndSync,
                 |mp| &mut mp.content_panel.credentials.status_message,
-                format!("VRC request sent to {}", log_did(relationship_p_did)),
-                dispatch_util::SyncLog::Plain(format!(
-                    "VRC request sent to {}",
-                    log_did(relationship_p_did)
-                )),
+                format!("VRC request sent to {display_name}"),
+                dispatch_util::SyncLog::Plain(format!("VRC request sent to {display_name}")),
             );
         }
         Err(e) => {

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -452,9 +452,12 @@ fn build_persona_options(config: &Config, vics: &[AvailableVic]) -> Vec<PersonaO
                 .memberships()
                 .filter(|c| c.persona_ref == p.persona_id)
                 .map(|c| {
-                    c.display_name
-                        .clone()
-                        .unwrap_or_else(|| shorten_did(&c.vtc_did, 40))
+                    crate::state_handler::community_label(
+                        config,
+                        &c.vtc_did,
+                        c.display_name.as_deref(),
+                        40,
+                    )
                 })
                 .collect();
             linked_communities.sort();
@@ -464,7 +467,14 @@ fn build_persona_options(config: &Config, vics: &[AvailableVic]) -> Vec<PersonaO
                 .count();
             PersonaOption {
                 id: p.persona_id,
-                label: p.label.clone().unwrap_or_else(|| shorten_did(&p.did, 32)),
+                // Explicit label, then the persona's verified agent name, then
+                // the DID — matching what the communities panel already does
+                // for the same personas.
+                label: p
+                    .label
+                    .clone()
+                    .or_else(|| config.agent_name_for(&p.did).map(str::to_owned))
+                    .unwrap_or_else(|| shorten_did(&p.did, 32)),
                 did: p.did.clone(),
                 linked_communities,
                 valid_vic_count,

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1731,7 +1731,10 @@ impl StateHandler {
                                 );
                             } else {
                                 state.main_page.log_detailed(
-                                    format!("Ping from {} — ignored", log_did(sender)),
+                                    format!(
+                                        "Ping from {} — ignored",
+                                        resolve_did_to_display(&config, sender)
+                                    ),
                                     format!(
                                         "Trust-Ping Rejected\n\
                                          ───────────────────\n\

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -375,7 +375,7 @@ fn create_request_message(
 // ============================================================
 
 use crate::state_handler::{
-    actions::RelationshipAction, dispatch_util, log_did, main_page::content::RelationshipsMode,
+    actions::RelationshipAction, dispatch_util, main_page::content::RelationshipsMode,
     resolve_did_to_display, state::State,
 };
 use openvtc_core::config::protected_config::Contact;
@@ -764,18 +764,19 @@ impl RelationshipOutcome {
                          Task ID:       {msg_id}",
                             if used_r_did { "yes" } else { "no" },
                         );
+                        // The summary is what the Logs list shows, so it names
+                        // the party; the detail block above keeps the raw DIDs
+                        // for diagnosis. Same shape as the trust-ping path.
+                        let display_name = resolve_did_to_display(config, &respondent_did);
                         dispatch_util::save_and_sync(
                             &mut state.main_page,
                             config,
                             save,
                             dispatch_util::Persist::SaveAndSync,
                             status,
-                            format!("Request sent to {}", log_did(&respondent_did)),
+                            format!("Request sent to {display_name}"),
                             dispatch_util::SyncLog::Detailed {
-                                summary: format!(
-                                    "Relationship request sent to {}",
-                                    log_did(&respondent_did)
-                                ),
+                                summary: format!("Relationship request sent to {display_name}"),
                                 detail,
                             },
                         );
@@ -1777,7 +1778,10 @@ mod tests {
                 .relationships
                 .status_message
                 .as_deref(),
-            Some("Request sent to did:peer:respondent")
+            // Names the party rather than echoing its DID: the fixture has a
+            // contact alias for this peer, and the status line honours the same
+            // alias → verified agent name → DID precedence as everywhere else.
+            Some("Request sent to Respondent")
         );
     }
 

--- a/openvtc/src/ui/pages/main/components/settings_panel.rs
+++ b/openvtc/src/ui/pages/main/components/settings_panel.rs
@@ -64,6 +64,9 @@ pub fn render(state: &SettingsState) -> Vec<Line<'static>> {
 
 const WIPE_CONFIRM_TOKEN: &str = "WIPE";
 
+/// Width the settings rows truncate their values to.
+const VALUE_WIDTH: usize = 50;
+
 fn render_wipe_confirm(confirm_input: &str) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from("")];
     lines.push(
@@ -128,11 +131,20 @@ fn render_wipe_confirm(confirm_input: &str) -> Vec<Line<'static>> {
 }
 
 fn render_view(state: &SettingsState) -> Vec<Line<'static>> {
+    // The persona row names the party, so it shows the verified agent name and
+    // falls back to the DID — hence "Persona", not "Persona DID". The value was
+    // already on the view model and simply never read here.
+    let persona = openvtc_core::display::display_identifier(
+        state.persona_agent_name.as_deref(),
+        &state.persona_did,
+        VALUE_WIDTH,
+    )
+    .into_owned();
     let settings = [
-        ("Friendly Name", &state.friendly_name, true),
-        ("Mediator DID", &state.mediator_did, true),
-        ("Org DID", &state.org_did, true),
-        ("Persona DID", &state.persona_did, false),
+        ("Friendly Name", state.friendly_name.clone(), true),
+        ("Mediator DID", state.mediator_did.clone(), true),
+        ("Org DID", state.org_did.clone(), true),
+        ("Persona", persona, false),
     ];
 
     let mut lines = vec![Line::from("")];
@@ -163,11 +175,10 @@ fn render_view(state: &SettingsState) -> Vec<Line<'static>> {
             Span::styled(prefix, style),
             Span::styled(format!("{}: ", label), style),
             Span::styled(
-                if value.len() > 50 {
-                    format!("{}...", &value[..47])
-                } else {
-                    value.to_string()
-                },
+                // `&value[..47]` sliced by *bytes* — it panics when the cut
+                // lands inside a multi-byte character, which a friendly name or
+                // an agent name may well contain.
+                openvtc_core::display::truncate_did(value, VALUE_WIDTH).into_owned(),
                 Style::new().fg(COLOR_SOFT_PURPLE),
             ),
             Span::styled(edit_hint, Style::new().fg(COLOR_DARK_GRAY)),


### PR DESCRIPTION
Stacked on #180 — review that first. Follow-up to a full audit of every place OpenVTC prints a DID.

## Converted

**Settings — persona row.** `SettingsState.persona_agent_name` was *already populated* and simply never read, so the row rendered a DID beside a name the view model was holding. Relabelled `Persona DID` → `Persona`: the row names the party, the DID is only the fallback.

That row also truncated with `&value[..47]` — a **byte** slice, which panics when the cut lands inside a multi-byte character. A friendly name or agent name can easily contain one. Now uses char-aware `truncate_did`.

**Join flow.** The identity picker and its linked-communities list skipped the `agent_name_for` step their communities-panel equivalents already apply — so the same personas and communities were named on one screen and DID'd on another. The community list now uses `community_label` (added in #180) which exists for exactly this.

**Status and log lines.** The last four user-visible `log_did` call sites — relationship request sent, VRC request sent, ignored-ping notice — now use `resolve_did_to_display`, matching the trust-ping path that already did. Detail panes keep raw DIDs: the summary identifies, the detail diagnoses.

One test asserted `"Request sent to did:peer:respondent"` and now expects `"Request sent to Respondent"` (the fixture's contact alias) — that behaviour change is the point.

## Deliberately left raw

No name can ever exist for these — `agent_name_refresh_targets` only resolves persona, community VTC, relationship remote-persona and contact DIDs:

- relationship **R-DIDs** and inbox `their_did` — per-relationship pseudonyms
- **mediator / VTA / admin / setup / credential** DIDs
- the capability **`delegate`** DID
- every `setup_flow/` screen, and DIDs shown in text inputs

Converting any of them would call `agent_name_for`, get `None` 100% of the time, and print the DID it already prints — dead code that reads like a feature.

Also left raw on judgement: **copy targets** (`[N] copy` rows), the **raw-credential JSON**, and the **persisted audit log**, where a stable identifier outlives a reclaimable name.

## Not done here

Three lower-traffic conversions need new view-model fields and are better as their own change: VIC issuer (`vta_panel.rs`), relationship VRC issuer/subject list rows, and the VIC `Bound to:` line.

One UX inconsistency worth a decision: the VTA orphan-delete prompt names a **DID** while the row you selected shows a **name** — so the prompt never looks like the thing you picked. Suggest `Remove <name> (did:webvh:…)?` rather than converting outright, keeping the destructive-confirm unambiguous.

## Verification

`openvtc` 221 passed, `openvtc-core` 251 passed, 0 failed. clippy and fmt clean.