### PR TITLE
chore: reach resolve_vta_with_resolver at its canonical path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5766,7 +5766,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.20.4",
+ "vta-sdk 0.20.6",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5825,7 +5825,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.20.4",
+ "vta-sdk 0.20.6",
  "vta-service",
  "wiremock",
  "x25519-dalek",
@@ -9455,9 +9455,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.4"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec68996cd07203472148a2a4b5b9ef2968e58b373ac6cc3ca3ed0057b4996b67"
+checksum = "d7ce960b92415dfe44977c2012033b7f79ae46a840d4bb1cae94edaf261a0caa"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,17 +104,18 @@ trust-tasks-capability-client = "0.1"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-vta-sdk = { version = "0.20.4", features = [
+vta-sdk = { version = "0.20.6", features = [
   "session",
   "client",
   "didcomm",
   "provision-client",
   # Routes the Trust-Task surface over TSP as a leg of the existing DIDComm
   # session (VTI #803 / #810) — no second socket, no second mediator connection.
-  # 0.20.2 is the floor for the leg itself: earlier 0.20.x only offered
+  # 0.20.6 is the floor: 0.20.2 first offered the leg (earlier 0.20.x only had
   # `connect_tsp`, which opens its own websocket and is unusable for a client
-  # that already holds a DIDComm session. 0.20.3 adds the resolver-injection
-  # seam this crate's discovery tests need (VTI #813).
+  # already holding a DIDComm session), 0.20.3 added the resolver-injection seam
+  # the discovery tests need (VTI #813), and 0.20.6 exports it from
+  # `provision_client` rather than only its inner `resolve` module (VTI #825).
   "tsp",
   # DCQL credential selection + holder-bound OID4VP `vp_token` assembly
   # (`vta_sdk::vp`), for answering a VTC's `credential-exchange/query`.

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -703,11 +703,7 @@ pub(crate) async fn discover_tsp_mediator(
 ) -> TspDiscovery {
     let resolved = match tokio::time::timeout(
         TSP_DISCOVERY_TIMEOUT,
-        // Note the deeper path: `provision_client/mod.rs` re-exports `resolve_vta`
-        // but not its `_with_resolver` sibling — an asymmetry introduced with the
-        // function in VTI #813 (mine). The module is `pub`, so this reaches it;
-        // an upstream re-export fix is filed separately.
-        vta_sdk::provision_client::resolve::resolve_vta_with_resolver(vta_did, resolver),
+        vta_sdk::provision_client::resolve_vta_with_resolver(vta_did, resolver),
     )
     .await
     {


### PR DESCRIPTION
Cleanup that #198 flagged. **No behaviour change** — same function, same call, shorter path.

## What

#198 had to import `resolve_vta_with_resolver` through `provision_client::resolve::`, because `provision_client` re-exported `resolve_vta` but not its `_with_resolver` sibling — an asymmetry introduced upstream with the function itself (mine, in VTI #813). VTI #825 fixed the re-export and shipped in **vta-sdk 0.20.6**, so the workaround and the comment explaining it both go.

## The version floor now says why

Rather than just naming the latest release, the comment records what each step buys:

- **0.20.2** — first offered the TSP leg (earlier 0.20.x only had `connect_tsp`, which opens its own websocket and is unusable for a client already holding a DIDComm session)
- **0.20.3** — the resolver-injection seam the discovery tests need (VTI #813)
- **0.20.6** — exports it from `provision_client` rather than only its inner module (VTI #825)

So someone lowering the pin later can see which capability they'd lose.

## Verification

- All **16** test binaries pass with `--include-ignored`, 0 failed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- **`cargo check --workspace --locked`** — clean. Added to my routine after a stale lockfile failed the MSRV job on VTI #825: every other local check lets cargo rewrite the lock, so none of them could have caught it.
