### PR TITLE
test: assert TSP discovery instead of trusting it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5766,7 +5766,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.20.2",
+ "vta-sdk 0.20.4",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5825,7 +5825,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.20.2",
+ "vta-sdk 0.20.4",
  "vta-service",
  "wiremock",
  "x25519-dalek",
@@ -9455,9 +9455,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.2"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e33bd7fc9bf9557724e730b62181774d778cbfa5a2525dac73e1449e73d199"
+checksum = "ec68996cd07203472148a2a4b5b9ef2968e58b373ac6cc3ca3ed0057b4996b67"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,16 +104,17 @@ trust-tasks-capability-client = "0.1"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-vta-sdk = { version = "0.20.2", features = [
+vta-sdk = { version = "0.20.4", features = [
   "session",
   "client",
   "didcomm",
   "provision-client",
   # Routes the Trust-Task surface over TSP as a leg of the existing DIDComm
   # session (VTI #803 / #810) — no second socket, no second mediator connection.
-  # 0.20.2 is the floor: earlier 0.20.x only offered `connect_tsp`, which opens
-  # its own websocket and is therefore unusable for a client that already holds
-  # a DIDComm session.
+  # 0.20.2 is the floor for the leg itself: earlier 0.20.x only offered
+  # `connect_tsp`, which opens its own websocket and is unusable for a client
+  # that already holds a DIDComm session. 0.20.3 adds the resolver-injection
+  # seam this crate's discovery tests need (VTI #813).
   "tsp",
   # DCQL credential selection + holder-bound OID4VP `vp_token` assembly
   # (`vta_sdk::vp`), for answering a VTC's `credential-exchange/query`.

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -657,35 +657,94 @@ const TSP_DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// degrade silently to the previous behaviour rather than failing a startup that
 /// would otherwise have succeeded.
 async fn enable_tsp_if_advertised(client: &mut vta_sdk::client::VtaClient, vta_did: &str) {
+    let resolver = match affinidi_did_resolver_cache_sdk::DIDCacheClient::new(
+        affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
+    )
+    .await
+    {
+        Ok(resolver) => resolver,
+        Err(e) => {
+            tracing::debug!("TSP discovery resolver init failed ({e}); staying on DIDComm");
+            return;
+        }
+    };
+    enable_tsp_with_resolver(client, vta_did, &resolver).await;
+}
+
+/// What transport discovery decided about the TSP leg.
+///
+/// Returned rather than logged-and-dropped so the decision is assertable. The
+/// caller turns it into a log line; a test turns it into an assertion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TspDiscovery {
+    /// The VTA advertises `#tsp` at this mediator — enable the leg.
+    Advertised(String),
+    /// Resolved fine; the VTA simply offers no `#tsp` service. Not a fault.
+    NotAdvertised,
+    /// Discovery could not complete (resolve error, or the bounded wait elapsed).
+    /// Also not a fault: TSP is an upgrade, so this degrades to DIDComm.
+    Unavailable(String),
+}
+
+/// Ask the VTA's DID document whether it advertises a TSP mediator.
+///
+/// Split from applying the result purely so it is testable. `resolve_vta` builds
+/// its resolver from the environment, so a test could not point discovery at a
+/// fixture — which is why #196 shipped with this path verified by construction
+/// rather than execution. vta-sdk 0.20.3 added the seam upstream (VTI #813); this
+/// is that seam one layer down, so a test can seed a `#tsp`-advertising document
+/// and assert what OpenVTC makes of it.
+///
+/// Bounded at [`TSP_DISCOVERY_TIMEOUT`] (R1.2): TSP is an upgrade, so discovery
+/// must never delay startup by more than a beat.
+pub(crate) async fn discover_tsp_mediator(
+    vta_did: &str,
+    resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
+) -> TspDiscovery {
     let resolved = match tokio::time::timeout(
         TSP_DISCOVERY_TIMEOUT,
-        vta_sdk::provision_client::resolve_vta(vta_did),
+        // Note the deeper path: `provision_client/mod.rs` re-exports `resolve_vta`
+        // but not its `_with_resolver` sibling — an asymmetry introduced with the
+        // function in VTI #813 (mine). The module is `pub`, so this reaches it;
+        // an upstream re-export fix is filed separately.
+        vta_sdk::provision_client::resolve::resolve_vta_with_resolver(vta_did, resolver),
     )
     .await
     {
         Ok(Ok(resolved)) => resolved,
-        Ok(Err(e)) => {
-            tracing::debug!("TSP discovery for {vta_did} failed ({e}); staying on DIDComm");
-            return;
-        }
+        Ok(Err(e)) => return TspDiscovery::Unavailable(e.to_string()),
         Err(_) => {
-            tracing::debug!(
-                "TSP discovery for {vta_did} timed out after {}s; staying on DIDComm",
+            return TspDiscovery::Unavailable(format!(
+                "timed out after {}s",
                 TSP_DISCOVERY_TIMEOUT.as_secs()
-            );
-            return;
+            ));
         }
     };
 
-    let Some(tsp_mediator_did) = resolved.tsp_mediator_did else {
-        tracing::debug!("{vta_did} advertises no #tsp service; trust tasks stay on DIDComm");
-        return;
-    };
+    match resolved.tsp_mediator_did {
+        Some(mediator) => TspDiscovery::Advertised(mediator),
+        None => TspDiscovery::NotAdvertised,
+    }
+}
 
-    match client.enable_tsp_trust_tasks(&tsp_mediator_did) {
-        Ok(()) => tracing::info!("trust tasks routed over TSP (mediator {tsp_mediator_did})"),
-        Err(e) => {
-            tracing::debug!("could not enable the TSP leg ({e}); trust tasks stay on DIDComm")
+/// [`enable_tsp_if_advertised`] over a caller-supplied resolver.
+async fn enable_tsp_with_resolver(
+    client: &mut vta_sdk::client::VtaClient,
+    vta_did: &str,
+    resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
+) {
+    match discover_tsp_mediator(vta_did, resolver).await {
+        TspDiscovery::Advertised(mediator) => match client.enable_tsp_trust_tasks(&mediator) {
+            Ok(()) => tracing::info!("trust tasks routed over TSP (mediator {mediator})"),
+            Err(e) => {
+                tracing::debug!("could not enable the TSP leg ({e}); trust tasks stay on DIDComm")
+            }
+        },
+        TspDiscovery::NotAdvertised => {
+            tracing::debug!("{vta_did} advertises no #tsp service; trust tasks stay on DIDComm")
+        }
+        TspDiscovery::Unavailable(reason) => {
+            tracing::debug!("TSP discovery for {vta_did} failed ({reason}); staying on DIDComm")
         }
     }
 }
@@ -815,6 +874,125 @@ impl std::fmt::Debug for KeyInfo {
             .field("expiry", &self.expiry)
             .field("created", &self.created)
             .finish()
+    }
+}
+
+/// TSP discovery against a **seeded** resolver.
+///
+/// These are the assertions #196 could not make. Its enablement path was verified
+/// by construction, because `resolve_vta` built its resolver from the environment
+/// and no fixture could reach it. vta-sdk 0.20.3 (VTI #813) added the seam; this
+/// exercises it, in-process with no network and no live VTA.
+#[cfg(test)]
+mod tsp_discovery_tests {
+    use super::{TspDiscovery, discover_tsp_mediator};
+    use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+    use serde_json::json;
+
+    const VTA: &str = "did:web:vta.example";
+    const MEDIATOR: &str = "did:web:mediator.example";
+
+    async fn resolver_serving(services: serde_json::Value) -> DIDCacheClient {
+        let mut client = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("local DID cache");
+        let doc = json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": VTA,
+            "service": services,
+        });
+        client
+            .add_did_document(VTA, serde_json::from_value(doc).expect("fixture document"))
+            .await;
+        client
+    }
+
+    /// The reference deployment's shape: `#tsp` and `#vta-didcomm` at the **same**
+    /// mediator. This is the case #196 wires up and could not previously assert.
+    #[tokio::test]
+    async fn a_tsp_advertising_vta_yields_its_mediator() {
+        let resolver = resolver_serving(json!([
+            { "id": format!("{VTA}#tsp"), "type": "TSPTransport", "serviceEndpoint": MEDIATOR },
+            { "id": format!("{VTA}#vta-didcomm"), "type": "DIDCommMessaging", "serviceEndpoint": MEDIATOR },
+        ]))
+        .await;
+
+        assert_eq!(
+            discover_tsp_mediator(VTA, &resolver).await,
+            TspDiscovery::Advertised(MEDIATOR.to_string()),
+        );
+    }
+
+    /// A VTA offering no `#tsp` must report exactly that — distinct from a
+    /// discovery failure, because only one of the two is worth an operator's
+    /// attention (R6.4). Both still degrade to DIDComm.
+    #[tokio::test]
+    async fn a_didcomm_only_vta_is_not_advertised_rather_than_failed() {
+        let resolver = resolver_serving(json!([
+            { "id": format!("{VTA}#vta-didcomm"), "type": "DIDCommMessaging", "serviceEndpoint": MEDIATOR },
+        ]))
+        .await;
+
+        assert_eq!(
+            discover_tsp_mediator(VTA, &resolver).await,
+            TspDiscovery::NotAdvertised,
+        );
+    }
+
+    /// A DID that resolves to nothing **and** yields no URL is `Unavailable`,
+    /// not `NotAdvertised`. Conflating them would report "this VTA offers no TSP"
+    /// about one we simply failed to ask — the false-certainty #187 fixed in the
+    /// panel.
+    #[tokio::test]
+    async fn an_unresolvable_vta_is_unavailable_not_unadvertised() {
+        let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("local DID cache");
+
+        assert!(matches!(
+            discover_tsp_mediator("did:example:nothing-seeded", &resolver).await,
+            TspDiscovery::Unavailable(_)
+        ));
+    }
+
+    /// **An unresolvable `did:web` reports `NotAdvertised`, not `Unavailable`** —
+    /// surprising, and worth pinning rather than discovering again.
+    ///
+    /// `resolve_vta_endpoint` falls back to synthesizing `https://<domain>` from
+    /// the DID itself when resolution fails, and returns that as a REST endpoint.
+    /// So discovery succeeds, reports no `#tsp`, and we degrade to DIDComm — the
+    /// right outcome, reached by a route that hides the resolution failure.
+    ///
+    /// Only `did:web` and `did:webvh` have a domain to synthesize from, which is
+    /// why the test above needs a method that does not.
+    #[tokio::test]
+    async fn an_unresolvable_did_web_falls_back_rather_than_failing() {
+        let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("local DID cache");
+
+        assert_eq!(
+            discover_tsp_mediator("did:web:nothing-seeded.example", &resolver).await,
+            TspDiscovery::NotAdvertised,
+            "the URL fallback makes this look resolved"
+        );
+    }
+
+    /// A `#tsp` entry carrying a URL rather than a mediator DID is a
+    /// misconfiguration, not a routable endpoint. Enabling the leg against it
+    /// would point trust tasks at something that cannot carry them.
+    #[tokio::test]
+    async fn a_non_did_tsp_endpoint_is_not_advertised() {
+        let resolver = resolver_serving(json!([
+            { "id": format!("{VTA}#tsp"), "type": "TSPTransport", "serviceEndpoint": "https://not-a-did.example" },
+            { "id": format!("{VTA}#vta-didcomm"), "type": "DIDCommMessaging", "serviceEndpoint": MEDIATOR },
+        ]))
+        .await;
+
+        assert_eq!(
+            discover_tsp_mediator(VTA, &resolver).await,
+            TspDiscovery::NotAdvertised,
+        );
     }
 }
 


### PR DESCRIPTION
Closes the caveat #196 shipped with. Uses the seam VTI #813 added upstream.

## Why this couldn't be done before

#196 wired trust tasks onto a TSP leg, but `resolve_vta` built its resolver from the environment — so no test could point discovery at a fixture. The enablement path was verified **by construction rather than execution**, which I flagged at the time. vta-sdk 0.20.3 added the injection seam; this uses it.

## Changes

- **Bump vta-sdk 0.20.2 → 0.20.4.** 0.20.3 carries the seam; 0.20.4 adds signing-oracle authorization *documentation* (VTI #805), no behaviour change. Verified rather than assumed — workspace builds and the full suite pass unchanged.

- **Split the decision from its application.** `discover_tsp_mediator` returns a `TspDiscovery` — `Advertised` / `NotAdvertised` / `Unavailable` — and `enable_tsp_with_resolver` applies it. Returned rather than logged-and-dropped so the decision is assertable: the caller turns it into a log line, a test turns it into an assertion. Same shape as the supervisor's `rebuild_due` in #195, for the same reason.

- **`NotAdvertised` and `Unavailable` stay distinct.** Both degrade to DIDComm, but only one is worth an operator's attention, and collapsing them would report "this VTA offers no TSP" about one we merely failed to ask — the false-certainty #187 fixed in the panel (R6.4).

## Tests

Five, seeding a document and asserting what discovery makes of it — in-process, no network, no live VTA:

- the reference deployment's dual `#tsp` + `#vta-didcomm` shape yields its mediator
- a DIDComm-only VTA is `NotAdvertised`
- an unresolvable DID is `Unavailable`
- a `#tsp` entry carrying a URL instead of a mediator DID is not treated as advertised

**The fifth pins something surprising**, found because my first attempt at the third asserted the opposite and failed: an unresolvable `did:web` reports `NotAdvertised`, **not** `Unavailable`. `resolve_vta_endpoint` synthesizes `https://<domain>` from the DID and returns it as REST, so discovery "succeeds". The outcome is right — degrade to DIDComm — but reached by a route that hides the resolution failure, and only `did:web`/`did:webvh` have a domain to synthesize from. Pinned so the next reader doesn't rediscover it the hard way.

## Verification

- All **16** test binaries pass with `--include-ignored`, 0 failed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean

## One wart, mine

`provision_client/mod.rs` re-exports `resolve_vta` but not `resolve_vta_with_resolver` — an asymmetry I introduced with the function in VTI #813. The module is `pub`, so the deeper path reaches it and that's what this uses, with a note in the code. An upstream re-export fix is worth doing so the canonical path exists; it's a one-line change to that `pub use` list.

## Still not covered

A trust task **actually traversing** TSP end to end. That needs MockVta to speak TSP (`tsp_profile` is `None` in its test app, on latest VTI main too) and is genuinely larger. This closes the discovery half — that everything up to `enable_tsp_trust_tasks` does the right thing against a real document — which was the part that was assumed rather than tested.
