### PR TITLE
feat: route trust tasks over TSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "affinidi-cesr"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e986f772f1639a7de3bf1ba1cf9b99aa87175fa28463d289a4afa5fc1c274266"
+dependencies = [
+ "base64ct",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "affinidi-crypto"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +459,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
  "affinidi-did-common 0.4.0",
+ "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "affinidi-messaging-core",
  "affinidi-messaging-didcomm",
@@ -456,12 +467,14 @@ dependencies = [
  "affinidi-secrets-resolver",
  "affinidi-task-utils",
  "affinidi-tdk-common",
+ "affinidi-tsp",
  "ahash 0.8.12",
  "async-trait",
  "base64 0.22.1",
  "futures-util",
  "rand 0.10.2",
  "regex",
+ "reqwest 0.13.4",
  "rustls",
  "rustls-pemfile 2.2.0",
  "serde",
@@ -669,6 +682,7 @@ dependencies = [
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
  "affinidi-tdk-common",
+ "affinidi-tsp",
  "clap",
  "rustls",
  "serde",
@@ -705,6 +719,32 @@ dependencies = [
  "tokio",
  "tracing",
  "windows-native-keyring-store",
+]
+
+[[package]]
+name = "affinidi-tsp"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9499c93bcd77125a532d4e881d5daff9844660ae0de03a5a085a71e97b7143"
+dependencies = [
+ "affinidi-cesr",
+ "affinidi-did-common 0.4.0",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-encoding",
+ "blake2",
+ "chacha20poly1305",
+ "ed25519-dalek",
+ "hex",
+ "hkdf 0.12.4",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.19",
+ "tokio",
+ "url",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -837,7 +877,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -848,7 +888,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2756,7 +2796,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3051,7 +3091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5271,7 +5311,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5726,7 +5766,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.20.1",
+ "vta-sdk 0.20.2",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5785,7 +5825,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.20.1",
+ "vta-sdk 0.20.2",
  "vta-service",
  "wiremock",
  "x25519-dalek",
@@ -5823,7 +5863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6537,7 +6577,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7184,7 +7224,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7260,7 +7300,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7905,7 +7945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8391,7 +8431,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8404,7 +8444,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8985,9 +9025,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15438a66c6f3e061554d8cd5a0e2c07c0828618f3e3ff3331be266347caccf25"
+checksum = "d7f80508c771f601bcd02b85d0a6d0890bdcee07b305d6afa9dff9d5c1f57f2c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9415,9 +9455,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4c5b889ee964e46fe15338b4aaad4318caeae191b8292b959a5a68ac92fd2"
+checksum = "e4e33bd7fc9bf9557724e730b62181774d778cbfa5a2525dac73e1449e73d199"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9425,6 +9465,7 @@ dependencies = [
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
+ "affinidi-messaging-sdk",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-secrets-resolver",
@@ -9988,7 +10029,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,11 +104,17 @@ trust-tasks-capability-client = "0.1"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-vta-sdk = { version = "0.20", features = [
+vta-sdk = { version = "0.20.2", features = [
   "session",
   "client",
   "didcomm",
   "provision-client",
+  # Routes the Trust-Task surface over TSP as a leg of the existing DIDComm
+  # session (VTI #803 / #810) — no second socket, no second mediator connection.
+  # 0.20.2 is the floor: earlier 0.20.x only offered `connect_tsp`, which opens
+  # its own websocket and is therefore unusable for a client that already holds
+  # a DIDComm session.
+  "tsp",
 ] }
 reqwest = { version = "0.13", features = ["json"] }
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -615,7 +615,7 @@ pub async fn build_runtime_vta_client(
     // encapsulates them so this no longer hand-rolls the branch (R22). The
     // issued REST token is dropped: runtime clients re-auth per process and
     // never cached it here.
-    vta_sdk::client::VtaClient::connect_auto(vta_sdk::client::AutoConnect {
+    let mut client = vta_sdk::client::VtaClient::connect_auto(vta_sdk::client::AutoConnect {
         vta_url,
         vta_did,
         credential_did,
@@ -624,7 +624,70 @@ pub async fn build_runtime_vta_client(
     })
     .await
     .map(|connected| connected.client)
-    .map_err(map_connect_error)
+    .map_err(map_connect_error)?;
+
+    enable_tsp_if_advertised(&mut client, vta_did).await;
+    Ok(client)
+}
+
+/// Ceiling on the `#tsp` discovery resolve.
+///
+/// TSP is an upgrade, not a requirement, so this must never be able to delay
+/// startup by more than a beat (R1.2). A resolver that hangs leaves the client on
+/// DIDComm, which is exactly where it was before.
+const TSP_DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Move the Trust-Task surface onto TSP when the VTA advertises `#tsp`.
+///
+/// Only the **trust-task** surface moves. `rpc`/`rpc_void` — key management,
+/// `create_did_webvh`, `list_contexts` — stay on DIDComm unconditionally, because
+/// the VTA has no TSP dispatcher behind them. That per-surface split is the whole
+/// reason this is a call on an existing client rather than a transport choice at
+/// connect time (VTI #803 / #810).
+///
+/// No second socket: `enable_tsp_trust_tasks` rides the DIDComm session's own
+/// mediator connection. The mediator permits one websocket per DID, and opening a
+/// second is what made the previous `connect_tsp` route unusable for a consumer
+/// that already held a session.
+///
+/// **Best-effort by construction.** Every failure path leaves the client exactly as
+/// `connect_auto` returned it — on DIDComm, fully working. A VTA that advertises no
+/// `#tsp`, a resolve that times out, or a split-mediator topology (which needs its
+/// own session and key material a `DIDCommSession` deliberately does not keep) all
+/// degrade silently to the previous behaviour rather than failing a startup that
+/// would otherwise have succeeded.
+async fn enable_tsp_if_advertised(client: &mut vta_sdk::client::VtaClient, vta_did: &str) {
+    let resolved = match tokio::time::timeout(
+        TSP_DISCOVERY_TIMEOUT,
+        vta_sdk::provision_client::resolve_vta(vta_did),
+    )
+    .await
+    {
+        Ok(Ok(resolved)) => resolved,
+        Ok(Err(e)) => {
+            tracing::debug!("TSP discovery for {vta_did} failed ({e}); staying on DIDComm");
+            return;
+        }
+        Err(_) => {
+            tracing::debug!(
+                "TSP discovery for {vta_did} timed out after {}s; staying on DIDComm",
+                TSP_DISCOVERY_TIMEOUT.as_secs()
+            );
+            return;
+        }
+    };
+
+    let Some(tsp_mediator_did) = resolved.tsp_mediator_did else {
+        tracing::debug!("{vta_did} advertises no #tsp service; trust tasks stay on DIDComm");
+        return;
+    };
+
+    match client.enable_tsp_trust_tasks(&tsp_mediator_did) {
+        Ok(()) => tracing::info!("trust tasks routed over TSP (mediator {tsp_mediator_did})"),
+        Err(e) => {
+            tracing::debug!("could not enable the TSP leg ({e}); trust tasks stay on DIDComm")
+        }
+    }
 }
 
 /// Map a `vta_sdk` connect error onto the typed [`OpenVTCError`] taxonomy so

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -2847,11 +2847,11 @@ impl StateHandler {
                                 .main_page
                                 .log("Joined — starting secure messaging…");
                             let _ = self.state_tx.send(state.clone());
-                            break DegradedOutcome::Joined(
+                            break DegradedOutcome::Joined(Box::new(
                                 join_ctx
                                     .take()
                                     .expect("join_ctx present when join succeeded"),
-                            );
+                            ));
                         }
                     }
                     Action::CreatePersonaSubmit => {
@@ -2984,7 +2984,12 @@ enum DegradedOutcome {
     /// An in-session join minted the account's first persona. The runtime
     /// context (with its still-open admin session) is handed back so `run()` can
     /// bring up the persona's DIDComm listener without a process restart.
-    Joined(DegradedJoinContext),
+    ///
+    /// Boxed because it dwarfs `Exit`: it carries the whole runtime context
+    /// including the `VtaClient`, which grew when the client gained its TSP leg.
+    /// Every `Exit` — the overwhelmingly common outcome — would otherwise pay for
+    /// the join case's size.
+    Joined(Box<DegradedJoinContext>),
 }
 
 /// Apply correlated `governance/capability/*` replies to the open

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -390,15 +390,15 @@ fn render_transports(state: &VtaState, lines: &mut Vec<Line<'static>>) {
                 others.push(Span::styled(format!("   ·   {name} also available"), dim));
             }
 
-            // TSP is reported separately from the transports we could switch
-            // to, because the CLI cannot speak it yet. Staying silent would
-            // reproduce the original defect; calling it "also available" would
-            // promise a transport the operator has no way to select.
+            // TSP is reported separately from the transports we could switch to,
+            // because it is not one: it carries the **trust-task surface only**,
+            // as a leg of the DIDComm session rather than an alternative to it.
+            // Key management, DID minting and context listing stay on DIDComm
+            // unconditionally — the VTA has no TSP dispatcher behind them. So
+            // "also available" would be wrong in the other direction now: TSP is
+            // in use for part of the traffic, not available to switch to.
             if a.tsp_mediator_did.is_some() {
-                others.push(Span::styled(
-                    "   ·   TSP advertised (not yet supported)",
-                    dim,
-                ));
+                others.push(Span::styled("   ·   TSP for trust tasks", dim));
             }
 
             if others.is_empty() {
@@ -711,24 +711,28 @@ mod tests {
             !out.contains("only transport offered"),
             "TSP is offered, so this claim is false: {out}"
         );
-        assert!(out.contains("TSP advertised"), "{out}");
+        assert!(out.contains("TSP for trust tasks"), "{out}");
     }
 
-    /// Advertised-but-unsupported is its own state. TSP must not read as
-    /// something the operator can switch to — we cannot speak it yet — nor as
-    /// absent (VTI R6.4).
+    /// TSP is neither "available to switch to" nor absent: it carries the
+    /// trust-task surface as a leg of the DIDComm session, while everything else
+    /// stays on DIDComm. The panel has to express that third thing (VTI R6.4).
     #[test]
-    fn tsp_reads_as_advertised_but_unsupported() {
+    fn tsp_reads_as_carrying_the_trust_task_surface() {
         let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
             tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
             mediator_did: Some(MEDIATOR_DID.to_string()),
             rest_url: None,
             error: None,
         }))));
-        assert!(out.contains("TSP advertised (not yet supported)"), "{out}");
+        assert!(out.contains("TSP for trust tasks"), "{out}");
         assert!(
             !out.contains("TSP also available"),
-            "must not promise a transport that cannot be selected: {out}"
+            "TSP is not an alternative transport to switch to: {out}"
+        );
+        assert!(
+            !out.contains("not yet supported"),
+            "TSP now carries the trust-task surface: {out}"
         );
     }
 
@@ -743,7 +747,7 @@ mod tests {
             error: None,
         }))));
         assert!(out.contains("REST also available"), "{out}");
-        assert!(out.contains("TSP advertised (not yet supported)"), "{out}");
+        assert!(out.contains("TSP for trust tasks"), "{out}");
     }
 
     /// The adjacent inconsistency #185 exposed: `rest_url` is stored config, so


### PR DESCRIPTION
Closes **#185 item 2b**, unblocked by OpenVTC/verifiable-trust-infrastructure#803 / #810 — **vta-sdk 0.20.2 is published**.

## Why this was blocked, and what changed

TSP was unreachable from OpenVTC for a structural reason, not a missing feature. The only route to a Trust-Task-over-TSP client was `connect_tsp`, which opens its **own** websocket. The mediator permits one per DID and rejects the second with `duplicate-channel` — and the reference VTA points both `#tsp` and `#vta-didcomm` at the same mediator, so the collision was the *normal* case.

0.20.2 makes TSP a **per-surface leg of the existing DIDComm session**. `enable_tsp_trust_tasks` needs no second socket and performs no I/O: TSP send is an HTTP post to the mediator, and TSP receive already arrives on the pickup socket we hold, tagged by protocol. The API also refuses the duplicate-session case outright, so the defect I filed is unrepresentable through it.

## What moves — and what deliberately does not

| Surface | Transport |
|---|---|
| `dispatch_trust_task` — the six `did-management/agent-name` Trust Tasks | **TSP** |
| `get_key_secret`, `create_key`, `create_did_webvh`, `delete_did_webvh`, `list_contexts`, `list_webvh_servers` | **DIDComm, unconditionally** |

Those six have no TSP dispatcher behind them at the VTA. Moving them would break them — which is the whole reason TSP is a per-surface choice rather than a client-wide transport, and why the original framing in #185 (a third `VtaTransport` variant) was wrong.

## Best-effort by construction

Discovery is bounded at 5 s (R1.2), and **every** failure path — no `#tsp` advertised, resolve timeout, resolve error, or a split-mediator topology the API refuses — leaves the client exactly as `connect_auto` returned it: on DIDComm, fully working. TSP is an upgrade; it must never be able to fail a startup that would otherwise have succeeded.

`connect_auto` itself is unchanged in 0.20.2 (verified — no TSP arm), so the bump alters no existing transport selection.

## The panel

`TSP advertised (not yet supported)` → **`TSP for trust tasks`**.

Both the old text and a plain "also available" would now be wrong, in opposite directions: TSP is neither unusable nor an alternative to switch to. It carries part of the traffic while the rest stays on DIDComm, and that third state is what the panel has to express (R6.4). The test asserting the old wording is replaced by one asserting the new state and explicitly rejecting both wrong readings.

## Verification

- All **16** test binaries pass with `--include-ignored`, 0 failed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean

Also boxed `DegradedOutcome::Joined`: `VtaClient` grew a TSP leg field, so the variant now dwarfs `Exit` — the common outcome — and clippy flagged it.

## Not verified here

No test exercises a trust task actually traversing TSP — that needs a `#tsp`-advertising VTA, and the test mediator fixture does not mint one. The wiring is covered by the panel tests and by the fact that every non-TSP path is unchanged; the leg itself is covered upstream in `tests/e2e/tests/tsp_dual_leg.rs`. Worth a follow-up if the fixture gains a TSP-advertising VTA.

I also could not re-measure the binary-size delta cleanly: the code now calls a `cfg`-gated method, so building without the feature no longer compiles. The earlier figure from #185 (**+148,944 bytes, +0.82%**) was measured on a clean baseline and remains the best estimate for the feature's cost.
