### PR TITLE
fix: follow the VTC Trust Tasks onto the spec/vtc registry authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Follow the VTC Trust Tasks onto the `spec/vtc` registry authority** —
+  `vta-sdk` 0.20.0 → 0.20.1 (and `trust-tasks-rs` 0.2.26 → 0.2.38). The VTC's
+  Trust Tasks have moved off the non-conformant
+  `trusttasks.org/openvtc/vtc/…` authority to the canonical registry at
+  `trusttasks.org/spec/vtc/…`
+  (OpenVTC/verifiable-trust-infrastructure#806, dtgwg-trust-tasks-tf#144).
+
+  No source change was needed: the join ceremony and the reciprocal-VMC
+  exchange dispatch on `vta_sdk::protocols` constants rather than string
+  literals, so the new URIs arrive with the bump —
+  `MEMBER_REQUEST_VMC_TYPE` and `MEMBER_VMC_TYPE` now read
+  `spec/vtc/members/{request-vmc,vmc}/0.1`, and the join-request and
+  self-remove receipts likewise. That indirection is why this is a lockfile
+  change and not an audit of every dispatch site.
+
+  The inbound router already accepted both authorities — `OPENVTC_CATCH_ALL_PATTERN`
+  gained its `spec/vtc/` arm ahead of the migration precisely so migrated
+  traffic would not be dropped before dispatch. It stays dual-arm for now:
+  the `openvtc/vtc/` arm can be retired once no supported VTC emits it, and
+  eight VTC tasks are still on the old authority awaiting a canonical fold.
+
 ## [0.2.1] - 2026-05-24
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -872,7 +872,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2780,7 +2780,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5295,7 +5295,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5751,7 +5751,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.20.0",
+ "vta-sdk 0.20.1",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5806,7 +5806,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.20.0",
+ "vta-sdk 0.20.1",
  "vta-service",
  "wiremock",
  "x25519-dalek",
@@ -5844,7 +5844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6558,7 +6558,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7205,7 +7205,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7281,7 +7281,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7926,7 +7926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8412,7 +8412,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8425,7 +8425,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9006,9 +9006,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.26"
+version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ed7e5b411e7113c7ef74739c44b2468659a64891d27e371e1720375f91fba"
+checksum = "15438a66c6f3e061554d8cd5a0e2c07c0828618f3e3ff3331be266347caccf25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9436,9 +9436,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af1b949066b998008e0b5ba3250ba07af6867e036ceef28e36c7726b94443a"
+checksum = "4df4c5b889ee964e46fe15338b4aaad4318caeae191b8292b959a5a68ac92fd2"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10009,7 +10009,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Follows the VTC Trust Task migration. `vta-sdk` **0.20.0 → 0.20.1** (and `trust-tasks-rs` 0.2.26 → 0.2.38).

The VTC's Trust Tasks have moved off the non-conformant `trusttasks.org/openvtc/vtc/…` authority onto the canonical registry at `trusttasks.org/spec/vtc/…` — see [verifiable-trust-infrastructure#806](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/806) and [dtgwg-trust-tasks-tf#144](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/144).

## Why this is only a lockfile change

The join ceremony and the reciprocal-VMC exchange dispatch on `vta_sdk::protocols` **constants**, not string literals. So the new URIs arrive with the bump:

| Constant | Now reads |
|---|---|
| `MEMBER_REQUEST_VMC_TYPE` | `spec/vtc/members/request-vmc/0.1` |
| `MEMBER_VMC_TYPE` | `spec/vtc/members/vmc/0.1` |
| `JOIN_REQUEST_SUBMIT_RECEIPT_TYPE` | `spec/vtc/join-requests/submit-receipt/0.1` |
| self-remove receipt | `spec/vtc/members/self-remove-receipt/0.1` |

That indirection is exactly why this isn't an audit of every dispatch site.

## The inbound router was already ready

`OPENVTC_CATCH_ALL_PATTERN` gained its `https://trusttasks\.org/spec/vtc/.*` arm ahead of the migration — deliberately, since that pattern decides whether a message reaches the handler *at all*, so accepting the new prefix late would have meant migrated traffic silently dropped before dispatch. Good call by whoever landed it; it means this bump carries no routing risk.

It stays **dual-arm** for now. The `openvtc/vtc/` arm retires once no supported VTC emits it, and eight VTC tasks are still on the old authority awaiting a canonical fold.

## Verification

`cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets`, `cargo fmt --check` — all clean. Full test suite green (262 + 257 + 26 + the rest, 0 failures).
