### PR TITLE
fix: show verified agent names on the last four DID surfaces

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,16 @@ no-default-features = false
 version = 2
 yanked = "deny"
 ignore = [
+    # RUSTSEC-2026-0215: smallstr is unmaintained. Not a vulnerability —
+    # no CVE, no known exploit; the crate is a `SmallVec`-backed string type
+    # and the advisory is purely a maintenance-status signal. Transitive and
+    # deep: smallstr <- json-syntax <- json-ld <- ssi-json-ld <-
+    # ssi-claims-core <- ssi-dids-core <- the affinidi DID resolver. Nothing
+    # here names it, and all versions are affected so there is nothing to
+    # upgrade to. The suggested replacements (compact_str, smol_str) are a
+    # change for the json-syntax / `ssi-*` maintainers. Drop this when
+    # json-syntax releases off smallstr and the `ssi-*` chain picks it up.
+    "RUSTSEC-2026-0215",
     # RUSTSEC-2023-0071: Marvin Attack — timing sidechannel in the `rsa`
     # crate's RSA key operations. There is no upstream patch yet; the
     # affected code is reachable only through `pgp`/`openpgp-card-rpgp`/

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -39,6 +39,11 @@ pub struct PresentedInvitation {
     pub id: String,
     /// The persona DID the VIC is bound to (`credentialSubject.id`), if present.
     pub subject: Option<String>,
+    /// Verified agent name for [`subject`](Self::subject), if cached. The subject
+    /// is one of this account's own persona DIDs, which the agent-name sweep
+    /// already targets, so a name is often available. Sourced only from
+    /// `Config::agent_name_for`; `None` keeps the DID on screen.
+    pub subject_agent_name: Option<String>,
 }
 
 /// One selectable existing persona on the identity-choice page (R-B-3).

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -31,7 +31,7 @@ use crate::{
         actions::Action,
         join::{AvailableVic, JoinPage, JoinState, PersonaOption, PresentedInvitation},
         main_page::content::{VicLifecycle, VicSummary},
-        main_page::shorten_did,
+        main_page::{sanitize_display, shorten_did},
         setup_sequence::{Completion, MessageType, config::ConfigExtension, vta},
         state::{ActivePage, State},
     },
@@ -1005,16 +1005,21 @@ async fn run_join_sequence(
     }
     state.invitation_credential = presentable;
     state.join.has_invitation = state.invitation_credential.is_some();
-    state.join.presented_invitation =
-        state
-            .invitation_credential
-            .as_ref()
-            .map(|vic| PresentedInvitation {
-                id: openvtc_core::join::invitation_id(vic)
-                    .unwrap_or_default()
-                    .to_string(),
-                subject: openvtc_core::join::invitation_subject(vic).map(str::to_string),
-            });
+    state.join.presented_invitation = state.invitation_credential.as_ref().map(|vic| {
+        let subject = openvtc_core::join::invitation_subject(vic).map(str::to_string);
+        PresentedInvitation {
+            id: openvtc_core::join::invitation_id(vic)
+                .unwrap_or_default()
+                .to_string(),
+            // Verified-only, from the persisted cache: the subject is one
+            // of our own personas, so the sweep normally has a name for it.
+            subject_agent_name: subject
+                .as_deref()
+                .and_then(|s| config.agent_name_for(s))
+                .map(|n| sanitize_display(n, 256)),
+            subject,
+        }
+    });
 
     // Present the holder VP. When a matching, unexpired invitation (VIC) is
     // resolved it rides in the VP's `verifiableCredential` array; the VTC

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -425,6 +425,14 @@ pub struct VicSummary {
     pub id: String,
     /// Issuer DID (the community that issued the invitation), if recorded.
     pub issuer: String,
+    /// Verified agent name for [`issuer`](Self::issuer), if cached.
+    ///
+    /// The issuer is a community VTC DID, which the agent-name background sweep
+    /// already targets, so a name is usually available. Not set by
+    /// [`VicSummary::from_descriptor`] — that maps a vault descriptor and has no
+    /// `Config` — but stitched on in `MainPageState::sync_vic_agent_names`,
+    /// which runs at every `sync_from_config` and after every vault reload.
+    pub issuer_agent_name: Option<String>,
     /// Validity status: "valid" / "expired" / "revoked" / "unknown".
     pub status: String,
     /// Archival lifecycle (active / archived / deleted), orthogonal to status.
@@ -440,6 +448,8 @@ impl VicSummary {
         VicSummary {
             id: s("id"),
             issuer: s("issuerDid"),
+            // No `Config` here; filled in by `sync_vic_agent_names`.
+            issuer_agent_name: None,
             status: {
                 let st = s("status");
                 if st.is_empty() {
@@ -761,14 +771,25 @@ pub struct RelationshipSummary {
 }
 
 /// VRC info for display in the relationship detail view.
+///
+/// Carries the same issuer/subject name pair as [`VrcSummary`] — the credentials
+/// panel and this list show the same credentials from two different screens, so
+/// they resolve names identically (verified-only, via `Config::agent_name_for`).
 #[derive(Clone, Debug)]
 pub struct RelationshipVrc {
     /// Issuer DID (shortened for display)
     pub issuer: String,
+    /// Verified agent name for the issuer DID, if cached. Shown in place of
+    /// [`issuer`](Self::issuer) on the list row; the expanded detail keeps
+    /// [`issuer_full`](Self::issuer_full) so the DID is still readable/copyable.
+    pub issuer_agent_name: Option<String>,
     /// Full issuer DID
     pub issuer_full: String,
     /// Subject DID (shortened for display)
     pub subject: String,
+    /// Verified agent name for the subject DID, if cached. Same treatment as
+    /// [`issuer_agent_name`](Self::issuer_agent_name).
+    pub subject_agent_name: Option<String>,
     /// Full subject DID
     pub subject_full: String,
     /// Formatted valid_from date

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -278,8 +278,14 @@ impl MainPageState {
                         m.values()
                             .map(|vrc| content::RelationshipVrc {
                                 issuer: shorten_did(vrc.issuer(), 40),
+                                issuer_agent_name: config
+                                    .agent_name_for(vrc.issuer())
+                                    .map(|n| sanitize_display(n, 256)),
                                 issuer_full: vrc.issuer().to_string(),
                                 subject: shorten_did(vrc.subject(), 40),
+                                subject_agent_name: config
+                                    .agent_name_for(vrc.subject())
+                                    .map(|n| sanitize_display(n, 256)),
                                 subject_full: vrc.subject().to_string(),
                                 valid_from: vrc.valid_from().format("%Y-%m-%d").to_string(),
                                 valid_until: vrc
@@ -300,8 +306,14 @@ impl MainPageState {
                         m.values()
                             .map(|vrc| content::RelationshipVrc {
                                 issuer: shorten_did(vrc.issuer(), 40),
+                                issuer_agent_name: config
+                                    .agent_name_for(vrc.issuer())
+                                    .map(|n| sanitize_display(n, 256)),
                                 issuer_full: vrc.issuer().to_string(),
                                 subject: shorten_did(vrc.subject(), 40),
+                                subject_agent_name: config
+                                    .agent_name_for(vrc.subject())
+                                    .map(|n| sanitize_display(n, 256)),
                                 subject_full: vrc.subject().to_string(),
                                 valid_from: vrc.valid_from().format("%Y-%m-%d").to_string(),
                                 valid_until: vrc
@@ -454,6 +466,10 @@ impl MainPageState {
         context_dids.sort_by(|a, b| a.did.cmp(&b.did));
         self.content_panel.vta.context_dids = context_dids.into();
 
+        // The VIC list is not derived from `Config` (it comes from the VTA
+        // credential vault), so it is annotated rather than rebuilt here.
+        self.sync_vic_agent_names(config);
+
         self.content_panel.settings.protection_type = match &config.public.protection {
             openvtc_core::config::ConfigProtectionType::Token(id) => {
                 format!(
@@ -538,6 +554,37 @@ impl MainPageState {
         if self.content_panel.communities.selected_index >= community_count {
             self.content_panel.communities.selected_index = community_count.saturating_sub(1);
         }
+    }
+
+    /// Stitch the verified agent name for each held VIC's issuer onto the VIC
+    /// list.
+    ///
+    /// The list itself comes from the VTA credential vault, not from `Config`
+    /// (`VicSummary::from_descriptor` has no `Config` to consult), so the names
+    /// are attached here instead of at construction. Called from
+    /// [`sync_from_config`](Self::sync_from_config) — so a background agent-name
+    /// sweep lands on the list — and again straight after each vault reload, so
+    /// a freshly loaded list is named without waiting for the next sync.
+    ///
+    /// Verified-only: the name always comes from `Config::agent_name_for`, and a
+    /// DID with no (or a cached-negative) entry keeps showing its DID.
+    pub fn sync_vic_agent_names(&mut self, config: &Config) {
+        if self.content_panel.vta.vics.is_empty() {
+            return;
+        }
+        let named: Vec<content::VicSummary> = self
+            .content_panel
+            .vta
+            .vics
+            .iter()
+            .map(|v| content::VicSummary {
+                issuer_agent_name: config
+                    .agent_name_for(&v.issuer)
+                    .map(|n| sanitize_display(n, 256)),
+                ..v.clone()
+            })
+            .collect();
+        self.content_panel.vta.vics = named.into();
     }
 }
 
@@ -1539,6 +1586,211 @@ mod tests {
         assert_eq!(row.agent_name.as_deref(), Some("example.com/@alice"));
         assert_eq!(row.did, ALICE_DID);
         assert_eq!(row.label, "Work me");
+    }
+
+    // --- agent names on the relationship-VRC rows and the VIC list ---
+
+    /// A config holding one relationship with `BOB_DID`, carrying one VRC we
+    /// issued (us → Bob) and one we received (Bob → us).
+    fn config_with_relationship_vrcs() -> Config {
+        use openvtc_core::relationships::{Relationship, RelationshipState};
+
+        let mut config = crate::state_handler::dispatch_util::test_config();
+        let remote = Arc::new(BOB_DID.to_string());
+        config.private.relationships.relationships.insert(
+            remote.clone(),
+            Relationship {
+                task_id: Arc::new("task-1".to_string()),
+                our_did: Arc::new(ALICE_DID.to_string()),
+                remote_did: remote.clone(),
+                remote_p_did: remote.clone(),
+                created: chrono::Utc::now(),
+                state: RelationshipState::Established,
+                our_persona: None,
+                needs_reestablishment: false,
+            },
+        );
+        config
+            .private
+            .vrcs_issued
+            .insert(&remote, signed_vrc(ALICE_DID, BOB_DID))
+            .expect("issued VRC stores");
+        config
+            .private
+            .vrcs_received
+            .insert(&remote, signed_vrc(BOB_DID, ALICE_DID))
+            .expect("received VRC stores");
+        config
+    }
+
+    /// The relationship detail's VRC rows carry the verified name for the
+    /// issuer/subject DID each row displays — the same pair the credentials
+    /// panel already carries, one screen behind.
+    #[test]
+    fn relationship_vrc_rows_carry_verified_agent_names() {
+        let mut config = config_with_relationship_vrcs();
+        let now = chrono::Utc::now();
+        config.set_cached_agent_name(BOB_DID, Some("example.com/@bob".into()), now);
+        config.set_cached_agent_name(ALICE_DID, Some("example.com/@alice".into()), now);
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let rel = &page.content_panel.relationships.relationships[0];
+
+        // "To: …" on an issued row renders the subject.
+        let issued = &rel.vrcs_issued[0];
+        assert_eq!(
+            issued.subject_agent_name.as_deref(),
+            Some("example.com/@bob")
+        );
+        assert_eq!(
+            issued.issuer_agent_name.as_deref(),
+            Some("example.com/@alice")
+        );
+        // "From: …" on a received row renders the issuer.
+        let received = &rel.vrcs_received[0];
+        assert_eq!(
+            received.issuer_agent_name.as_deref(),
+            Some("example.com/@bob")
+        );
+        assert_eq!(
+            received.subject_agent_name.as_deref(),
+            Some("example.com/@alice")
+        );
+
+        // The shortened DIDs are untouched — the name sits beside them, and
+        // that is what the row renders through `display_identifier`.
+        assert_eq!(issued.subject, shorten_did(BOB_DID, 40));
+        assert_eq!(
+            openvtc_core::display::display_identifier(
+                issued.subject_agent_name.as_deref(),
+                &issued.subject,
+                40
+            ),
+            "example.com/@bob"
+        );
+        assert_eq!(
+            openvtc_core::display::display_identifier(
+                received.issuer_agent_name.as_deref(),
+                &received.issuer,
+                40
+            ),
+            "example.com/@bob"
+        );
+    }
+
+    /// A cached *negative* lookup (and an uncached DID) leaves the VRC rows
+    /// showing the DID.
+    #[test]
+    fn relationship_vrc_rows_ignore_a_cached_negative_lookup() {
+        let mut config = config_with_relationship_vrcs();
+        config.set_cached_agent_name(BOB_DID, None, chrono::Utc::now());
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let rel = &page.content_panel.relationships.relationships[0];
+
+        let issued = &rel.vrcs_issued[0];
+        let received = &rel.vrcs_received[0];
+        assert!(issued.subject_agent_name.is_none());
+        assert!(received.issuer_agent_name.is_none());
+        // ALICE_DID was never looked up at all.
+        assert!(issued.issuer_agent_name.is_none());
+        assert!(received.subject_agent_name.is_none());
+        assert_eq!(
+            openvtc_core::display::display_identifier(
+                issued.subject_agent_name.as_deref(),
+                &issued.subject,
+                40
+            ),
+            shorten_did(BOB_DID, 40)
+        );
+    }
+
+    /// Seed the VTA panel's VIC list with one entry issued by `issuer`.
+    fn page_with_vic(issuer: &str) -> MainPageState {
+        let mut page = MainPageState::default();
+        page.content_panel.vta.vics = vec![content::VicSummary {
+            id: "urn:vic:1".to_string(),
+            issuer: issuer.to_string(),
+            issuer_agent_name: None,
+            status: "valid".to_string(),
+            lifecycle: content::VicLifecycle::Active,
+            valid_until: String::new(),
+        }]
+        .into();
+        page
+    }
+
+    /// The VIC list is annotated at sync time (it is not derived from `Config`),
+    /// so the row can show the issuing community's verified name.
+    #[test]
+    fn vic_row_carries_the_issuers_verified_agent_name() {
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(ALICE_DID, None, vtc_did, None);
+        config.set_cached_agent_name(
+            vtc_did,
+            Some("example.com/@acme".into()),
+            chrono::Utc::now(),
+        );
+
+        let mut page = page_with_vic(vtc_did);
+        page.sync_from_config(&config);
+        let vic = &page.content_panel.vta.vics[0];
+
+        assert_eq!(vic.issuer_agent_name.as_deref(), Some("example.com/@acme"));
+        assert_eq!(vic.issuer, vtc_did);
+        assert_eq!(
+            openvtc_core::display::display_identifier(
+                vic.issuer_agent_name.as_deref(),
+                &vic.issuer,
+                256
+            ),
+            "example.com/@acme"
+        );
+    }
+
+    /// A cached negative lookup leaves the VIC row on the issuer DID.
+    #[test]
+    fn vic_row_ignores_a_cached_negative_lookup() {
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(ALICE_DID, None, vtc_did, None);
+        config.set_cached_agent_name(vtc_did, None, chrono::Utc::now());
+
+        let mut page = page_with_vic(vtc_did);
+        page.sync_from_config(&config);
+        let vic = &page.content_panel.vta.vics[0];
+
+        assert!(vic.issuer_agent_name.is_none());
+        assert_eq!(
+            openvtc_core::display::display_identifier(
+                vic.issuer_agent_name.as_deref(),
+                &vic.issuer,
+                256
+            ),
+            vtc_did
+        );
+    }
+
+    /// Re-syncing must not leave a stale name behind: a name that disappears
+    /// from the cache (re-checked, no longer verifiable) clears from the row.
+    #[test]
+    fn vic_row_name_clears_when_the_lookup_turns_negative() {
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(ALICE_DID, None, vtc_did, None);
+        config.set_cached_agent_name(
+            vtc_did,
+            Some("example.com/@acme".into()),
+            chrono::Utc::now(),
+        );
+
+        let mut page = page_with_vic(vtc_did);
+        page.sync_from_config(&config);
+        assert!(page.content_panel.vta.vics[0].issuer_agent_name.is_some());
+
+        config.set_cached_agent_name(vtc_did, None, chrono::Utc::now());
+        page.sync_from_config(&config);
+        assert!(page.content_panel.vta.vics[0].issuer_agent_name.is_none());
     }
 
     /// A cached negative lookup leaves the Context Identities row on the DID.

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1374,23 +1374,32 @@ impl StateHandler {
                         .await;
                     },
                     Action::VicRefresh => {
-                        self.refresh_vics(&mut state, admin_vta.as_ref()).await;
+                        self.refresh_vics(&mut state, admin_vta.as_ref(), Some(&config))
+                            .await;
                     },
                     Action::VicToggleInactive => {
                         state.main_page.content_panel.vta.vic_show_inactive =
                             !state.main_page.content_panel.vta.vic_show_inactive;
-                        self.refresh_vics(&mut state, admin_vta.as_ref()).await;
+                        self.refresh_vics(&mut state, admin_vta.as_ref(), Some(&config))
+                            .await;
                     },
                     Action::AddVicSubmit => {
-                        self.run_add_vic(&mut state, admin_vta.as_ref()).await;
+                        self.run_add_vic(&mut state, admin_vta.as_ref(), Some(&config))
+                            .await;
                     },
                     Action::VicArchive(i)
                     | Action::VicUnarchive(i)
                     | Action::VicRestore(i)
                     | Action::DeleteVic(i)
                     | Action::PurgeVic(i) => {
-                        self.run_vic_lifecycle(&mut state, admin_vta.as_ref(), &action, i)
-                            .await;
+                        self.run_vic_lifecycle(
+                            &mut state,
+                            admin_vta.as_ref(),
+                            Some(&config),
+                            &action,
+                            i,
+                        )
+                        .await;
                     },
                     Action::CreatePersonaCopy => {
                         if let Some(did) = state
@@ -2433,10 +2442,16 @@ impl StateHandler {
     /// honouring the "show inactive" toggle. Best-effort: a query failure logs
     /// and leaves the previous list in place. Called when the operator focuses
     /// the VIC list, toggles inactive, and after every mutation.
+    ///
+    /// `config` (when available) supplies the verified agent names for the
+    /// issuer DIDs: the vault descriptors carry only DIDs, so the freshly loaded
+    /// list is annotated here rather than waiting for the next
+    /// `sync_from_config`.
     async fn refresh_vics(
         &self,
         state: &mut State,
         admin_vta: Option<&vta_sdk::client::VtaClient>,
+        config: Option<&Config>,
     ) {
         let Some(admin_vta) = admin_vta else { return };
         let include_inactive = state.main_page.content_panel.vta.vic_show_inactive;
@@ -2445,6 +2460,9 @@ impl StateHandler {
                 let vta = &mut state.main_page.content_panel.vta;
                 vta.vic_selected_index = vta.vic_selected_index.min(list.len().saturating_sub(1));
                 vta.vics = list.into();
+                if let Some(config) = config {
+                    state.main_page.sync_vic_agent_names(config);
+                }
             }
             Err(e) => {
                 state
@@ -2457,7 +2475,12 @@ impl StateHandler {
 
     /// Validate + store the pasted VIC from the add-VIC overlay, then refresh the
     /// list. Mirrors `run_create_persona`'s phase handling.
-    async fn run_add_vic(&self, state: &mut State, admin_vta: Option<&vta_sdk::client::VtaClient>) {
+    async fn run_add_vic(
+        &self,
+        state: &mut State,
+        admin_vta: Option<&vta_sdk::client::VtaClient>,
+        config: Option<&Config>,
+    ) {
         use crate::state_handler::main_page::content::AddVicPhase;
 
         let json = match state.main_page.add_vic.as_ref() {
@@ -2493,7 +2516,7 @@ impl StateHandler {
                     o.messages.push("Invitation credential stored.".to_string());
                 }
                 state.main_page.log("Stored an invitation credential.");
-                self.refresh_vics(state, Some(admin_vta)).await;
+                self.refresh_vics(state, Some(admin_vta), config).await;
             }
             Err(e) => {
                 // A validation error keeps the operator on the input phase so they
@@ -2517,6 +2540,7 @@ impl StateHandler {
         &self,
         state: &mut State,
         admin_vta: Option<&vta_sdk::client::VtaClient>,
+        config: Option<&Config>,
         action: &Action,
         index: usize,
     ) {
@@ -2552,7 +2576,7 @@ impl StateHandler {
                 .main_page
                 .log_error(format!("VIC {} failed", verb.to_lowercase()), &e),
         }
-        self.refresh_vics(state, Some(admin_vta)).await;
+        self.refresh_vics(state, Some(admin_vta), config).await;
     }
 
     /// Remove the community at `index` in the Communities display list: withdraw
@@ -2809,17 +2833,20 @@ impl StateHandler {
                     }
                     Action::VicRefresh => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        self.refresh_vics(state, av).await;
+                        let cfg = join_ctx.as_ref().map(|c| &*c.config);
+                        self.refresh_vics(state, av, cfg).await;
                     }
                     Action::VicToggleInactive => {
                         state.main_page.content_panel.vta.vic_show_inactive =
                             !state.main_page.content_panel.vta.vic_show_inactive;
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        self.refresh_vics(state, av).await;
+                        let cfg = join_ctx.as_ref().map(|c| &*c.config);
+                        self.refresh_vics(state, av, cfg).await;
                     }
                     Action::AddVicSubmit => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        self.run_add_vic(state, av).await;
+                        let cfg = join_ctx.as_ref().map(|c| &*c.config);
+                        self.run_add_vic(state, av, cfg).await;
                     }
                     Action::VicArchive(i)
                     | Action::VicUnarchive(i)
@@ -2827,7 +2854,8 @@ impl StateHandler {
                     | Action::DeleteVic(i)
                     | Action::PurgeVic(i) => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        self.run_vic_lifecycle(state, av, &action, i).await;
+                        let cfg = join_ctx.as_ref().map(|c| &*c.config);
+                        self.run_vic_lifecycle(state, av, cfg, &action, i).await;
                     }
                     Action::CreatePersonaCopy => {
                         if let Some(did) = state

--- a/openvtc/src/ui/pages/join_flow/join_progress.rs
+++ b/openvtc/src/ui/pages/join_flow/join_progress.rs
@@ -10,6 +10,7 @@ use crate::colors::{
     COLOR_TEXT_DEFAULT, COLOR_WARNING_ACCESSIBLE_RED,
 };
 use crossterm::event::{KeyCode, KeyEvent};
+use openvtc_core::display::display_identifier;
 use ratatui::{
     Frame,
     layout::{
@@ -24,11 +25,23 @@ use ratatui::{
 use crate::{
     state_handler::{
         actions::Action,
-        join::JoinState,
+        join::{JoinState, PresentedInvitation},
         setup_sequence::{Completion, MessageType},
     },
     ui::pages::join_flow::JoinFlow,
 };
+
+/// Width the success page renders the invitation's bound-to identifier at. The
+/// page has never truncated this DID, so this only bounds an agent name shown in
+/// its place.
+const BOUND_TO_WIDTH: usize = 256;
+
+/// What the success page's `Bound to:` row shows for the invitation's subject —
+/// the verified agent name of the persona the VIC binds when one is cached,
+/// otherwise the DID itself.
+fn bound_to_display(vic: &PresentedInvitation, subject: &str) -> String {
+    display_identifier(vic.subject_agent_name.as_deref(), subject, BOUND_TO_WIDTH).into_owned()
+}
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct JoinProgress;
@@ -127,7 +140,7 @@ impl JoinProgress {
                                         Style::new().fg(COLOR_SUCCESS),
                                     ),
                                     Span::styled(
-                                        subject.clone(),
+                                        bound_to_display(vic, subject),
                                         Style::new().fg(COLOR_SOFT_PURPLE),
                                     ),
                                 ]));
@@ -183,5 +196,36 @@ impl JoinProgress {
             Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
             bottom,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PERSONA_DID: &str = "did:webvh:QmScidAliceAAAAAAAAAAAAAAAAAAAA:example.com:alice";
+
+    /// The `Bound to:` row shows the verified name of the persona the invitation
+    /// binds, in place of that persona's DID.
+    #[test]
+    fn bound_to_prefers_the_verified_agent_name() {
+        let vic = PresentedInvitation {
+            id: "urn:vic:1".to_string(),
+            subject: Some(PERSONA_DID.to_string()),
+            subject_agent_name: Some("example.com/@alice".to_string()),
+        };
+        assert_eq!(bound_to_display(&vic, PERSONA_DID), "example.com/@alice");
+    }
+
+    /// No cached name — including a cached *negative* lookup, which reads the
+    /// same as uncached — leaves the DID on screen.
+    #[test]
+    fn bound_to_falls_back_to_the_did() {
+        let vic = PresentedInvitation {
+            id: "urn:vic:1".to_string(),
+            subject: Some(PERSONA_DID.to_string()),
+            subject_agent_name: None,
+        };
+        assert_eq!(bound_to_display(&vic, PERSONA_DID), PERSONA_DID);
     }
 }

--- a/openvtc/src/ui/pages/main/components/relationships_panel.rs
+++ b/openvtc/src/ui/pages/main/components/relationships_panel.rs
@@ -7,10 +7,16 @@ use crate::state_handler::{
     main_page::content::{ContentPanelState, RelationshipsMode, RelationshipsState},
     state::ConnectionState,
 };
+use openvtc_core::display::display_identifier;
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
 };
+
+/// Width the VRC list rows render an identifier at. Matches the `shorten_did`
+/// width the summaries are built with, so swapping in an agent name does not
+/// change the row's budget.
+const VRC_ID_WIDTH: usize = 40;
 
 /// Relationships content panel.
 pub struct RelationshipsPanel;
@@ -220,7 +226,17 @@ fn render_detail(
                 lines.push(Line::from(vec![
                     Span::styled(prefix, bullet_style),
                     Span::styled("● ", bullet_style),
-                    Span::styled(format!("To: {}  ", vrc.subject), text_style),
+                    Span::styled(
+                        format!(
+                            "To: {}  ",
+                            display_identifier(
+                                vrc.subject_agent_name.as_deref(),
+                                &vrc.subject,
+                                VRC_ID_WIDTH,
+                            )
+                        ),
+                        text_style,
+                    ),
                     Span::styled(
                         validity,
                         if is_selected {
@@ -289,7 +305,17 @@ fn render_detail(
                 lines.push(Line::from(vec![
                     Span::styled(prefix, bullet_style),
                     Span::styled("● ", bullet_style),
-                    Span::styled(format!("From: {}  ", vrc.issuer), text_style),
+                    Span::styled(
+                        format!(
+                            "From: {}  ",
+                            display_identifier(
+                                vrc.issuer_agent_name.as_deref(),
+                                &vrc.issuer,
+                                VRC_ID_WIDTH,
+                            )
+                        ),
+                        text_style,
+                    ),
                     Span::styled(
                         validity,
                         if is_selected {
@@ -460,4 +486,110 @@ fn render_form(
     );
 
     lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::main_page::content::{
+        RawCredential, RelationshipSummary, RelationshipVrc,
+    };
+    use crate::state_handler::main_page::shorten_did;
+    use std::sync::Arc;
+
+    const ALICE_DID: &str = "did:webvh:QmScidAliceAAAAAAAAAAAAAAAAAAAA:example.com:alice";
+    const BOB_DID: &str = "did:webvh:QmScidBobBBBBBBBBBBBBBBBBBBBBBB:example.com:bob";
+
+    /// Flatten the rendered lines to plain text, one entry per line.
+    fn text(lines: &[Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    fn raw() -> RawCredential {
+        RawCredential::Value(Arc::new(serde_json::json!({})))
+    }
+
+    fn vrc(issuer_name: Option<&str>, subject_name: Option<&str>) -> RelationshipVrc {
+        // `issuer` / `subject` arrive pre-shortened to `VRC_ID_WIDTH`, exactly
+        // as `sync_from_config` builds them.
+        RelationshipVrc {
+            issuer: shorten_did(BOB_DID, VRC_ID_WIDTH),
+            issuer_agent_name: issuer_name.map(str::to_owned),
+            issuer_full: BOB_DID.to_string(),
+            subject: shorten_did(ALICE_DID, VRC_ID_WIDTH),
+            subject_agent_name: subject_name.map(str::to_owned),
+            subject_full: ALICE_DID.to_string(),
+            valid_from: "2024-06-18".to_string(),
+            valid_until: None,
+            raw_json: raw(),
+        }
+    }
+
+    /// A detail view holding the same VRC on both the issued and received lists,
+    /// so one render exercises the "To: …" and "From: …" rows together.
+    fn detail_state(vrc: RelationshipVrc) -> RelationshipsState {
+        RelationshipsState {
+            relationships: vec![RelationshipSummary {
+                remote_p_did: BOB_DID.to_string(),
+                alias: None,
+                agent_name: None,
+                state: "Established".to_string(),
+                our_did: ALICE_DID.to_string(),
+                remote_did: BOB_DID.to_string(),
+                created: "2024-06-18 10:00".to_string(),
+                vrcs_issued: vec![vrc.clone()],
+                vrcs_received: vec![vrc],
+                needs_reestablishment: false,
+            }]
+            .into(),
+            mode: RelationshipsMode::Detail {
+                index: 0,
+                selected_vrc: None,
+            },
+            ..RelationshipsState::default()
+        }
+    }
+
+    #[test]
+    fn vrc_rows_show_verified_agent_names() {
+        let out = text(&render(&detail_state(vrc(
+            Some("example.com/@bob"),
+            Some("example.com/@alice"),
+        ))));
+
+        assert!(
+            out.iter().any(|l| l.contains("To: example.com/@alice")),
+            "issued row names the subject: {out:?}"
+        );
+        assert!(
+            out.iter().any(|l| l.contains("From: example.com/@bob")),
+            "received row names the issuer: {out:?}"
+        );
+    }
+
+    /// A cached *negative* lookup reaches the panel as `None`, so both rows keep
+    /// showing the DID.
+    #[test]
+    fn vrc_rows_without_names_keep_the_dids() {
+        let out = text(&render(&detail_state(vrc(None, None))));
+
+        let subject = shorten_did(ALICE_DID, VRC_ID_WIDTH);
+        let issuer = shorten_did(BOB_DID, VRC_ID_WIDTH);
+        assert!(
+            out.iter().any(|l| l.contains(&format!("To: {subject}"))),
+            "issued row keeps the subject DID: {out:?}"
+        );
+        assert!(
+            out.iter().any(|l| l.contains(&format!("From: {issuer}"))),
+            "received row keeps the issuer DID: {out:?}"
+        );
+    }
 }

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -6,7 +6,7 @@ use crate::state_handler::{
     main_page::content::{ContentPanelState, VicLifecycle, VtaFocus, VtaState},
     state::ConnectionState,
 };
-use openvtc_core::display::display_identifier;
+use openvtc_core::display::{display_identifier, truncate_did_centered};
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
@@ -15,6 +15,11 @@ use ratatui::{
 /// Width the DID lists render an identifier at. The panel has never truncated
 /// these, so this only bounds an agent name shown in a DID's place.
 const ID_WIDTH: usize = 256;
+
+/// Width the delete-confirm prompt renders the target DID at. The prompt carries
+/// a name *and* the DID plus the y/n hint, so the DID is centre-truncated here
+/// (both ends stay visible) to keep the line on one row.
+const CONFIRM_DID_WIDTH: usize = 48;
 
 /// VTA service information panel.
 pub struct VtaPanel;
@@ -231,11 +236,21 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         // Confirmation prompt (a delete is armed) or the navigation/remove hint.
         lines.push(Line::from(""));
         if let Some(idx) = state.confirm_delete_did {
-            let target = state
-                .context_dids
-                .get(idx)
-                .map(|d| d.did.as_str())
-                .unwrap_or("this identity");
+            // Keep *both* the name and the DID. The row the operator selected
+            // shows the name, so a DID-only prompt names something they never
+            // saw; but a destructive confirm must stay unambiguous, so the DID
+            // is not dropped either — it is centre-truncated to keep the line
+            // readable while both ends stay checkable.
+            let target = match state.context_dids.get(idx) {
+                Some(d) => {
+                    let did = truncate_did_centered(&d.did, CONFIRM_DID_WIDTH);
+                    match d.agent_name.as_deref() {
+                        Some(name) => format!("{name} ({did})"),
+                        None => did.into_owned(),
+                    }
+                }
+                None => "this identity".to_string(),
+            };
             lines.push(
                 Line::from(format!("Remove {target}?   y: confirm    n: cancel"))
                     .fg(COLOR_ORANGE)
@@ -316,10 +331,13 @@ fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
             Span::styled(v.id.clone(), id_style),
         ]));
 
+        // The issuer is a community VTC DID, which the agent-name sweep already
+        // targets — so a verified name is usually available and shown in its
+        // place. No name (or a cached negative) keeps the DID.
         let issuer = if v.issuer.is_empty() {
             "issuer unknown".to_string()
         } else {
-            v.issuer.clone()
+            display_identifier(v.issuer_agent_name.as_deref(), &v.issuer, ID_WIDTH).into_owned()
         };
         let mut detail = format!("      {issuer}  ·  {}", v.status);
         if v.lifecycle != VicLifecycle::Active {
@@ -373,6 +391,126 @@ fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
                 "↑/↓ select   a: import   {restore_verb}   d: delete   p: purge   i: inactive"
             ))
             .fg(COLOR_DARK_GRAY),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::main_page::content::{ManagedDid, VicSummary};
+
+    const PERSONA_DID: &str = "did:webvh:QmScidAliceAAAAAAAAAAAAAAAAAAAA:example.com:alice";
+    const VTC_DID: &str = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+
+    /// Flatten the rendered lines to plain text, one entry per line.
+    fn text(lines: &[Line<'static>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    fn managed_did(agent_name: Option<&str>) -> ManagedDid {
+        ManagedDid {
+            did: PERSONA_DID.to_string(),
+            agent_name: agent_name.map(str::to_owned),
+            label: "Work me".to_string(),
+            bound_communities: 0,
+            is_active: false,
+        }
+    }
+
+    fn vic(issuer_agent_name: Option<&str>) -> VicSummary {
+        VicSummary {
+            id: "urn:vic:1".to_string(),
+            issuer: VTC_DID.to_string(),
+            issuer_agent_name: issuer_agent_name.map(str::to_owned),
+            status: "valid".to_string(),
+            lifecycle: VicLifecycle::Active,
+            valid_until: String::new(),
+        }
+    }
+
+    fn state_with(dids: Vec<ManagedDid>, vics: Vec<VicSummary>) -> VtaState {
+        VtaState {
+            context_dids: dids.into(),
+            vics: vics.into(),
+            ..VtaState::default()
+        }
+    }
+
+    // --- VIC issuer ---------------------------------------------------------
+
+    #[test]
+    fn vic_row_shows_the_issuers_verified_agent_name() {
+        let out = text(&render(&state_with(
+            vec![],
+            vec![vic(Some("example.com/@acme"))],
+        )));
+        assert!(
+            out.iter().any(|l| l.contains("example.com/@acme")),
+            "issuer name is shown: {out:?}"
+        );
+        assert!(
+            !out.iter().any(|l| l.contains(VTC_DID)),
+            "the DID is replaced by the name: {out:?}"
+        );
+    }
+
+    /// A cached negative lookup arrives as `None`, so the row keeps the DID.
+    #[test]
+    fn vic_row_without_a_name_keeps_the_issuer_did() {
+        let out = text(&render(&state_with(vec![], vec![vic(None)])));
+        assert!(
+            out.iter().any(|l| l.contains(VTC_DID)),
+            "issuer DID is shown: {out:?}"
+        );
+    }
+
+    // --- delete-confirm prompt (KEEP-BOTH) ----------------------------------
+
+    /// The destructive confirm names what the operator selected *and* keeps the
+    /// DID, so it is both recognisable and unambiguous.
+    #[test]
+    fn delete_confirm_keeps_both_the_name_and_the_did() {
+        let mut state = state_with(vec![managed_did(Some("example.com/@alice"))], vec![]);
+        state.confirm_delete_did = Some(0);
+        let out = text(&render(&state));
+
+        let prompt = out
+            .iter()
+            .find(|l| l.starts_with("Remove "))
+            .expect("confirm prompt rendered");
+        assert!(prompt.contains("example.com/@alice"), "{prompt}");
+        // The DID is centre-truncated, so both ends must still be checkable.
+        assert!(prompt.contains("did:webvh:QmScidAlice"), "{prompt}");
+        assert!(prompt.contains("example.com:alice"), "{prompt}");
+        assert!(prompt.contains("y: confirm"), "{prompt}");
+    }
+
+    /// With no verified name (uncached or a cached negative) the prompt falls
+    /// back to the DID alone — never to an empty or name-less "this identity".
+    #[test]
+    fn delete_confirm_without_a_name_shows_the_did() {
+        let mut state = state_with(vec![managed_did(None)], vec![]);
+        state.confirm_delete_did = Some(0);
+        let out = text(&render(&state));
+
+        let prompt = out
+            .iter()
+            .find(|l| l.starts_with("Remove "))
+            .expect("confirm prompt rendered");
+        assert!(prompt.contains("did:webvh:QmScidAlice"), "{prompt}");
+        assert!(prompt.contains("example.com:alice"), "{prompt}");
+        assert!(
+            !prompt.contains('('),
+            "no empty name parenthetical: {prompt}"
         );
     }
 }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -3398,6 +3398,7 @@ mod key_handler_tests {
         VicSummary {
             id: id.to_string(),
             issuer: "did:webvh:example:community".to_string(),
+            issuer_agent_name: None,
             status: "valid".to_string(),
             lifecycle,
             valid_until: String::new(),


### PR DESCRIPTION
Closes out the audit from #181. These four needed new view-model fields, which is why they were deferred.

## Converted

1. **VIC issuer** (`vta_panel.rs`) — the issuer is a community VTC DID, which *is* an `agent_name_refresh_targets` entry, so a name usually exists. `VicSummary` gains `issuer_agent_name`.
2. **Relationship VRC rows** (`relationships_panel.rs`) — `To:` / `From:` now name the party. `RelationshipVrc` gains `issuer_agent_name` / `subject_agent_name`; the credentials panel already carried exactly these, so this was the same data model one screen behind.
3. **VIC `Bound to:`** (`join_progress.rs`) — which of your identities the invitation binds.
4. **VTA delete-confirm — KEEP-BOTH, not converted.** Previously the prompt named a raw DID while the row you'd selected showed a *name*, so the prompt never looked like the thing you picked. Now `Remove <name> (did:webvh:Qm…:alice)?`, DID centre-truncated so both ends stay checkable. **A name is never shown alone** — with no name it falls back to the DID, keeping the destructive confirm unambiguous.

## Deliberately not converted

R-DIDs, inbox `their_did`, mediator/VTA/admin/setup/credential DIDs, capability `delegate`. `agent_name_refresh_targets` never resolves those, so `agent_name_for` returns `None` 100% of the time — converting them is dead code that reads like a feature.

## One judgement call worth review

`VicSummary::from_descriptor` has no `Config`, so the brief said populate at sync time. Sync-only would leave VIC names **blank between a vault reload and the next config mutation** — indefinitely on an idle app. So `config: Option<&Config>` is threaded into `refresh_vics` / `run_add_vic` / `run_vic_lifecycle` (6 call sites). If you'd rather keep those signatures narrow, dropping the `refresh_vics` annotation is a two-line revert and the sync-time path still works.

## Verification

`openvtc` **234 passed**, `openvtc-core` **251 passed**, 0 failed. clippy and fmt clean.

12 new tests. Every conversion has a **cached-negative** case asserting the DID still shows, plus `vic_row_name_clears_when_the_lookup_turns_negative` — a stale name surviving a re-sync is a real risk here, since the VIC list is annotated in place rather than rebuilt.