### PR TITLE
feat: run the join ceremony over TSP when the community offers it

### DIFF
--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -671,6 +671,61 @@ async fn enable_tsp_if_advertised(client: &mut vta_sdk::client::VtaClient, vta_d
     enable_tsp_with_resolver(client, vta_did, &resolver).await;
 }
 
+/// The TSP mediator `peer_did` advertises, if any — for a **VTC**, not the VTA.
+///
+// Not an intra-doc link: `discover_tsp_mediator` is private, and a public item
+// linking to it fails `rustdoc -D warnings`.
+/// Same `#tsp` / `TSPTransport` lookup `discover_tsp_mediator` does for a VTA:
+/// the service entry is generic, so what changes is only whose document is read.
+/// Exposed publicly because the ceremony call sites live in the binary crate.
+///
+/// `None` on every non-answer — not advertised, unresolvable, or the bounded wait
+/// elapsed — because all three mean the same thing to a caller: **use DIDComm**.
+/// The distinction is kept in the log rather than the return type (R6.4), since
+/// unlike the VTA panel there is nothing here to render it into.
+///
+/// Discovery is deliberately per-send rather than cached on the community: the
+/// resolver caches the document, so a repeat is cheap, and a VTC that gains or
+/// loses `#tsp` is picked up without a restart or a migration.
+pub async fn peer_tsp_mediator(peer_did: &str) -> Option<String> {
+    let resolver = match affinidi_did_resolver_cache_sdk::DIDCacheClient::new(
+        affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
+    )
+    .await
+    {
+        Ok(resolver) => resolver,
+        Err(e) => {
+            tracing::debug!(
+                peer = %peer_did,
+                "TSP discovery resolver init failed ({e}); using DIDComm"
+            );
+            return None;
+        }
+    };
+    match discover_tsp_mediator(peer_did, &resolver).await {
+        TspDiscovery::Advertised(mediator) => {
+            tracing::info!(
+                peer = %peer_did,
+                mediator = %mediator,
+                "peer advertises #tsp — sending trust tasks over TSP"
+            );
+            Some(mediator)
+        }
+        TspDiscovery::NotAdvertised => {
+            tracing::debug!(peer = %peer_did, "peer advertises no #tsp — using DIDComm");
+            None
+        }
+        TspDiscovery::Unavailable(reason) => {
+            tracing::warn!(
+                peer = %peer_did,
+                reason = %reason,
+                "could not determine whether the peer offers TSP — using DIDComm"
+            );
+            None
+        }
+    }
+}
+
 /// What transport discovery decided about the TSP leg.
 ///
 /// Returned rather than logged-and-dropped so the decision is assertable. The

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -41,6 +41,7 @@ use crate::relationships::RelationshipState;
 /// need not depend on `affinidi-messaging-core` directly.
 pub use affinidi_messaging_core::ConnState;
 use affinidi_messaging_core::MessageTransport;
+use affinidi_messaging_core::types::Protocol;
 use affinidi_messaging_delivery::{
     Delivery, InMemoryOutboxStore, MessagingService, OutboxStore, drain_loop_via,
 };
@@ -638,12 +639,23 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
 
     let mut inbound = service.subscribe();
     while let Some(item) = inbound.next().await {
-        // A DIDComm frame's payload is the `Message` JSON (`to_inbound` in the
-        // SDK adapter). A TSP frame's is not, so it will not parse here — TSP
-        // routing lands with #185 and is deliberately skipped rather than logged
-        // as an error.
-        let Ok(message) = serde_json::from_slice::<Message>(&item.message.payload) else {
-            continue;
+        // Both protocols arrive on this one stream — `DidCommTransport` owns the
+        // single mediator socket and surfaces each, tagged. A DIDComm frame's
+        // payload is the `Message` JSON (`to_inbound` in the SDK adapter); a TSP
+        // frame's is a bare Trust Task document, which is normalised into the
+        // same shape so everything below is transport-agnostic.
+        let message = match item.message.protocol {
+            Protocol::DIDComm => match serde_json::from_slice::<Message>(&item.message.payload) {
+                Ok(message) => message,
+                Err(e) => {
+                    debug!(error = %e, "inbound DIDComm frame is not a Message — dropped");
+                    continue;
+                }
+            },
+            Protocol::TSP => match tsp_frame_to_message(&item) {
+                Some(message) => message,
+                None => continue,
+            },
         };
         // The transport authenticated the sender; the plaintext `from` header is
         // sender-controlled. Prefer the cryptographically-bound one.
@@ -691,6 +703,72 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
             tracing::warn!(error = %e, "DIDComm event channel saturated — dropping inbound message");
         }
     }
+}
+
+/// Normalise an inbound TSP frame into the [`Message`] shape the dispatcher and
+/// the whole `crate::messaging` handler set already speak.
+///
+/// This is lossless rather than lossy, because the two transports carry the
+/// **same document**. A VTC reply routed through `dispatch_trust_task_core` is
+/// serialised once; DIDComm then wraps it in an envelope that repeats two of its
+/// members outside (`tt_didcomm_reply` sets the message `type` from the
+/// document's `type` and threads on the request's message id), whereas TSP
+/// carries it bare. So the mapping just reads back out of the document what
+/// DIDComm would have put in the envelope:
+///
+/// | `Message` field | taken from |
+/// |---|---|
+/// | `typ`  | the document's `type` |
+/// | `thid` | the document's `threadId` |
+/// | `id`   | the document's `id` (falling back to the frame hash) |
+/// | `body` | the whole document — the same value `tt_didcomm_reply` sets |
+/// | `from` | the TSP-authenticated sender VID, never a self-asserted field |
+///
+/// `body` being the whole document is what makes the handlers work unchanged:
+/// they read their payload through `messaging::trust_task_reply_payload`, which
+/// unwraps `payload` (#200). Had that fix not landed first, every TSP reply
+/// would have parsed at the wrong nesting.
+///
+/// A frame that is not a JSON object, or carries no `type`, is dropped with a
+/// warning rather than guessed at: unlike DIDComm there is no envelope to fall
+/// back on, and inventing a type would route it to the wrong handler.
+fn tsp_frame_to_message(item: &affinidi_messaging_core::transport::Inbound) -> Option<Message> {
+    let doc: serde_json::Value = match serde_json::from_slice(&item.message.payload) {
+        Ok(doc) => doc,
+        Err(e) => {
+            tracing::warn!(error = %e, "inbound TSP frame is not JSON — dropped");
+            return None;
+        }
+    };
+    let Some(typ) = doc.get("type").and_then(|t| t.as_str()) else {
+        tracing::warn!(
+            "inbound TSP frame carries no `type` — dropped (a TSP frame has no \
+             envelope to recover it from)"
+        );
+        return None;
+    };
+
+    // The document id, when it has one. A TSP frame carries no message id of its
+    // own; the SDK substitutes the frame hash, which stays the fallback so a
+    // malformed document still gets a unique id rather than an empty one.
+    let id = doc
+        .get("id")
+        .and_then(|i| i.as_str())
+        .unwrap_or(&item.message.id)
+        .to_string();
+
+    let mut builder = Message::build(id, typ.to_string(), doc.clone());
+    // `threadId` is the correlation key on this transport, and it is the request
+    // *document* id — which OpenVTC makes equal to the request message id when it
+    // sends (see `join::submit_join_request`), so one handle correlates a reply
+    // arriving on either transport.
+    if let Some(thid) = doc.get("threadId").and_then(|t| t.as_str()) {
+        builder = builder.thid(thid.to_string());
+    }
+    if let Some(sender) = item.message.sender.as_deref() {
+        builder = builder.from(sender.to_string());
+    }
+    Some(builder.to(item.message.recipient.clone()).finalize())
 }
 
 /// Catch-all pattern for OpenVTC protocol messages + VTC Trust-Task
@@ -1342,6 +1420,119 @@ mod persona_listener_id_tests {
     #[test]
     fn an_empty_did_falls_back_to_the_generic_id() {
         assert_eq!(persona_listener_id(""), PERSONA_LISTENER_ID);
+    }
+}
+
+#[cfg(test)]
+mod tsp_inbound_tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::tsp_frame_to_message;
+    use affinidi_messaging_core::transport::{Inbound, InboundAck};
+    use affinidi_messaging_core::types::{Protocol, ReceivedMessage};
+
+    const VERDICT_TYPE: &str = "https://trusttasks.org/spec/vtc/join-requests/submit/0.1#response";
+
+    /// A TSP frame as the transport hands it over: the payload is the bare Trust
+    /// Task document, and `sender` is the VID `unpack` authenticated.
+    fn tsp_frame(payload: serde_json::Value, sender: Option<&str>) -> Inbound {
+        Inbound {
+            message: ReceivedMessage {
+                id: "frame-hash".to_string(),
+                sender: sender.map(str::to_string),
+                recipient: "did:webvh:example:alice".to_string(),
+                payload: serde_json::to_vec(&payload).unwrap(),
+                protocol: Protocol::TSP,
+                verified: true,
+                encrypted: true,
+            },
+            thread_id: None,
+            ack: InboundAck("frame-hash".to_string()),
+        }
+    }
+
+    fn verdict_document(thread_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": "urn:uuid:11111111-1111-4111-8111-111111111111",
+            "threadId": thread_id,
+            "type": VERDICT_TYPE,
+            "issuer": "did:webvh:example:vtc",
+            "recipient": "did:webvh:example:alice",
+            "payload": {
+                "requestId": "22222222-2222-4222-8222-222222222222",
+                "verdict": { "effect": "allow", "with": {} },
+            },
+        })
+    }
+
+    /// The whole point: a TSP frame must land in the same shape the DIDComm
+    /// dispatcher already routes, with `type`/`threadId` lifted out of the
+    /// document into the envelope positions DIDComm would have filled.
+    #[test]
+    fn verdict_document_normalises_into_a_message() {
+        let thid = "urn:uuid:33333333-3333-4333-8333-333333333333";
+        let doc = verdict_document(thid);
+        let message =
+            tsp_frame_to_message(&tsp_frame(doc.clone(), Some("did:webvh:example:vtc"))).unwrap();
+
+        assert_eq!(message.typ, VERDICT_TYPE, "type comes from the document");
+        assert_eq!(
+            message.thid.as_deref(),
+            Some(thid),
+            "threadId is the correlation key on this transport"
+        );
+        assert_eq!(
+            message.id, "urn:uuid:11111111-1111-4111-8111-111111111111",
+            "the document id, not the frame hash, when the document has one"
+        );
+        assert_eq!(
+            message.body, doc,
+            "body is the whole document — the same value tt_didcomm_reply sets, \
+             which is what lets the handlers read it unchanged"
+        );
+        assert_eq!(
+            message.from.as_deref(),
+            Some("did:webvh:example:vtc"),
+            "from is the TSP-authenticated sender"
+        );
+    }
+
+    /// The `from` header must never be recovered from the document's own
+    /// `issuer`: that field is written by the sender, so trusting it would let
+    /// any TSP peer claim to be the VTC.
+    #[test]
+    fn unauthenticated_frame_carries_no_sender() {
+        let doc = verdict_document("urn:uuid:44444444-4444-4444-8444-444444444444");
+        let message = tsp_frame_to_message(&tsp_frame(doc, None)).unwrap();
+
+        assert!(
+            message.from.is_none(),
+            "a frame with no proven sender must not inherit the document's issuer"
+        );
+    }
+
+    /// No envelope to fall back on, so an untyped document cannot be routed —
+    /// dropping beats guessing a type and reaching the wrong handler.
+    #[test]
+    fn document_without_a_type_is_dropped() {
+        let doc = serde_json::json!({ "id": "urn:uuid:5", "payload": {} });
+        assert!(tsp_frame_to_message(&tsp_frame(doc, Some("did:webvh:example:vtc"))).is_none());
+    }
+
+    #[test]
+    fn non_json_frame_is_dropped() {
+        let mut frame = tsp_frame(serde_json::json!({}), Some("did:webvh:example:vtc"));
+        frame.message.payload = b"not json at all".to_vec();
+        assert!(tsp_frame_to_message(&frame).is_none());
+    }
+
+    /// A document with no `id` still needs a unique message id; the frame hash
+    /// is the transport's own stable handle for it.
+    #[test]
+    fn frame_hash_is_the_id_fallback() {
+        let doc = serde_json::json!({ "type": VERDICT_TYPE, "payload": {} });
+        let message = tsp_frame_to_message(&tsp_frame(doc, Some("did:webvh:example:vtc"))).unwrap();
+        assert_eq!(message.id, "frame-hash");
     }
 }
 

--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -1,12 +1,20 @@
 /*!
  * VTC join-ceremony client helpers.
  *
- * Sends the applicant side of the join ceremony to a VTC over DIDComm.
- * Authcrypt makes the sender (the persona DID) the authenticated
- * applicant — the VTC reads it from the envelope, so no separate
- * holder-binding signature is needed. DIDComm is also the *only* path
- * that works for a `did:webvh` persona: the VTC's REST holder-binding
- * verification accepts `did:key` applicants only.
+ * Sends the applicant side of the join ceremony to a VTC over DIDComm or,
+ * when the community advertises `#tsp`, over TSP (#185 item 2f).
+ *
+ * The payload is the same either way: a Trust Task **document**, which is
+ * what the VTC's `dispatch_trust_task_core` reads on every transport.
+ * DIDComm wraps that document in an authcrypt envelope; TSP carries it bare
+ * and seals it in the routing layer. So the transport choice changes the
+ * wire, not the ceremony.
+ *
+ * Either way the sender is cryptographically proven — the authcrypt sender
+ * over DIDComm, the sender VID over TSP — so no separate holder-binding
+ * signature is needed. **REST remains unusable** for a `did:webvh` persona
+ * regardless: the VTC's REST holder-binding verification accepts `did:key`
+ * applicants only.
  */
 
 use std::sync::Arc;
@@ -33,11 +41,23 @@ use crate::errors::OpenVTCError;
 /// `mediator_did`; the VTC authenticates the applicant from the
 /// envelope's `from`.
 ///
-/// Returns the DIDComm message id. That id is the thread root the VTC's
-/// `join-requests/submit-receipt/1.0` reply references (`thid`); the
-/// authoritative VTC `requestId` arrives on that asynchronous receipt
-/// (handled separately), so callers use the returned id as the
-/// client-side correlation handle until then.
+/// Returns the correlation handle the VTC's reply threads on. **The same value
+/// on either transport**, which is what lets one handle correlate a reply that
+/// may arrive over either.
+///
+/// That takes a deliberate step, because the two transports thread differently:
+/// DIDComm threads the reply on the request *message* id (`vtc-service` sets
+/// `thid = msg.id`), while TSP has no message and threads on the request
+/// *document* id (`threadId`). Those are two different UUIDs unless something
+/// makes them one — so the DIDComm message is built with `id` equal to the Trust
+/// Task document's id. `Uuid::parse_str` accepts the `urn:uuid:` form, so the
+/// existing correlation code reads either unchanged.
+///
+/// `tsp_mediator_did` selects the wire: `Some` sends the bare Trust Task
+/// document over TSP through that (the VTC's **advertised**) mediator; `None`
+/// wraps it in DIDComm as before. Discovery belongs to the caller so that a VTC
+/// which does not advertise `#tsp` simply degrades to DIDComm rather than
+/// failing.
 pub async fn submit_join_request(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
@@ -45,23 +65,33 @@ pub async fn submit_join_request(
     vtc_did: &str,
     mediator_did: &str,
     vp: Value,
+    tsp_mediator_did: Option<&str>,
 ) -> Result<Uuid, OpenVTCError> {
-    let body = build_join_submit_document(persona_did, vtc_did, vp)?;
+    // One id, used as both the document id and — on the DIDComm path — the
+    // message id, so the two transports' threading conventions coincide.
+    let request_id = Uuid::new_v4();
+    let document_id = format!("urn:uuid:{request_id}");
+    let body = build_join_submit_document(persona_did, vtc_did, vp, &document_id)?;
 
-    let msg_id = Uuid::new_v4();
-    let now = Utc::now().timestamp().max(0) as u64;
-    let msg = Message::build(
-        msg_id.to_string(),
-        JOIN_REQUEST_SUBMIT_TYPE.to_string(),
-        body,
-    )
-    .from(persona_did.to_string())
-    .to(vtc_did.to_string())
-    .created_time(now)
-    .finalize();
+    match tsp_mediator_did {
+        // TSP carries the Trust Task document as-is: no DIDComm envelope, and
+        // the VTC's dispatcher reads `type`/`threadId` out of the document.
+        Some(tsp_mediator) => {
+            crate::tsp::send_trust_task(atm, profile, &body, vtc_did, tsp_mediator).await?;
+        }
+        None => {
+            let now = Utc::now().timestamp().max(0) as u64;
+            let msg = Message::build(document_id, JOIN_REQUEST_SUBMIT_TYPE.to_string(), body)
+                .from(persona_did.to_string())
+                .to(vtc_did.to_string())
+                .created_time(now)
+                .finalize();
 
-    crate::pack_and_send(atm, profile, &msg, persona_did, vtc_did, mediator_did).await?;
-    Ok(msg_id)
+            crate::pack_and_send(atm, profile, &msg, persona_did, vtc_did, mediator_did).await?;
+        }
+    }
+
+    Ok(request_id)
 }
 
 /// Build the DIDComm body for a join-request submit: a Trust Task *document*
@@ -78,6 +108,7 @@ fn build_join_submit_document(
     persona_did: &str,
     vtc_did: &str,
     vp: Value,
+    document_id: &str,
 ) -> Result<Value, OpenVTCError> {
     let payload = JoinRequestSubmitBody {
         vp,
@@ -87,7 +118,10 @@ fn build_join_submit_document(
     let type_uri = JOIN_REQUEST_SUBMIT_TYPE
         .parse()
         .map_err(|e| OpenVTCError::Config(format!("join submit type URI parse: {e}")))?;
-    let mut doc = TrustTask::new(format!("urn:uuid:{}", Uuid::new_v4()), type_uri, payload);
+    // Supplied rather than minted here: on the DIDComm path this same id is the
+    // message id, which is what makes the two transports' reply threading agree
+    // (see [`submit_join_request`]).
+    let mut doc = TrustTask::new(document_id.to_string(), type_uri, payload);
     doc.issuer = Some(persona_did.to_string());
     doc.recipient = Some(vtc_did.to_string());
     doc.issued_at = Some(Utc::now());
@@ -511,6 +545,7 @@ mod tests {
             "did:webvh:example.com:alice",
             "did:webvh:example.com:community",
             vp,
+            &format!("urn:uuid:{}", Uuid::new_v4()),
         )
         .expect("build document");
 

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod presentation;
 pub mod process_lock;
 pub mod relationships;
 pub mod tasks;
+pub mod tsp;
 pub mod vrc;
 
 /// Primary Linux Foundation Mediator DID.

--- a/openvtc-core/src/tsp.rs
+++ b/openvtc-core/src/tsp.rs
@@ -1,0 +1,112 @@
+/*!
+ * The TSP send leg for VTC-facing ceremonies (#185 item 2f).
+ *
+ * ## Why this is send-only
+ *
+ * Inbound TSP is **already arriving**. `DidCommTransport` owns the one mediator
+ * websocket and surfaces both protocols off it, unpacking each TSP frame with
+ * `atm.tsp().unpack` — which authenticates the sender VID — and tagging it
+ * `Protocol::TSP`. So receiving needed no new transport, only routing: see
+ * `didcomm::tsp_frame_to_message`, where those frames used to be dropped.
+ *
+ * What was missing is the other direction. `ATM::forward_and_send_message` — the
+ * send half of [`crate::pack_and_send`] — builds a DIDComm `routing/2.0` forward
+ * unconditionally, so it cannot carry a Trust Task document as TSP. This module
+ * is that one missing call and nothing more.
+ *
+ * Send-only is also why there is **no second websocket**. The mediator permits
+ * one channel per DID and evicts a second as `duplicate-channel`; a TSP send is
+ * an HTTP post through the mediator, holding no socket of its own, so it cannot
+ * duel with the DIDComm one. Same shape as the VTA leg
+ * (`enable_tsp_trust_tasks`) and for the same reason.
+ *
+ * ## Why this is not a `MessageTransport`
+ *
+ * The delivery layer would take one — `MessagingService` holds any number of
+ * transports over a single outbox, which is what `OutboxEntry::via` exists for —
+ * and an earlier draft of this change registered a TSP leg that way.
+ *
+ * It was the wrong fit *here*. The ceremony sends do not go through the delivery
+ * layer at all: [`crate::pack_and_send`] posts straight through the ATM, so a
+ * TSP leg on the outbox would have given TSP joins durability that DIDComm joins
+ * do not have, and would have meant threading a `Messaging` handle down into
+ * `join_flow.rs`. Matching the transport this change is *about* — same call
+ * shape, same failure semantics, only the wire differs — keeps the swap
+ * reviewable and the two paths comparable.
+ *
+ * Putting the ceremony sends behind the outbox is worth doing, but for **both**
+ * transports at once and as its own change; doing it here would have hidden a
+ * durability change inside a transport change.
+ */
+
+use std::sync::Arc;
+
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use serde_json::Value;
+
+use crate::errors::OpenVTCError;
+
+/// Seal a Trust Task `document` to `to_did` and route it through that peer's
+/// advertised TSP mediator.
+///
+/// The TSP counterpart of [`crate::pack_and_send`], and deliberately the same
+/// signature shape so the two are directly comparable at a call site.
+///
+/// `tsp_mediator_did` is the peer's **advertised** `#tsp` mediator — the hop the
+/// routing layer is sealed to — not ours. That is the addressing information the
+/// peer published for exactly this purpose (`discover_tsp_mediator`), and using
+/// ours instead would only work while the two happen to coincide.
+///
+/// Unlike the DIDComm path the caller does **not** pack: `send_routed` seals the
+/// payload end-to-end to `route.last()` and wraps that in a routing layer sealed
+/// to `route[0]`, so the document goes in as plaintext JSON.
+///
+/// # Errors
+///
+/// Returns [`OpenVTCError`] if the document will not serialise, or if the
+/// mediator did not accept the frame. The message names both the peer and the
+/// mediator (R6.4), so an operator can tell a wrong advertised mediator from a
+/// refused send from an unreachable hop.
+pub async fn send_trust_task(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    document: &Value,
+    to_did: &str,
+    tsp_mediator_did: &str,
+) -> Result<(), OpenVTCError> {
+    let payload = serde_json::to_vec(document)
+        .map_err(|e| OpenVTCError::Config(format!("serialise Trust Task document for TSP: {e}")))?;
+    let route = [tsp_mediator_did.to_string(), to_did.to_string()];
+
+    atm.tsp()
+        .send_routed(profile, &route, &payload)
+        .await
+        .map_err(|e| {
+            OpenVTCError::Config(format!(
+                "TSP send to {to_did} via advertised mediator {tsp_mediator_did}: {e}"
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+
+    /// The hop order is the part that is easy to get backwards and impossible to
+    /// see in a signature: `route[0]` is the mediator the routing layer is sealed
+    /// to, `route.last()` the final recipient the payload is sealed to. Reversed,
+    /// the mediator would receive a frame it cannot forward.
+    #[test]
+    fn route_is_mediator_then_recipient() {
+        let to = "did:webvh:example:vtc";
+        let mediator = "did:webvh:example:mediator";
+        let route = [mediator.to_string(), to.to_string()];
+
+        assert_eq!(route[0], mediator, "route[0] must be the routing hop");
+        assert_eq!(
+            route.last().map(String::as_str),
+            Some(to),
+            "route.last() must be the final recipient"
+        );
+    }
+}

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -1056,6 +1056,10 @@ async fn run_join_sequence(
         state.invitation_credential.as_ref(),
         linkage.as_ref(),
     );
+    // Does this community accept Trust Tasks over TSP? `None` — not advertised,
+    // or discovery could not answer — sends over DIDComm exactly as before, so a
+    // VTC that has not been flipped is unaffected.
+    let vtc_tsp_mediator = openvtc_core::config::peer_tsp_mediator(&vtc_did).await;
     let request_id = match openvtc_core::join::submit_join_request(
         atm,
         &persona_profile,
@@ -1063,6 +1067,7 @@ async fn run_join_sequence(
         &vtc_did,
         &persona_mediator,
         vp,
+        vtc_tsp_mediator.as_deref(),
     )
     .await
     {


### PR DESCRIPTION
Completes #185 item 2f — the VTC-facing ceremonies can now use TSP.

Both halves land together by necessity: the VTC never initiates TSP to a member (`tsp-enablement.md` §14 Q4), so inbound routing alone would be dead code and outbound alone would throw away the reply.

## Inbound was never a missing transport — only missing routing

`DidCommTransport` owns the one mediator socket and **already** surfaces TSP frames off it, unpacked and sender-authenticated, tagged `Protocol::TSP`. The dispatcher discarded them at its first line — a deliberate placeholder left for this issue. `tsp_frame_to_message` now normalises a frame into the `Message` shape everything downstream already speaks.

That mapping is *lossless* because both transports carry the **same document**. DIDComm's envelope merely repeats two of its members outside it:

| `Message` field | taken from |
|---|---|
| `typ` | the document's `type` |
| `thid` | the document's `threadId` |
| `body` | the whole document — exactly what `tt_didcomm_reply` sets |
| `from` | the TSP-authenticated sender VID, never the document's `issuer` |

So every existing handler works unchanged. **This only holds because #200 landed first** — before it taught the handlers to unwrap `payload`, every TSP reply would have parsed at the wrong nesting and been dropped as malformed.

## Outbound is the one call `pack_and_send` cannot make

It forwards a DIDComm `routing/2.0` envelope unconditionally. `tsp::send_trust_task` is its counterpart with the same signature shape: `send_routed` with the peer's **advertised** mediator as the routing hop and the peer as the final recipient.

## Correlation had to be *made* to agree

DIDComm threads the reply on the request **message** id; TSP has no message and threads on the request **document** id. Two different UUIDs — so the DIDComm message is now built with `id` equal to the document id. `Uuid::parse_str` accepts the `urn:uuid:` form, so the existing correlation code reads either unchanged and one handle works on both wires.

## Discovery degrades quietly

`peer_tsp_mediator` runs the same `#tsp` lookup against the community's document that the VTA path already runs. Not-advertised, unresolvable and timed-out all mean *use DIDComm*, with the distinction kept in the log rather than the return type (R6.4) — there is no panel here to render it into. A community that has not been flipped is unaffected.

## What this deliberately is *not*

An earlier draft registered TSP as a `MessageTransport` on the delivery layer, per the plan in my scoping comment above. That was the wrong fit: the ceremony sends don't go through that layer at all (`pack_and_send` posts straight through the ATM), so an outbox-backed TSP leg would have given TSP joins durability that DIDComm joins lack, and would have meant threading a `Messaging` handle into `join_flow.rs`. Putting the ceremonies behind the outbox is worth doing — for **both** transports, as its own change, rather than hiding a reliability change inside a transport change.

## Verification

Against the live deployment's actual shapes: the test VTC (`did:webvh:QmXi1PZD4…:webvh.storm.ws:first-vtc`) now advertises `#tsp` at the shared mediator, and the VTC accepts Trust Tasks over TSP as of VTI #833, with the member verbs added in #838.

- `cargo test --workspace` — 290 `openvtc-core` + 255 `openvtc` + every integration binary, 0 failed
- Six new tests cover the normaliser, including that a frame with **no proven sender does not inherit the document's `issuer`** — which would otherwise let any TSP peer claim to be the VTC
- `fmt`, `clippy --workspace --all-targets`, `rustdoc -D warnings`, `cargo check --workspace --locked` — all clean

## Follow-ups, not in scope here

- `submit_self_remove` and `send_member_vmc` still send bare bodies over DIDComm. VTI #838 added their Trust Task handlers, but #839 established the document form is reachable over TSP/REST only — so moving them is a wire change *and* a transport change together, worth its own PR.
- Ceremony sends bypass the durable outbox on both transports.

Closes #185
