### PR TITLE
fix: read a join verdict at the nesting the VTC actually sends

### DIFF
--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -234,6 +234,33 @@ impl StatusOutcome {
     };
 }
 
+/// Extract the task-specific *payload* from a VTC Trust Task reply body.
+///
+/// The VTC replies to a Trust Task in one of two shapes, and which one you get
+/// depends on how the reply was built, not on the message type:
+///
+/// - Anything dispatched through `dispatch_trust_task_core` is returned by
+///   `vtc-service`'s `tt_didcomm_reply`, which sets the DIDComm body to the
+///   **whole `#response` document** — `{id, threadId, type, issuer, …,
+///   payload}` — with the task-specific members nested under `payload`. The
+///   join verdict and the status response arrive this way.
+/// - Replies the VTC hand-builds as a `Reply` carry the **bare body** with no
+///   document around it. `join-requests/submit-receipt` arrives this way.
+///
+/// So a handler cannot deserialize the body directly and be right for both.
+/// Prefer `payload` when present, else take the body whole: none of the bare
+/// reply bodies has a `payload` member, so the test is unambiguous.
+///
+/// This also makes the handlers transport-agnostic. A TSP frame carries the
+/// response document raw, with no DIDComm envelope around it, so it normalises
+/// into exactly the document shape this already accepts (#185).
+fn trust_task_reply_payload(body: &Value) -> Value {
+    match body.get("payload") {
+        Some(payload) => payload.clone(),
+        None => body.clone(),
+    }
+}
+
 /// Apply a VTC `join-requests/status-response` to the matching Pending community
 /// (R-B-8). Correlated by the body's `request_id` against the Pending record's
 /// stored id, and gated on the sender being the community's own VTC (anti-spoof).
@@ -252,13 +279,14 @@ pub fn handle_join_status_response(
     message: &Message,
     from_did: &str,
 ) -> StatusOutcome {
-    let body: JoinRequestStatusResponseBody = match serde_json::from_value(message.body.clone()) {
-        Ok(b) => b,
-        Err(e) => {
-            warn!(error = %e, "malformed join status-response body — ignoring");
-            return StatusOutcome::NONE;
-        }
-    };
+    let body: JoinRequestStatusResponseBody =
+        match serde_json::from_value(trust_task_reply_payload(&message.body)) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, "malformed join status-response body — ignoring");
+                return StatusOutcome::NONE;
+            }
+        };
     // Correlate to the specific pending membership by the authoritative
     // request id (a community may hold several memberships).
     let Some(record) = account.membership_by_pending_request(from_did, body.request_id) else {
@@ -337,13 +365,14 @@ pub fn handle_join_verdict(
         warn!(thid = %thid, "join verdict thid is not a uuid — ignoring");
         return StatusOutcome::NONE;
     };
-    let body: VerdictResponse = match serde_json::from_value(message.body.clone()) {
-        Ok(b) => b,
-        Err(e) => {
-            warn!(error = %e, "malformed join verdict body — ignoring");
-            return StatusOutcome::NONE;
-        }
-    };
+    let body: VerdictResponse =
+        match serde_json::from_value(trust_task_reply_payload(&message.body)) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, "malformed join verdict body — ignoring");
+                return StatusOutcome::NONE;
+            }
+        };
     let Some(record) = account.membership_by_pending_request(from_did, placeholder) else {
         warn!(vtc = %from_did, "verdict did not match a pending request id — ignoring");
         return StatusOutcome::NONE;
@@ -994,6 +1023,56 @@ mod tests {
         .finalize()
     }
 
+    /// The status response in its wire form — the `#response` document, payload
+    /// nested — as `tt_didcomm_reply` sends it.
+    fn status_response_document(from: &str, request_id: Uuid, status: &str) -> Message {
+        Message::build(
+            Uuid::new_v4().to_string(),
+            JOIN_REQUEST_STATUS_RESPONSE_TYPE.to_string(),
+            serde_json::json!({
+                "id": format!("urn:uuid:{}", Uuid::new_v4()),
+                "threadId": format!("urn:uuid:{}", Uuid::new_v4()),
+                "type": JOIN_REQUEST_STATUS_RESPONSE_TYPE,
+                "issuer": from,
+                "payload": { "requestId": request_id, "status": status },
+            }),
+        )
+        .from(from.to_string())
+        .finalize()
+    }
+
+    #[test]
+    fn status_response_approved_activates_from_response_document() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out = handle_join_status_response(
+            &mut acct,
+            &status_response_document(vtc, rid, "approved"),
+            vtc,
+        );
+        assert!(
+            out.changed,
+            "an approved status response in its wire form must activate the membership"
+        );
+        assert!(matches!(only(&acct, vtc).status, CommunityStatus::Active));
+    }
+
+    /// Both reply shapes reach the same payload, and a bare body is left alone.
+    #[test]
+    fn reply_payload_accepts_document_and_bare_shapes() {
+        let bare = serde_json::json!({ "requestId": "r", "status": "approved" });
+        assert_eq!(trust_task_reply_payload(&bare), bare);
+
+        let document = serde_json::json!({
+            "id": "urn:uuid:1",
+            "type": "https://example.org/x/1.0#response",
+            "payload": bare.clone(),
+        });
+        assert_eq!(trust_task_reply_payload(&document), bare);
+    }
+
     #[test]
     fn status_response_approved_activates() {
         let vtc = "did:webvh:example:vtc";
@@ -1091,6 +1170,50 @@ mod tests {
         .from(from.to_string())
         .thid(thid.to_string())
         .finalize()
+    }
+
+    /// The verdict as the VTC actually puts it on the wire: the whole
+    /// `#response` Trust Task *document*, with the [`VerdictResponse`] nested
+    /// under `payload`. `vtc-service`'s `tt_didcomm_reply` sets the DIDComm body
+    /// to the parsed reply document, so this — not the bare payload the
+    /// `verdict` helper builds — is what arrives.
+    fn verdict_document(thid: &str, from: &str, effect: &str, with: serde_json::Value) -> Message {
+        Message::build(
+            Uuid::new_v4().to_string(),
+            vta_sdk::protocols::join_requests::JOIN_REQUEST_SUBMIT_RESPONSE_TYPE.to_string(),
+            serde_json::json!({
+                "id": format!("urn:uuid:{}", Uuid::new_v4()),
+                "threadId": thid,
+                "type": vta_sdk::protocols::join_requests::JOIN_REQUEST_SUBMIT_RESPONSE_TYPE,
+                "issuer": from,
+                "payload": {
+                    "requestId": Uuid::new_v4(),
+                    "verdict": { "effect": effect, "with": with },
+                },
+            }),
+        )
+        .from(from.to_string())
+        .thid(thid.to_string())
+        .finalize()
+    }
+
+    #[test]
+    fn verdict_allow_activates_from_response_document() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        let out = handle_join_verdict(
+            &mut acct,
+            &verdict_document(&rid.to_string(), vtc, "allow", serde_json::json!({})),
+            vtc,
+        );
+        assert!(
+            out.changed,
+            "an allow verdict in its wire form (payload nested in the #response \
+             document) must activate the membership"
+        );
+        assert!(matches!(only(&acct, vtc).status, CommunityStatus::Active));
     }
 
     #[test]


### PR DESCRIPTION
## What

A VTC's join verdict never took effect. `handle_join_verdict` deserialized the DIDComm body straight into a `VerdictResponse`, but that is not what arrives — `vtc-service`'s `tt_didcomm_reply` sets the body to the whole `#response` Trust Task **document**, with the task-specific members nested under `payload`:

```json
{ "id": "urn:uuid:…", "threadId": "…", "type": "…#response",
  "payload": { "requestId": "…", "verdict": { "effect": "allow", … } } }
```

`VerdictResponse { request_id, verdict }` has no `payload` member and both fields are required, so the parse failed, the handler logged `malformed join verdict body — ignoring`, and the membership stayed **Pending** — through an `allow` exactly as through a `deny`.

`handle_join_status_response` had the identical defect. Its handler is reached through `dispatch_trust_task_core` + `tt_didcomm_reply` too, so an `approved` status response was dropped the same way.

## Why the tests didn't catch it

They built the **bare payload** as the message body rather than the document the VTC sends — the shape the code expected, not the shape on the wire. Both handlers now have a test that constructs the real `#response` document; each fails without the fix:

```
test verdict_allow_activates ... ok                             ← bare payload (the old fiction)
test verdict_allow_activates_from_response_document ... FAILED  ← the actual wire form
```

## The fix

`trust_task_reply_payload` prefers `payload` when present and takes the body whole otherwise, so both reply shapes reach the same parse.

The two shapes are **not** distinguishable by message type — they are distinguishable by how the VTC built the reply. Anything routed through `dispatch_trust_task_core` comes back as a document; a hand-built `Reply` comes back bare. That is why `join-requests/submit-receipt` is correct as it stands (it is hand-built by `credential_present_handler`) and is deliberately left alone rather than made tolerant for symmetry's sake.

`handle_join_trust_task_error` already read `/payload/code` — it was written against the document form. Two handlers disagreeing about the same wire is what surfaced this.

## Context

Found while scoping #185. TSP delivers that same response document with **no DIDComm envelope around it**, so the handlers had to agree on the document shape before the transport could change under them — the tolerant form is what lets a TSP frame normalise into the existing dispatch unchanged. Fixing it separately because it is a live join-ceremony defect on the DIDComm path today, independent of any TSP work.

## Verification

- `cargo test --workspace` — all binaries green, 0 failed
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets`, `RUSTDOCFLAGS="-D warnings" cargo doc` — clean
- `cargo check --workspace --locked` — clean

Refs #185
