### PR TITLE
refactor: move the DIDComm transport module into openvtc-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5794,6 +5794,7 @@ dependencies = [
  "openssl-sys",
  "pgp",
  "rand 0.8.7",
+ "regex",
  "reqwest 0.13.4",
  "secrecy",
  "serde",

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -31,6 +31,12 @@ argon2.workspace = true
 affinidi-tdk.workspace = true
 affinidi-data-integrity.workspace = true
 affinidi-did-resolver-cache-sdk.workspace = true
+# Both promoted from dev-dependencies when the DIDComm transport module moved
+# here from the `openvtc` binary crate (#189) — `crate::didcomm` wraps
+# `DIDCommService` and takes a `CancellationToken` for shutdown, so these are now
+# real dependencies rather than test-only scaffolding.
+affinidi-messaging-didcomm-service = { workspace = true }
+tokio-util = { workspace = true }
 agent-names.workspace = true
 base64.workspace = true
 bip39.workspace = true
@@ -70,6 +76,9 @@ openpgp-card-rpgp = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+# `didcomm::catch_all_tests` compiles the router's catch-all pattern to assert
+# which message types reach the handler at all — test-only, so a dev-dependency.
+regex = { workspace = true }
 # In-process mediator for integration tests. `memory-backend` keeps the
 # whole mediator (config + queue + secrets) in RAM — no Redis sidecar,
 # no on-disk fixtures — so `cargo test` stays self-contained. Slow tests
@@ -80,7 +89,6 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # defaults, and local-DID whitelisting set up. Replaces the hand-rolled
 # harness that did the same dance manually.
 affinidi-messaging-test-mediator = "0.2"
-affinidi-messaging-didcomm-service = { workspace = true }
 # The delivery layer, for the integration harness. The harness has to move with
 # the production code: it builds its own messaging stack, so tests left on the old
 # framework would keep passing while covering none of the migrated path.
@@ -101,7 +109,6 @@ secrecy = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tokio-util = { workspace = true }
 # Mock HTTP server for the agent-name resolve→verify e2e: it serves the
 # `/@name` → 302 → DID redirect the `HttpRedirectResolver` follows, so the whole
 # chain is exercised without a live host.

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -26,8 +26,9 @@
 //!   into it.
 //! - this module is the **transport**: sockets, listeners, mediators, retries.
 //!
-//! The one crossing point is [`build_didcomm_message`], re-exported below because
-//! building a message is pure and belongs with the protocol logic.
+//! The one crossing point is [`crate::messaging::build_didcomm_message`],
+//! re-exported below because building a message is pure and belongs with the
+//! protocol logic.
 
 use crate::config::Config;
 use crate::relationships::RelationshipState;

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -1,9 +1,36 @@
-//! DIDComm service integration for the TUI.
+//! DIDComm **transport** plumbing: listener construction, routing, outbound
+//! sending, and listener lifecycle.
 //!
-//! Replaces the manual ATM/WebSocket/message-loop plumbing in `messaging/mod.rs`
-//! with `DIDCommService`, which handles connection lifecycle, message pickup,
+//! Wraps `DIDCommService`, which handles connection lifecycle, message pickup,
 //! dispatch via `Router`, and outbound sending with retry.
+//!
+//! ## Why this is in `openvtc-core` and not the TUI
+//!
+//! It lived at `openvtc/src/state_handler/didcomm.rs` until the delivery-layer
+//! migration (#189) needed it under test. `openvtc` is a **binary-only** crate
+//! (`[[bin]]`, no `src/lib.rs`), so no integration test can import it — which is
+//! why this module, alone among OpenVTC's messaging code, had no coverage beyond
+//! two pure unit groups. Its failure mode is `duplicate-channel` and duelling
+//! reconnect loops, which produce neither a compile error nor a failing unit
+//! test, so rewriting it without integration coverage was the wrong trade.
+//!
+//! Nothing here referenced the binary crate, so the move is mechanical.
+//!
+//! ## Relationship to [`crate::messaging`]
+//!
+//! Deliberately separate, and the split is load-bearing:
+//!
+//! - [`crate::messaging`] is **pure protocol logic** — inbound handling over core
+//!   domain types, no async I/O orchestration. That purity is what makes the
+//!   dispatch state machine unit-testable, so transport plumbing must not leak
+//!   into it.
+//! - this module is the **transport**: sockets, listeners, mediators, retries.
+//!
+//! The one crossing point is [`build_didcomm_message`], re-exported below because
+//! building a message is pure and belongs with the protocol logic.
 
+use crate::config::Config;
+use crate::relationships::RelationshipState;
 use affinidi_messaging_didcomm_service::{
     DIDCommService, DIDCommServiceConfig, DIDCommServiceError, ListenerConfig, ListenerEvent,
     RestartPolicy, RetryConfig, Router, handler_fn,
@@ -11,8 +38,6 @@ use affinidi_messaging_didcomm_service::{
 use affinidi_tdk::common::profiles::TDKProfile;
 use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::secrets_resolver::SecretsResolver;
-use openvtc_core::config::Config;
-use openvtc_core::relationships::RelationshipState;
 use tokio::sync::mpsc;
 use tracing::debug;
 
@@ -52,9 +77,9 @@ pub fn persona_listener_id(persona_did: &str) -> String {
 
 /// Build a timestamped DIDComm message with standard 48-hour expiry.
 ///
-/// Re-exported from [`openvtc_core::messaging`]; the implementation moved to
+/// Re-exported from [`crate::messaging`]; the implementation moved to
 /// core (it is pure) so the protocol logic there can build its own messages.
-pub use openvtc_core::messaging::build_didcomm_message;
+pub use crate::messaging::build_didcomm_message;
 
 /// Events sent from DIDComm router handlers to the state handler main loop.
 #[derive(Debug)]
@@ -177,10 +202,10 @@ pub fn build_router(event_tx: mpsc::Sender<DIDCommEvent>) -> Result<Router, anyh
                     from = ?msg
                         .from
                         .as_deref()
-                        .map(|d| openvtc_core::display::truncate_did(d, 32)),
+                        .map(|d| crate::display::truncate_did(d, 32)),
                     to = ?msg.to.as_ref().map(|dids| {
                         dids.iter()
-                            .map(|d| openvtc_core::display::truncate_did(d, 32))
+                            .map(|d| crate::display::truncate_did(d, 32))
                             .collect::<Vec<_>>()
                     }),
                     thid = ?msg.thid,
@@ -263,7 +288,7 @@ pub fn build_router(event_tx: mpsc::Sender<DIDCommEvent>) -> Result<Router, anyh
         .route_regex(OPENVTC_CATCH_ALL_PATTERN, openvtc_handler)?
         // Message pickup status — silently drop
         .route(
-            openvtc_core::protocol_urls::MESSAGEPICKUP_STATUS,
+            crate::protocol_urls::MESSAGEPICKUP_STATUS,
             handler_fn(
                 |_ctx: affinidi_messaging_didcomm_service::HandlerContext, _msg: Message| async {
                     Ok(None)
@@ -413,7 +438,7 @@ pub async fn build_listener_configs(
                 config.mediator_did(),
                 &format!(
                     "R-DID for {}",
-                    openvtc_core::display::truncate_did(remote_p_did, 32)
+                    crate::display::truncate_did(remote_p_did, 32)
                 ),
                 r_did_secrets,
             ),
@@ -475,8 +500,8 @@ pub async fn send_message_via(
         from = ?message
             .from
             .as_deref()
-            .map(|d| openvtc_core::display::truncate_did(d, 32)),
-        to = %openvtc_core::display::truncate_did(to_did, 32),
+            .map(|d| crate::display::truncate_did(d, 32)),
+        to = %crate::display::truncate_did(to_did, 32),
         thid = ?message.thid,
         "sending DIDComm message"
     );
@@ -601,7 +626,7 @@ pub async fn persona_listener_config(config: &Config, tdk: &affinidi_tdk::TDK) -
 pub async fn persona_listener_config_for(
     config: &Config,
     tdk: &affinidi_tdk::TDK,
-    persona_id: openvtc_core::config::account::PersonaId,
+    persona_id: crate::config::account::PersonaId,
 ) -> Option<ListenerConfig> {
     let ident = config.identities.get(&persona_id)?;
     let did = ident.did.as_str();
@@ -669,7 +694,7 @@ pub fn relationship_listener_config_from_secrets(
             mediator_did,
             &format!(
                 "R-DID for {}",
-                openvtc_core::display::truncate_did(remote_p_did, 32)
+                crate::display::truncate_did(remote_p_did, 32)
             ),
             secrets,
         ),

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -17,6 +17,9 @@ pub mod agent_name;
 pub mod bip32;
 pub mod capabilities;
 pub mod config;
+/// DIDComm transport plumbing (listeners, routing, sending). Distinct from
+/// [`messaging`], which is the pure protocol logic — see that module's docs.
+pub mod didcomm;
 pub mod display;
 pub mod errors;
 pub mod identity;

--- a/openvtc-core/tests/didcomm_transport_e2e.rs
+++ b/openvtc-core/tests/didcomm_transport_e2e.rs
@@ -1,0 +1,194 @@
+//! Integration coverage for the production DIDComm transport module
+//! ([`openvtc_core::didcomm`]) over a real mediator.
+//!
+//! **This test could not exist before the module moved into `openvtc-core`.** It
+//! lived at `openvtc/src/state_handler/didcomm.rs`, and `openvtc` is a
+//! binary-only crate (`[[bin]]`, no `src/lib.rs`), so nothing could import it.
+//! That is why the module that owns every socket in the TUI had no coverage
+//! beyond two pure unit groups — a regex and an id function — while its actual
+//! failure mode is `duplicate-channel` and duelling reconnect loops, which
+//! produce neither a compile error nor a failing unit test.
+//!
+//! So this asserts the three things the delivery-layer swap (#189) is about to
+//! rewrite, against the real mediator rather than a mock:
+//!
+//! 1. `build_router` routes an OpenVTC protocol message to the event channel —
+//!    the catch-all regex working on a real wire, not just against `Regex::new`.
+//! 2. `send_message_via` actually delivers through the mediator.
+//! 3. A listener built by `relationship_listener_config_from_secrets` connects.
+//!
+//! Deliberately uses the `..._from_secrets` constructor: it is the one listener
+//! builder that takes no `Config`, so the transport path is exercised without
+//! standing up an encrypted on-disk config. The `Config`-taking builders
+//! (`build_listener_configs`, `persona_listener_config_for`) differ only in where
+//! the DID, mediator and secrets come from.
+//!
+//! `#[ignore]` like its siblings — booting the mediator is slow. CI's coverage
+//! job runs `--include-ignored`.
+
+mod common;
+
+use std::time::Duration;
+
+use affinidi_tdk::didcomm::Message;
+use common::{MockMediator, init_test_tracing};
+use openvtc_core::didcomm::{
+    DIDCommEvent, build_router, relationship_listener_config_from_secrets, send_message_via,
+};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+/// An OpenVTC protocol type the production catch-all pattern must route.
+const OPENVTC_TYPE: &str = "https://linuxfoundation.org/openvtc/test/1.0/ping";
+
+/// Start a `DIDCommService` for one profile using the **production** router and
+/// the production `Config`-free listener builder.
+async fn start_production_service(
+    profile: common::TestProfile,
+    remote_did: &str,
+    event_tx: mpsc::Sender<DIDCommEvent>,
+) -> (
+    affinidi_messaging_didcomm_service::DIDCommService,
+    String,
+    CancellationToken,
+) {
+    let listener = relationship_listener_config_from_secrets(
+        &profile.did,
+        remote_did,
+        &profile.mediator_did,
+        profile.secrets.clone(),
+    );
+    let listener_id = listener.id.clone();
+    let router = build_router(event_tx).expect("production router builds");
+    let shutdown = CancellationToken::new();
+    let service = affinidi_messaging_didcomm_service::DIDCommService::start(
+        affinidi_messaging_didcomm_service::DIDCommServiceConfig {
+            listeners: vec![listener],
+        },
+        router,
+        shutdown.clone(),
+    )
+    .await
+    .expect("production listener config starts");
+    (service, listener_id, shutdown)
+}
+
+/// The end-to-end path the swap will replace: production listener → production
+/// send → mediator → production router → event channel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "slow: spawns a real mediator (~1s)"]
+async fn an_openvtc_message_routes_through_the_production_transport() {
+    init_test_tracing();
+    let mediator = MockMediator::start().await.expect("mediator start");
+    let alice = mediator.profile("alice").expect("alice");
+    let bob = mediator.profile("bob").expect("bob");
+    let alice_did = alice.did.clone();
+    let bob_did = bob.did.clone();
+
+    // Receiver first: a listener that is not yet polling would miss the frame.
+    let (bob_tx, mut bob_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (bob_service, bob_listener, _bob_shutdown) =
+        start_production_service(bob, &alice_did, bob_tx).await;
+    bob_service
+        .wait_connected(&bob_listener, Duration::from_secs(15))
+        .await
+        .expect("bob listener connects");
+
+    let (alice_tx, _alice_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (alice_service, alice_listener, _alice_shutdown) =
+        start_production_service(alice, &bob_did, alice_tx).await;
+    alice_service
+        .wait_connected(&alice_listener, Duration::from_secs(15))
+        .await
+        .expect("alice listener connects");
+
+    let message = Message::build(
+        Uuid::new_v4().to_string(),
+        OPENVTC_TYPE.to_string(),
+        serde_json::json!({ "hello": "transport" }),
+    )
+    .from(alice_did.clone())
+    .to(bob_did.clone())
+    .finalize();
+
+    send_message_via(&alice_service, &message, &alice_listener, &bob_did)
+        .await
+        .expect("production send delivers");
+
+    let event = tokio::time::timeout(Duration::from_secs(20), bob_rx.recv())
+        .await
+        .expect("bob receives within 20s")
+        .expect("event channel still open");
+
+    match event {
+        DIDCommEvent::InboundMessage { message, from } => {
+            assert_eq!(
+                message.typ, OPENVTC_TYPE,
+                "the catch-all pattern routed this type"
+            );
+            assert_eq!(
+                from.as_deref(),
+                Some(alice_did.as_str()),
+                "the sender survives the round trip"
+            );
+            assert_eq!(
+                message.body.get("hello").and_then(|v| v.as_str()),
+                Some("transport"),
+                "the body survives pack/unpack"
+            );
+        }
+        other => panic!("expected InboundMessage, got {other:?}"),
+    }
+}
+
+/// A type the catch-all must *not* route reaches no handler, so nothing lands on
+/// the event channel. The unit test asserts this against the regex; this asserts
+/// it against a real delivered message, which is the claim that actually matters
+/// — a routing gate that leaks would hand unvetted traffic to dispatch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "slow: spawns a real mediator (~1s)"]
+async fn an_unrelated_message_type_reaches_no_handler() {
+    init_test_tracing();
+    let mediator = MockMediator::start().await.expect("mediator start");
+    let alice = mediator.profile("alice").expect("alice");
+    let bob = mediator.profile("bob").expect("bob");
+    let alice_did = alice.did.clone();
+    let bob_did = bob.did.clone();
+
+    let (bob_tx, mut bob_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (bob_service, bob_listener, _bob_shutdown) =
+        start_production_service(bob, &alice_did, bob_tx).await;
+    bob_service
+        .wait_connected(&bob_listener, Duration::from_secs(15))
+        .await
+        .expect("bob listener connects");
+
+    let (alice_tx, _alice_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (alice_service, alice_listener, _alice_shutdown) =
+        start_production_service(alice, &bob_did, alice_tx).await;
+    alice_service
+        .wait_connected(&alice_listener, Duration::from_secs(15))
+        .await
+        .expect("alice listener connects");
+
+    let message = Message::build(
+        Uuid::new_v4().to_string(),
+        "https://example.com/not-openvtc/1.0/whatever".to_string(),
+        serde_json::json!({}),
+    )
+    .from(alice_did.clone())
+    .to(bob_did.clone())
+    .finalize();
+
+    send_message_via(&alice_service, &message, &alice_listener, &bob_did)
+        .await
+        .expect("send delivers");
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(2500), bob_rx.recv())
+            .await
+            .is_err(),
+        "an unrelated type must not reach the event channel"
+    );
+}

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -138,7 +138,15 @@ mod agent_name_refresh;
 mod background_dispatch;
 mod create_persona;
 mod credential_actions;
-pub mod didcomm;
+/// The DIDComm transport module, which now lives in `openvtc-core`.
+///
+/// Re-exported under its former path so every `didcomm::…` / `super::didcomm::…`
+/// call site in `state_handler` keeps resolving. It moved because `openvtc` is a
+/// binary-only crate and nothing there can be integration-tested — see
+/// [`openvtc_core::didcomm`] for the full rationale (#189). Keeping the shim
+/// means the move itself changed no call sites, so a regression in the messaging
+/// layer cannot hide inside an import churn diff.
+pub use openvtc_core::didcomm;
 mod dispatch_util;
 mod inbox_actions;
 pub mod join;


### PR DESCRIPTION
Option (1) from #189. **No behaviour change** — this gives the messaging module a testable home *before* the delivery-layer swap rewrites it.

## Why

The module that owns every socket in the TUI had no integration coverage, and the reason was structural: it lived at `openvtc/src/state_handler/didcomm.rs`, and `openvtc` is a **binary-only** crate (`[[bin]]`, no `src/lib.rs`), so no integration test could import it. Its only coverage was two pure unit groups — a regex and an id function.

That is a bad place to start rewriting from. The swap replaces this module's listener construction, dispatch, send and reconnect paths, and its failure mode is `duplicate-channel` plus duelling reconnect loops — which produce neither a compile error nor a failing unit test. They surface as a dropped response on the first burst of requests, in front of a user.

## The move

Nothing in the module referenced the binary crate, so it is mechanical — only `openvtc_core::` → `crate::` prefixes changed.

- `openvtc/src/state_handler/didcomm.rs` → `openvtc-core/src/didcomm.rs`, kept **distinct from `crate::messaging`**, whose module doc promises pure protocol logic with no async I/O orchestration. That purity is what makes the dispatch state machine unit-testable, so transport plumbing must not leak into it. Both module docs now state the split.
- `state_handler` keeps a `pub use openvtc_core::didcomm;` re-export under the old path, so **all nine dependent files' call sites are untouched**. A regression in the messaging layer cannot hide inside an import-churn diff.
- `affinidi-messaging-didcomm-service` and `tokio-util` promoted from dev-dependencies to dependencies of `openvtc-core`; `regex` added as a dev-dependency for the catch-all tests that came with the module.

The 7 unit tests moved with it — `openvtc` bin 262 → 255, `openvtc-core` lib 257 → 264, total unchanged.

## New coverage, which is the point

`openvtc-core/tests/didcomm_transport_e2e.rs` — two tests that **could not have been written before this move**. Against the real mediator:

1. The production `build_router` routes an OpenVTC protocol type through to the event channel, and the sender and body survive the round trip.
2. An unrelated type reaches **no** handler. The routing gate not leaking was previously only asserted against `Regex::new` — never against an actually-delivered message, which is the claim that matters, since a leak hands unvetted traffic to dispatch.
3. Production `send_message_via` delivers through the mediator.

They use `relationship_listener_config_from_secrets` because it is the one listener builder that takes no `Config`, so the transport path is covered without standing up an encrypted on-disk config. The `Config`-taking builders differ only in where the DID, mediator and secrets come from.

## Verification

- `cargo test --workspace -- --include-ignored` — all 16 test binaries pass, 0 failed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean

## Next

The delivery-layer swap of this module, now landing under real integration coverage. As noted on #189 it must bring `Delivery::Guaranteed` with it — the framework's `send_message_with_retry` retried on a disconnected listener and `BestEffort` has no retry, so the outbox is the replacement rather than a follow-up.
