### PR TITLE
feat: run OpenVTC messaging on the delivery layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,30 +327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "affinidi-messaging-didcomm-service"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8537805a24165d2c07c3db3f668dacea4eb86db17d698b12bcd141493dfd7df5"
-dependencies = [
- "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk",
- "affinidi-secrets-resolver",
- "affinidi-tdk-common",
- "async-trait",
- "regex",
- "serde",
- "serde_json",
- "sha256",
- "thiserror 2.0.19",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "trust-tasks-rs",
- "uuid",
-]
-
-[[package]]
 name = "affinidi-messaging-mediator"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5705,7 +5681,6 @@ version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "affinidi-data-integrity",
- "affinidi-messaging-didcomm-service",
  "affinidi-tdk",
  "anyhow",
  "apple-native-keyring-store",
@@ -5766,7 +5741,6 @@ dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm-service",
  "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
  "affinidi-tdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,8 @@ aes-gcm = "0.10"
 argon2 = "0.5"
 affinidi-tdk = "0.8"
 affinidi-data-integrity = "0.7"
-affinidi-messaging-didcomm-service = "0.3"
-# The delivery layer (D1) that replaces the `affinidi-messaging-didcomm-service`
-# type-routed framework — both VTI services have already cut over to it (see #189).
+# The delivery layer (D1). Replaced `affinidi-messaging-didcomm-service`, the
+# type-routed framework both VTI services had already cut over from (#189).
 # `-delivery` is the durable outbox + `MessagingService`; `-core` is the
 # `MessageTransport` contract it builds on; `-sdk` supplies `DidCommTransport`, the
 # DIDComm implementation of that contract (and the one that also surfaces inbound

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -31,12 +31,20 @@ argon2.workspace = true
 affinidi-tdk.workspace = true
 affinidi-data-integrity.workspace = true
 affinidi-did-resolver-cache-sdk.workspace = true
-# Both promoted from dev-dependencies when the DIDComm transport module moved
-# here from the `openvtc` binary crate (#189) — `crate::didcomm` wraps
-# `DIDCommService` and takes a `CancellationToken` for shutdown, so these are now
-# real dependencies rather than test-only scaffolding.
-affinidi-messaging-didcomm-service = { workspace = true }
+# `CancellationToken`, for `start_service`'s shutdown hook.
 tokio-util = { workspace = true }
+# The delivery layer this module now runs on (#189): `-delivery` is the durable
+# outbox + `MessagingService`, `-core` the `MessageTransport` contract, `-sdk` the
+# `DidCommTransport` implementing it over DIDComm (and surfacing inbound TSP off
+# the same multiplexed pickup socket).
+affinidi-messaging-delivery = { workspace = true }
+affinidi-messaging-core = { workspace = true }
+affinidi-messaging-sdk = { workspace = true }
+futures-util = { workspace = true }
+# The inbound dispatcher compiles `OPENVTC_CATCH_ALL_PATTERN` to decide which
+# message types reach the state handler — the delivery layer has no type-routed
+# dispatch, so this replaces the framework's `route_regex`.
+regex = { workspace = true }
 agent-names.workspace = true
 base64.workspace = true
 bip39.workspace = true
@@ -76,9 +84,6 @@ openpgp-card-rpgp = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-# `didcomm::catch_all_tests` compiles the router's catch-all pattern to assert
-# which message types reach the handler at all — test-only, so a dev-dependency.
-regex = { workspace = true }
 # In-process mediator for integration tests. `memory-backend` keeps the
 # whole mediator (config + queue + secrets) in RAM — no Redis sidecar,
 # no on-disk fixtures — so `cargo test` stays self-contained. Slow tests
@@ -89,13 +94,6 @@ regex = { workspace = true }
 # defaults, and local-DID whitelisting set up. Replaces the hand-rolled
 # harness that did the same dance manually.
 affinidi-messaging-test-mediator = "0.2"
-# The delivery layer, for the integration harness. The harness has to move with
-# the production code: it builds its own messaging stack, so tests left on the old
-# framework would keep passing while covering none of the migrated path.
-affinidi-messaging-delivery = { workspace = true }
-affinidi-messaging-core = { workspace = true }
-affinidi-messaging-sdk = { workspace = true }
-futures-util = { workspace = true }
 # In-process MockVta for the bootstrap e2e (VTI#406/#427 test-support seams).
 # `vta-service` is the VTA server crate; it carries the credential-vault
 # lifecycle tasks (receive/query/archive/delete/restore/purge) + the

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -1,8 +1,13 @@
 //! DIDComm **transport** plumbing: listener construction, routing, outbound
 //! sending, and listener lifecycle.
 //!
-//! Wraps `DIDCommService`, which handles connection lifecycle, message pickup,
-//! dispatch via `Router`, and outbound sending with retry.
+//! Runs on the **delivery layer** (`affinidi-messaging-delivery`): one
+//! [`MessagingService`] holding one `DidCommTransport` per identity, with a
+//! durable outbox behind every send.
+//!
+//! It used to wrap `affinidi-messaging-didcomm-service`, the type-routed framework
+//! both VTI services cut away from (#189). That crate is no longer a dependency of
+//! this workspace.
 //!
 //! ## Why this is in `openvtc-core` and not the TUI
 //!
@@ -32,16 +37,47 @@
 
 use crate::config::Config;
 use crate::relationships::RelationshipState;
-use affinidi_messaging_didcomm_service::{
-    DIDCommService, DIDCommServiceConfig, DIDCommServiceError, ListenerConfig, ListenerEvent,
-    RestartPolicy, RetryConfig, Router, handler_fn,
+/// A listener's live connection state, re-exported so consumers of this module
+/// need not depend on `affinidi-messaging-core` directly.
+pub use affinidi_messaging_core::ConnState;
+use affinidi_messaging_core::MessageTransport;
+use affinidi_messaging_delivery::{
+    Delivery, InMemoryOutboxStore, MessagingService, OutboxStore, drain_loop_via,
 };
+use affinidi_messaging_sdk::DidCommTransport;
+use affinidi_tdk::common::TDKSharedState;
+use affinidi_tdk::common::config::TDKConfig;
 use affinidi_tdk::common::profiles::TDKProfile;
 use affinidi_tdk::didcomm::Message;
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::config::ATMConfig;
+use affinidi_tdk::messaging::profiles::ATMProfile;
 use affinidi_tdk::secrets_resolver::SecretsResolver;
 use affinidi_tdk::secrets_resolver::secrets::Secret;
+use futures_util::StreamExt;
+use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::debug;
+
+/// Anything that can go wrong bringing a listener up or sending through one.
+#[derive(Debug, thiserror::Error)]
+pub enum MessagingError {
+    /// The identity's ATM / profile / websocket could not be established.
+    #[error("could not bring up listener {listener_id}: {reason}")]
+    Listener { listener_id: String, reason: String },
+    /// A send named a listener that is not installed. Distinct from a transport
+    /// failure: this is a caller bug or a torn-down listener, not the network
+    /// (R6.4 — the operator must be able to tell them apart).
+    #[error("no listener installed for {0}")]
+    UnknownListener(String),
+    /// Packing the message for the recipient failed.
+    #[error("could not pack message for {recipient}: {reason}")]
+    Pack { recipient: String, reason: String },
+    /// The delivery layer rejected the send or the outbox enqueue.
+    #[error("send failed: {0}")]
+    Send(String),
+}
 
 /// How a listener is described, independently of the framework that runs it.
 ///
@@ -84,29 +120,216 @@ impl std::fmt::Debug for ListenerSpec {
     }
 }
 
-impl ListenerSpec {
-    /// The framework `ListenerConfig` this spec describes.
+/// DIDComm trust-ping / trust-pong types.
+///
+/// Re-declared rather than imported from the framework: this module is moving off
+/// `affinidi-messaging-didcomm-service`, and these two constants are the only part
+/// of its type vocabulary the dispatcher still needs. `vtc-service` re-declared the
+/// same pair for the same reason when it cut over.
+const TRUST_PING_TYPE: &str = "https://didcomm.org/trust-ping/2.0/ping";
+const TRUST_PONG_TYPE: &str = "https://didcomm.org/trust-ping/2.0/ping-response";
+
+/// How often the drain retries a queued outbound message.
+///
+/// The outbox replaces the framework's `send_message_with_retry` (3 attempts, 2 s
+/// exponential, on a disconnected listener). A short interval keeps the common
+/// case — a send issued moments before the socket settles — feeling immediate;
+/// the per-entry exponential backoff in `drain_once_via` is what stops a genuinely
+/// unreachable mediator from being hammered.
+const DRAIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// The delivery window for an outbound message before the outbox settles it
+/// visibly rather than retrying forever (R1.2 — every wait is bounded).
+///
+/// Generous relative to the framework's ~6 s of retries, because the outbox
+/// survives a reconnect where the old path simply failed. Past this the entry
+/// becomes `Failed` and is surfaced, never a silent success.
+const DELIVER_BY: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// How often listener connection state is sampled for the activity log.
+///
+/// The framework pushed `ListenerEvent`s; the delivery layer exposes a live state
+/// per transport instead, so transitions are sampled. 500 ms is well inside human
+/// perception for a status line and cheap — reading a `watch` borrow per transport.
+const LIFECYCLE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Two disconnects closer together than this are reported as rapid cycling —
+/// usually a duplicate connection fighting itself for one DID.
+const CYCLING_WINDOW: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Buffered connection transitions per subscriber. Transitions are rare (a
+/// listener connects, drops, reconnects), so this is generous; a subscriber that
+/// still lags reports the gap rather than silently missing a state change.
+const LISTENER_STATUS_CAPACITY: usize = 64;
+
+/// One identity's wire: the ATM and profile outbound packing needs.
+///
+/// The delivery layer's `MessageTransport::send` takes **already-packed** bytes —
+/// packing is `MessagingProtocol`'s concern, not the transport's — so sending *as*
+/// an identity needs that identity's ATM, not just its transport. The framework
+/// hid this behind `send_message(listener_id, …)`.
+struct IdentityWire {
+    atm: ATM,
+    did: String,
+}
+
+/// The runtime messaging handle: one transport per identity, multiplexed through
+/// one [`MessagingService`], with a durable outbox behind every send.
+///
+/// Replaces `DIDCommService`. The shape difference that matters: the framework
+/// owned N *listeners*, and this owns N *transports keyed by identity* — the
+/// transport determines the proven sender, so "send as this persona" is
+/// `send_via(persona_did, …)` rather than a listener lookup.
+///
+/// Cheap to clone (`Arc` inside), because call sites hand it to spawned tasks.
+#[derive(Clone)]
+pub struct Messaging {
+    inner: Arc<MessagingInner>,
+}
+
+/// A listener's connection transition, broadcast to every interested consumer.
+///
+/// Replaces the framework's `ListenerEvent`. Emitted by the single connection
+/// poller [`Messaging`] owns, so the session manager and the activity log observe
+/// the *same* transitions rather than each sampling independently and disagreeing.
+#[derive(Debug, Clone)]
+pub enum ListenerStatus {
+    Connected {
+        listener_id: String,
+    },
+    Disconnected {
+        listener_id: String,
+        /// Always `None` on the delivery layer: a transport surfaces a *state*,
+        /// not a cause, and the framework's socket error has no equivalent here.
+        /// Kept so the session manager's failed-vs-disconnected distinction stays
+        /// expressible if the transport ever carries a reason.
+        error: Option<String>,
+    },
+}
+
+struct MessagingInner {
+    service: Arc<MessagingService>,
+    /// Connection transitions from the one poller.
+    status_tx: tokio::sync::broadcast::Sender<ListenerStatus>,
+    /// Shared by every identity's drain. One store, `via`-partitioned, so each
+    /// entry is claimed by exactly one `drain_loop_via` (see
+    /// `affinidi-messaging-delivery` 0.1.12).
+    outbox: Arc<dyn OutboxStore>,
+    identities: tokio::sync::RwLock<HashMap<String, IdentityWire>>,
+    /// Dispatcher + per-identity drains, aborted on [`Messaging::shutdown`].
+    tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
+}
+
+impl Messaging {
+    /// Stand up an empty messaging runtime and start its inbound dispatcher.
     ///
-    /// The one place the framework type is constructed, so the swap has a single
-    /// seam to cut rather than four scattered struct literals.
-    fn to_listener_config(&self) -> ListenerConfig {
-        ListenerConfig {
-            id: self.id.clone(),
-            profile: make_profile(
-                &self.did,
-                &self.mediator_did,
-                &self.label,
-                self.secrets.clone(),
-            ),
-            restart_policy: default_listener_restart_policy(),
-            // Keep `auto_delete: true`. It delegates message deletion to the
-            // mediator's live-stream protocol, which uses the mediator-native
-            // storage id. If you ever set this to false and delete from app
-            // code, you MUST delete by `UnpackMetadata.sha256_hash` (the
-            // mediator-native id), NOT by the DIDComm protocol id `msg.id`.
-            auto_delete: true,
-            ..Default::default()
+    /// Listeners are added with [`add_listener`]; starting empty is what lets the
+    /// dispatcher be running before the first transport connects, so no inbound
+    /// frame is missed on a listener that comes up quickly.
+    pub fn start(event_tx: mpsc::Sender<DIDCommEvent>) -> Self {
+        let outbox: Arc<dyn OutboxStore> = Arc::new(InMemoryOutboxStore::new());
+        let service = Arc::new(MessagingService::empty(outbox.clone()));
+        let (status_tx, _) = tokio::sync::broadcast::channel(LISTENER_STATUS_CAPACITY);
+        let inner = Arc::new(MessagingInner {
+            service: service.clone(),
+            status_tx: status_tx.clone(),
+            outbox,
+            identities: tokio::sync::RwLock::new(HashMap::new()),
+            tasks: std::sync::Mutex::new(Vec::new()),
+        });
+
+        let dispatcher = tokio::spawn(dispatch_inbound(service.clone(), event_tx));
+        let poller = tokio::spawn(poll_listener_status(service, status_tx));
+        {
+            let mut tasks = inner.tasks.lock().expect("tasks mutex");
+            tasks.push(dispatcher);
+            tasks.push(poller);
         }
+
+        Self { inner }
+    }
+
+    /// Whether a transport is installed for `listener_id`.
+    pub async fn has_listener(&self, listener_id: &str) -> bool {
+        self.inner.identities.read().await.contains_key(listener_id)
+    }
+
+    /// Every installed listener id.
+    pub async fn list_listeners(&self) -> Vec<String> {
+        self.inner.identities.read().await.keys().cloned().collect()
+    }
+
+    /// Remove a listener: drop its transport (closing the socket) and forget its
+    /// wire. Queued outbox entries pinned to it stay queued — they are bound to an
+    /// identity, and re-routing them would send from the wrong sender — and settle
+    /// visibly when their delivery window expires.
+    pub async fn remove_listener(&self, listener_id: &str) {
+        self.inner.service.remove_transport(listener_id);
+        self.inner.identities.write().await.remove(listener_id);
+    }
+
+    /// This listener's live connection state, or `None` if not installed.
+    pub fn listener_state(&self, listener_id: &str) -> Option<ConnState> {
+        self.inner.service.transport_state(listener_id)
+    }
+
+    /// The DID a listener speaks as.
+    ///
+    /// For a persona listener this is the id itself; for a relationship listener
+    /// the id is a hash, so the mapping has to be looked up rather than assumed.
+    pub async fn listener_did(&self, listener_id: &str) -> Option<String> {
+        self.inner
+            .identities
+            .read()
+            .await
+            .get(listener_id)
+            .map(|wire| wire.did.clone())
+    }
+
+    /// Subscribe to listener connection transitions.
+    ///
+    /// Every subscriber sees the same transitions from the one poller, so the
+    /// session manager and the activity log cannot disagree about whether a
+    /// listener is up.
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<ListenerStatus> {
+        self.inner.status_tx.subscribe()
+    }
+
+    /// Wait until `listener_id` reports `Connected`, or `timeout` elapses.
+    ///
+    /// Polls the transport's live signal rather than latching at boot (R6.2), so a
+    /// listener that connects, drops and reconnects reads truthfully throughout.
+    pub async fn wait_connected(
+        &self,
+        listener_id: &str,
+        timeout: std::time::Duration,
+    ) -> Result<(), String> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match self.listener_state(listener_id) {
+                Some(ConnState::Connected) => return Ok(()),
+                state if tokio::time::Instant::now() >= deadline => {
+                    return Err(format!(
+                        "listener {listener_id} did not connect within {timeout:?} \
+                         (last state: {state:?})"
+                    ));
+                }
+                _ => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+            }
+        }
+    }
+
+    /// Stop every drain and the dispatcher, and drop all transports.
+    pub async fn shutdown(&self) {
+        let handles: Vec<_> = std::mem::take(&mut *self.inner.tasks.lock().expect("tasks mutex"));
+        for handle in handles {
+            handle.abort();
+        }
+        let ids: Vec<String> = self.inner.identities.read().await.keys().cloned().collect();
+        for id in ids {
+            self.inner.service.remove_transport(&id);
+        }
+        self.inner.identities.write().await.clear();
     }
 }
 
@@ -202,21 +425,23 @@ pub enum ReconnectOutcome {
 ///
 /// This is the I/O-only half: it tears down the existing persona listener,
 /// installs the prebuilt `new_config`, and waits up to 30 s for it to connect.
-/// It borrows nothing tied to the loop's `Config`/`TDK` — `DIDCommService` is
-/// cheap to clone (`Arc`-based) and `ListenerConfig`/`listener_id` are owned —
+/// It borrows nothing tied to the loop's `Config`/`TDK` — [`Messaging`] is
+/// cheap to clone (`Arc`-based) and [`ListenerSpec`]/`listener_id` are owned —
 /// which makes it `tokio::spawn`-friendly.
 ///
 /// Active-persona only (these manual actions act on the active identity);
 /// per-persona reconnect lands with the persona-selection slice.
 pub async fn reconnect_persona_listener_io(
-    service: &DIDCommService,
+    service: &Messaging,
     listener_id: String,
     new_config: ListenerSpec,
 ) -> ReconnectOutcome {
-    if let Err(e) = service.remove_listener(&listener_id).await {
-        debug!("remove_listener during reconnect: {e}");
-    }
-    if let Err(e) = service.add_listener(new_config.to_listener_config()).await {
+    // Drop the old transport first. The mediator permits one websocket per DID,
+    // rejecting a second with `duplicate-channel`, so adding before removing would
+    // leave two sockets racing on the same identity — the duelling-reconnect
+    // failure this codebase has already been bitten by (#132).
+    service.remove_listener(&listener_id).await;
+    if let Err(e) = add_listener(service, &new_config).await {
         return ReconnectOutcome::Failed(format!("{e:#}"));
     }
     match service
@@ -224,22 +449,163 @@ pub async fn reconnect_persona_listener_io(
         .await
     {
         Ok(()) => ReconnectOutcome::Connected,
-        Err(e) => ReconnectOutcome::Failed(format!("{e:#}")),
+        Err(e) => ReconnectOutcome::Failed(e),
     }
 }
 
-/// Install a listener described by `spec` on a running service.
+/// Install a listener described by `spec` on a running [`Messaging`].
 ///
-/// The public way to add a listener, so `ListenerConfig` stays inside this
-/// module: every caller names a [`ListenerSpec`] and this is the only place the
-/// framework type is handed over. At the delivery-layer swap the body becomes
-/// "build an ATM profile + `DidCommTransport` and `add_transport`", and no
-/// caller changes.
-pub async fn add_listener(
-    service: &DIDCommService,
-    spec: &ListenerSpec,
-) -> Result<(), DIDCommServiceError> {
-    service.add_listener(spec.to_listener_config()).await
+/// Brings up one identity's wire, in the order the SDK requires: secrets seeded
+/// **before** `ATM::new` (the resolver is read during construction), profile via
+/// `from_tdk_profile`, then `profile_add(_, true)` to connect the websocket —
+/// `DidCommTransport::new` fails on a profile with no websocket running.
+///
+/// The transport is installed under `spec.id`, which is the identity's DID. That
+/// is what makes `send_via` mean "send **as** this persona": the transport
+/// determines the proven sender, so the wire is not interchangeable between
+/// identities.
+///
+/// Each identity also gets its own `drain_loop_via` over the shared outbox, so a
+/// retried message goes back out over the socket it was queued for rather than
+/// whichever transport happens to be primary.
+pub async fn add_listener(service: &Messaging, spec: &ListenerSpec) -> Result<(), MessagingError> {
+    let fail = |reason: String| MessagingError::Listener {
+        listener_id: spec.id.clone(),
+        reason,
+    };
+
+    let tdk_profile = make_profile(
+        &spec.did,
+        &spec.mediator_did,
+        &spec.label,
+        spec.secrets.clone(),
+    );
+    let tdk = TDKSharedState::new(
+        TDKConfig::builder()
+            .build()
+            .map_err(|e| fail(format!("TDK config: {e}")))?,
+    )
+    .await
+    .map_err(|e| fail(format!("TDK init: {e}")))?;
+    for secret in spec.secrets.clone() {
+        tdk.secrets_resolver().insert(secret).await;
+    }
+    let atm = ATM::new(
+        ATMConfig::builder()
+            .build()
+            .map_err(|e| fail(format!("ATM config: {e}")))?,
+        Arc::new(tdk),
+    )
+    .await
+    .map_err(|e| fail(format!("ATM init: {e}")))?;
+    let atm_profile = ATMProfile::from_tdk_profile(&atm, &tdk_profile)
+        .await
+        .map_err(|e| fail(format!("profile: {e}")))?;
+    let profile = atm
+        .profile_add(&atm_profile, true)
+        .await
+        .map_err(|e| fail(format!("mediator connect: {e}")))?;
+    let transport: Arc<dyn MessageTransport> = Arc::new(
+        DidCommTransport::new(atm.clone(), profile)
+            .await
+            .map_err(|e| fail(format!("transport bind: {e}")))?,
+    );
+
+    service
+        .inner
+        .service
+        .add_transport(spec.id.clone(), transport.clone());
+    service.inner.identities.write().await.insert(
+        spec.id.clone(),
+        IdentityWire {
+            atm,
+            did: spec.did.clone(),
+        },
+    );
+
+    let drain = tokio::spawn(drain_loop_via(
+        service.inner.outbox.clone(),
+        spec.id.clone(),
+        transport,
+        DRAIN_INTERVAL,
+    ));
+    service.inner.tasks.lock().expect("tasks mutex").push(drain);
+
+    debug!(listener = %spec.id, "listener installed on the delivery layer");
+    Ok(())
+}
+
+/// The single inbound dispatcher: read every transport's merged stream, classify
+/// by message type, and forward as [`DIDCommEvent`].
+///
+/// Replaces the framework's `Router`. The delivery layer has no type-routed
+/// dispatch — a consumer matches on the message itself — which is the same move
+/// `vtc-service` made when it cut over. Acking is **not** done here: the service's
+/// own dispatcher acks after handoff, never before.
+async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender<DIDCommEvent>) {
+    let catch_all = match regex::Regex::new(&format!("^(?:{OPENVTC_CATCH_ALL_PATTERN})$")) {
+        Ok(re) => re,
+        Err(e) => {
+            tracing::error!(error = %e, "catch-all pattern failed to compile — inbound dispatch is dead");
+            return;
+        }
+    };
+
+    let mut inbound = service.subscribe();
+    while let Some(item) = inbound.next().await {
+        // A DIDComm frame's payload is the `Message` JSON (`to_inbound` in the
+        // SDK adapter). A TSP frame's is not, so it will not parse here — TSP
+        // routing lands with #185 and is deliberately skipped rather than logged
+        // as an error.
+        let Ok(message) = serde_json::from_slice::<Message>(&item.message.payload) else {
+            continue;
+        };
+        // The transport authenticated the sender; the plaintext `from` header is
+        // sender-controlled. Prefer the cryptographically-bound one.
+        let from = item.message.sender.clone().or_else(|| message.from.clone());
+        let listener_id = item.message.recipient.clone();
+
+        let event = if message.typ == TRUST_PING_TYPE {
+            // Not auto-answered: the state handler pongs only after checking the
+            // sender has a relationship.
+            DIDCommEvent::TrustPingReceived {
+                from,
+                listener_id,
+                message_id: message.id.clone(),
+            }
+        } else if message.typ == TRUST_PONG_TYPE {
+            // Forwarded as both: InboundMessage drives task removal, the pong
+            // event drives the activity log.
+            let _ = event_tx
+                .try_send(DIDCommEvent::TrustPongReceived { from: from.clone() })
+                .inspect_err(|e| tracing::warn!(error = %e, "dropping trust-pong log event"));
+            DIDCommEvent::InboundMessage {
+                from,
+                message: Box::new(message),
+            }
+        } else if catch_all.is_match(&message.typ) {
+            tracing::info!(
+                listener = %crate::display::truncate_did(&item.message.recipient, 32),
+                msg_type = %message.typ,
+                from = ?from.as_deref().map(|d| crate::display::truncate_did(d, 32)),
+                thid = ?message.thid,
+                "inbound OpenVTC message received"
+            );
+            DIDCommEvent::InboundMessage {
+                from,
+                message: Box::new(message),
+            }
+        } else {
+            // Pickup-status heartbeats and anything else: dropped, as the
+            // framework's ignore-handler and fallback did.
+            debug!(typ = %message.typ, "unhandled message type — dropped");
+            continue;
+        };
+
+        if let Err(e) = event_tx.try_send(event) {
+            tracing::warn!(error = %e, "DIDComm event channel saturated — dropping inbound message");
+        }
+    }
 }
 
 /// Catch-all pattern for OpenVTC protocol messages + VTC Trust-Task
@@ -263,130 +629,6 @@ pub const OPENVTC_CATCH_ALL_PATTERN: &str = concat!(
     r"|https://trusttasks\.org/spec/credential-exchange/.*",
     r"|https://didcomm\.org/report-problem/.*",
 );
-
-/// Build the DIDComm message router.
-///
-/// Trust pings are handled automatically via the built-in handler.
-/// All OpenVTC protocol messages and trust pongs are forwarded as
-/// `DIDCommEvent::InboundMessage` for the state handler to process.
-///
-/// Returns an error if any route or regex registration fails. Routes
-/// are otherwise stable — only the OpenVTC protocol regex can fail at
-/// runtime if it ever becomes invalid.
-pub fn build_router(event_tx: mpsc::Sender<DIDCommEvent>) -> Result<Router, anyhow::Error> {
-    let openvtc_handler = handler_fn({
-        let tx = event_tx.clone();
-        move |ctx: affinidi_messaging_didcomm_service::HandlerContext, msg: Message| {
-            let tx = tx.clone();
-            async move {
-                tracing::info!(
-                    listener = %ctx.listener_id,
-                    msg_type = %msg.typ,
-                    from = ?msg
-                        .from
-                        .as_deref()
-                        .map(|d| crate::display::truncate_did(d, 32)),
-                    to = ?msg.to.as_ref().map(|dids| {
-                        dids.iter()
-                            .map(|d| crate::display::truncate_did(d, 32))
-                            .collect::<Vec<_>>()
-                    }),
-                    thid = ?msg.thid,
-                    "inbound OpenVTC message received"
-                );
-                if let Err(e) = tx.try_send(DIDCommEvent::InboundMessage {
-                    from: msg.from.clone(),
-                    message: Box::new(msg),
-                }) {
-                    tracing::warn!(error = %e, "DIDComm event channel saturated — dropping inbound message");
-                }
-                Ok(None)
-            }
-        }
-    });
-
-    let router = Router::new()
-        // Trust ping — forward to state handler for relationship verification
-        // before responding. Only respond to pings from established relationships.
-        .route(
-            affinidi_messaging_didcomm_service::TRUST_PING_TYPE,
-            handler_fn({
-                let tx = event_tx.clone();
-                move |ctx: affinidi_messaging_didcomm_service::HandlerContext, msg: Message| {
-                    let tx = tx.clone();
-                    let listener_id = ctx.listener_id.clone();
-                    async move {
-                        if let Err(e) = tx.try_send(DIDCommEvent::TrustPingReceived {
-                            from: msg.from.clone(),
-                            listener_id,
-                            message_id: msg.id.clone(),
-                        }) {
-                            tracing::warn!(error = %e, "DIDComm event channel saturated — dropping trust-ping");
-                        }
-                        // Do NOT auto-respond — state handler will send pong
-                        // only after verifying the sender has a relationship.
-                        Ok(None)
-                    }
-                }
-            }),
-        )?
-        // Trust pong — notify state handler for logging and task removal
-        .route(
-            affinidi_messaging_didcomm_service::TRUST_PONG_TYPE,
-            handler_fn({
-                let tx = event_tx.clone();
-                move |_ctx: affinidi_messaging_didcomm_service::HandlerContext, msg: Message| {
-                    let tx = tx.clone();
-                    async move {
-                        let from = msg.from.clone();
-                        // Forward the pong as InboundMessage for task removal
-                        if let Err(e) = tx.try_send(DIDCommEvent::InboundMessage {
-                            from: from.clone(),
-                            message: Box::new(msg),
-                        }) {
-                            tracing::warn!(error = %e, "DIDComm event channel saturated — dropping trust-pong");
-                            return Ok(None);
-                        }
-                        // Also send specific pong event for logging — best-effort.
-                        let _ = tx.try_send(DIDCommEvent::TrustPongReceived { from });
-                        Ok(None)
-                    }
-                }
-            }),
-        )?
-        // Catch-all for OpenVTC protocol messages + VTC Trust-Task replies
-        // (e.g. join-requests/submit-receipt). The state handler dispatches
-        // by type and ignores any it doesn't handle.
-        //
-        // Both VTC prefixes are accepted. The VTC's Trust Tasks are moving
-        // from the non-conformant `trusttasks.org/openvtc/vtc/…` authority
-        // to the canonical registry at `trusttasks.org/spec/vtc/…`. This
-        // regex is what decides whether a message reaches the handler at
-        // all, so it has to accept the new prefix *before* any VTC starts
-        // emitting it — otherwise migrated traffic is dropped here, silently
-        // and before dispatch ever sees it. Accepting both also means a
-        // migrated VTC and an unmigrated one can both be talked to during
-        // the rollout. The `openvtc/vtc/` arm can be retired once no
-        // supported VTC emits it.
-        .route_regex(OPENVTC_CATCH_ALL_PATTERN, openvtc_handler)?
-        // Message pickup status — silently drop
-        .route(
-            crate::protocol_urls::MESSAGEPICKUP_STATUS,
-            handler_fn(
-                |_ctx: affinidi_messaging_didcomm_service::HandlerContext, _msg: Message| async {
-                    Ok(None)
-                },
-            ),
-        )?
-        // Fallback for unknown message types
-        .fallback(handler_fn(
-            |_ctx: affinidi_messaging_didcomm_service::HandlerContext, msg: Message| async move {
-                debug!(typ = %msg.typ, "unhandled message type — dropped");
-                Ok(None)
-            },
-        ));
-    Ok(router)
-}
 
 /// Extract secrets for a DID from the TDK's secrets resolver.
 ///
@@ -418,22 +660,6 @@ fn make_profile(
     secrets: Vec<affinidi_tdk::secrets_resolver::secrets::Secret>,
 ) -> TDKProfile {
     TDKProfile::new(alias, did, Some(mediator), secrets)
-}
-
-/// Default restart policy for all listeners.
-///
-/// Only restart on failure, not on clean disconnect. This prevents a
-/// reconnect loop when the mediator closes our connection as a "duplicate"
-/// (e.g. when a second process or listener opens a connection for the same DID).
-/// Clean exits (listen() returns Ok) will NOT trigger a restart.
-fn default_listener_restart_policy() -> RestartPolicy {
-    RestartPolicy::OnFailure {
-        max_retries: None,
-        backoff: RetryConfig {
-            initial_delay_secs: 5,
-            max_delay_secs: 60,
-        },
-    }
 }
 
 /// Build [`ListenerSpec`]s from the loaded `Config`.
@@ -538,29 +764,29 @@ pub fn listener_id_for_did(our_did: &str, config: &Config) -> String {
 /// Convenience wrapper: send a DIDComm message through the correct listener
 /// based on the sender DID, with retry on transient failures.
 pub async fn send_message(
-    service: &DIDCommService,
+    service: &Messaging,
     config: &Config,
     message: &Message,
     from_did: &str,
     to_did: &str,
-) -> Result<(), DIDCommServiceError> {
+) -> Result<(), MessagingError> {
     let listener_id = listener_id_for_did(from_did, config);
     send_message_via(service, message, &listener_id, to_did).await
 }
 
-/// Send a DIDComm message through a specific listener, with retry on transient failures.
+/// Send a DIDComm message through a specific listener, durably.
 ///
 /// Use this when the transport listener should differ from the logical sender —
 /// for example, sending via the already-connected persona listener when a newly
 /// created R-DID listener may not be ready yet.
 pub async fn send_message_via(
-    service: &DIDCommService,
+    service: &Messaging,
     message: &Message,
     listener_id: &str,
     to_did: &str,
-) -> Result<(), DIDCommServiceError> {
+) -> Result<(), MessagingError> {
     tracing::info!(
-        listener = %listener_id,
+        listener = %crate::display::truncate_did(listener_id, 32),
         msg_type = %message.typ,
         from = ?message
             .from
@@ -570,15 +796,49 @@ pub async fn send_message_via(
         thid = ?message.thid,
         "sending DIDComm message"
     );
+
+    // Pack as the sending identity. `MessageTransport::send` takes already-packed
+    // bytes — packing is the protocol's concern, not the transport's — so this
+    // needs that identity's own ATM, which is why the wire is kept per listener.
+    let packed = {
+        let identities = service.inner.identities.read().await;
+        let wire = identities
+            .get(listener_id)
+            .ok_or_else(|| MessagingError::UnknownListener(listener_id.to_string()))?;
+        wire.atm
+            .pack_encrypted(message, to_did, Some(&wire.did), Some(&wire.did))
+            .await
+            .map_err(|e| MessagingError::Pack {
+                recipient: to_did.to_string(),
+                reason: e.to_string(),
+            })?
+            .0
+    };
+
+    // `Guaranteed`, not `BestEffort`. The framework call this replaces
+    // (`send_message_with_retry`) retried on a disconnected listener; `BestEffort`
+    // has no retry, so a straight swap would trade a retry for a dropped message
+    // whenever a send lands mid-reconnect. The outbox IS that retry, and a better
+    // one: it survives the reconnect and settles visibly if the window expires.
+    //
+    // Keyed by the message id, so a re-send of the same message dedups at the
+    // recipient rather than double-delivering.
     service
-        .send_message_with_retry(
+        .inner
+        .service
+        .send_via(
             listener_id,
-            message.clone(),
             to_did,
-            3,
-            std::time::Duration::from_secs(2),
+            packed.into_bytes(),
+            Delivery::Guaranteed {
+                idempotency_key: Some(message.id.clone()),
+                ordering_key: None,
+                deliver_by: DELIVER_BY,
+            },
         )
         .await
+        .map(|_accepted| ())
+        .map_err(|e| MessagingError::Send(e.to_string()))
 }
 
 /// A listener lifecycle event, ready to be rendered into the activity log.
@@ -611,60 +871,89 @@ pub enum LifecycleLog {
     Missed { count: u64 },
 }
 
-/// Subscribe to `DIDCommService` lifecycle events and forward them as
+/// Subscribe to listener lifecycle transitions and forward them as
 /// structured log events via the provided sender. Detects rapid reconnect
 /// cycling. Returns the spawned task handle.
 pub fn spawn_lifecycle_logger(
-    service: &DIDCommService,
+    service: &Messaging,
     log_tx: mpsc::UnboundedSender<LifecycleLog>,
 ) -> tokio::task::JoinHandle<()> {
-    let mut events_rx = service.subscribe();
+    let mut status_rx = service.subscribe();
     tokio::spawn(async move {
-        // Track disconnect timestamps per listener to detect rapid cycling
-        let mut last_disconnect: std::collections::HashMap<String, std::time::Instant> =
-            std::collections::HashMap::new();
+        // Disconnect timestamps, for the rapid-cycling heuristic.
+        let mut last_disconnect: HashMap<String, std::time::Instant> = HashMap::new();
 
         loop {
-            match events_rx.recv().await {
-                Ok(ListenerEvent::Connected { listener_id }) => {
+            match status_rx.recv().await {
+                Ok(ListenerStatus::Connected { listener_id }) => {
                     let _ = log_tx.send(LifecycleLog::Connected { listener_id });
                 }
-                Ok(ListenerEvent::Disconnected { listener_id, error }) => {
+                Ok(ListenerStatus::Disconnected { listener_id, error }) => {
                     let now = std::time::Instant::now();
                     let _ = log_tx.send(LifecycleLog::Disconnected {
                         listener_id: listener_id.clone(),
-                        error: error.as_ref().map(ToString::to_string),
+                        error,
                     });
-
-                    // Detect rapid cycling: if we disconnected within 10s of last disconnect
-                    if let Some(prev) = last_disconnect.get(&listener_id)
-                        && now.duration_since(*prev).as_secs() < 10
+                    if let Some(previous_drop) = last_disconnect.get(&listener_id)
+                        && now.duration_since(*previous_drop) < CYCLING_WINDOW
                     {
-                        tracing::warn!(listener = %listener_id, "rapid disconnect cycling detected");
+                        tracing::warn!(
+                            listener = %crate::display::truncate_did(&listener_id, 32),
+                            "rapid disconnect cycling detected"
+                        );
                         let _ = log_tx.send(LifecycleLog::CyclingRapidly {
                             listener_id: listener_id.clone(),
                         });
                     }
                     last_disconnect.insert(listener_id, now);
                 }
-                Ok(ListenerEvent::Restarting {
-                    listener_id,
-                    attempt,
-                    delay,
-                }) => {
-                    let _ = log_tx.send(LifecycleLog::Restarting {
-                        listener_id,
-                        attempt,
-                        delay,
-                    });
-                }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    let _ = log_tx.send(LifecycleLog::Missed { count: n });
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
+                    let _ = log_tx.send(LifecycleLog::Missed { count });
                 }
             }
         }
     })
+}
+
+/// The one connection poller: sample every transport's live state and broadcast
+/// the transitions.
+///
+/// The framework pushed `ListenerEvent`s; the delivery layer exposes a live
+/// `ConnState` per transport instead (R6.2 — re-falsifiable, never a boot-time
+/// latch), so transitions are derived by sampling. Doing that once and
+/// broadcasting is what keeps every consumer's view identical.
+async fn poll_listener_status(
+    service: Arc<MessagingService>,
+    status_tx: tokio::sync::broadcast::Sender<ListenerStatus>,
+) {
+    let mut seen: HashMap<String, ConnState> = HashMap::new();
+    loop {
+        tokio::time::sleep(LIFECYCLE_POLL_INTERVAL).await;
+
+        let states = service.transport_states();
+        for (listener_id, state) in &states {
+            if seen.insert(listener_id.clone(), *state) == Some(*state) {
+                continue;
+            }
+            let event = match state {
+                ConnState::Connected => ListenerStatus::Connected {
+                    listener_id: listener_id.clone(),
+                },
+                _ => ListenerStatus::Disconnected {
+                    listener_id: listener_id.clone(),
+                    error: None,
+                },
+            };
+            // `Err` only means nobody is subscribed yet — not a failure.
+            let _ = status_tx.send(event);
+        }
+
+        // Forget removed transports, so a re-added listener reports its connect
+        // rather than looking like it never dropped.
+        let live: std::collections::HashSet<&String> = states.iter().map(|(id, _)| id).collect();
+        seen.retain(|id, _| live.contains(id));
+    }
 }
 
 /// Build a single [`ListenerSpec`] for the persona DID.
@@ -711,16 +1000,34 @@ pub async fn start_service(
     tdk: &affinidi_tdk::TDK,
     event_tx: mpsc::Sender<DIDCommEvent>,
     shutdown: tokio_util::sync::CancellationToken,
-) -> Result<DIDCommService, DIDCommServiceError> {
-    let router = build_router(event_tx)
-        .map_err(|e| DIDCommServiceError::Internal(format!("router init failed: {e}")))?;
-    let listeners = build_listener_configs(config, tdk)
-        .await
-        .iter()
-        .map(ListenerSpec::to_listener_config)
-        .collect();
+) -> Result<Messaging, MessagingError> {
+    let service = Messaging::start(event_tx);
 
-    DIDCommService::start(DIDCommServiceConfig { listeners }, router, shutdown).await
+    // Listeners are installed one at a time rather than handed over as a set: each
+    // is an independent mediator connect, and one persona whose mediator is down
+    // must not stop the others coming up. A failure is logged and skipped — the
+    // panel reports per-listener state, so a missing one is visible rather than
+    // silent, and `reconnect_persona_listener_io` is the recovery path.
+    for spec in build_listener_configs(config, tdk).await {
+        if let Err(e) = add_listener(&service, &spec).await {
+            tracing::warn!(
+                listener = %crate::display::truncate_did(&spec.id, 32),
+                error = %e,
+                "listener failed to come up; continuing without it"
+            );
+        }
+    }
+
+    // The framework owned the shutdown token; now it is ours to honour. Dropping
+    // every transport on cancel is what stops a stale socket racing the next
+    // process for the same DID (`duplicate-channel`).
+    let on_cancel = service.clone();
+    tokio::spawn(async move {
+        shutdown.cancelled().await;
+        on_cancel.shutdown().await;
+    });
+
+    Ok(service)
 }
 
 /// Produce a short, collision-resistant identifier from a DID for listener IDs.

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -2,7 +2,7 @@
 //! sending, and listener lifecycle.
 //!
 //! Runs on the **delivery layer** (`affinidi-messaging-delivery`): one
-//! [`MessagingService`] holding one `DidCommTransport` per identity, with a
+//! `MessagingService` holding one `DidCommTransport` per identity, with a
 //! durable outbox behind every send.
 //!
 //! It used to wrap `affinidi-messaging-didcomm-service`, the type-routed framework

--- a/openvtc-core/tests/didcomm_transport_e2e.rs
+++ b/openvtc-core/tests/didcomm_transport_e2e.rs
@@ -33,27 +33,21 @@ use std::time::Duration;
 use affinidi_tdk::didcomm::Message;
 use common::{MockMediator, init_test_tracing};
 use openvtc_core::didcomm::{
-    DIDCommEvent, add_listener, build_router, relationship_listener_config_from_secrets,
+    DIDCommEvent, Messaging, add_listener, relationship_listener_config_from_secrets,
     send_message_via,
 };
 use tokio::sync::mpsc;
-use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 /// An OpenVTC protocol type the production catch-all pattern must route.
 const OPENVTC_TYPE: &str = "https://linuxfoundation.org/openvtc/test/1.0/ping";
 
-/// Start a `DIDCommService` for one profile using the **production** router and
-/// the production `Config`-free listener builder.
+/// Stand up one profile's production `Messaging` runtime and install its listener.
 async fn start_production_service(
     profile: common::TestProfile,
     remote_did: &str,
     event_tx: mpsc::Sender<DIDCommEvent>,
-) -> (
-    affinidi_messaging_didcomm_service::DIDCommService,
-    String,
-    CancellationToken,
-) {
+) -> (Messaging, String) {
     let listener = relationship_listener_config_from_secrets(
         &profile.did,
         remote_did,
@@ -61,22 +55,11 @@ async fn start_production_service(
         profile.secrets.clone(),
     );
     let listener_id = listener.id.clone();
-    let router = build_router(event_tx).expect("production router builds");
-    let shutdown = CancellationToken::new();
-    // Start empty and install through the production `add_listener` seam, so the
-    // test drives the same path the runtime does rather than reaching past it
-    // into the framework's own config type.
-    let service = affinidi_messaging_didcomm_service::DIDCommService::start(
-        affinidi_messaging_didcomm_service::DIDCommServiceConfig { listeners: vec![] },
-        router,
-        shutdown.clone(),
-    )
-    .await
-    .expect("service starts");
+    let service = Messaging::start(event_tx);
     add_listener(&service, &listener)
         .await
         .expect("production listener spec installs");
-    (service, listener_id, shutdown)
+    (service, listener_id)
 }
 
 /// The end-to-end path the swap will replace: production listener → production
@@ -93,18 +76,16 @@ async fn an_openvtc_message_routes_through_the_production_transport() {
 
     // Receiver first: a listener that is not yet polling would miss the frame.
     let (bob_tx, mut bob_rx) = mpsc::channel::<DIDCommEvent>(16);
-    let (bob_service, bob_listener, _bob_shutdown) =
-        start_production_service(bob, &alice_did, bob_tx).await;
+    let (bob_service, bob_listener) = start_production_service(bob, &alice_did, bob_tx).await;
     bob_service
-        .wait_connected(&bob_listener, Duration::from_secs(15))
+        .wait_connected(&bob_listener, Duration::from_secs(20))
         .await
         .expect("bob listener connects");
 
     let (alice_tx, _alice_rx) = mpsc::channel::<DIDCommEvent>(16);
-    let (alice_service, alice_listener, _alice_shutdown) =
-        start_production_service(alice, &bob_did, alice_tx).await;
+    let (alice_service, alice_listener) = start_production_service(alice, &bob_did, alice_tx).await;
     alice_service
-        .wait_connected(&alice_listener, Duration::from_secs(15))
+        .wait_connected(&alice_listener, Duration::from_secs(20))
         .await
         .expect("alice listener connects");
 
@@ -162,18 +143,16 @@ async fn an_unrelated_message_type_reaches_no_handler() {
     let bob_did = bob.did.clone();
 
     let (bob_tx, mut bob_rx) = mpsc::channel::<DIDCommEvent>(16);
-    let (bob_service, bob_listener, _bob_shutdown) =
-        start_production_service(bob, &alice_did, bob_tx).await;
+    let (bob_service, bob_listener) = start_production_service(bob, &alice_did, bob_tx).await;
     bob_service
-        .wait_connected(&bob_listener, Duration::from_secs(15))
+        .wait_connected(&bob_listener, Duration::from_secs(20))
         .await
         .expect("bob listener connects");
 
     let (alice_tx, _alice_rx) = mpsc::channel::<DIDCommEvent>(16);
-    let (alice_service, alice_listener, _alice_shutdown) =
-        start_production_service(alice, &bob_did, alice_tx).await;
+    let (alice_service, alice_listener) = start_production_service(alice, &bob_did, alice_tx).await;
     alice_service
-        .wait_connected(&alice_listener, Duration::from_secs(15))
+        .wait_connected(&alice_listener, Duration::from_secs(20))
         .await
         .expect("alice listener connects");
 

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -26,7 +26,6 @@ ratatui.workspace = true
 aes-gcm.workspace = true
 affinidi-tdk.workspace = true
 affinidi-data-integrity.workspace = true
-affinidi-messaging-didcomm-service.workspace = true
 anyhow.workspace = true
 # did-git-sign exposes init::install so the cli2 setup wizard can configure
 # git commit signing for the freshly-provisioned persona without having to

--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
-use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::TDK;
 use anyhow::Result;
+use openvtc_core::didcomm::Messaging;
 use openvtc_core::{config::Config, logs::LogFamily, tasks::TaskType, vrc::VrcRequest};
 use tracing::{debug, info};
 
@@ -12,7 +12,7 @@ use tracing::{debug, info};
 pub async fn send_vrc_request(
     config: &mut Config,
     _tdk: &TDK,
-    service: &DIDCommService,
+    service: &Messaging,
     remote_p_did: &str,
     reason: Option<&str>,
 ) -> Result<()> {
@@ -147,7 +147,7 @@ fn handle_reason_update(state: &mut State, value: String) {
 async fn handle_submit_request(
     config: &mut Box<Config>,
     tdk: &TDK,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     save: &mut SaveScheduler,
     relationship_p_did: &str,
@@ -210,7 +210,7 @@ pub(crate) async fn dispatch(
     action: CredentialAction,
     config: &mut Box<Config>,
     tdk: &TDK,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     save: &mut SaveScheduler,
 ) {

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -6,11 +6,11 @@
 
 use std::sync::Arc;
 
-use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::TDK;
 use affinidi_tdk::didcomm::Message;
 use anyhow::Result;
 use chrono::Utc;
+use openvtc_core::didcomm::Messaging;
 use openvtc_core::{
     config::Config,
     logs::LogFamily,
@@ -267,7 +267,7 @@ impl InboxJob {
 /// Owned inputs for a backgrounded relationship-acceptance.
 pub(crate) struct AcceptJob {
     tdk: TDK,
-    service: DIDCommService,
+    service: Messaging,
     /// `Some` ⇒ mint an R-DID first; `None` ⇒ use the persona DID directly.
     rdid_plan: Option<crate::state_handler::relationship_actions::RDidPlan>,
     persona_did: Arc<String>,
@@ -336,7 +336,7 @@ impl AcceptJob {
 
 /// A single backgrounded inbox DIDComm send + the post-send effect.
 pub(crate) struct InboxSend {
-    service: DIDCommService,
+    service: Messaging,
     listener_id: String,
     to_did: Arc<String>,
     message: Box<Message>,
@@ -564,7 +564,7 @@ async fn prepare_accept_relationship(
     config: &mut Box<Config>,
     tdk: &TDK,
     state: &mut State,
-    service: &DIDCommService,
+    service: &Messaging,
     task_id: &str,
     generate_r_did: bool,
     admin_vta: Option<&vta_sdk::client::VtaClient>,
@@ -654,7 +654,7 @@ async fn prepare_accept_relationship(
 /// + resolve the persona listener; the task sends it.
 fn prepare_reject_relationship(
     config: &mut Box<Config>,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     task_id: &str,
     reason: Option<&str>,
@@ -695,7 +695,7 @@ fn prepare_reject_relationship(
 async fn prepare_accept_vrc_request(
     config: &mut Box<Config>,
     tdk: &TDK,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     task_id: &str,
 ) -> Result<InboxJob> {
@@ -759,7 +759,7 @@ async fn prepare_accept_vrc_request(
 /// the task sends it.
 fn prepare_reject_vrc_request(
     config: &mut Box<Config>,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     task_id: &str,
     reason: Option<&str>,
@@ -877,7 +877,7 @@ pub(crate) async fn dispatch(
     action: InboxAction,
     config: &mut Box<Config>,
     tdk: &TDK,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     save: &mut SaveScheduler,
     admin_vta: Option<&vta_sdk::client::VtaClient>,

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -11,9 +11,9 @@
 
 use std::sync::Arc;
 
-use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::{TDK, didcomm::Message};
 use dtg_credentials::DTGCredential;
+use openvtc_core::didcomm::Messaging;
 use openvtc_core::messaging::{
     SeenMessages, check_message_age, check_task_capacity, create_finalize_message,
     handle_credential_issue, handle_join_problem_report, handle_join_status_response,
@@ -161,7 +161,7 @@ pub(crate) async fn capability_toggle_for(
 pub async fn process_inbound_message(
     config: &mut Config,
     tdk: &TDK,
-    service: &DIDCommService,
+    service: &Messaging,
     seen: &mut SeenMessages,
     message: &Message,
     inactivated: &mut Vec<(VtcDid, openvtc_core::config::account::PersonaId)>,
@@ -411,10 +411,10 @@ pub async fn process_inbound_message(
                 .filter(|our_did| !config.is_persona_did(our_did.as_str()));
             let listener_to_remove =
                 our_did.map(|our_did| super::didcomm::listener_id_for_did(&our_did, config));
-            if let Some(lid) = listener_to_remove
-                && let Err(e) = service.remove_listener(&lid).await
-            {
-                warn!(listener = %lid, error = %e, "failed to remove R-DID listener during rejection cleanup");
+            if let Some(lid) = listener_to_remove {
+                // Infallible now: dropping a transport closes its socket and
+                // forgets its wire, with nothing left that can fail.
+                service.remove_listener(&lid).await;
             }
             let _ = config.private.relationships.remove_by_task_id(
                 &task_id,

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -675,8 +675,12 @@ impl StateHandler {
 
         // Log registered listeners for diagnostics
         let listeners = didcomm_service.list_listeners().await;
-        for l in &listeners {
-            debug!(id = %l.id, state = ?l.state, "registered listener");
+        for id in &listeners {
+            debug!(
+                listener = %openvtc_core::display::truncate_did(id, 32),
+                state = ?didcomm_service.listener_state(id),
+                "registered listener"
+            );
         }
         info!(count = listeners.len(), "DIDComm listeners registered");
 
@@ -830,11 +834,7 @@ impl StateHandler {
                                 let listener_id = removed
                                     .map(|s| s.listener_id)
                                     .unwrap_or_else(|| didcomm::persona_listener_id(&did));
-                                if let Err(e) =
-                                    didcomm_service.remove_listener(&listener_id).await
-                                {
-                                    debug!("remove_listener after community delete: {e}");
-                                }
+                                didcomm_service.remove_listener(&listener_id).await;
                                 state
                                     .main_page
                                     .log("Community removed — persona listener stopped.");
@@ -1729,9 +1729,13 @@ impl StateHandler {
                                 if let Some(ref from_did) = from
                                     && let Ok(pong_msg) =
                                         build_trust_pong(&our_listener_did, from_did, &message_id)
-                                    && let Err(e) = didcomm_service
-                                        .send_message(&listener_id, pong_msg, from_did)
-                                        .await
+                                    && let Err(e) = didcomm::send_message_via(
+                                        &didcomm_service,
+                                        &pong_msg,
+                                        &listener_id,
+                                        from_did,
+                                    )
+                                    .await
                                 {
                                     state.main_page.log_error("Failed to send pong", &e);
                                 }
@@ -1823,7 +1827,7 @@ impl StateHandler {
                         outcome,
                     );
                 },
-                // Lifecycle log messages from the DIDCommService
+                // Lifecycle log messages from the Messaging
                 Some(event) = lifecycle_log_rx.recv() => {
                     // Formatted here, not in the logger task: naming a listener
                     // needs `config`, which only this thread holds.
@@ -1834,8 +1838,7 @@ impl StateHandler {
                 // the status to Connected; a disconnect drops back to Connecting
                 // while the service auto-reconnects.
                 ev = listener_events.recv() => {
-                    use affinidi_messaging_didcomm_service::ListenerEvent;
-                    if let Ok(ev) = ev {
+                                        if let Ok(ev) = ev {
                         // Route persona-listener lifecycle through the session
                         // manager (D11/D15), which holds per-session status; a
                         // disconnect carrying an error is recorded as that one
@@ -1845,15 +1848,14 @@ impl StateHandler {
                         // Events for R-DID listeners (not persona sessions) match
                         // nothing and are ignored.
                         let changed = match ev {
-                            ListenerEvent::Connected { listener_id } => {
+                            didcomm::ListenerStatus::Connected { listener_id } => {
                                 session_manager.mark_connected(&listener_id)
                             }
-                            ListenerEvent::Disconnected { listener_id, error } => match error {
-                                Some(e) => session_manager.mark_failed(&listener_id, e),
-                                None => session_manager.mark_disconnected(&listener_id),
-                            },
-                            ListenerEvent::Restarting { listener_id, .. } => {
-                                session_manager.mark_disconnected(&listener_id)
+                            didcomm::ListenerStatus::Disconnected { listener_id, error } => {
+                                match error {
+                                    Some(e) => session_manager.mark_failed(&listener_id, e),
+                                    None => session_manager.mark_disconnected(&listener_id),
+                                }
                             }
                         };
                         // Derive the global connection indicator from the
@@ -2678,7 +2680,7 @@ impl StateHandler {
         state: &mut State,
         config: &mut Config,
         admin_vta: Option<&vta_sdk::client::VtaClient>,
-        didcomm_service: &affinidi_messaging_didcomm_service::DIDCommService,
+        didcomm_service: &openvtc_core::didcomm::Messaging,
         index: usize,
     ) -> Option<relationship_actions::DidDeleteJob> {
         state.main_page.content_panel.vta.confirm_delete_did = None;
@@ -3284,7 +3286,7 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
 /// `NoActiveCommunity` when the account has no live community left.
 async fn deregister_inactive_community(
     session_manager: &mut session_manager::SessionManager,
-    service: &affinidi_messaging_didcomm_service::DIDCommService,
+    service: &openvtc_core::didcomm::Messaging,
     config: &Config,
     state: &mut State,
     vtc: &openvtc_core::config::account::VtcDid,
@@ -3302,9 +3304,7 @@ async fn deregister_inactive_community(
         let listener_id = removed
             .map(|s| s.listener_id)
             .unwrap_or_else(|| didcomm::persona_listener_id(&did));
-        if let Err(e) = service.remove_listener(&listener_id).await {
-            debug!("remove_listener after community inactivation: {e}");
-        }
+        service.remove_listener(&listener_id).await;
         state
             .main_page
             .log("Community inactive — persona listener stopped.");
@@ -3318,7 +3318,7 @@ async fn deregister_inactive_community(
 
 async fn register_joined_session(
     session_manager: &mut session_manager::SessionManager,
-    service: &affinidi_messaging_didcomm_service::DIDCommService,
+    service: &openvtc_core::didcomm::Messaging,
     tdk: &TDK,
     config: &Config,
     joined: join_flow::JoinedSession,
@@ -3350,13 +3350,9 @@ async fn register_joined_session(
             // listener SessionManager isn't tracking may linger. `add_listener`
             // errors on a duplicate id ("Listener already exists"), so reuse the
             // existing listener rather than failing the join's live session (D1).
-            if let Some(existing) = service
-                .list_listeners()
-                .await
-                .into_iter()
-                .find(|l| l.id == lid)
-            {
-                if existing.state == affinidi_messaging_didcomm_service::ListenerState::Running {
+            if service.has_listener(&lid).await {
+                if service.listener_state(&lid) == Some(openvtc_core::didcomm::ConnState::Connected)
+                {
                     session_manager.mark_connected(&lid);
                     state
                         .main_page

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use crate::state_handler::setup_sequence::vta;
-use affinidi_messaging_didcomm_service::DIDCommService;
 use affinidi_tdk::{
     TDK,
     affinidi_crypto::ed25519::ed25519_private_to_x25519,
@@ -15,6 +14,7 @@ use anyhow::Result;
 use base64::Engine;
 use chrono::Utc;
 use ed25519_dalek_bip32::DerivationPath;
+use openvtc_core::didcomm::Messaging;
 use openvtc_core::{
     config::{
         Config, KeyBackend, KeyTypes,
@@ -145,7 +145,7 @@ impl RDidPlan {
     pub(crate) async fn create_io(
         self,
         tdk: &TDK,
-        service: &DIDCommService,
+        service: &Messaging,
         remote_p_did: &str,
     ) -> Result<CreatedRDid> {
         let mediator = self.mediator().to_string();
@@ -387,10 +387,10 @@ use openvtc_core::relationships::Relationship as RelRecord;
 /// validation, contact add, R-DID key creation + listener registration), then a
 /// `tokio::spawn`ed task does the slow network send with these owned values and
 /// reports the result back as a [`RelationshipOutcome`]. It borrows nothing tied
-/// to the loop's `Config`/`TDK`: `DIDCommService` is `Arc`-cheap to clone and the
+/// to the loop's `Config`/`TDK`: `Messaging` is `Arc`-cheap to clone and the
 /// message/ids are owned, so the future is `'static` + `Send`.
 pub(crate) struct RelationshipSend {
-    service: DIDCommService,
+    service: Messaging,
     /// The listener id the message is sent through, resolved on the loop thread
     /// (`listener_id_for_did`) so the task needs no `Config`. Persona listener for
     /// handshake messages; R-DID listener once established.
@@ -418,7 +418,7 @@ pub(crate) enum RelationshipJob {
     /// Remove: tear down the (optional) R-DID listener, then the loop thread
     /// removes the relationship/contact records.
     Remove {
-        service: DIDCommService,
+        service: Messaging,
         /// `Some` only when the relationship used a dedicated R-DID listener.
         listener_id: Option<String>,
         remote_p_did: String,
@@ -430,7 +430,7 @@ pub(crate) enum RelationshipJob {
 /// the task is `'static` + `Send`.
 pub(crate) struct CreateJob {
     tdk: TDK,
-    service: DIDCommService,
+    service: Messaging,
     /// `Some` ⇒ mint an R-DID first; `None` ⇒ use the persona DID directly.
     rdid_plan: Option<RDidPlan>,
     /// Our persona DID (message `from`, and the listener the request is sent via).
@@ -565,10 +565,8 @@ impl RelationshipJob {
                 listener_id,
                 remote_p_did,
             } => {
-                if let Some(lid) = listener_id
-                    && let Err(e) = service.remove_listener(&lid).await
-                {
-                    tracing::warn!(listener = %lid, error = %e, "failed to remove R-DID listener");
+                if let Some(lid) = listener_id {
+                    service.remove_listener(&lid).await;
                 }
                 RelationshipOutcome {
                     effect: RelationshipEffect::Remove { remote_p_did },
@@ -966,7 +964,7 @@ impl RelationshipOutcome {
 /// resolution) ran on the loop thread before this was built.
 pub(crate) struct DidDeleteJob {
     pub(crate) admin_vta: Option<vta_sdk::client::VtaClient>,
-    pub(crate) service: DIDCommService,
+    pub(crate) service: Messaging,
     pub(crate) did: String,
     pub(crate) persona_id: openvtc_core::config::account::PersonaId,
     pub(crate) key_ids: Vec<String>,
@@ -990,9 +988,7 @@ impl DidDeleteJob {
             tracing::debug!("delete_did_webvh({did}) failed (continuing local cleanup): {e}");
         }
         let listener_id = super::didcomm::persona_listener_id(&did);
-        if let Err(e) = service.remove_listener(&listener_id).await {
-            tracing::debug!("remove_listener after DID delete: {e}");
-        }
+        service.remove_listener(&listener_id).await;
         DidDeleteOutcome {
             did,
             persona_id,
@@ -1094,7 +1090,7 @@ fn handle_toggle_r_did(state: &mut State) {
 async fn prepare_submit(
     config: &mut Box<Config>,
     tdk: &TDK,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     did: &str,
     alias: &str,
@@ -1224,7 +1220,7 @@ async fn prepare_submit(
 /// `apply` on success.
 fn prepare_ping(
     config: &mut Box<Config>,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     remote_p_did: &str,
 ) -> Result<RelationshipJob> {
@@ -1271,7 +1267,7 @@ fn prepare_ping(
 /// then the task tears the listener down; the record removal happens in `apply`.
 fn prepare_remove(
     config: &mut Box<Config>,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     remote_p_did: &str,
 ) -> RelationshipJob {
@@ -1299,7 +1295,7 @@ fn prepare_remove(
 /// success. Mirrors the pre-R14 `credential_actions::send_vrc_request` split.
 fn prepare_request_vrc(
     config: &mut Box<Config>,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     remote_p_did: &str,
 ) -> Result<RelationshipJob> {
@@ -1442,7 +1438,7 @@ pub(crate) async fn dispatch(
     action: RelationshipAction,
     config: &mut Box<Config>,
     tdk: &TDK,
-    service: &DIDCommService,
+    service: &Messaging,
     state: &mut State,
     save: &mut crate::state_handler::save_coalesce::SaveScheduler,
     admin_vta: Option<&vta_sdk::client::VtaClient>,

--- a/openvtc/src/state_handler/session_manager.rs
+++ b/openvtc/src/state_handler/session_manager.rs
@@ -10,14 +10,14 @@
 //! the registry of live persona-sessions, their per-session connection status, a
 //! bounded maximum number of concurrent sessions, and the register/deregister
 //! bookkeeping for join/leave. The actual connect / restart / recovery I/O stays
-//! in the SDK `DIDCommService`, which already supervises each listener
+//! in the SDK `Messaging`, which already supervises each listener
 //! independently (per-listener restart policy) — a mediator outage on one session
 //! is contained by the SDK and reflected here as that session's status, never
 //! affecting the others.
 //!
 //! It is **pure bookkeeping** (no I/O, no SDK types) so it is unit-testable with
 //! simulated sessions without a live mediator. The runtime loop turns its
-//! decisions into `DIDCommService` `add_listener`/`remove_listener` calls and
+//! decisions into `Messaging` `add_listener`/`remove_listener` calls and
 //! feeds `ListenerEvent`s back into [`SessionManager::mark_connected`] etc.
 
 use std::collections::{BTreeSet, HashMap};


### PR DESCRIPTION
Closes #189. **OpenVTC no longer depends on `affinidi-messaging-didcomm-service` at all** — the type-routed framework both VTI services had already cut away from.

## The shape change

The old framework owned N *listeners* and hid packing, retry and routing behind them. The delivery layer owns N *transports keyed by identity*, and the transport determines the proven sender — so "send as this persona" is `send_via(persona_did, …)` rather than a listener lookup, and packing is the caller's job because `MessageTransport::send` takes already-packed bytes.

- **`Messaging` replaces `DIDCommService`** — one `MessagingService`, one `DidCommTransport` per identity, a shared `via`-partitioned outbox, per-identity drains. Cloneable, since call sites hand it to spawned tasks.
- **`add_listener`** brings up one identity's wire in the order the SDK requires: secrets seeded *before* `ATM::new`, profile via `from_tdk_profile`, `profile_add(_, true)` to connect the websocket, then `DidCommTransport::new` — which fails on a profile with no websocket running.
- **`dispatch_inbound` replaces `Router`** — the delivery layer has no type-routed dispatch, so the catch-all regex, trust-ping/pong and the drop cases are matched here. It prefers the transport's **cryptographically-bound** sender over the plaintext `from` header, which the framework did not.
- **One connection poller broadcasts `ListenerStatus`**, consumed by both the session manager and the activity log, so the two cannot disagree about whether a listener is up. Read live, never latched at boot (R6.2).
- **`start_service` installs listeners one at a time** — each is an independent mediator connect, so one persona whose mediator is down no longer stops the others coming up.

## Two decisions worth review

**`Delivery::Guaranteed`, not `BestEffort`.** `send_message_with_retry` retried on a disconnected listener; `BestEffort` has no retry. A straight swap would have traded a retry for a message dropped whenever a send landed mid-reconnect — in a TUI, exactly when someone presses a key. The outbox is that retry and survives the reconnect; the delivery window bounds it (R1.2) so an entry settles visibly rather than never.

**`reconnect_persona_listener_io` removes before it adds.** The mediator permits one websocket per DID and rejects a second with `duplicate-channel`, so add-before-remove would race two sockets on one identity — the duelling-reconnect failure behind #132. The reason is in the code, not just here.

`MessagingError` replaces `DIDCommServiceError` with variants an operator can act on separately — listener-bringup, unknown-listener, pack, send (R6.4). `remove_listener` is now infallible (dropping a transport cannot fail), so four call sites lose dead error handling.

## Verification

- **All 16 test binaries pass** with `--include-ignored`, 0 failed
- `didcomm_transport_e2e` drives the production `Messaging`, `add_listener`, dispatcher and `Guaranteed` send **against a real mediator**, asserting an OpenVTC type routes through to the event channel and an unrelated one reaches no handler
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean

## What this does not cover, honestly

The e2e test exercises listener bringup, routing and send. It does **not** exercise a mediator dropping a live socket and the transport recovering — `DidCommTransport::inbound()` stays alive across reconnects (verified by reading the adapter), but a full ATM task teardown would leave the transport stale where the framework's `RestartPolicy` rebuilt it. **No such rebuild is implemented here.** `transport_state` is the signal it would key off, and I'd rather land the swap with that gap named than paper it with logic no test covers. Worth a follow-up issue if you agree.

## Follow-on

TSP **inbound** is now one feature flag away: `DidCommTransport` surfaces TSP frames off this same multiplexed pickup socket tagged `Protocol::TSP`, with no second socket — which is what sidesteps the `duplicate-channel` wall blocking #185 item 2b. The dispatcher currently skips non-DIDComm payloads; routing them is #185's remaining work.
