### PR TITLE
fix: cut untrusted strings on character boundaries, not byte offsets

### DIFF
--- a/openvtc-core/src/display.rs
+++ b/openvtc-core/src/display.rs
@@ -5,20 +5,42 @@
 
 use std::borrow::Cow;
 
-/// Tail-truncate `did` to at most `max_len` bytes, replacing the dropped
+/// Cut `s` down to at most `max_chars` characters, borrowing throughout.
+///
+/// The cut always lands on a character boundary, so this never panics on any
+/// input — which a byte slice (`&s[..n]`) does not guarantee. Every truncation
+/// in the tree goes through here or [`truncate_did`]: the strings we shorten
+/// (DIDs, agent names, peer-supplied error text, timestamps off the wire) are
+/// attacker-controlled, and a mid-scalar cut on one of them is a remote crash,
+/// not a cosmetic bug.
+///
+/// Counts characters, not display columns — wide glyphs still render wider than
+/// `max_chars` cells. Callers sizing a TUI column should treat it as an upper
+/// bound, not an exact width.
+#[must_use]
+pub fn truncate_chars(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((end, _)) => &s[..end],
+        None => s,
+    }
+}
+
+/// Tail-truncate `did` to at most `max_len` characters, replacing the dropped
 /// suffix with `...`. Returns the input borrowed when it already fits, so
 /// the common no-truncation case avoids an allocation.
 ///
-/// `max_len` is interpreted in bytes. DIDs are restricted to ASCII, so
-/// byte-len matches char-len for any input we'll see in practice.
+/// `max_len` counts characters and the cut is always character-aligned: DIDs
+/// are ASCII by spec, but this is also the truncator for agent names, friendly
+/// names and DIDs that arrive off the wire *before* validation, none of which
+/// are ASCII by construction.
 #[must_use]
 pub fn truncate_did(did: &str, max_len: usize) -> Cow<'_, str> {
-    if did.len() <= max_len {
+    if did.char_indices().nth(max_len).is_none() {
         Cow::Borrowed(did)
     } else if max_len > 3 {
-        Cow::Owned(format!("{}...", &did[..max_len - 3]))
+        Cow::Owned(format!("{}...", truncate_chars(did, max_len - 3)))
     } else {
-        Cow::Owned(did[..max_len].to_string())
+        Cow::Owned(truncate_chars(did, max_len).to_string())
     }
 }
 
@@ -81,6 +103,29 @@ mod tests {
     fn truncate_did_below_ellipsis_width_returns_raw_truncation() {
         let out = truncate_did("did:web:example.com", 2);
         assert_eq!(out, "di");
+    }
+
+    /// OVTC-01, display side: the truncators run on unvalidated inbound DIDs
+    /// (log lines) and on agent / friendly names, so a byte-aligned cut was a
+    /// panic waiting on any multi-byte input. Cuts must land on a boundary for
+    /// 2-, 3- and 4-byte scalars alike.
+    #[test]
+    fn truncators_cut_on_char_boundaries() {
+        for scalar in ['\u{0281}', '\u{20AC}', '\u{1F600}'] {
+            let s = format!("{}{scalar}{}", "x".repeat(19), "y".repeat(40));
+            for max in 0..25 {
+                let out = truncate_did(&s, max);
+                assert!(out.chars().count() <= max.max(3), "max {max}: over budget");
+                assert!(truncate_chars(&s, max).chars().count() <= max);
+            }
+        }
+    }
+
+    #[test]
+    fn truncate_chars_counts_characters_not_bytes() {
+        assert_eq!(truncate_chars("😀😀😀", 2), "😀😀");
+        assert_eq!(truncate_chars("abc", 10), "abc");
+        assert_eq!(truncate_chars("abc", 0), "");
     }
 
     #[test]

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -796,8 +796,14 @@ pub fn require_thid(message: &Message) -> Result<Arc<String>, anyhow::Error> {
 /// identities. We don't ship the full DID resolver here, but a strict
 /// syntactic gate is cheap insurance against malformed payloads.
 pub fn validate_did(did: &str) -> Result<(), anyhow::Error> {
+    // Character-aligned truncation, not `&did[..64]`: this runs on unvalidated
+    // inbound DIDs, and a byte cut inside a multi-byte scalar panics — turning
+    // the rejection path into a remote crash (OVTC-01).
     let bail = || -> anyhow::Error {
-        anyhow::anyhow!("invalid DID format: '{}'", &did[..did.len().min(64)])
+        anyhow::anyhow!(
+            "invalid DID format: '{}'",
+            crate::display::truncate_chars(did, 64)
+        )
     };
 
     let rest = did.strip_prefix("did:").ok_or_else(bail)?;
@@ -1709,6 +1715,29 @@ mod tests {
     fn validate_did_rejects_msi_with_invalid_chars() {
         assert!(validate_did("did:web:exam ple.com").is_err()); // space
         assert!(validate_did("did:web:exam\u{200E}ple.com").is_err()); // LRM
+    }
+
+    /// OVTC-01: the error path used to truncate the rejected input with a
+    /// *byte* slice, so an invalid DID longer than the cap whose cut landed
+    /// inside a multi-byte scalar panicked instead of returning `Err`. The
+    /// input here is attacker-controlled (an inbound `RelationshipRequest`
+    /// body), so the panic was a remote crash of the whole client.
+    #[test]
+    fn validate_did_rejects_oversized_multibyte_input_without_panicking() {
+        // Each case puts a 2-, 3- and 4-byte scalar across the 64-byte cut.
+        for (label, filler, scalar) in [
+            ("2-byte", 63, '\u{0281}'),  // ʁ  — bytes 63..65
+            ("3-byte", 62, '\u{20AC}'),  // €  — bytes 62..65
+            ("4-byte", 61, '\u{1F600}'), // 😀 — bytes 61..65
+        ] {
+            let did = format!("{}{scalar}", "x".repeat(filler));
+            assert!(did.len() > 64, "{label}: case must exceed the cap");
+            assert!(validate_did(&did).is_err(), "{label}: must reject, not panic");
+        }
+        // Same shape, but past the `did:` prefix so a later gate does the
+        // rejecting — the truncation runs for every bail arm.
+        let msi = format!("did:web:{}\u{1F600}", "x".repeat(60));
+        assert!(validate_did(&msi).is_err());
     }
 
     // --- inbound VRC-issued vetting (task R2) ---

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -1732,7 +1732,10 @@ mod tests {
         ] {
             let did = format!("{}{scalar}", "x".repeat(filler));
             assert!(did.len() > 64, "{label}: case must exceed the cap");
-            assert!(validate_did(&did).is_err(), "{label}: must reject, not panic");
+            assert!(
+                validate_did(&did).is_err(),
+                "{label}: must reject, not panic"
+            );
         }
         // Same shape, but past the `did:` prefix so a later gate does the
         // rejecting — the truncation runs for every bail arm.

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -506,7 +506,7 @@ impl MainPageState {
             openvtc_core::config::ConfigProtectionType::Token(id) => {
                 format!(
                     "Hardware Token ({})",
-                    if id.len() > 20 { &id[..20] } else { id }
+                    openvtc_core::display::truncate_chars(id, 20)
                 )
             }
             openvtc_core::config::ConfigProtectionType::Encrypted => {

--- a/openvtc/src/ui/pages/join_flow/invitation_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/invitation_choice.rs
@@ -36,10 +36,10 @@ pub struct InvitationChoice;
 fn short_date(ts: &str) -> String {
     if ts.is_empty() {
         "—".to_string()
-    } else if ts.len() >= 10 {
-        ts[..10].to_string()
     } else {
-        ts.to_string()
+        // Character-aligned: the timestamp comes off a credential we did not
+        // mint, so a byte cut here would panic on a multi-byte scalar.
+        openvtc_core::display::truncate_chars(ts, 10).to_string()
     }
 }
 

--- a/openvtc/src/ui/pages/main/components/capabilities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/capabilities_panel.rs
@@ -98,7 +98,10 @@ impl Panel for CapabilitiesPanel {
                     if item.enabled {
                         if let Some(at) = &item.enabled_at {
                             spans.push(Span::styled(
-                                format!("   enabled {}", &at[..at.len().min(10)]),
+                                format!(
+                                    "   enabled {}",
+                                    openvtc_core::display::truncate_chars(at, 10)
+                                ),
                                 Style::default().fg(COLOR_DARK_GRAY),
                             ));
                         }

--- a/openvtc/src/ui/pages/main/components/inbox_panel.rs
+++ b/openvtc/src/ui/pages/main/components/inbox_panel.rs
@@ -51,11 +51,10 @@ pub fn render(state: &InboxState, connection: &ConnectionState) -> Vec<Line<'sta
         MediatorStatus::Connected => Line::from("Connected").fg(COLOR_SUCCESS),
         MediatorStatus::Connecting => Line::from("Connecting...").fg(COLOR_TEXT_DEFAULT),
         MediatorStatus::Failed(reason) => {
-            let display = if reason.len() > 40 {
-                format!("Failed: {}...", &reason[..37])
-            } else {
-                format!("Failed: {}", reason)
-            };
+            let display = format!(
+                "Failed: {}",
+                openvtc_core::display::truncate_did(reason, 40)
+            );
             Line::from(display).fg(COLOR_WARNING_ACCESSIBLE_RED)
         }
         MediatorStatus::Initializing(step) => {

--- a/openvtc/src/ui/pages/main/components/logs_panel.rs
+++ b/openvtc/src/ui/pages/main/components/logs_panel.rs
@@ -81,12 +81,9 @@ pub fn render(
             Style::new().fg(COLOR_TEXT_DEFAULT)
         };
 
-        // Truncate long entries for list display
-        let display = if entry.summary.len() > 80 {
-            format!("{}...", &entry.summary[..77])
-        } else {
-            entry.summary.clone()
-        };
+        // Truncate long entries for list display. Character-aligned — a summary
+        // can carry peer-supplied text, and a byte cut would panic mid-scalar.
+        let display = openvtc_core::display::truncate_did(&entry.summary, 80).into_owned();
 
         lines.push(Line::from(vec![Span::styled(
             format!("{}{}", prefix, display),

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2149,11 +2149,10 @@ impl ComponentRender<()> for MainPage {
                 ratatui::style::Style::default().fg(COLOR_TEXT_DEFAULT),
             )),
             MediatorStatus::Failed(reason) => {
-                let display = if reason.len() > 20 {
-                    format!("Failed: {}...", &reason[..17])
-                } else {
-                    format!("Failed: {}", reason)
-                };
+                let display = format!(
+                    "Failed: {}",
+                    openvtc_core::display::truncate_did(reason, 20)
+                );
                 Line::from(Span::styled(
                     display,
                     ratatui::style::Style::default().fg(COLOR_WARNING_ACCESSIBLE_RED),


### PR DESCRIPTION
Fixes the remote-DoS panic reported as **VLM-4154 / OVTC-01**, and the wider class it belongs to.

Identified by @VikramVashisth (https://github.com/VikramVashisth) during a security fuzzing engagement against OpenVTC, with a minimal reproducer and a full source-adjudicated data-flow trace.

## The reported bug

`validate_did` built its rejection message with `&did[..did.len().min(64)]`. A byte slice panics unless the offset lands on a UTF-8 character boundary, so any invalid DID longer than 64 bytes whose 64th byte splits a multi-byte scalar panicked instead of returning `Err`.

Reproduced before the fix, with the reporter's minimal input (63 filler bytes + `U+0281`):

```
panicked at openvtc-core/src/messaging.rs:800:57:
end byte index 64 is not a char boundary; it is inside 'ʁ' (bytes 63..65 of string)
```

The reachability claim holds as written:

- `message_dispatch.rs:610` calls `validate_did(&body.did)` as the **first statement** of the `RelationshipRequest` arm — ahead of `check_task_capacity` and the `MAX_RELATIONSHIPS` gate — on a message type that needs no prior relationship or handshake.
- `process_inbound_message` is awaited inline in the state handler's `select!` loop (`state_handler/mod.rs:1639`), and `main_loop` is awaited directly in `tokio::try_join!` (`main.rs:267`). Not spawned, not wrapped in `catch_unwind`.

So the unwind takes the whole client down, not one message. The payload is small and cheap to repeat, and the `seen` dedup LRU is process-lifetime, so mediator redelivery re-crashes on launch until the ±48h freshness window closes. Availability only — safe Rust throughout, no corruption, no exposure.

## Why the fix is wider than the report

`validate_did` was not the only site. `display::truncate_did` byte-sliced as well, on the strength of a doc comment claiming DIDs are ASCII in practice. That holds for DIDs we have already validated and for nothing else it is called on — inbound `from` headers logged before validation (`didcomm.rs:687`, which falls back to the plaintext sender-controlled header when the transport authenticates no sender), agent names, friendly names.

Worth noting: `settings_panel.rs:178` carries a comment explaining that an **earlier fix for this same panic class** replaced `&value[..47]` with a call to `truncate_did`. That remediation moved the panic instead of removing it, because the helper it delegated to had the same defect. Fixing the helper retroactively makes that fix real.

## What changed

- `display::truncate_chars(&str, usize) -> &str` — the single boundary-safe primitive. Cuts via `char_indices().nth()`, so the offset is character-aligned by construction and cannot panic on any input; borrows in both arms.
- `truncate_did` now counts characters and delegates the cut. Identical output for ASCII, which is every DID that reaches it today.
- `validate_did`'s `bail` closure uses `truncate_chars(did, 64)`.
- Every remaining byte-slice on a string we did not mint routed through one of the two: capability `enabled_at` off a VTC reply, the invitation timestamp off a credential, activity summaries, mediator failure reasons (two panels), the hardware token id.

`config/did.rs:315` was checked and left alone — `find("://")` returns a character boundary.

## Verification

- `validate_did_rejects_oversized_multibyte_input_without_panicking` — 2-, 3- and 4-byte scalars straddling the 64-byte cut, plus a case that fails past the `did:` prefix so a later bail arm exercises the same truncation.
- `truncators_cut_on_char_boundaries` — sweeps every width 0..25 across all three scalar widths against both truncators.
- `truncate_chars_counts_characters_not_bytes` — character semantics, including the zero-width and no-truncation cases.
- `cargo test --workspace` green (293 core + 255 CLI + integration suites), `cargo clippy --workspace --all-targets` clean.

Not run: the reporter's `./fuzz-asan.sh validate_did` acceptance criterion. That harness lives out-of-tree in `openvtc-fuzzer`, which is not part of this repository — @VikramVashisth, happy to have it re-run against this branch to close that box.

## Credit

Reported and reproduced by @VikramVashisth (https://github.com/VikramVashisth). The report pinned the sink to a commit, traced the taint from the remote peer through both dispatch call sites, and correctly called out that a panic in a validator suggested the input-hardening boundary needed a systematic audit — which is exactly what turned up the six further sites fixed here.
