### PR TITLE
test: move the integration harness onto the delivery layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-delivery"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb92150efbc0d18868510c2163ab0e314b34e71a16a032688c6f3033eb1f4e14"
+checksum = "d6ea99eb78ae37cf0092d7669a1e2b76ad6e4a5fe71099ca2144bd89653ec01f"
 dependencies = [
  "affinidi-messaging-core",
  "async-trait",
@@ -5764,7 +5764,10 @@ dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm-service",
+ "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-tdk",
  "agent-names",
@@ -5781,6 +5784,7 @@ dependencies = [
  "dirs",
  "dtg-credentials",
  "ed25519-dalek-bip32",
+ "futures-util",
  "hex",
  "hkdf 0.13.0",
  "keyring-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,17 @@ argon2 = "0.5"
 affinidi-tdk = "0.8"
 affinidi-data-integrity = "0.7"
 affinidi-messaging-didcomm-service = "0.3"
+# The delivery layer (D1) that replaces the `affinidi-messaging-didcomm-service`
+# type-routed framework — both VTI services have already cut over to it (see #189).
+# `-delivery` is the durable outbox + `MessagingService`; `-core` is the
+# `MessageTransport` contract it builds on; `-sdk` supplies `DidCommTransport`, the
+# DIDComm implementation of that contract (and the one that also surfaces inbound
+# TSP off the same multiplexed pickup socket).
+affinidi-messaging-delivery = "0.1.12"
+affinidi-messaging-core = "0.1.5"
+affinidi-messaging-sdk = "0.18.60"
+# `StreamExt::next` on the `BoxStream` returned by `MessagingService::subscribe`.
+futures-util = "0.3"
 # Agent names (DID shortcuts). `agent-names` carries the parse /
 # canonicalisation / `alsoKnownAs`-verification half; the resolver's
 # `agent-names` feature is NOT default, and a direct dependency here is what

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -81,6 +81,13 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # harness that did the same dance manually.
 affinidi-messaging-test-mediator = "0.2"
 affinidi-messaging-didcomm-service = { workspace = true }
+# The delivery layer, for the integration harness. The harness has to move with
+# the production code: it builds its own messaging stack, so tests left on the old
+# framework would keep passing while covering none of the migrated path.
+affinidi-messaging-delivery = { workspace = true }
+affinidi-messaging-core = { workspace = true }
+affinidi-messaging-sdk = { workspace = true }
+futures-util = { workspace = true }
 # In-process MockVta for the bootstrap e2e (VTI#406/#427 test-support seams).
 # `vta-service` is the VTA server crate; it carries the credential-vault
 # lifecycle tasks (receive/query/archive/delete/restore/purge) + the

--- a/openvtc-core/tests/common/mod.rs
+++ b/openvtc-core/tests/common/mod.rs
@@ -17,20 +17,39 @@
 //!
 //! CI's coverage job runs `--include-ignored` so the integration suite
 //! still contributes to the report.
+//!
+//! ## Which messaging stack this builds
+//!
+//! [`ProfileMessaging`] / [`start_profile_messaging`] stand a profile up on the
+//! **delivery layer** (`affinidi-messaging-delivery`'s `MessagingService` over a
+//! `DidCommTransport`), not the `affinidi-messaging-didcomm-service` framework the
+//! production code still uses. That is deliberate and it is the point: the harness
+//! builds its own messaging stack, so had it stayed on the framework these tests
+//! would keep passing while covering none of the migrated path (#189). Migrating it
+//! first makes the suite the regression net for the production swap rather than a
+//! green light that proves nothing.
 
 #![allow(dead_code)]
 
-use affinidi_messaging_didcomm_service::{
-    DIDCommResponse, DIDCommService, DIDCommServiceConfig, DIDCommServiceError, HandlerContext,
-    ListenerConfig, RestartPolicy, RetryConfig, Router, handler_fn, ignore_handler,
-    trust_ping_handler,
+use affinidi_messaging_core::{ConnState, MessageTransport};
+use affinidi_messaging_delivery::{
+    Delivery, InMemoryOutboxStore, MessagingService, OutboxStore, Sent, drain_loop_via,
 };
+use affinidi_messaging_sdk::DidCommTransport;
 use affinidi_messaging_test_mediator::{TestMediator, TestMediatorHandle, TestMediatorUser};
+use affinidi_tdk::common::TDKSharedState;
+use affinidi_tdk::common::config::TDKConfig;
 use affinidi_tdk::common::profiles::TDKProfile;
 use affinidi_tdk::didcomm::Message;
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::config::ATMConfig;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::secrets_resolver::SecretsResolver;
 use affinidi_tdk::secrets_resolver::secrets::Secret;
+use futures_util::StreamExt;
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio_util::sync::CancellationToken;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
 
@@ -118,18 +137,107 @@ pub fn init_test_tracing() {
         .try_init();
 }
 
-/// Build a `DIDCommService` for `profile` with a router that captures
-/// any inbound message in `routes` into `inbound_tx`. Returns the
-/// running service plus the cancellation token guarding its background
-/// tasks.
-pub async fn start_profile_service(
+/// A profile's messaging stack on the **delivery layer** — the replacement for
+/// the `DIDCommService` the framework harness used to build.
+///
+/// Holds the pieces a test needs to send, plus the dispatcher task that pumps
+/// inbound messages into the test's channel. Dropping it aborts the dispatcher.
+///
+/// The ATM and profile are kept because outbound is now a two-step the framework
+/// used to hide: the delivery layer's `MessageTransport::send` takes **already
+/// packed** bytes, so packing is the caller's job (`MessagingProtocol`'s concern,
+/// not the transport's). This mirrors what `vtc-service` does on the same layer.
+pub struct ProfileMessaging {
+    pub service: Arc<MessagingService>,
+    pub atm: ATM,
+    pub profile: Arc<ATMProfile>,
+    /// The transport id this profile is installed under — its own DID, matching
+    /// the production convention where the transport *is* the identity.
+    pub transport_id: String,
+    did: String,
+    dispatcher: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ProfileMessaging {
+    fn drop(&mut self) {
+        self.dispatcher.abort();
+    }
+}
+
+impl ProfileMessaging {
+    /// Wait until this profile's transport reports `Connected`, or `timeout`.
+    ///
+    /// Replaces the framework's `wait_connected`. Polls
+    /// `transport_state`, which reads the transport's live connection signal
+    /// rather than a boot-time latch — so a transport that connects, drops and
+    /// reconnects is reported truthfully throughout (R6.2).
+    pub async fn wait_connected(&self, timeout: Duration) -> Result<()> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.service.transport_state(&self.transport_id) == Some(ConnState::Connected) {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "transport {} did not reach Connected within {timeout:?} (last state: {:?})",
+                    self.transport_id,
+                    self.service.transport_state(&self.transport_id)
+                )
+                .into());
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Pack `message` authcrypt (from this profile's DID to `to`) and send it over
+    /// this profile's transport.
+    ///
+    /// `Delivery::Guaranteed` rather than `BestEffort`, because the framework call
+    /// this replaces (`send_message_with_retry`) retried on a disconnected
+    /// listener. The outbox is that retry, so a send issued while the socket is
+    /// reconnecting still lands instead of failing the test flakily.
+    pub async fn send(&self, message: &Message, to: &str) -> Result<Sent> {
+        let (packed, _meta) = self
+            .atm
+            .pack_encrypted(message, to, Some(&self.did), Some(&self.did))
+            .await?;
+        let sent = self
+            .service
+            .send_via(
+                &self.transport_id,
+                to,
+                packed.into_bytes(),
+                Delivery::Guaranteed {
+                    idempotency_key: Some(message.id.clone()),
+                    ordering_key: None,
+                    deliver_by: Duration::from_secs(30),
+                },
+            )
+            .await?;
+        Ok(sent)
+    }
+}
+
+/// Build a profile's messaging stack on the delivery layer, capturing inbound
+/// messages whose type is in `routes` into `inbound_tx`.
+///
+/// The construction sequence is the canonical one (secrets seeded **before**
+/// `ATM::new`, profile via `from_tdk_profile`, then `profile_add(_, true)` to
+/// bring the websocket up before binding the transport) — `DidCommTransport::new`
+/// fails on a profile with no websocket running.
+///
+/// The transport is installed under the profile's **DID** rather than the
+/// `"default"` id, so this harness exercises the same
+/// one-transport-per-identity shape the production code uses.
+///
+/// Type filtering replaces the old `Router`: the delivery layer has no
+/// type-routed dispatch, so a consumer matches on the message itself — the same
+/// move `vtc-service` made when it cut over.
+pub async fn start_profile_messaging(
     profile: TestProfile,
     routes: &[&'static str],
     inbound_tx: mpsc::UnboundedSender<Message>,
-) -> std::result::Result<
-    (DIDCommService, CancellationToken),
-    Box<dyn std::error::Error + Send + Sync>,
-> {
+) -> Result<ProfileMessaging> {
     let TestProfile {
         alias,
         did,
@@ -137,51 +245,61 @@ pub async fn start_profile_service(
         mediator_did,
     } = profile;
 
-    let tdk_profile = TDKProfile::new(&alias, &did, Some(&mediator_did), secrets);
+    let tdk_profile = TDKProfile::new(&alias, &did, Some(&mediator_did), secrets.clone());
+    let tdk = Arc::new(TDKSharedState::new(TDKConfig::builder().build()?).await?);
+    for secret in secrets {
+        tdk.secrets_resolver().insert(secret).await;
+    }
+    let atm = ATM::new(ATMConfig::builder().build()?, tdk).await?;
+    let atm_profile = ATMProfile::from_tdk_profile(&atm, &tdk_profile).await?;
+    let profile = atm.profile_add(&atm_profile, true).await?;
 
-    let config = DIDCommServiceConfig {
-        listeners: vec![ListenerConfig {
-            id: alias.clone(),
-            profile: tdk_profile,
-            restart_policy: RestartPolicy::Always {
-                backoff: RetryConfig::default(),
-            },
-            // Use the default acl_mode (None) — the mediator's own
-            // global mode (ExplicitDeny by default) is what governs
-            // whether new accounts are accepted.
-            ..Default::default()
-        }],
-    };
+    let transport: Arc<dyn MessageTransport> =
+        Arc::new(DidCommTransport::new(atm.clone(), profile.clone()).await?);
+    // The store is held here as well as handed to the service: `MessagingService`
+    // does not expose its outbox, and the drain needs the same one the service
+    // enqueues into.
+    let store: Arc<dyn OutboxStore> = Arc::new(InMemoryOutboxStore::new());
+    // `empty` + `add_transport` rather than `new`, which would install the
+    // transport as `"default"`. Keying it by DID is what makes this harness
+    // exercise the production one-transport-per-identity shape.
+    let service = Arc::new(MessagingService::empty(store.clone()));
+    service.add_transport(did.clone(), transport.clone());
 
-    let make_capture = || {
-        let tx = inbound_tx.clone();
-        handler_fn(move |_ctx: HandlerContext, msg: Message| {
-            let tx = tx.clone();
-            async move {
-                let _ = tx.send(msg);
-                Ok::<Option<DIDCommResponse>, DIDCommServiceError>(None)
+    // One drain per identity, keyed by the same id the transport is installed
+    // under, so a `Guaranteed` send is retried over its own socket rather than
+    // another identity's.
+    let drain = tokio::spawn(drain_loop_via(
+        store,
+        did.clone(),
+        transport,
+        Duration::from_millis(200),
+    ));
+
+    let wanted: Vec<String> = routes.iter().map(|r| (*r).to_string()).collect();
+    let dispatcher = {
+        let mut inbound = service.subscribe();
+        tokio::spawn(async move {
+            // Keep the drain alive for as long as the dispatcher: both die with
+            // the `ProfileMessaging` that owns them.
+            let _drain = drain;
+            while let Some(item) = inbound.next().await {
+                let Ok(message) = serde_json::from_slice::<Message>(&item.message.payload) else {
+                    continue;
+                };
+                if wanted.contains(&message.typ) {
+                    let _ = inbound_tx.send(message);
+                }
             }
         })
     };
 
-    let mut router = Router::new()
-        // Built-in trust-ping responder so the mediator sees a connected
-        // and well-behaved listener.
-        .route(
-            affinidi_messaging_didcomm_service::TRUST_PING_TYPE,
-            handler_fn(trust_ping_handler),
-        )?
-        // Drop pickup-status messages — the SDK handles them internally
-        // but the router still gets them as a courtesy event.
-        .route(
-            affinidi_messaging_didcomm_service::MESSAGE_PICKUP_STATUS_TYPE,
-            handler_fn(ignore_handler),
-        )?;
-    for type_url in routes {
-        router = router.route(type_url, make_capture())?;
-    }
-
-    let shutdown = CancellationToken::new();
-    let service = DIDCommService::start(config, router, shutdown.clone()).await?;
-    Ok((service, shutdown))
+    Ok(ProfileMessaging {
+        service,
+        atm,
+        profile,
+        transport_id: did.clone(),
+        did,
+        dispatcher,
+    })
 }

--- a/openvtc-core/tests/join_lifecycle_e2e.rs
+++ b/openvtc-core/tests/join_lifecycle_e2e.rs
@@ -47,7 +47,7 @@ use vta_sdk::protocols::join_requests::{
     JoinRequestSubmitBody, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
 };
 
-use common::{MockMediator, init_test_tracing, start_profile_service};
+use common::{MockMediator, ProfileMessaging, init_test_tracing, start_profile_messaging};
 
 /// Connect the persona (alice) and VTC (bob) profiles to the mediator,
 /// each routing `routes` into its own inbound channel, and wait for both
@@ -57,8 +57,8 @@ async fn connect_persona_and_vtc(
     mediator: &MockMediator,
     routes: &[&'static str],
 ) -> (
-    affinidi_messaging_didcomm_service::DIDCommService,
-    affinidi_messaging_didcomm_service::DIDCommService,
+    ProfileMessaging,
+    ProfileMessaging,
     String,
     String,
     mpsc::UnboundedReceiver<Message>,
@@ -72,21 +72,21 @@ async fn connect_persona_and_vtc(
     // VTC listener comes up first so its pickup queue is ready when the
     // persona pushes the join request.
     let (vtc_tx, vtc_rx) = mpsc::unbounded_channel::<Message>();
-    let (vtc_service, _vtc_shutdown) = start_profile_service(vtc, routes, vtc_tx)
+    let vtc_service = start_profile_messaging(vtc, routes, vtc_tx)
         .await
-        .expect("vtc service");
+        .expect("vtc messaging");
 
     let (persona_tx, persona_rx) = mpsc::unbounded_channel::<Message>();
-    let (persona_service, _persona_shutdown) = start_profile_service(persona, routes, persona_tx)
+    let persona_service = start_profile_messaging(persona, routes, persona_tx)
         .await
-        .expect("persona service");
+        .expect("persona messaging");
 
     vtc_service
-        .wait_connected("bob", Duration::from_secs(15))
+        .wait_connected(Duration::from_secs(15))
         .await
         .expect("vtc connect");
     persona_service
-        .wait_connected("alice", Duration::from_secs(15))
+        .wait_connected(Duration::from_secs(15))
         .await
         .expect("persona connect");
 
@@ -118,7 +118,7 @@ fn pending_account(vtc_did: &str, request_id: Uuid) -> Account {
 /// Send the persona's join request to the VTC and assert the VTC
 /// deserialises the production `JoinRequestSubmitBody` off the wire.
 async fn submit_and_assert(
-    persona_service: &affinidi_messaging_didcomm_service::DIDCommService,
+    persona_service: &ProfileMessaging,
     persona_did: &str,
     vtc_did: &str,
     vtc_rx: &mut mpsc::UnboundedReceiver<Message>,
@@ -142,7 +142,7 @@ async fn submit_and_assert(
     .finalize();
 
     persona_service
-        .send_message_with_retry("alice", submit, vtc_did, 3, Duration::from_secs(2))
+        .send(&submit, vtc_did)
         .await
         .expect("persona -> vtc submit");
 
@@ -165,7 +165,7 @@ async fn submit_and_assert(
 /// (correlated to `request_id`) back to the persona, who receives it off
 /// the wire. Returns the delivered message for the reducer to consume.
 async fn respond_status(
-    vtc_service: &affinidi_messaging_didcomm_service::DIDCommService,
+    vtc_service: &ProfileMessaging,
     vtc_did: &str,
     persona_did: &str,
     request_id: Uuid,
@@ -188,7 +188,7 @@ async fn respond_status(
     .finalize();
 
     vtc_service
-        .send_message_with_retry("bob", response, persona_did, 3, Duration::from_secs(2))
+        .send(&response, persona_did)
         .await
         .expect("vtc -> persona status response");
 
@@ -316,7 +316,7 @@ async fn member_self_remove_round_trip() {
     .finalize();
 
     persona_service
-        .send_message_with_retry("alice", leave, &vtc_did, 3, Duration::from_secs(2))
+        .send(&leave, &vtc_did)
         .await
         .expect("persona -> vtc self-remove");
 

--- a/openvtc-core/tests/relationship_e2e.rs
+++ b/openvtc-core/tests/relationship_e2e.rs
@@ -26,14 +26,13 @@ mod common;
 
 use std::time::Duration;
 
-use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::didcomm::Message;
 use openvtc_core::protocol_urls::{RELATIONSHIP_REQUEST, VRC_REJECTED, VRC_REQUEST};
 use openvtc_core::relationships::RelationshipRequestBody;
 use openvtc_core::vrc::{VRCRequestReject, VrcRequest};
 use tokio::sync::mpsc;
 
-use common::{MockMediator, init_test_tracing, start_profile_service};
+use common::{MockMediator, ProfileMessaging, init_test_tracing, start_profile_messaging};
 
 const TEST_MESSAGE_TYPE: &str = "https://example.com/openvtc-test/1.0/echo";
 
@@ -44,8 +43,8 @@ async fn connect_alice_and_bob(
     mediator: &MockMediator,
     routes: &[&'static str],
 ) -> (
-    DIDCommService,
-    DIDCommService,
+    ProfileMessaging,
+    ProfileMessaging,
     String,
     String,
     mpsc::UnboundedReceiver<Message>,
@@ -56,21 +55,21 @@ async fn connect_alice_and_bob(
     let bob_did = bob.did.clone();
 
     let (bob_inbound_tx, bob_inbound_rx) = mpsc::unbounded_channel::<Message>();
-    let (bob_service, _bob_shutdown) = start_profile_service(bob, routes, bob_inbound_tx)
+    let bob_service = start_profile_messaging(bob, routes, bob_inbound_tx)
         .await
         .expect("bob service");
 
     let (alice_inbound_tx, _alice_inbound_rx) = mpsc::unbounded_channel::<Message>();
-    let (alice_service, _alice_shutdown) = start_profile_service(alice, routes, alice_inbound_tx)
+    let alice_service = start_profile_messaging(alice, routes, alice_inbound_tx)
         .await
         .expect("alice service");
 
     bob_service
-        .wait_connected("bob", Duration::from_secs(15))
+        .wait_connected(Duration::from_secs(15))
         .await
         .expect("bob connect");
     alice_service
-        .wait_connected("alice", Duration::from_secs(15))
+        .wait_connected(Duration::from_secs(15))
         .await
         .expect("alice connect");
 
@@ -102,7 +101,7 @@ async fn alice_sends_to_bob_via_mediator() {
     .finalize();
 
     alice_service
-        .send_message_with_retry("alice", msg, &bob_did, 3, Duration::from_secs(2))
+        .send(&msg, &bob_did)
         .await
         .expect("alice send");
 
@@ -152,7 +151,7 @@ async fn relationship_request_round_trip() {
     .finalize();
 
     alice_service
-        .send_message_with_retry("alice", msg, &bob_did, 3, Duration::from_secs(2))
+        .send(&msg, &bob_did)
         .await
         .expect("alice send");
 
@@ -193,21 +192,21 @@ async fn vrc_request_and_reject_round_trip() {
     let routes: &[&'static str] = &[VRC_REQUEST, VRC_REJECTED];
 
     let (alice_inbound_tx, mut alice_inbound_rx) = mpsc::unbounded_channel::<Message>();
-    let (alice_service, _alice_shutdown) = start_profile_service(alice, routes, alice_inbound_tx)
+    let alice_service = start_profile_messaging(alice, routes, alice_inbound_tx)
         .await
         .expect("alice service");
 
     let (bob_inbound_tx, mut bob_inbound_rx) = mpsc::unbounded_channel::<Message>();
-    let (bob_service, _bob_shutdown) = start_profile_service(bob, routes, bob_inbound_tx)
+    let bob_service = start_profile_messaging(bob, routes, bob_inbound_tx)
         .await
         .expect("bob service");
 
     bob_service
-        .wait_connected("bob", Duration::from_secs(15))
+        .wait_connected(Duration::from_secs(15))
         .await
         .expect("bob connect");
     alice_service
-        .wait_connected("alice", Duration::from_secs(15))
+        .wait_connected(Duration::from_secs(15))
         .await
         .expect("alice connect");
 
@@ -226,7 +225,7 @@ async fn vrc_request_and_reject_round_trip() {
     .finalize();
 
     alice_service
-        .send_message_with_retry("alice", request_msg, &bob_did, 3, Duration::from_secs(2))
+        .send(&request_msg, &bob_did)
         .await
         .expect("alice -> bob send");
 
@@ -257,7 +256,7 @@ async fn vrc_request_and_reject_round_trip() {
     .finalize();
 
     bob_service
-        .send_message_with_retry("bob", reject_msg, &alice_did, 3, Duration::from_secs(2))
+        .send(&reject_msg, &alice_did)
         .await
         .expect("bob -> alice send");
 


### PR DESCRIPTION
First step of #189 (adopting `affinidi-messaging-delivery`). Harness only — **no production code changes**.

## Why the harness goes first

The e2e tests build their **own** messaging stack: `common::start_profile_service` constructed a `DIDCommService` with its own `Router` and listeners. So migrating `openvtc`'s production `didcomm.rs` would have left `join_lifecycle_e2e` and `relationship_e2e` passing while exercising the framework being replaced — six green tests, over a real mediator, proving nothing about the change. That is the most convincing kind of false confidence available, so it seemed worth eliminating before rewriting 775 lines on top of it.

Moving the harness first inverts it: these tests become the regression net for the production swap, and the whole pattern is proven end-to-end against a real mediator first.

## What the harness now builds, per profile

- Secrets seeded **before** `ATM::new`, profile via `ATMProfile::from_tdk_profile`, then `profile_add(_, true)` to bring the websocket up — `DidCommTransport::new` fails on a profile with no websocket running.
- `MessagingService::empty` + `add_transport` keyed by the profile's **DID**, not `new`'s `"default"`. The transport *is* the identity here, so the harness exercises the same one-transport-per-identity shape production will.
- `drain_loop_via` on that same id, so a `Guaranteed` send retries over its own socket rather than another identity's.
- Own type-filtered dispatch off `subscribe()`, replacing `Router`/`handler_fn` — the delivery layer has no type-routed dispatch. Same move `vtc-service` made when it cut over.

## Two decisions worth flagging

**Sends use `Delivery::Guaranteed`, not `BestEffort`.** The call being replaced (`send_message_with_retry`) retried on a disconnected listener; `BestEffort` has no retry, so a straight swap would quietly trade a retry for a flake. The outbox *is* that retry. This is also why PR 2's outbox work can't be cleanly deferred out of the production swap — noted on #189.

**Outbound is now two steps.** `MessageTransport::send` takes already-packed bytes (packing is `MessagingProtocol`'s concern, not the transport's), so `ProfileMessaging::send` packs authcrypt via `atm.pack_encrypted` then `send_via`. The framework hid this.

`wait_connected` is polled off `transport_state` — the live connection signal rather than a boot-time latch (R6.2).

The old `start_profile_service` is **deleted** rather than left alongside: two harness paths is how a test silently drifts back onto the retired framework.

## Verification

- All **13** `openvtc-core` test binaries pass with `--include-ignored` — including the mediator-backed `join_lifecycle_e2e` (3) and `relationship_e2e` (3), which now round-trip real DIDComm over the delivery layer
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean

The mediator-backed tests went 1.03s → ~2.1s, which is the drain interval plus outbox round-trip. Acceptable for what they now cover.

## Not in this PR

The production swap (`openvtc/src/state_handler/didcomm.rs` and its 8 dependent files). Two things I found while scoping it, both recorded on #189:

- `DidCommTransport::inbound()` **does** stay alive across websocket reconnects, so no restart policy needs reimplementing for receive. But a full ATM task teardown leaves the transport stale where the framework's `RestartPolicy` would have rebuilt it — that gap is mine to handle, and `transport_state` is the signal for it.
- `DidCommTransport` (with its `tsp` feature) already surfaces inbound **TSP** frames off the same multiplexed pickup socket, tagged `Protocol::TSP`. So TSP receive arrives with this migration, without the second socket that blocks #185 item 2b.
