### PR TITLE
fix: make the VTA screen say what it means

### DIFF
--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -471,9 +471,17 @@ impl Config {
     /// Every DID the UI displays that needs an agent-name lookup — those with no
     /// cache entry or a stale one (`now` past [`AGENT_NAME_TTL`]).
     ///
-    /// Covers persona DIDs, community VTC DIDs, relationship remote-persona DIDs
-    /// and contact DIDs. De-duplicated; the same DID appearing in several places
-    /// is resolved once. Fed to the background batch refresh.
+    /// Covers persona DIDs, community VTC DIDs, relationship remote-persona DIDs,
+    /// contact DIDs, and the two infrastructure DIDs the VTA panel displays (the
+    /// VTA's own DID and the active persona's mediator). De-duplicated; the same
+    /// DID appearing in several places is resolved once. Fed to the background
+    /// batch refresh.
+    ///
+    /// The infrastructure DIDs are included because the VTA panel renders them
+    /// to the operator: a `did:webvh` VTA or mediator can publish a verifiable
+    /// name like any other party, and leaving them out of the sweep was the only
+    /// reason those two rows always showed a raw DID. A DID with no verifiable
+    /// name simply caches a negative and keeps rendering as a DID.
     ///
     /// [`AGENT_NAME_TTL`]: crate::agent_name::AGENT_NAME_TTL
     #[must_use]
@@ -490,6 +498,20 @@ impl Config {
         }
         for contact in self.private.contacts.contacts.keys() {
             dids.insert(contact.to_string());
+        }
+        // Every persona's mediator, plus the VTA's DID. Only `did:*` values —
+        // a mediator field left empty must not become a lookup for "".
+        for persona in self.account.personas.values() {
+            if let Some(mediator) = persona.mediator_did.as_deref()
+                && mediator.starts_with("did:")
+            {
+                dids.insert(mediator.to_string());
+            }
+        }
+        if let KeyBackend::Vta { vta_did, .. } = &self.key_backend
+            && vta_did.starts_with("did:")
+        {
+            dids.insert(vta_did.clone());
         }
         dids.into_iter()
             .filter(|did| {
@@ -861,6 +883,86 @@ mod tests {
         // Once stale, the entry becomes a target again.
         let later = now + crate::agent_name::AGENT_NAME_TTL;
         assert!(config.agent_name_refresh_targets(later).contains(&did));
+    }
+
+    /// The VTA panel renders the VTA's DID and the persona's mediator DID, so
+    /// both must be swept — leaving them out was the only reason those two rows
+    /// always showed a raw DID even when the party published a verifiable name.
+    #[test]
+    fn agent_name_targets_include_the_vta_and_mediator_dids() {
+        use crate::config::account::{PersonaId, PersonaRecord};
+        use chrono::Utc;
+
+        let now = Utc::now();
+        let mut config = test_config(BTreeMap::new());
+        let pid = PersonaId::new();
+        let mediator = "did:webvh:example.com:mediator".to_string();
+        config.account.personas.insert(
+            pid,
+            PersonaRecord {
+                persona_id: pid,
+                did: "did:webvh:example.com:alice".into(),
+                did_document: None,
+                key_refs: vec![],
+                mediator_did: Some(mediator.clone()),
+                origin_context_id: "openvtc/alice".into(),
+                created_at: now,
+                label: None,
+            },
+        );
+        let vta_did = "did:webvh:example.com:vta".to_string();
+        config.key_backend = KeyBackend::Vta {
+            vta_url: "https://vta.example".into(),
+            vta_did: vta_did.clone(),
+            credential_did: "did:key:z6MkTest".into(),
+            credential_private_key: SecretString::new("z6Mktest".into()),
+            mediator_did: Some(mediator.clone()),
+            credential_bundle: SecretString::new("bundle".into()),
+            encryption_seed: SecretBox::new(Box::new(vec![0u8; 32])),
+        };
+
+        let targets = config.agent_name_refresh_targets(now);
+        assert!(targets.contains(&mediator), "mediator swept: {targets:?}");
+        assert!(targets.contains(&vta_did), "VTA DID swept: {targets:?}");
+    }
+
+    /// An unset mediator field must not become a lookup for the empty string.
+    #[test]
+    fn agent_name_targets_skip_non_did_infrastructure_values() {
+        use crate::config::account::{PersonaId, PersonaRecord};
+        use chrono::Utc;
+
+        let now = Utc::now();
+        let mut config = test_config(BTreeMap::new());
+        let pid = PersonaId::new();
+        config.account.personas.insert(
+            pid,
+            PersonaRecord {
+                persona_id: pid,
+                did: "did:webvh:example.com:alice".into(),
+                did_document: None,
+                key_refs: vec![],
+                mediator_did: Some(String::new()),
+                origin_context_id: "openvtc/alice".into(),
+                created_at: now,
+                label: None,
+            },
+        );
+        config.key_backend = KeyBackend::Vta {
+            vta_url: "https://vta.example".into(),
+            vta_did: String::new(),
+            credential_did: "did:key:z6MkTest".into(),
+            credential_private_key: SecretString::new("z6Mktest".into()),
+            mediator_did: None,
+            credential_bundle: SecretString::new("bundle".into()),
+            encryption_seed: SecretBox::new(Box::new(vec![0u8; 32])),
+        };
+
+        let targets = config.agent_name_refresh_targets(now);
+        assert!(
+            !targets.iter().any(|t| t.is_empty()),
+            "no empty target: {targets:?}"
+        );
     }
 
     /// A State-A (account-bootstrap, R-A-5) config carries an account but no

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -70,6 +70,9 @@ pub(crate) enum DispatchDomain {
     /// many DIDs (the busy-guard is per-domain, so per-DID jobs would serialise),
     /// each a network round-trip; read-only, off the loop.
     AgentName,
+    /// VTA transport probe: resolve the VTA's DID document to learn which
+    /// transports it advertises. Read-only, one resolve, off the loop.
+    VtaTransports,
 }
 
 impl DispatchDomain {
@@ -81,6 +84,7 @@ impl DispatchDomain {
             DispatchDomain::Inbox => "Inbox action",
             DispatchDomain::Did => "Identity deletion",
             DispatchDomain::AgentName => "Agent name refresh",
+            DispatchDomain::VtaTransports => "VTA transport probe",
         }
     }
 }
@@ -149,6 +153,10 @@ pub(crate) enum DispatchOutcome {
     /// each DID resolved — `resolved_name` is `None` for a DID with no
     /// verifiable name (a cached negative). Applied on the loop thread.
     AgentName(Vec<(String, Option<String>)>),
+    /// A VTA transport probe finished. Carries what the VTA's DID document
+    /// advertises, or the reason the probe could not tell. Display-only — it
+    /// touches no `Config`, so it never marks the config dirty.
+    VtaTransports(crate::state_handler::main_page::content::AdvertisedTransports),
     /// A spawned dispatch job panicked (or was cancelled) and so never produced a
     /// real outcome. Synthesised by [`spawn_dispatch`] from the `JoinError` so the
     /// domain's busy-flag is still cleared (a panicking job that sent nothing would
@@ -166,6 +174,7 @@ impl DispatchOutcome {
             DispatchOutcome::Inbox(_) => DispatchDomain::Inbox,
             DispatchOutcome::Did(_) => DispatchDomain::Did,
             DispatchOutcome::AgentName(_) => DispatchDomain::AgentName,
+            DispatchOutcome::VtaTransports(_) => DispatchDomain::VtaTransports,
             DispatchOutcome::Panicked(domain) => *domain,
         }
     }
@@ -276,6 +285,12 @@ pub(crate) fn apply_outcome(
             if display_changed {
                 state.main_page.sync_from_config(config);
             }
+        }
+        DispatchOutcome::VtaTransports(advertised) => {
+            // Display-only: assign straight onto the panel state. Deliberately
+            // NOT written through `sync_from_config`, which rebuilds the panel
+            // from `Config` and would drop a field the config does not hold.
+            state.main_page.content_panel.vta.transports.advertised = Some(advertised);
         }
         DispatchOutcome::Panicked(domain) => {
             // The job panicked and produced no real outcome. Surface a generic

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -836,9 +836,16 @@ async fn run_join_sequence(
                 openvtc_core::config::KeyBackend::Vta { mediator_did, .. } => mediator_did.clone(),
                 _ => None,
             };
-            state.setup.username = display_name.clone().unwrap_or_else(|| {
-                openvtc_core::config::context_path::render_for_display(&vtc_did).to_string()
-            });
+            // A join mints the persona *unlabelled*. `display_name` here is the
+            // COMMUNITY's name — naming the persona after it (or, with no
+            // verified name, after a DID-derived rendering of the VTC DID) put a
+            // community identifier in the persona's own label, and
+            // `mint_persona_into` copied that on into `public.friendly_name`, so
+            // the header announced the community twice and the DID manager
+            // listed a persona labelled with a community DID. The persona's
+            // community binding is recorded on the membership record and shown
+            // beside it; the label is for a name the operator chose.
+            state.setup.username = String::new();
 
             // 5. Persist the persona into the account. `mint_persona_into` writes the
             // persona record + runtime identity + key info to disk *immediately* (a

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -358,12 +358,18 @@ pub struct VtaState {
     pub persona_agent_name: Option<String>,
     /// Mediator DID
     pub mediator_did: String,
+    /// Verified agent name for [`mediator_did`](Self::mediator_did), if cached.
+    pub mediator_agent_name: Option<String>,
     /// VTA service URL
     pub vta_url: String,
     /// VTA service DID
     pub vta_did: String,
+    /// Verified agent name for [`vta_did`](Self::vta_did), if cached.
+    pub vta_agent_name: Option<String>,
     /// Credential DID used for VTA authentication
     pub credential_did: String,
+    /// Which transports the VTA advertises and which one this process is on.
+    pub transports: VtaTransports,
     /// Total number of keys managed
     pub key_count: usize,
     /// Number of persona keys
@@ -404,6 +410,68 @@ pub struct VtaState {
     /// Which of the two manageable lists (Context Identities vs Invitation
     /// Credentials) has keyboard focus, so `↑/↓` and the verbs apply to it.
     pub focus: VtaFocus,
+}
+
+/// How this process reaches the VTA, and what the VTA says it offers.
+///
+/// Two independently-sourced halves, deliberately kept apart:
+///
+/// - [`in_use`](Self::in_use) is what *this* process connects over, derived
+///   synchronously from the stored key backend — `build_runtime_vta_client`
+///   picks DIDComm when a mediator DID is recorded and REST otherwise, so the
+///   same condition decides the label. No network, always accurate.
+/// - [`advertised`](Self::advertised) is what the VTA's own DID document
+///   publishes (`#vta-rest` and `DIDCommMessaging` services), which needs a
+///   resolve. `None` until the background probe lands, so the panel can say
+///   "checking…" rather than claim a transport is unavailable merely because
+///   nothing has been asked yet.
+///
+/// Keeping them separate is what makes the panel able to distinguish "the VTA
+/// offers REST too" from "we could not ask" (VTI R6.4).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct VtaTransports {
+    /// Transport this process is configured to use.
+    pub in_use: VtaTransport,
+    /// REST base URL from the stored config, if any. This is the URL that was
+    /// `VTA URL` before — kept as *detail under* the transport rather than as
+    /// the headline fact.
+    pub rest_url: String,
+    /// What the VTA's DID document advertises. `None` until probed.
+    pub advertised: Option<AdvertisedTransports>,
+}
+
+/// One VTA transport.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum VtaTransport {
+    /// DIDComm via a mediator (the VTA session is the authenticator).
+    #[default]
+    DidComm,
+    /// REST challenge-response against the VTA URL.
+    Rest,
+}
+
+impl VtaTransport {
+    /// Label for the panel.
+    pub fn label(self) -> &'static str {
+        match self {
+            VtaTransport::DidComm => "DIDComm",
+            VtaTransport::Rest => "REST",
+        }
+    }
+}
+
+/// The transports a VTA's DID document advertises, as resolved by
+/// `vta_sdk::provision_client::resolve_vta`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AdvertisedTransports {
+    /// Mediator DID from the document's `DIDCommMessaging` service, if any.
+    pub mediator_did: Option<String>,
+    /// REST base URL from the document's `#vta-rest` service, if any.
+    pub rest_url: Option<String>,
+    /// Set when the probe itself failed — the transports are unknown, not
+    /// absent. Rendered as an explicit "could not check" so an unreachable
+    /// publication endpoint never reads as "the VTA offers nothing".
+    pub error: Option<String>,
 }
 
 /// Which manageable list in the VTA panel has keyboard focus (toggled by `Tab`).

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use openvtc_core::{
-    config::{Config, KeyBackend, account::PersonaId},
+    config::{Config, KeyBackend, KeyTypes, account::PersonaId},
     display::truncate_did,
     tasks::TaskType,
 };
@@ -375,38 +375,70 @@ impl MainPageState {
             .agent_name_for(config.persona_did())
             .map(str::to_owned);
         self.content_panel.vta.mediator_did = config.mediator_did().to_string();
+        self.content_panel.vta.mediator_agent_name = config
+            .agent_name_for(config.mediator_did())
+            .map(str::to_owned);
         match &config.key_backend {
             KeyBackend::Vta {
                 vta_url,
                 vta_did,
                 credential_did,
+                mediator_did,
                 ..
             } => {
                 self.content_panel.vta.vta_url = vta_url.clone();
                 self.content_panel.vta.vta_did = vta_did.clone();
+                self.content_panel.vta.vta_agent_name =
+                    config.agent_name_for(vta_did).map(str::to_owned);
                 self.content_panel.vta.credential_did = credential_did.clone();
                 self.content_panel.vta.is_vta_managed = true;
+                // Same condition `build_runtime_vta_client` branches on, so the
+                // panel names the transport this process actually connects over
+                // rather than guessing from the URL being non-empty (it stays
+                // populated on the DIDComm path as the REST fallback).
+                self.content_panel.vta.transports.in_use = if mediator_did.is_some() {
+                    content::VtaTransport::DidComm
+                } else {
+                    content::VtaTransport::Rest
+                };
+                self.content_panel.vta.transports.rest_url = vta_url.clone();
             }
             _ => {
                 self.content_panel.vta.is_vta_managed = false;
             }
         }
         self.content_panel.vta.key_count = config.key_info.len();
-        // Count persona vs relationship keys. With no active persona (State A)
-        // there are no persona keys — and `starts_with("")` would otherwise match
-        // every key, so guard on a non-empty persona DID.
+        // Classify keys by their recorded purpose, not by DID-prefix arithmetic.
+        // Counting persona keys with `k.starts_with(active_persona_did)` and
+        // calling the remainder "relationship" mislabelled every key belonging to
+        // a *different* persona — a two-persona account reported relationship
+        // keys it did not have. `KeyInfoConfig::purpose` already says what each
+        // key is for; anything outside the two buckets (e.g. webvh update keys)
+        // is counted as neither, so the two figures never over-claim.
         let persona_did = config.persona_did();
-        self.content_panel.vta.persona_key_count = if persona_did.is_empty() {
-            0
-        } else {
-            config
-                .key_info
-                .keys()
-                .filter(|k| k.starts_with(persona_did))
-                .count()
-        };
-        self.content_panel.vta.relationship_key_count =
-            self.content_panel.vta.key_count - self.content_panel.vta.persona_key_count;
+        self.content_panel.vta.persona_key_count = config
+            .key_info
+            .values()
+            .filter(|info| {
+                matches!(
+                    info.purpose,
+                    KeyTypes::PersonaSigning
+                        | KeyTypes::PersonaAuthentication
+                        | KeyTypes::PersonaEncryption
+                        | KeyTypes::PersonaOther
+                )
+            })
+            .count();
+        self.content_panel.vta.relationship_key_count = config
+            .key_info
+            .values()
+            .filter(|info| {
+                matches!(
+                    info.purpose,
+                    KeyTypes::RelationshipVerification | KeyTypes::RelationshipEncryption
+                )
+            })
+            .count();
         // Collect active DIDs — none for a zero-persona (State-A) account.
         let mut active_dids = Vec::new();
         if !persona_did.is_empty() {
@@ -1586,6 +1618,81 @@ mod tests {
         assert_eq!(row.agent_name.as_deref(), Some("example.com/@alice"));
         assert_eq!(row.did, ALICE_DID);
         assert_eq!(row.label, "Work me");
+    }
+
+    // --- VTA panel key counts ---
+
+    /// A `KeyInfoConfig` carrying just the purpose the count reads.
+    fn key_info(
+        purpose: openvtc_core::config::KeyTypes,
+    ) -> openvtc_core::config::secured_config::KeyInfoConfig {
+        openvtc_core::config::secured_config::KeyInfoConfig {
+            path: openvtc_core::config::secured_config::KeySourceMaterial::Derived {
+                path: String::new(),
+            },
+            create_time: chrono::Utc::now(),
+            purpose,
+        }
+    }
+
+    /// Key counts are a classification, not a subtraction. Counting persona keys
+    /// by `starts_with(active_persona_did)` and calling everything else
+    /// "relationship" reported a second persona's keys as relationship keys — an
+    /// account with no relationships at all showed a non-zero relationship
+    /// count. `KeyInfoConfig::purpose` already records what each key is for.
+    #[test]
+    fn key_counts_classify_by_purpose_not_by_active_persona_prefix() {
+        use openvtc_core::config::KeyTypes;
+
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(ALICE_DID, None, vtc_did, None);
+
+        let mut key = |id: &str, purpose: KeyTypes| {
+            config.key_info.insert(id.to_string(), key_info(purpose));
+        };
+        // Two personas' worth of persona keys. Only ALICE is active, so the old
+        // prefix match saw BOB's as "relationship".
+        key(&format!("{ALICE_DID}#sign"), KeyTypes::PersonaSigning);
+        key(
+            &format!("{ALICE_DID}#auth"),
+            KeyTypes::PersonaAuthentication,
+        );
+        key(&format!("{BOB_DID}#sign"), KeyTypes::PersonaSigning);
+        key(&format!("{BOB_DID}#auth"), KeyTypes::PersonaAuthentication);
+        // A webvh update key belongs to neither bucket.
+        key(&format!("{ALICE_DID}#update"), KeyTypes::WebVHManagement);
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+        let vta = &page.content_panel.vta;
+
+        assert_eq!(vta.key_count, 5, "total is every managed key");
+        assert_eq!(vta.persona_key_count, 4, "both personas' keys count");
+        assert_eq!(
+            vta.relationship_key_count, 0,
+            "no relationships means no relationship keys"
+        );
+    }
+
+    #[test]
+    fn relationship_keys_are_counted_by_their_own_purposes() {
+        use openvtc_core::config::KeyTypes;
+
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let mut config = config_with_membership(ALICE_DID, None, vtc_did, None);
+        for (id, purpose) in [
+            ("r1#verify", KeyTypes::RelationshipVerification),
+            ("r1#encrypt", KeyTypes::RelationshipEncryption),
+            (&format!("{ALICE_DID}#sign"), KeyTypes::PersonaSigning),
+        ] {
+            config.key_info.insert(id.to_string(), key_info(purpose));
+        }
+
+        let mut page = MainPageState::default();
+        page.sync_from_config(&config);
+
+        assert_eq!(page.content_panel.vta.persona_key_count, 1);
+        assert_eq!(page.content_panel.vta.relationship_key_count, 2);
     }
 
     // --- agent names on the relationship-VRC rows and the VIC list ---

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -157,6 +157,7 @@ mod setup_vta_actions;
 mod setup_wizard;
 pub mod state;
 mod vic;
+mod vta_transports;
 
 pub struct DeferredLoad {
     pub profile: String,
@@ -1936,6 +1937,38 @@ impl StateHandler {
                                 let results =
                                     agent_name_refresh::resolve_batch(resolver, targets).await;
                                 background_dispatch::DispatchOutcome::AgentName(results)
+                            },
+                        );
+                    }
+
+                    // Probe what transports the VTA advertises, for the VTA
+                    // panel. Runs on this tick rather than its own so the loop
+                    // gains no extra timer. Re-probed only while the answer is
+                    // still missing or failed — once a VTA has answered, its
+                    // advertised services are stable for the session, so a
+                    // healthy setup probes exactly once per launch (R1.4).
+                    let needs_probe = state
+                        .main_page
+                        .content_panel
+                        .vta
+                        .transports
+                        .advertised
+                        .as_ref()
+                        .is_none_or(|a| a.error.is_some());
+                    if needs_probe
+                        && let openvtc_core::config::KeyBackend::Vta { vta_did, .. } =
+                            &config.key_backend
+                        && !vta_did.is_empty()
+                        && in_flight.try_begin(background_dispatch::DispatchDomain::VtaTransports)
+                    {
+                        let vta_did = vta_did.clone();
+                        background_dispatch::spawn_dispatch(
+                            dispatch_tx.clone(),
+                            background_dispatch::DispatchDomain::VtaTransports,
+                            async move {
+                                background_dispatch::DispatchOutcome::VtaTransports(
+                                    vta_transports::probe(vta_did).await,
+                                )
                             },
                         );
                     }

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -56,17 +56,37 @@ pub trait ConfigExtension {
     /// into an existing account `config`, persist, and return its id. Used by the
     /// join flow (Stage 4) once a community has been chosen.
     ///
-    /// The persona label/username is read from `state.username` (set by the
-    /// caller — the setup wizard via `Action::SetUsername`, or the join flow from
-    /// the community display name). This replaces the previous
+    /// The persona label/username is read from `state.username` — a name the
+    /// *operator* chose (the setup wizard via `Action::SetUsername`, or the
+    /// create-persona overlay). This replaces the previous
     /// `setup_flow.username.username` read so the join flow needn't construct a
     /// full `SetupFlow` UI component just to carry one string.
+    ///
+    /// An **empty** `username` mints the persona unlabelled and leaves
+    /// `public.friendly_name` alone: the join flow has no operator-chosen name
+    /// to offer, and the community name it used to pass here is not a name for
+    /// the persona.
     async fn mint_persona_into(
         config: &mut Config,
         state: &SetupState,
         tdk: &TDK,
         profile: &str,
     ) -> Result<PersonaId>;
+}
+
+/// The operator-chosen name in `SetupState::username`, or `None` when there
+/// isn't one.
+///
+/// Gates both the persona's `label` and the account's `public.friendly_name`.
+/// The join flow used to pass the *community's* name here (falling back to a
+/// rendering of the community's VTC DID when it had no verified name), which
+/// labelled the persona with a community identifier and made the account's
+/// self-display name the community it had just joined — the top bar then named
+/// that community twice. A join now passes nothing and both fields are left
+/// alone; only a name the operator actually typed sets them.
+fn operator_chosen_name(username: &str) -> Option<&str> {
+    let name = username.trim();
+    (!name.is_empty()).then_some(name)
 }
 
 impl ConfigExtension for Config {
@@ -323,7 +343,7 @@ impl ConfigExtension for Config {
             mediator_did: Some(mediator_did.clone()),
             origin_context_id: String::new(),
             created_at: Utc::now(),
-            label: Some(state.username.clone()),
+            label: operator_chosen_name(&state.username).map(str::to_owned),
         };
 
         config.account.personas.insert(persona_id, persona_record);
@@ -338,7 +358,12 @@ impl ConfigExtension for Config {
             },
         );
         config.key_info.extend(key_info);
-        config.public.friendly_name = state.username.clone();
+        // Only an operator-chosen name may become the account's self-display
+        // name. The join flow passes nothing, so a join no longer overwrites
+        // `friendly_name` with the community it was joining.
+        if let Some(name) = operator_chosen_name(&state.username) {
+            config.public.friendly_name = name.to_string();
+        }
 
         config.save(
             profile,
@@ -442,6 +467,24 @@ mod tests {
     use super::*;
     use crate::state_handler::setup_sequence::VtaSetupState;
     use vta_sdk::provision_client::AdminCredentialReply;
+
+    // --- operator-chosen name gate ---
+
+    /// A name the operator typed labels the persona and becomes the account's
+    /// self-display name.
+    #[test]
+    fn an_operator_chosen_name_is_used() {
+        assert_eq!(operator_chosen_name("Glenn"), Some("Glenn"));
+        assert_eq!(operator_chosen_name("  Glenn  "), Some("Glenn"));
+    }
+
+    /// The join flow passes nothing, so the persona is minted unlabelled and
+    /// `friendly_name` is left alone — it must not inherit the community.
+    #[test]
+    fn no_name_leaves_both_fields_alone() {
+        assert_eq!(operator_chosen_name(""), None);
+        assert_eq!(operator_chosen_name("   "), None);
+    }
 
     /// A `SetupState` carrying just the VTA bootstrap output an account needs:
     /// the admin credential, top context, and (plaintext) protection.

--- a/openvtc/src/state_handler/vta_transports.rs
+++ b/openvtc/src/state_handler/vta_transports.rs
@@ -19,26 +19,47 @@
 
 use crate::state_handler::main_page::content::AdvertisedTransports;
 
+/// Ceiling on one probe. `resolve_vta` resolves a DID document through the
+/// resolver cache and sets no deadline of its own, so the bound is imposed here
+/// (VTI R1.2): a hung publication endpoint must produce an error the panel can
+/// show, not a job that never returns. A job that never returns would also hold
+/// the `VtaTransports` dispatch domain for the life of the process, which is
+/// what stops the tick from ever retrying.
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Probe `vta_did` for its advertised transports.
 ///
-/// Never fails: a resolve error comes back as an `AdvertisedTransports` with
-/// [`error`](AdvertisedTransports::error) set and both endpoints `None`, so the
-/// panel can say "could not check" instead of rendering an unreachable VTA as
-/// one that offers nothing (VTI R6.4).
+/// Never fails: a resolve error or a timeout comes back as an
+/// `AdvertisedTransports` with [`error`](AdvertisedTransports::error) set and
+/// both endpoints `None`, so the panel can say "could not check" instead of
+/// rendering an unreachable VTA as one that offers nothing (VTI R6.4). The two
+/// cases carry distinct messages so the operator can tell an unreachable
+/// endpoint from one that answered with something unusable.
 pub(crate) async fn probe(vta_did: String) -> AdvertisedTransports {
-    match vta_sdk::provision_client::resolve_vta(&vta_did).await {
-        Ok(resolved) => AdvertisedTransports {
+    let failed = |reason: String| {
+        tracing::debug!("VTA transport probe for {vta_did} failed: {reason}");
+        AdvertisedTransports {
+            mediator_did: None,
+            rest_url: None,
+            error: Some(reason),
+        }
+    };
+
+    match tokio::time::timeout(
+        PROBE_TIMEOUT,
+        vta_sdk::provision_client::resolve_vta(&vta_did),
+    )
+    .await
+    {
+        Ok(Ok(resolved)) => AdvertisedTransports {
             mediator_did: resolved.mediator_did,
             rest_url: resolved.rest_url,
             error: None,
         },
-        Err(e) => {
-            tracing::debug!("VTA transport probe for {vta_did} failed: {e}");
-            AdvertisedTransports {
-                mediator_did: None,
-                rest_url: None,
-                error: Some(e.to_string()),
-            }
-        }
+        Ok(Err(e)) => failed(e.to_string()),
+        Err(_) => failed(format!(
+            "timed out after {}s resolving the VTA's DID document",
+            PROBE_TIMEOUT.as_secs()
+        )),
     }
 }

--- a/openvtc/src/state_handler/vta_transports.rs
+++ b/openvtc/src/state_handler/vta_transports.rs
@@ -1,0 +1,44 @@
+//! Off-loop probe of the transports a VTA advertises.
+//!
+//! The VTA panel used to show a bare `VTA URL`, which says nothing about *how*
+//! the CLI is talking to the VTA — the URL stays populated on the DIDComm path
+//! too, where it is only the REST fallback. What the operator needs is the pair
+//! "what does this VTA offer" / "which one are we on".
+//!
+//! The second half is free (see
+//! [`VtaTransports::in_use`](crate::state_handler::main_page::content::VtaTransports::in_use)).
+//! The first needs the VTA's DID document resolved, so it runs here as a
+//! background job on its own dispatch domain and is applied to the panel state
+//! on the loop thread, preserving the single-mutator invariant.
+//!
+//! The endpoint extraction is **not** hand-rolled: `vta_sdk`'s
+//! `provision_client::resolve_vta` already reads the `#vta-rest` and
+//! `DIDCommMessaging` services out of the document, and the setup flow calls the
+//! same function — so the panel and the bootstrap diagnostics can never disagree
+//! about what a VTA advertises.
+
+use crate::state_handler::main_page::content::AdvertisedTransports;
+
+/// Probe `vta_did` for its advertised transports.
+///
+/// Never fails: a resolve error comes back as an `AdvertisedTransports` with
+/// [`error`](AdvertisedTransports::error) set and both endpoints `None`, so the
+/// panel can say "could not check" instead of rendering an unreachable VTA as
+/// one that offers nothing (VTI R6.4).
+pub(crate) async fn probe(vta_did: String) -> AdvertisedTransports {
+    match vta_sdk::provision_client::resolve_vta(&vta_did).await {
+        Ok(resolved) => AdvertisedTransports {
+            mediator_did: resolved.mediator_did,
+            rest_url: resolved.rest_url,
+            error: None,
+        },
+        Err(e) => {
+            tracing::debug!("VTA transport probe for {vta_did} failed: {e}");
+            AdvertisedTransports {
+                mediator_did: None,
+                rest_url: None,
+                error: Some(e.to_string()),
+            }
+        }
+    }
+}

--- a/openvtc/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc/src/ui/pages/main/components/content_panel.rs
@@ -64,6 +64,11 @@ impl ContentPanelState {
                 .title("Content")
         };
 
+        // Record this frame's usable content width before any panel renders, so
+        // status messages wrap to the terminal rather than a fixed 76 columns.
+        // Two columns come off for the panel's own leading indentation.
+        super::status::set_wrap_width(content_block.inner(rect).width.saturating_sub(2) as usize);
+
         let panel: Option<Box<dyn Panel>> = match menu.selected_menu {
             MainMenu::Communities => {
                 if self.capabilities.view.is_some() {

--- a/openvtc/src/ui/pages/main/components/status.rs
+++ b/openvtc/src/ui/pages/main/components/status.rs
@@ -10,10 +10,38 @@ use ratatui::{
     text::{Line, Span},
 };
 
-/// Approximate visible width of the content panel after borders and padding.
-/// Panels don't know their own width at render time; this matches the width
-/// used by the logs-panel detail view.
-const STATUS_WRAP_WIDTH: usize = 76;
+/// Fallback wrap width, used only before the first frame has recorded a real
+/// one. Matches the width the logs-panel detail view has always assumed.
+const DEFAULT_STATUS_WRAP_WIDTH: usize = 76;
+
+/// Narrowest width worth wrapping to. Below this a "wrapped" message is one
+/// word per line, which is less readable than letting it run.
+const MIN_STATUS_WRAP_WIDTH: usize = 24;
+
+thread_local! {
+    /// Visible width of the content panel, recorded by [`set_wrap_width`] at the
+    /// top of each frame.
+    ///
+    /// The `Panel` trait renders to `Vec<Line>` without being told its area, so
+    /// wrapping used to be hardcoded to 76 columns — on a wide terminal every
+    /// status message wrapped at less than half the available width. Threading
+    /// the width through every panel signature would touch all of them for one
+    /// consumer; the render path is single-threaded and strictly
+    /// set-then-render within a frame, so a thread-local carries it instead.
+    static WRAP_WIDTH: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(DEFAULT_STATUS_WRAP_WIDTH) };
+}
+
+/// Record the content panel's visible width for this frame. Called by the
+/// content panel before it renders, so `push_status` wraps to the real width.
+pub fn set_wrap_width(width: usize) {
+    WRAP_WIDTH.set(width.max(MIN_STATUS_WRAP_WIDTH));
+}
+
+/// The width [`push_status`] wraps to.
+fn wrap_width() -> usize {
+    WRAP_WIDTH.get()
+}
 
 /// Push a status message as one or more wrapped lines (no trailing blank).
 ///
@@ -23,7 +51,7 @@ const STATUS_WRAP_WIDTH: usize = 76;
 /// a panel.
 pub fn push_status(lines: &mut Vec<Line<'static>>, msg: &str, indent: &'static str) {
     let style = status_style(msg);
-    let width = STATUS_WRAP_WIDTH.saturating_sub(indent.len()).max(1);
+    let width = wrap_width().saturating_sub(indent.len()).max(1);
     for wrapped in wrap_text(msg, width) {
         lines.push(Line::from(vec![Span::styled(
             format!("{}{}", indent, wrapped),

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -1,9 +1,10 @@
 use super::panel::Panel;
+use super::status::push_status;
 use crate::colors::{
     COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
 };
 use crate::state_handler::{
-    main_page::content::{ContentPanelState, VicLifecycle, VtaFocus, VtaState},
+    main_page::content::{ContentPanelState, VicLifecycle, VtaFocus, VtaState, VtaTransport},
     state::ConnectionState,
 };
 use openvtc_core::display::{display_identifier, truncate_did_centered};
@@ -72,20 +73,29 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
             ),
         ]));
     } else {
-        if let Some(agent_name) = &state.persona_agent_name {
-            lines.push(Line::from(vec![
-                Span::styled("  Agent name:    ", label_style),
-                Span::styled(agent_name.clone(), value_style),
-            ]));
+        // One row per identity, not two. The name is the value and the DID is
+        // dimmed detail beneath it — the same shape the identity lists below
+        // already use, instead of an "Agent name" row and a "Persona DID" row
+        // naming the same party twice. With no verified name the DID *is* the
+        // value and there is no second line.
+        push_identity(
+            &mut lines,
+            "  Persona:       ",
+            state.persona_agent_name.as_deref(),
+            &state.persona_did,
+        );
+        // The mediator is a *transport* fact, not an identity one, so on a
+        // VTA-managed account it lives under `Transport:` below rather than
+        // being named here as well. A local-key account has no VTA Service
+        // section to host it, so it stays here.
+        if !state.is_vta_managed {
+            push_identity(
+                &mut lines,
+                "  Mediator:      ",
+                state.mediator_agent_name.as_deref(),
+                &state.mediator_did,
+            );
         }
-        lines.push(Line::from(vec![
-            Span::styled("  Persona DID:   ", label_style),
-            Span::styled(state.persona_did.clone(), value_style),
-        ]));
-        lines.push(Line::from(vec![
-            Span::styled("  Mediator DID:  ", label_style),
-            Span::styled(state.mediator_did.clone(), value_style),
-        ]));
     }
 
     if !state.is_vta_managed {
@@ -103,17 +113,22 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         lines.push(Line::from(" VTA Service").fg(COLOR_SUCCESS).bold());
         lines.push(Line::from(""));
 
+        push_identity(
+            &mut lines,
+            "  VTA:           ",
+            state.vta_agent_name.as_deref(),
+            &state.vta_did,
+        );
+        render_transports(state, &mut lines);
         lines.push(Line::from(vec![
-            Span::styled("  VTA URL:       ", label_style),
-            Span::styled(state.vta_url.clone(), value_style),
-        ]));
-        lines.push(Line::from(vec![
-            Span::styled("  VTA DID:       ", label_style),
-            Span::styled(state.vta_did.clone(), value_style),
-        ]));
-        lines.push(Line::from(vec![
-            Span::styled("  Credential:    ", label_style),
-            Span::styled(state.credential_did.clone(), value_style),
+            // "Credential" said nothing about what the credential is *for*. It
+            // is the DID this client authenticates to the VTA as; a `did:key`
+            // can never carry an agent name, so it stays a (truncated) DID.
+            Span::styled("  Authenticated: ", label_style),
+            Span::styled(
+                truncate_did_centered(&state.credential_did, CONFIRM_DID_WIDTH).into_owned(),
+                value_style,
+            ),
         ]));
 
         lines.push(Line::from(""));
@@ -137,8 +152,15 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         ]));
     }
 
-    // Active DIDs
-    if !state.active_dids.is_empty() {
+    // Active DIDs — the persona plus one relationship pseudonym (R-DID) per
+    // relationship. Suppressed when it holds nothing but the persona: that row
+    // duplicates the one already marked `active` in Context Identities below,
+    // and a section that restates the row under it is noise, not structure.
+    let active_dids_worth_showing = state
+        .active_dids
+        .iter()
+        .any(|d| d.label.starts_with("R-DID"));
+    if active_dids_worth_showing {
         lines.push(Line::from(""));
         lines.push(
             Line::from(format!(" Active DIDs ({})", state.active_dids.len()))
@@ -169,19 +191,35 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
     // Context identities — every persona DID in this context, with its binding.
     // Orphans (no community) are flagged so they can be spotted and removed.
     if !state.context_dids.is_empty() {
+        // Same focus affordance the VIC section carries. Without it this list
+        // showed a `▸` selection cursor and a key-hint row with no indication
+        // that it was the focused list — the two lists looked equally live.
+        let focused = state.focus == VtaFocus::Dids;
         lines.push(Line::from(""));
-        lines.push(
-            Line::from(format!(
-                " Context Identities ({})",
-                state.context_dids.len()
-            ))
-            .fg(COLOR_SUCCESS)
-            .bold(),
-        );
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!(" Context Identities ({})", state.context_dids.len()),
+                if focused {
+                    Style::new().fg(COLOR_SUCCESS).bold()
+                } else {
+                    Style::new().fg(COLOR_DARK_GRAY).bold()
+                },
+            ),
+            Span::styled(
+                if focused {
+                    "   ◀ focus"
+                } else {
+                    "   [Tab] focus"
+                },
+                Style::new().fg(COLOR_DARK_GRAY),
+            ),
+        ]));
         lines.push(Line::from(""));
 
         for (i, d) in state.context_dids.iter().enumerate() {
-            let is_selected = i == state.did_selected_index;
+            // Only the focused list shows a selection cursor, so `↑/↓` never
+            // appears to be driving two lists at once (matches the VIC rows).
+            let is_selected = focused && i == state.did_selected_index;
             let orphan = d.bound_communities == 0;
             let prefix = if is_selected { "▸ " } else { "  " };
             let marker = if orphan { "○ " } else { "● " };
@@ -233,8 +271,12 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
             ]));
         }
 
-        // Confirmation prompt (a delete is armed) or the navigation/remove hint.
-        lines.push(Line::from(""));
+        // Confirmation prompt (a delete is armed) or, when focused, the
+        // navigation/remove hint. The spacer goes with them — an unfocused list
+        // ends at its last row rather than trailing a blank.
+        if state.confirm_delete_did.is_some() || focused {
+            lines.push(Line::from(""));
+        }
         if let Some(idx) = state.confirm_delete_did {
             // Keep *both* the name and the DID. The row the operator selected
             // shows the name, so a DID-only prompt names something they never
@@ -256,12 +298,12 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
                     .fg(COLOR_ORANGE)
                     .bold(),
             );
-        } else {
+        } else if focused {
+            // Same verb order as the VIC hints: navigation, then create, then
+            // the rest, each `key: verb` with the same separator.
             lines.push(
-                Line::from(
-                    "↑/↓ select   n: new persona   g: agent names   d: remove selected orphan",
-                )
-                .fg(COLOR_DARK_GRAY),
+                Line::from("↑/↓ select   n: new persona   g: agent names   d: remove orphan")
+                    .fg(COLOR_DARK_GRAY),
             );
         }
     } else {
@@ -275,6 +317,108 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
     render_vics(state, &mut lines);
 
     lines
+}
+
+/// Push a labelled identity as one row: the verified agent name as the value,
+/// with the DID as a dimmed second line. With no verified name the DID is the
+/// value and only one line is pushed — a party is never named twice.
+fn push_identity(
+    lines: &mut Vec<Line<'static>>,
+    label: &'static str,
+    agent_name: Option<&str>,
+    did: &str,
+) {
+    let label_style = Style::new().fg(COLOR_TEXT_DEFAULT);
+    let value_style = Style::new().fg(COLOR_SOFT_PURPLE);
+    match agent_name {
+        Some(name) => {
+            lines.push(Line::from(vec![
+                Span::styled(label, label_style),
+                Span::styled(name.to_string(), value_style),
+            ]));
+            lines.push(Line::from(Span::styled(
+                format!("{:width$}{did}", "", width = label.len()),
+                Style::new().fg(COLOR_DARK_GRAY),
+            )));
+        }
+        None => lines.push(Line::from(vec![
+            Span::styled(label, label_style),
+            Span::styled(did.to_string(), value_style),
+        ])),
+    }
+}
+
+/// Render the transport block: which transport this process is on, what the VTA
+/// advertises, and the endpoint behind each.
+///
+/// This replaced a bare `VTA URL:` row. The URL alone was misleading — it stays
+/// populated on the DIDComm path (where it is only the REST fallback), so it
+/// read as "we talk to the VTA over HTTPS" even when every call went over
+/// DIDComm. A probe that has not landed says "checking…", and a probe that
+/// *failed* says so explicitly, so an unreachable VTA is never rendered as one
+/// that advertises nothing (VTI R6.4).
+fn render_transports(state: &VtaState, lines: &mut Vec<Line<'static>>) {
+    let label_style = Style::new().fg(COLOR_TEXT_DEFAULT);
+    let dim = Style::new().fg(COLOR_DARK_GRAY);
+    let t = &state.transports;
+
+    let mut spans = vec![
+        Span::styled("  Transport:     ", label_style),
+        Span::styled(t.in_use.label().to_string(), Style::new().fg(COLOR_SUCCESS)),
+        Span::styled("  (in use)", dim),
+    ];
+    match &t.advertised {
+        None => spans.push(Span::styled("   ·   checking what else is offered…", dim)),
+        Some(a) if a.error.is_some() => {
+            spans.push(Span::styled("   ·   other transports unknown", {
+                Style::new().fg(COLOR_ORANGE)
+            }));
+        }
+        Some(a) => {
+            // Only mention the transport we are *not* on; the one in use is
+            // already the headline.
+            let other = match t.in_use {
+                VtaTransport::DidComm => a.rest_url.is_some().then_some("REST"),
+                VtaTransport::Rest => a.mediator_did.is_some().then_some("DIDComm"),
+            };
+            match other {
+                Some(name) => {
+                    spans.push(Span::styled(format!("   ·   {name} also available"), dim))
+                }
+                None => spans.push(Span::styled("   ·   only transport offered", dim)),
+            }
+        }
+    }
+    lines.push(Line::from(spans));
+
+    // Endpoint detail, indented under the transport it belongs to.
+    if !state.mediator_did.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("    via mediator  ", dim),
+            Span::styled(
+                display_identifier(
+                    state.mediator_agent_name.as_deref(),
+                    &state.mediator_did,
+                    ID_WIDTH,
+                )
+                .into_owned(),
+                dim,
+            ),
+        ]));
+    }
+    if !t.rest_url.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("    REST endpoint ", dim),
+            Span::styled(t.rest_url.clone(), dim),
+        ]));
+    }
+    if let Some(err) = t.advertised.as_ref().and_then(|a| a.error.as_deref()) {
+        push_status(
+            lines,
+            &format!("Could not read the VTA's advertised transports: {err}"),
+            "    ",
+        );
+    }
 }
 
 /// Render the "Invitation Credentials" (VIC) manager section: the held VICs with
@@ -398,7 +542,9 @@ fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state_handler::main_page::content::{ManagedDid, VicSummary};
+    use crate::state_handler::main_page::content::{
+        ActiveDid, AdvertisedTransports, ManagedDid, VicSummary, VtaTransports,
+    };
 
     const PERSONA_DID: &str = "did:webvh:QmScidAliceAAAAAAAAAAAAAAAAAAAA:example.com:alice";
     const VTC_DID: &str = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
@@ -443,6 +589,206 @@ mod tests {
             vics: vics.into(),
             ..VtaState::default()
         }
+    }
+
+    // --- transports ---------------------------------------------------------
+
+    const VTA_DID: &str = "did:webvh:QmScidVtaCCCCCCCCCCCCCCCCCCCCCC:example.com:vta";
+    const MEDIATOR_DID: &str = "did:webvh:QmScidMediatorDDDDDDDDDDDDDDDD:example.com:mediator";
+
+    /// A VTA-managed account on the DIDComm transport with a REST fallback URL.
+    fn vta_managed(advertised: Option<AdvertisedTransports>) -> VtaState {
+        VtaState {
+            is_vta_managed: true,
+            persona_did: PERSONA_DID.to_string(),
+            mediator_did: MEDIATOR_DID.to_string(),
+            vta_did: VTA_DID.to_string(),
+            credential_did: "did:key:z6MkTestCredentialKeyAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+            transports: VtaTransports {
+                in_use: VtaTransport::DidComm,
+                rest_url: "https://vta.example".to_string(),
+                advertised,
+            },
+            ..VtaState::default()
+        }
+    }
+
+    fn joined(lines: &[Line<'static>]) -> String {
+        text(lines).join("\n")
+    }
+
+    /// The headline fact is the transport in use, not the URL. A populated
+    /// `vta_url` on the DIDComm path is the REST *fallback* and must not read as
+    /// "we talk to the VTA over HTTPS".
+    #[test]
+    fn transport_row_names_the_transport_in_use() {
+        let out = joined(&render(&vta_managed(None)));
+        assert!(out.contains("Transport:"), "{out}");
+        assert!(out.contains("DIDComm"), "{out}");
+        assert!(out.contains("(in use)"), "{out}");
+        assert!(!out.contains("VTA URL"), "the bare URL row is gone: {out}");
+    }
+
+    /// Until the probe lands the panel says so, rather than claiming the VTA
+    /// offers only the transport we happen to be on.
+    #[test]
+    fn transport_row_says_checking_before_the_probe_lands() {
+        let out = joined(&render(&vta_managed(None)));
+        assert!(out.contains("checking"), "{out}");
+    }
+
+    #[test]
+    fn transport_row_reports_the_other_advertised_transport() {
+        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
+            mediator_did: Some(MEDIATOR_DID.to_string()),
+            rest_url: Some("https://vta.example".to_string()),
+            error: None,
+        }))));
+        assert!(out.contains("REST also available"), "{out}");
+    }
+
+    /// A VTA that advertises only the transport in use says exactly that.
+    #[test]
+    fn transport_row_reports_a_single_advertised_transport() {
+        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
+            mediator_did: Some(MEDIATOR_DID.to_string()),
+            rest_url: None,
+            error: None,
+        }))));
+        assert!(out.contains("only transport offered"), "{out}");
+    }
+
+    /// A failed probe must be distinguishable from "nothing else is offered" —
+    /// an unreachable publication endpoint is not the same fact (VTI R6.4).
+    #[test]
+    fn a_failed_probe_reads_as_unknown_not_as_unavailable() {
+        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
+            mediator_did: None,
+            rest_url: None,
+            error: Some("DID did not resolve".to_string()),
+        }))));
+        assert!(out.contains("other transports unknown"), "{out}");
+        assert!(
+            out.contains("DID did not resolve"),
+            "reason is shown: {out}"
+        );
+        assert!(
+            !out.contains("only transport offered"),
+            "must not claim the transports are known: {out}"
+        );
+    }
+
+    /// The credential DID is what we authenticate *as*; the old "Credential:"
+    /// label said nothing about that.
+    #[test]
+    fn the_credential_row_says_what_the_credential_is_for() {
+        let out = joined(&render(&vta_managed(None)));
+        assert!(out.contains("Authenticated:"), "{out}");
+    }
+
+    // --- identity rows ------------------------------------------------------
+
+    /// One row per party: the verified name is the value, the DID is dimmed
+    /// detail below it — not a separate "Agent name" row naming the same party.
+    #[test]
+    fn an_identity_row_leads_with_the_name_and_keeps_the_did_below() {
+        let mut state = vta_managed(None);
+        state.persona_agent_name = Some("example.com/@alice".to_string());
+        let out = text(&render(&state));
+
+        let name_row = out
+            .iter()
+            .position(|l| l.contains("Persona:") && l.contains("example.com/@alice"))
+            .expect("named persona row");
+        assert!(
+            out[name_row + 1].contains(PERSONA_DID),
+            "DID sits under the name: {:?}",
+            &out[name_row..name_row + 2]
+        );
+        assert!(
+            !out.iter().any(|l| l.contains("Agent name:")),
+            "no separate agent-name row: {out:?}"
+        );
+    }
+
+    /// With no verified name the DID is the value and there is no second line.
+    #[test]
+    fn an_identity_row_without_a_name_shows_only_the_did() {
+        let out = text(&render(&vta_managed(None)));
+        let rows: Vec<_> = out.iter().filter(|l| l.contains(PERSONA_DID)).collect();
+        assert_eq!(rows.len(), 1, "DID appears once: {out:?}");
+        assert!(rows[0].contains("Persona:"), "{rows:?}");
+    }
+
+    // --- section suppression ------------------------------------------------
+
+    /// "Active DIDs" holding nothing but the persona restates the row already
+    /// marked `active` in Context Identities, so it is suppressed.
+    #[test]
+    fn active_dids_is_hidden_when_it_only_restates_the_persona() {
+        let mut state = vta_managed(None);
+        state.active_dids = vec![ActiveDid {
+            did: PERSONA_DID.to_string(),
+            agent_name: None,
+            label: "Persona".to_string(),
+        }]
+        .into();
+        let out = joined(&render(&state));
+        assert!(!out.contains("Active DIDs"), "{out}");
+    }
+
+    /// A relationship pseudonym is information the identity list does not carry,
+    /// so the section comes back.
+    #[test]
+    fn active_dids_is_shown_once_a_relationship_pseudonym_exists() {
+        let mut state = vta_managed(None);
+        state.active_dids = vec![
+            ActiveDid {
+                did: PERSONA_DID.to_string(),
+                agent_name: None,
+                label: "Persona".to_string(),
+            },
+            ActiveDid {
+                did: "did:peer:2.Ez6Mk".to_string(),
+                agent_name: None,
+                label: "R-DID (bob)".to_string(),
+            },
+        ]
+        .into();
+        let out = joined(&render(&state));
+        assert!(out.contains("Active DIDs (2)"), "{out}");
+    }
+
+    // --- focus cues ---------------------------------------------------------
+
+    /// Both manageable lists carry the same focus affordance, and only the
+    /// focused one shows a selection cursor and its key hints.
+    #[test]
+    fn only_the_focused_identity_list_shows_a_cursor_and_hints() {
+        let mut state = state_with(vec![managed_did(None)], vec![vic(None)]);
+
+        state.focus = VtaFocus::Dids;
+        let focused = joined(&render(&state));
+        assert!(
+            focused.contains("Context Identities (1)   ◀ focus"),
+            "{focused}"
+        );
+        assert!(
+            focused.contains("▸ "),
+            "cursor shown when focused: {focused}"
+        );
+        assert!(focused.contains("n: new persona"), "{focused}");
+
+        state.focus = VtaFocus::Vics;
+        let unfocused = joined(&render(&state));
+        assert!(
+            unfocused.contains("Context Identities (1)   [Tab] focus"),
+            "{unfocused}"
+        );
+        assert!(
+            !unfocused.contains("n: new persona"),
+            "hints belong to the focused list: {unfocused}"
+        );
     }
 
     // --- VIC issuer ---------------------------------------------------------

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2073,6 +2073,19 @@ fn view_id(page: &MainPageState) -> String {
     format!("{menu:?}:{mode}")
 }
 
+/// The account's self-display name for the top-right header slot, or `None` when
+/// it would only repeat the community chip already shown top-left.
+///
+/// A join used to copy the community's name into `public.friendly_name`, so this
+/// slot rendered the community a second time; accounts carrying that legacy
+/// value still would, and a user may also have typed the community's name in
+/// themselves. Either way the top bar should read "community · you", never
+/// "community · community · you".
+fn header_self_name<'a>(name: &'a str, community: &str) -> Option<&'a str> {
+    let name = name.trim();
+    (!name.is_empty() && name != community.trim()).then_some(name)
+}
+
 /// Copy text to the system clipboard, log the result to the activity log,
 /// and update the status panel message to give the user visual feedback.
 fn copy_to_clipboard(
@@ -2170,20 +2183,31 @@ impl ComponentRender<()> for MainPage {
             top[1],
         );
 
+        // Top-right: who *we* are. The account's self-display name goes above the
+        // active persona's identity — but only when it says something the chrome
+        // isn't already saying. A join used to copy the community's name into
+        // `friendly_name`, so this line rendered the community a second time,
+        // right of the community chip top-left; an account carrying that legacy
+        // value still would. Suppressing the duplicate leaves the top bar reading
+        // "community · you" instead of "community · community · you".
+        let mut top_right = Vec::new();
+        if let Some(self_name) = header_self_name(
+            &self.props.main_page.config.name,
+            &self.props.main_page.config.community,
+        ) {
+            top_right.push(Line::from(self_name.to_string()).fg(COLOR_SUCCESS));
+        }
+        top_right.push(
+            Line::from(match &self.props.main_page.config.agent_name {
+                // A verified agent name is short and human-readable — show it
+                // whole in place of the truncated DID.
+                Some(name) => name.clone(),
+                None => truncate_did_centered(&self.props.main_page.config.did, 30).into_owned(),
+            })
+            .fg(COLOR_TEXT_DEFAULT),
+        );
         frame.render_widget(
-            Paragraph::new(vec![
-                Line::from(self.props.main_page.config.name.to_string()).fg(COLOR_SUCCESS),
-                Line::from(match &self.props.main_page.config.agent_name {
-                    // A verified agent name is short and human-readable — show it
-                    // whole in place of the truncated DID.
-                    Some(name) => name.clone(),
-                    None => {
-                        truncate_did_centered(&self.props.main_page.config.did, 30).into_owned()
-                    }
-                })
-                .fg(COLOR_TEXT_DEFAULT),
-            ])
-            .alignment(Alignment::Right),
+            Paragraph::new(top_right).alignment(Alignment::Right),
             top[2],
         );
 
@@ -2683,6 +2707,43 @@ impl MainPage {
         }
 
         frame.render_widget(Paragraph::new(lines).block(block), popup_area);
+    }
+}
+
+#[cfg(test)]
+mod header_tests {
+    use super::header_self_name;
+
+    /// A distinct self-name is the point of the slot and is kept.
+    #[test]
+    fn a_distinct_self_name_is_shown() {
+        assert_eq!(
+            header_self_name("Glenn", "webvh.storm.ws/@first-vtc"),
+            Some("Glenn")
+        );
+    }
+
+    /// The regression: a join copied the community's name into `friendly_name`,
+    /// so the header announced the community either side of the connection
+    /// indicator.
+    #[test]
+    fn a_self_name_equal_to_the_community_is_suppressed() {
+        assert_eq!(
+            header_self_name("webvh.storm.ws/@first-vtc", "webvh.storm.ws/@first-vtc"),
+            None
+        );
+    }
+
+    /// Whitespace must not smuggle the duplicate back in.
+    #[test]
+    fn the_comparison_ignores_surrounding_whitespace() {
+        assert_eq!(header_self_name("  Acme  ", "Acme"), None);
+    }
+
+    #[test]
+    fn an_empty_self_name_is_suppressed() {
+        assert_eq!(header_self_name("", "Acme"), None);
+        assert_eq!(header_self_name("   ", ""), None);
     }
 }
 


### PR DESCRIPTION
The VTA Service screen led with a bare `VTA URL`, which says nothing about how the CLI actually reaches the VTA — the URL stays populated on the DIDComm path, where it is only the REST fallback, so it read as "we talk to the VTA over HTTPS" even when every call went over DIDComm. Several rows also showed raw DIDs for parties that can publish a verifiable name, and two numbers on the screen were wrong.

### Before / after

```
  VTA URL:       https://glenn.storm.ws                 →   VTA:           webvh.storm.ws/@glenn-vta
  VTA DID:       did:webvh:QmWoJD2kpP6A…:glenn-vta          Transport:     DIDComm  (in use)   ·   REST also available
  Credential:    did:key:z6Mkogx4T4h4k63LrYKdh…             via mediator  did:webvh:QmTS3a3H9Dk4…:mediator
                                                            REST endpoint https://glenn.storm.ws
                                                          Authenticated: did:key:z6Mkogx4T4h4k6...fD4gKSXgHYyxNvQU3uvv4e
```

### Transports

`Transport:` replaces `VTA URL:`, naming the transport in use and what else the VTA offers.

- **In use** is derived from the same condition `build_runtime_vta_client` branches on (`mediator_did.is_some()`), so the panel cannot drift from the client.
- **Advertised** comes from `vta_sdk::provision_client::resolve_vta` — the same call the setup flow already makes, so the panel and the bootstrap diagnostics can never disagree about what a VTA offers. It runs as a background probe on its own dispatch domain, bounded by a 10 s timeout.
- A probe that has not landed reads *checking*; one that failed reads *other transports unknown* **with the reason**, so an unreachable publication endpoint is never rendered as a VTA that offers nothing (R6.4).

### Names

The VTA's DID and the persona's mediator DID were the only displayed DIDs missing from `agent_name_refresh_targets`, which is why those two rows always showed a raw DID. Both are swept now; a party with no verifiable name still renders as a DID, and nothing is displayed that has not round-tripped (`CLAUDE.md` agent-name rules unchanged). Identity rows also collapse to one row each — verified name as the value, DID as dimmed detail — instead of an "Agent name" row and a "&lt;party&gt; DID" row naming the same party twice.

### Persona labels (bug)

A join set the persona's label **and** the account's `public.friendly_name` from the *community's* name, falling back to a rendering of the community's VTC DID. That labelled a persona with a community DID in the identity list, and made the header announce the community on both sides of the connection indicator. A join now mints the persona unlabelled and leaves `friendly_name` alone; only an operator-chosen name sets either. The header additionally suppresses a self-name identical to the community chip, so accounts already carrying the legacy value read correctly too.

Note: legacy `friendly_name` values on disk are suppressed in the header, not rewritten — a migration would have to decide what to replace them with.

### Key counts (bug)

Persona keys were matched by `starts_with(active_persona_did)` and everything else was called "relationship", so a second persona's keys were reported as relationship keys — an account with no relationships at all showed a non-zero relationship count. Both figures are now classified from `KeyInfoConfig::purpose`; keys in neither bucket (e.g. webvh update keys) are counted as neither, so the two figures never over-claim.

### Layout

- "Active DIDs" suppressed when it holds nothing but the persona (the row below already marks it active).
- Mediator moves under `Transport:`, where it is a transport fact rather than an identity one. Local-key accounts keep it in Context, which has no VTA Service section to host it.
- `Credential:` → `Authenticated:`, centre-truncated.
- Context Identities gains the focus affordance the VIC list already had, and shows its cursor and key hints only when focused.
- Status wrapping follows the real content width instead of a hardcoded 76 columns.

### Testing

`cargo test --workspace` — 619 pass, 0 fail. `cargo clippy --all-targets -- -D warnings` clean. 24 new tests covering: the transport row in each of its four states (in use / checking / other-available / probe-failed), identity rows with and without a verified name, section suppression, focus cues, key classification across two personas, sweep-target inclusion of the infrastructure DIDs, and the two name gates.

Panel output verified by rendering it to text; the shape in the before/after above is the real output.

### Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
      No new HTTP client. The one new outbound call (resolve_vta) sets no deadline
      of its own, so the probe wraps it in a 10 s tokio::time::timeout — see
      openvtc/src/state_handler/vta_transports.rs.
- [x] No lock held across a network await (R1.3)
      The probe holds nothing; its result is applied on the loop thread via
      apply_outcome, preserving the single-mutator invariant.
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
      No new mutations. The join-flow change removes two writes rather than adding any.
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
      The probe re-runs only while the answer is missing or failed, on the existing
      300 s tick, guarded by its own dispatch domain — a healthy setup probes once
      per launch. Read-only, so retry is safe.
- [x] Accept/poll/listen loops survive transient errors (R1.5)
      Probe failure is a value, not an error path; the tick is unaffected.
- [x] Acks/deletes happen only after durable handoff (R1.6)
      N/A — no acks or deletes touched.
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*)
      N/A — no wire types. VtaTransports/AdvertisedTransports are display-only
      structs, never serialised or persisted.
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*)
      An unprobed or failed probe renders as "unknown", never as "no other
      transport" — the display fails closed on the claim it cannot back.
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*)
      This is most of the PR: the transport row distinguishes checking / known /
      unknown and shows the failure reason; key counts state only what purpose
      classification supports; agent names remain verified-only.
- [x] "Process dies on the next line" answered for every mutation touched (R2.1)
      mint_persona_into now writes strictly less than before (label None,
      friendly_name untouched); the existing save and the join's
      rollback_minted_persona are unchanged and still restore prior friendly_name.
- [x] Deviations from this guide flagged explicitly with rule numbers
      One design note, not a rule deviation: status wrap width is carried to the
      panels through a thread-local set once per frame rather than by widening the
      Panel trait signature, which would touch all seven implementors for one
      consumer. The render path is single-threaded and strictly set-then-render
      within a frame.
```
