### PR TITLE
fix: build against the current vta-sdk, and refresh every dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -888,7 +888,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2401,7 +2401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.119",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2796,7 +2796,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3091,7 +3091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5311,7 +5311,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5766,7 +5766,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.20.6",
+ "vta-sdk 0.20.24",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5825,7 +5825,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.20.6",
+ "vta-sdk 0.20.24",
  "vta-service",
  "wiremock",
  "x25519-dalek",
@@ -5863,7 +5863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6120,7 +6120,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -6577,7 +6577,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7224,7 +7224,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7300,7 +7300,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7945,7 +7945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8431,7 +8431,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8444,7 +8444,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9025,9 +9025,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.39"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f80508c771f601bcd02b85d0a6d0890bdcee07b305d6afa9dff9d5c1f57f2c"
+checksum = "647c5ff5d054287bd42c34eaf8bc5ba8f3c3c063dcdc744acd45c9c6cf9bded3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9455,9 +9455,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.20.6"
+version = "0.20.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ce960b92415dfe44977c2012033b7f79ae46a840d4bb1cae94edaf261a0caa"
+checksum = "53959519b5acfa1080e91c650dfa2455783578d8bdfc9b3651648b603eaee81e"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10029,7 +10029,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,14 +39,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -55,11 +76,25 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.2",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
  "subtle",
 ]
 
@@ -69,7 +104,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
 dependencies = [
- "aes",
+ "aes 0.8.4",
 ]
 
 [[package]]
@@ -88,7 +123,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e7ea1c5a572bab1a8af43b517e4a7674d57c061dd75e61799ec9fc9f356b4e"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "affinidi-encoding",
  "base58",
  "base64 0.22.1",
@@ -113,12 +148,12 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab562d8232a2837c8fd23c06688ac5dc3ed2f8fdf5b503344b50677d3ef2a38"
+checksum = "bf2bf693c0bb26ea6c0a0d04ea1391500d694cda95d98c7918354e29292e566d"
 dependencies = [
  "affinidi-crypto",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-rdf-encoding",
  "affinidi-secrets-resolver",
  "async-trait",
@@ -141,7 +176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c566099c0d490d74c836d1008eabb2da3bafc0acd9653d802893893134e91bff"
 dependencies = [
  "affinidi-crypto",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "affinidi-messaging-didcomm",
@@ -155,23 +190,6 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "affinidi-did-common"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f36c0ae3c4991f7d059358e2d9a637c826110df3c72d4ce8caf20204ed55647"
-dependencies = [
- "affinidi-crypto",
- "affinidi-encoding",
- "base64 0.22.1",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "url",
- "x25519-dalek",
- "zeroize",
 ]
 
 [[package]]
@@ -193,11 +211,11 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad166a17f2222def03193ffd8d601a85e6e04f2214e9494db6a6156efaba48b"
+checksum = "7c6fd1d099f394056d9eaf853211421b97dffb04c4f00de242ebf23cce812a6b"
 dependencies = [
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-did-resolver-traits",
  "affinidi-did-web",
  "affinidi-task-utils",
@@ -207,7 +225,7 @@ dependencies = [
  "did-ethr",
  "did-pkh",
  "did-scid",
- "didwebvh-rs 0.6.0",
+ "didwebvh-rs",
  "highway",
  "moka",
  "rand 0.10.2",
@@ -234,7 +252,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "923fc32fdf5fea0925fd29b81a427bc6d6550063ae2de692d1fa0dd1cb57efed"
 dependencies = [
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "thiserror 2.0.19",
 ]
 
@@ -244,7 +262,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48bff79fe41fa2bd3e50b9ac14cdc660a83f61ebbb7fd321517b478781dd3046"
 dependencies = [
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "percent-encoding",
  "reqwest 0.13.4",
  "serde_json",
@@ -272,7 +290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6565622f50c85268391a202f5783e9917fa7bb0f39270c5f141c1ed4e573b7bc"
 dependencies = [
  "affinidi-did-authentication",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
  "affinidi-tdk-common",
@@ -338,12 +356,12 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.17.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1c3bcbd1c3bc5ef993c8d181cb010ead46d130aa31c4340821190946cc5800"
+checksum = "3cdd9b715dda0d25b9fa5afce0ea96540e5e5fc4067503357c08126ab40d3f59"
 dependencies = [
  "affinidi-crypto",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "affinidi-messaging-didcomm",
@@ -363,11 +381,11 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
- "didwebvh-rs 0.6.0",
+ "didwebvh-rs",
  "futures-util",
  "governor",
  "hostname",
- "http 1.4.2",
+ "http 1.5.0",
  "humantime",
  "itertools 0.14.0",
  "jsonwebtoken",
@@ -397,16 +415,16 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.20.30",
 ]
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.30"
+version = "0.15.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f271a25216dfff7ec10e30c9d73b78f705f6319d1bd1544dc221a9dee331cc"
+checksum = "e8740756329af4040d2c488f2d2e5c27a62b91c4cdde04e9f8d3876cb583ce9a"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "ahash 0.8.12",
  "argon2",
  "async-trait",
@@ -452,13 +470,13 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.18.60"
+version = "0.18.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d435cbd3fabbca6bfdc7ecb56af0974cee5f5d4d8283436ba304aae1066b4368"
+checksum = "3b4901696220a28519f77af11ec6c38ebfde678ce7c59f6748f0a65d7166d688"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "affinidi-messaging-core",
@@ -490,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.39"
+version = "0.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1dcf7fd903356e230912801b3b0f92633e6e76a8fea8f9b36438be3f4c39359"
+checksum = "000d5bb24597fe363a376cf6d845e7c842e27aa46f1c13a49974d829cc574d8d"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -568,7 +586,7 @@ checksum = "894d604fc9b9d10eaf5c48b1f063a263048a7d4f13e648c9580c32de1f90d5fe"
 dependencies = [
  "axum",
  "governor",
- "http 1.4.2",
+ "http 1.5.0",
  "tokio",
  "tokio-util",
  "tower",
@@ -675,7 +693,7 @@ dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-authentication",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-meeting-place",
  "affinidi-messaging-didcomm",
@@ -694,13 +712,13 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ff6b46621c148d7dc175f2f5aefa955b5dfbc1c8d5ea92a0e4def55cb69463"
+checksum = "28b84deea82515fc558c7c663986060b227b7604612e48fe31ce8cde688fc3ed"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-secrets-resolver",
  "ahash 0.8.12",
@@ -728,7 +746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9499c93bcd77125a532d4e881d5daff9844660ae0de03a5a085a71e97b7143"
 dependencies = [
  "affinidi-cesr",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
  "blake2",
@@ -764,11 +782,11 @@ dependencies = [
 
 [[package]]
 name = "agent-names"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edee04827df678e4da8cba74b02345456924121f815b331fca09df013977df62"
+checksum = "6b7e2b7857b1f2aadbf3216a02046bef6a66fed4b199108d46d29953b5b487b0"
 dependencies = [
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "reqwest 0.13.4",
  "serde_json",
  "thiserror 2.0.19",
@@ -877,7 +895,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -888,7 +906,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1070,7 +1088,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1129,7 +1147,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper 1.11.0",
@@ -1162,7 +1180,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "mime",
@@ -1185,7 +1203,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "headers",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "mime",
@@ -1205,7 +1223,7 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "hyper 1.11.0",
  "hyper-util",
@@ -1271,6 +1289,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "base64ct"
@@ -1462,7 +1486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1576,9 +1600,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "byteview"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
+checksum = "0d74937895e761d5984206f82ca8ff7725d0fd8021921011921894b41ab1b9f7"
 
 [[package]]
 name = "bzip2"
@@ -1596,7 +1620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1610,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "card-backend-pcsc"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9abd829326b7cbf5e71dc81485f4bc839ac938813f6e5e02c9033b6dee71f1e"
+checksum = "78ce74865d9359eb375834f907c25515e8f7f1d1de71b6414e9f17e66d042d80"
 dependencies = [
  "card-backend",
  "iso7816-tlv",
@@ -1632,7 +1656,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1650,14 +1674,14 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1680,7 +1704,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1702,7 +1726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -1723,9 +1747,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -1789,15 +1813,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.3"
+name = "cipher"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1817,14 +1852,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1857,7 +1892,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "dbl",
  "digest 0.10.7",
 ]
@@ -1931,15 +1966,6 @@ name = "compare"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "console"
@@ -2017,6 +2043,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -2199,7 +2231,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2239,7 +2273,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2401,7 +2444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2430,7 +2473,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "block-padding",
  "cbc",
  "dbus",
@@ -2593,7 +2636,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2626,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "did-git-sign"
-version = "0.1.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4bc8d3eade166d4222f4ec9a1787dd42aa1aa393b28ef5fca1eee429431cfd0"
+checksum = "6cc080e47affe93f97a4442bd8757f379a88424a59432f48e49b6f0032d885cc"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -2650,7 +2693,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vgi-core",
- "vta-sdk 0.18.21",
+ "vta-sdk 0.19.28",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -2682,8 +2725,8 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c561e24bc18abb948ac11528239d8aec6918c1345c1c11265fd8cf65d2eb28f2"
 dependencies = [
- "affinidi-did-common 0.4.0",
- "didwebvh-rs 0.6.0",
+ "affinidi-did-common",
+ "didwebvh-rs",
  "regex",
  "serde_json",
  "ssi-dids-core",
@@ -2693,39 +2736,12 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47e062185f7da3d0f9953f73c7c3e3873a0fba15b8ca7530285b8c1875b8dcd"
-dependencies = [
- "affinidi-data-integrity",
- "affinidi-did-common 0.3.9",
- "affinidi-secrets-resolver",
- "ahash 0.8.12",
- "async-trait",
- "base58",
- "chrono",
- "getrandom 0.4.3",
- "percent-encoding",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "serde_json_canonicalizer",
- "serde_with",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "didwebvh-rs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b131547e3380c910c2cdc078299bd07ec510d6aa5c074f83bdbf3852c77ba8c0"
 dependencies = [
  "affinidi-data-integrity",
- "affinidi-did-common 0.4.0",
+ "affinidi-did-common",
  "affinidi-secrets-resolver",
  "ahash 0.8.12",
  "async-trait",
@@ -2796,7 +2812,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2811,13 +2827,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2884,10 +2900,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
 dependencies = [
- "aead",
- "cipher",
+ "aead 0.5.2",
+ "cipher 0.4.4",
  "cmac",
- "ctr",
+ "ctr 0.9.2",
  "subtle",
 ]
 
@@ -2960,7 +2976,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
 dependencies = [
- "enum-ordinalize 4.4.1",
+ "enum-ordinalize 4.4.2",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2968,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -3048,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
@@ -3091,7 +3107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3111,11 +3127,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3560,7 +3575,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.3",
 ]
 
 [[package]]
@@ -3639,7 +3663,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -3728,7 +3752,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.2",
+ "http 1.5.0",
  "httpdate",
  "mime",
  "sha1",
@@ -3740,7 +3764,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -3841,8 +3865,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.5.2",
+ "aes-gcm 0.10.3",
  "chacha20poly1305",
  "digest 0.10.7",
  "generic-array",
@@ -3869,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3895,7 +3919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -3906,7 +3930,7 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
 ]
@@ -3931,9 +3955,9 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -3973,7 +3997,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.15",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
  "httpdate",
@@ -3990,7 +4014,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper 1.11.0",
  "hyper-util",
  "rustls",
@@ -4036,7 +4060,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "hyper 1.11.0",
  "ipnet",
@@ -4163,7 +4187,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -4261,6 +4285,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -4817,9 +4850,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.188"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -5311,7 +5344,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5474,7 +5507,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5589,9 +5621,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
 dependencies = [
- "aead",
- "cipher",
- "ctr",
+ "aead 0.5.2",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
  "subtle",
 ]
 
@@ -5630,9 +5662,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openpgp-card"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a3953947ab2bc105fd007670101c13a61e4fc41f04cd1b537f6fabbbc16a7b"
+checksum = "6e49c0d2302c2f052c5d081f25100bcd89f46eec726c6674cbdeadd798bfc78d"
 dependencies = [
  "card-backend",
  "hex-slice",
@@ -5645,9 +5677,9 @@ dependencies = [
 
 [[package]]
 name = "openpgp-card-rpgp"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3c2dbf032c1403df9fb3f4e3c25ee80ea89cffab86869bd039bbda400ea7c5"
+checksum = "2c0a443281913544afc20d9deab29e9a60eb3b197f9d840b62d68bb1f6674a3c"
 dependencies = [
  "ed25519-dalek",
  "openpgp-card",
@@ -5719,13 +5751,13 @@ dependencies = [
 name = "openvtc"
 version = "0.2.1"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.0",
  "affinidi-data-integrity",
  "affinidi-tdk",
  "anyhow",
  "apple-native-keyring-store",
  "arboard",
- "base64 0.22.1",
+ "base64 0.23.0",
  "byteorder",
  "card-backend-pcsc",
  "chrono",
@@ -5734,7 +5766,7 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "did-git-sign",
- "didwebvh-rs 0.6.0",
+ "didwebvh-rs",
  "dirs",
  "dtg-credentials",
  "ed25519-dalek-bip32",
@@ -5766,7 +5798,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.20.24",
+ "vta-sdk 0.20.30",
  "windows-native-keyring-store",
  "x25519-dalek",
  "zeroize",
@@ -5776,7 +5808,7 @@ dependencies = [
 name = "openvtc-core"
 version = "0.2.1"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.0",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-core",
@@ -5788,13 +5820,13 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "argon2",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bip39",
  "byteorder",
  "card-backend-pcsc",
  "chrono",
  "criterion",
- "didwebvh-rs 0.6.0",
+ "didwebvh-rs",
  "dirs",
  "dtg-credentials",
  "ed25519-dalek-bip32",
@@ -5825,7 +5857,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.20.24",
+ "vta-sdk 0.20.30",
  "vta-service",
  "wiremock",
  "x25519-dalek",
@@ -5863,7 +5895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6058,9 +6090,9 @@ checksum = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -6068,9 +6100,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6078,9 +6110,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -6091,9 +6123,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -6111,16 +6143,16 @@ dependencies = [
 
 [[package]]
 name = "pgp"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaffe1ec22db286599c30ae6be75b37493b558735d86c8e59ec5c38794415fe4"
+checksum = "1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1"
 dependencies = [
- "aead",
- "aes",
- "aes-gcm",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -6131,7 +6163,7 @@ dependencies = [
  "camellia",
  "cast5",
  "cfb-mode",
- "cipher",
+ "cipher 0.4.4",
  "const-oid 0.9.6",
  "crc24",
  "curve25519-dalek",
@@ -6153,6 +6185,7 @@ dependencies = [
  "k256",
  "log",
  "md-5",
+ "memchr",
  "nom 8.0.0",
  "num-bigint-dig",
  "num-traits",
@@ -6162,7 +6195,6 @@ dependencies = [
  "p384",
  "p521",
  "rand 0.8.7",
- "regex",
  "replace_with",
  "ripemd",
  "rsa",
@@ -6173,6 +6205,7 @@ dependencies = [
  "signature",
  "smallvec",
  "snafu",
+ "subtle",
  "twofish",
  "x25519-dalek",
  "zeroize",
@@ -6350,7 +6383,7 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -6362,7 +6395,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -6436,15 +6480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6506,9 +6541,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -6577,7 +6612,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6881,9 +6916,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b9503711b03773e43b31668c7b5bd279ee7cd9b7d18cff7c23a42cc1d08e5a"
+checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
 dependencies = [
  "ahash 0.8.12",
  "arc-swap",
@@ -6948,7 +6983,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7097,7 +7132,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "h2 0.4.15",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper 1.11.0",
@@ -7224,14 +7259,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7274,9 +7309,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7300,7 +7335,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7383,9 +7418,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7513,7 +7548,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7606,7 +7641,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -7909,18 +7944,18 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snafu"
-version = "0.8.9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -7945,7 +7980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8317,9 +8352,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8431,7 +8466,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8444,7 +8479,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8547,7 +8582,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8668,13 +8703,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8699,9 +8734,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8726,23 +8761,24 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -8763,22 +8799,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.25.13+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
-dependencies = [
- "indexmap 2.14.0",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -8800,7 +8824,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.15",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper 1.11.0",
@@ -8846,7 +8870,7 @@ dependencies = [
  "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
@@ -8879,7 +8903,7 @@ dependencies = [
  "axum",
  "forwarded-header-value",
  "governor",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project",
  "thiserror 2.0.19",
  "tonic",
@@ -9008,9 +9032,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0138696d9a4d052ee0c7d780a7ba28d469c41dc3157312ae222c9e54d484fe9"
+checksum = "88908c703a80ae8716603fba04fdbe5ef91dae66c433ce07267bf589b616bd6a"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9025,9 +9049,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.2.43"
+version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c5ff5d054287bd42c34eaf8bc5ba8f3c3c063dcdc744acd45c9c6cf9bded3"
+checksum = "2e0b56c949946c8b79072036414e3d18fc0b87f5edd309311282d17e9a780510"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9064,7 +9088,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.5",
@@ -9080,7 +9104,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -9171,6 +9195,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -9328,9 +9362,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vgi-core"
-version = "0.1.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c011e1ed578890abb02536d1914693ac9e265f85deba8805fa08b41259175b"
+checksum = "d3ee216f6927fdcc11b16d9e1ce3b78a112ae5815d62c509a5fc855984687a4a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -9347,12 +9381,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
-name = "vta-cli-common"
-version = "0.10.8"
+name = "vta-audit"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fef769946f5ea8a783317952699db4ead7834013117bf0bfdebcea381aed9b8"
+checksum = "990caec9d1646413acc8a6a05ddb8bb4261d2174c484a58072267d7127b63084"
 dependencies = [
- "aes-gcm",
+ "tracing",
+ "uuid",
+ "vta-sdk 0.20.30",
+ "vti-common",
+]
+
+[[package]]
+name = "vta-backup"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b437f4f8014785c36d908e7123a264b1162ad1d3596a05530d170191fa69bde"
+dependencies = [
+ "aes-gcm 0.10.3",
+ "argon2",
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "subtle",
+ "tokio",
+ "tracing",
+ "uuid",
+ "vta-config",
+ "vta-keys",
+ "vta-keyspaces",
+ "vta-sdk 0.20.30",
+ "vta-support",
+ "vti-common",
+ "zeroize",
+]
+
+[[package]]
+name = "vta-cli-common"
+version = "0.10.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67726e8e3661c1e28641d3f869419c161d9b97fa9bd24dad4da65fba42cef546"
+dependencies = [
+ "aes-gcm 0.10.3",
  "affinidi-crypto",
  "base64 0.22.1",
  "chrono",
@@ -9367,32 +9440,113 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.19",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.20.30",
  "vti-common",
  "x25519-dalek",
 ]
 
 [[package]]
-name = "vta-sdk"
-version = "0.18.21"
+name = "vta-config"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feff04a721d51bbfdd5952b2d8d86b17ce24ad7d9891e2a4e5fce2936543218a"
+checksum = "54866a3e7569b33ccc0a1e6bcc40258b9eca931ef38cd33790b82f3c22abf976"
+dependencies = [
+ "serde",
+ "serde_ignored",
+ "toml",
+ "tracing",
+ "vti-common",
+ "vti-secrets",
+]
+
+[[package]]
+name = "vta-keys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd113f33632b726cfeac95e52f6b6e1d71feff3416635af7131cac068d59bd5"
+dependencies = [
+ "aes-gcm 0.10.3",
+ "affinidi-crypto",
+ "affinidi-tdk",
+ "base64 0.22.1",
+ "bip39",
+ "chrono",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "multibase",
+ "p256",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tokio",
+ "tracing",
+ "uuid",
+ "vta-config",
+ "vta-keyspaces",
+ "vta-sdk 0.20.30",
+ "vti-common",
+ "vti-secrets",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "vta-keyspaces"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b32bcddd018e5cf8f94cdd77d06e7865596903da36cc0602d81e3c4842c2ddc"
+dependencies = [
+ "vti-common",
+]
+
+[[package]]
+name = "vta-policy"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e792b96d81cffaaf78cadf29d9c2ed17c5958c35ca4e86beef2465f26877e85b"
+dependencies = [
+ "hex",
+ "regorus",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.11.0",
+ "tracing",
+ "vta-config",
+ "vta-keyspaces",
+ "vti-common",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.19.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5c6b5be45c551ee4f7bfcd1165125c04fc7cbd7485b266e197eb6467bcaa17"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
+ "agent-names",
  "base64 0.22.1",
  "chrono",
  "ciborium",
  "curve25519-dalek",
- "didwebvh-rs 0.5.7",
+ "didwebvh-rs",
  "ed25519-dalek",
+ "futures-util",
  "getrandom 0.4.3",
  "hpke",
  "multibase",
@@ -9412,9 +9566,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.19.20"
+version = "0.20.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bfd9bbf74ea936a57729e01a1c69e14f74d06d22b70aa3872798dc723e6804"
+checksum = "41e152193db01dca124989069508741658721ed5a7c0a9814f9728c69788bb42"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9422,6 +9576,7 @@ dependencies = [
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
+ "affinidi-messaging-sdk",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-secrets-resolver",
@@ -9431,7 +9586,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "curve25519-dalek",
- "didwebvh-rs 0.6.0",
+ "didwebvh-rs",
  "ed25519-dalek",
  "futures-util",
  "getrandom 0.4.3",
@@ -9454,54 +9609,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "vta-sdk"
-version = "0.20.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53959519b5acfa1080e91c650dfa2455783578d8bdfc9b3651648b603eaee81e"
-dependencies = [
- "affinidi-crypto",
- "affinidi-data-integrity",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-secrets-resolver",
- "affinidi-tdk",
- "affinidi-vc",
- "base64 0.22.1",
- "chrono",
- "ciborium",
- "curve25519-dalek",
- "didwebvh-rs 0.6.0",
- "ed25519-dalek",
- "futures-util",
- "getrandom 0.4.3",
- "hpke",
- "multibase",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.19",
- "tokio",
- "tracing",
- "trust-tasks-rs",
- "url",
- "uuid",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
 name = "vta-service"
-version = "0.11.14"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57c33f38b25f135510caa6a0a2ec982046e5a436a46155ba80b3bce005456e3"
+checksum = "3eaaedc9ee0ae52a19eb7ec96b67853564c222e3fff70b0e280adc6651325f03"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
@@ -9526,7 +9639,7 @@ dependencies = [
  "ciborium",
  "clap",
  "dialoguer",
- "didwebvh-rs 0.6.0",
+ "didwebvh-rs",
  "dirs",
  "ed25519-dalek",
  "ed25519-dalek-bip32",
@@ -9567,8 +9680,18 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
+ "vta-audit",
+ "vta-backup",
  "vta-cli-common",
- "vta-sdk 0.19.20",
+ "vta-config",
+ "vta-keys",
+ "vta-keyspaces",
+ "vta-policy",
+ "vta-sdk 0.20.30",
+ "vta-support",
+ "vta-sweepers",
+ "vta-vault",
+ "vta-webvh",
  "vti-common",
  "vti-secrets",
  "vti-webauthn",
@@ -9579,12 +9702,94 @@ dependencies = [
 ]
 
 [[package]]
-name = "vti-common"
-version = "0.11.10"
+name = "vta-support"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a858573f8f09c07404fd29e4c5b129e5132ebf139227916fea3936e844a707"
+checksum = "c0dfa781af779aaee0c0aa5c72d36aa0b7d69e5e21c516c62f7b720d844d9cbe"
 dependencies = [
- "aes-gcm",
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "multibase",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "vta-config",
+ "vta-keyspaces",
+ "vta-sdk 0.20.30",
+ "vti-common",
+]
+
+[[package]]
+name = "vta-sweepers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0261c9b72560af3ed58f86b93de0a111595364d70d6bcac2604f895bf17d11"
+dependencies = [
+ "chrono",
+ "serde_json",
+ "tracing",
+ "vta-audit",
+ "vta-keyspaces",
+ "vta-vault",
+ "vti-common",
+]
+
+[[package]]
+name = "vta-vault"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91bfeb783a71a1ea926db93277f6e2cd376e16d313256fc368de45ea54891f77"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-data-integrity",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-sd-jwt",
+ "affinidi-sd-jwt-vc",
+ "affinidi-secrets-resolver",
+ "affinidi-status-list",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "ed25519-dalek",
+ "multibase",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tracing",
+ "uuid",
+ "vta-keyspaces",
+ "vta-sdk 0.20.30",
+ "vti-common",
+]
+
+[[package]]
+name = "vta-webvh"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1600085d934dc5d74b00dc395a89fe41eeefed8bf7232022c0fd9d6b5681979c"
+dependencies = [
+ "affinidi-tdk",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tracing",
+ "url",
+ "vta-keyspaces",
+ "vta-sdk 0.20.30",
+ "vti-common",
+ "zeroize",
+]
+
+[[package]]
+name = "vti-common"
+version = "0.11.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d20be527376a360082d0842298dc2afdb4ed612a4857a397fce63246a65e48c"
+dependencies = [
+ "aes-gcm 0.10.3",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-delivery",
@@ -9616,16 +9821,16 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.19.20",
+ "vta-sdk 0.20.30",
  "webauthn-rs",
  "zeroize",
 ]
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e05fd9d5330b736f96a16386a903430ddd5a41b63619473c408bffabeb1d11"
+checksum = "904de391ebcb6ec39778ce60b7b9588868703ca4fa274d1962c5bf6acc33f48d"
 dependencies = [
  "hex",
  "serde",
@@ -9754,9 +9959,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -9767,9 +9972,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.14"
+version = "0.31.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
 dependencies = [
  "bitflags 2.13.1",
  "rustix",
@@ -9804,9 +10009,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -10029,7 +10234,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10399,9 +10604,6 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"
@@ -10423,7 +10625,7 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper 1.11.0",
  "hyper-util",
@@ -10543,9 +10745,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ openvtc-core = { version = "0.2", path = "openvtc-core", default-features = fals
 # Decentralized Trust Graph Credentials
 dtg-credentials = "0.1"
 
-aes-gcm = "0.10"
+aes-gcm = "0.11"
 argon2 = "0.5"
 affinidi-tdk = "0.8"
 affinidi-data-integrity = "0.7"
@@ -52,7 +52,7 @@ anyhow = "1.0"
 # `#[derive(arbitrary::Arbitrary)]` proc-macro.
 arbitrary = { version = "1", features = ["derive"] }
 arboard = { version = "3.6.1", features = ["wayland-data-control"] }
-base64 = "0.22"
+base64 = "0.23"
 bip39 = "2.2"
 byteorder = "1.5"
 chrono = "0.4"
@@ -73,15 +73,15 @@ apple-native-keyring-store = { version = "1", features = ["keychain"] }
 linux-keyutils-keyring-store = "1"
 windows-native-keyring-store = "1"
 multibase = "0.9"
-pgp = "0.19"
-# Stays on 0.8 until pgp 0.19 / aes-gcm 0.10 / ed25519-dalek-bip32 0.3
-# move off rand_core 0.6 — they all sit on the old trait set and rand 0.10
-# drops `OsRng`. Our `OsRng` call sites feed those crates directly
-# (pgp key gen + encrypt, aes-gcm `generate_nonce`), so they must share the
-# crate's RNG trait set. Re-evaluated 2026-06-03: pgp 0.19.0 and
-# ed25519-dalek-bip32 0.3.0 are still the latest releases and remain on
-# rand_core 0.6; aes-gcm 0.11 (rand_core 0.9) is still only a release
-# candidate. Bump together when the crypto stack is refreshed.
+pgp = "0.20"
+# Stays on 0.8 because pgp 0.20 does: it takes an `R: Rng + CryptoRng` from
+# the rand_core 0.6 trait set for key signing / `set_password` / ESK
+# encryption, and we hand it our `OsRng` directly, so the two must agree.
+# rand 0.10 also drops `OsRng` outright. Re-evaluated 2026-07-31: pgp 0.20.0
+# still declares `rand ^0.8.6`, and ed25519-dalek-bip32 0.3.0 is still the
+# latest release. aes-gcm no longer holds this pin — it moved to 0.11 and its
+# one RNG call site now fills the nonce from `rand`'s OsRng directly rather
+# than going through `AeadCore::generate_nonce`.
 rand = "0.8"
 ratatui = "0.30"
 regex = "1.12"
@@ -106,12 +106,7 @@ url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # Floor is 0.20.24: `protocols::members::MemberVmcBody` grew a `request_id`
 # field there, so `members.rs`'s initializer no longer builds against anything
-# older. The lock deliberately stays *at* 0.20.24 rather than the latest 0.20.x:
-# 0.20.30 requires trust-tasks-rs 0.2.51, which drags affinidi-messaging-sdk to
-# 0.18.65, whose `TrustTasksOps` dropped `acl_set` — still called by the
-# vta-sdk 0.19 line that the `vta-service` / test-mediator dev-dependencies pull
-# in, so an unpinned resolve builds the binary but breaks `cargo test`. Build
-# and install with `--locked`; lift the pin once those dev-deps move to 0.20.
+# older.
 vta-sdk = { version = "0.20.24", features = [
   "session",
   "client",
@@ -130,13 +125,17 @@ vta-sdk = { version = "0.20.24", features = [
   "vp",
 ] }
 reqwest = { version = "0.13", features = ["json"] }
+# Held at 2.x by the OpenPGP stack: pgp 0.20 and openpgp-card-rpgp 0.8 both
+# declare `x25519-dalek ^2`, and we hand our `StaticSecret` straight to pgp's
+# `ecdh::SecretKey::Curve25519Legacy` — a 3.x secret is a different type there
+# and would not compile. 3.0 also moves to curve25519-dalek 5 / rand_core 0.10.
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 zeroize = "1.8"
 
 # Openpgp-Card Support
-openpgp-card = "0.6"
+openpgp-card = "0.7"
 card-backend-pcsc = "0.5"
-openpgp-card-rpgp = "0.7"
+openpgp-card-rpgp = "0.8"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,15 @@ trust-tasks-capability-client = "0.1"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-vta-sdk = { version = "0.20.6", features = [
+# Floor is 0.20.24: `protocols::members::MemberVmcBody` grew a `request_id`
+# field there, so `members.rs`'s initializer no longer builds against anything
+# older. The lock deliberately stays *at* 0.20.24 rather than the latest 0.20.x:
+# 0.20.30 requires trust-tasks-rs 0.2.51, which drags affinidi-messaging-sdk to
+# 0.18.65, whose `TrustTasksOps` dropped `acl_set` — still called by the
+# vta-sdk 0.19 line that the `vta-service` / test-mediator dev-dependencies pull
+# in, so an unpinned resolve builds the binary but breaks `cargo test`. Build
+# and install with `--locked`; lift the pin once those dev-deps move to 0.20.
+vta-sdk = { version = "0.20.24", features = [
   "session",
   "client",
   "didcomm",

--- a/deny.toml
+++ b/deny.toml
@@ -47,15 +47,6 @@ ignore = [
     # advisory. Will fall off when the upstream chains migrate to
     # rustls-pki-types/rustls-types.
     "RUSTSEC-2025-0134",
-    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml DoS vectors
-    # (quadratic duplicate-attribute check; unbounded namespace
-    # allocation) fixed in 0.41. Pulled only via the Linux clipboard
-    # stack (arboard → wl-clipboard-rs → wayland-scanner), which pins
-    # quick-xml 0.39 and parses local Wayland protocol XML at build
-    # time — never attacker-supplied input. Re-check when wayland-scanner
-    # moves to quick-xml >= 0.41.
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
     # RUSTSEC-2024-0436: paste is unmaintained. Build-time proc-macro
     # pulled transitively via vta-service/vti-common (utoipa-axum). No
     # runtime code; falls off when utoipa migrates off paste.

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -97,10 +97,10 @@ affinidi-messaging-test-mediator = "0.2"
 # In-process MockVta for the bootstrap e2e (VTI#406/#427 test-support seams).
 # `vta-service` is the VTA server crate; it carries the credential-vault
 # lifecycle tasks (receive/query/archive/delete/restore/purge) + the
-# `MockVta::start_provisionable` seams used by the e2e tests. 0.11 is the
-# line built against vta-sdk 0.19 — 0.10.25 no longer compiles against the
-# current vti-common.
-vta-service = { version = "0.11", default-features = false, features = ["test-support", "rest", "didcomm"] }
+# `MockVta::start_provisionable` seams used by the e2e tests. 0.13 is the
+# line built against vta-sdk 0.20 — 0.11 still pulled the 0.19 line, which
+# calls an `acl_set` that the current affinidi-messaging-sdk no longer has.
+vta-service = { version = "0.13", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc-core/src/config/secured_config.rs
+++ b/openvtc-core/src/config/secured_config.rs
@@ -14,12 +14,12 @@ use crate::{
     config::{Config, KeyBackend, KeyTypes, UnlockCode},
     errors::OpenVTCError,
 };
-use aes_gcm::{AeadCore, Aes256Gcm, KeyInit, aead::Aead};
+use aes_gcm::{Aes256Gcm, KeyInit, aead::Aead};
 use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
 use chrono::{DateTime, Utc};
 use hkdf::Hkdf;
 use keyring_core::Entry;
-use rand::rngs::OsRng;
+use rand::{RngCore, rngs::OsRng};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -608,7 +608,14 @@ fn derive_key(unlock: &[u8; 32], nonce: &[u8]) -> Result<Aes256Gcm, OpenVTCError
 ///
 /// Output format: `[12-byte nonce | ciphertext + auth tag]`
 pub fn unlock_code_encrypt(unlock: &[u8; 32], input: &[u8]) -> Result<Vec<u8>, OpenVTCError> {
-    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    // Fill the nonce from `rand`'s OsRng rather than aes-gcm's own
+    // `AeadCore::generate_nonce`: that helper wants an RNG from the rand_core
+    // 0.9 trait set, and this crate is pinned to rand 0.8 by the OpenPGP stack
+    // (see the `rand` entry in the workspace manifest). Same 12 random OS
+    // bytes either way.
+    let mut nonce_bytes = [0u8; NONCE_SIZE];
+    OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = aes_gcm::Nonce::from(nonce_bytes);
     let cipher = derive_key(unlock, &nonce)?;
 
     match cipher.encrypt(&nonce, input) {
@@ -638,9 +645,12 @@ pub fn unlock_code_decrypt(unlock: &[u8; 32], input: &[u8]) -> Result<Vec<u8>, O
 
     let (nonce_bytes, ciphertext) = input.split_at(NONCE_SIZE);
     // `nonce_bytes` is exactly NONCE_SIZE long (checked above + split_at), so
-    // the infallible slice→GenericArray conversion is safe. Using `.into()`
-    // avoids naming the now-deprecated `GenericArray::from_slice` path.
-    let nonce: &aes_gcm::Nonce<_> = nonce_bytes.into();
+    // the slice→array conversion cannot fail; aes-gcm 0.11's `Nonce` borrows
+    // from a fixed-size array rather than a slice.
+    let nonce_arr: &[u8; NONCE_SIZE] = nonce_bytes
+        .try_into()
+        .map_err(|_| OpenVTCError::Decrypt("Nonce is not 12 bytes".to_string()))?;
+    let nonce: &aes_gcm::Nonce<_> = nonce_arr.into();
     let cipher = derive_key(unlock, nonce_bytes)?;
 
     cipher.decrypt(nonce, ciphertext).map_err(|e| {

--- a/openvtc-core/src/members.rs
+++ b/openvtc-core/src/members.rs
@@ -73,7 +73,14 @@ pub async fn submit_member_vmc(
     mediator_did: &str,
     vc: Value,
 ) -> Result<Uuid, OpenVTCError> {
-    let body = serde_json::to_value(MemberVmcBody { vc })
+    // `request_id` closes an *approved join request* as a side effect of the
+    // delivery. Neither caller here is join-time — this is the manual "issue
+    // VMC" action and the auto-answer to a VTC `members/request-vmc` — so the
+    // delivery carries no request to close.
+    let body = serde_json::to_value(MemberVmcBody {
+        vc,
+        request_id: None,
+    })
         .map_err(|e| OpenVTCError::Config(format!("member vmc body serialize: {e}")))?;
 
     let msg_id = Uuid::new_v4();

--- a/openvtc-core/src/members.rs
+++ b/openvtc-core/src/members.rs
@@ -81,7 +81,7 @@ pub async fn submit_member_vmc(
         vc,
         request_id: None,
     })
-        .map_err(|e| OpenVTCError::Config(format!("member vmc body serialize: {e}")))?;
+    .map_err(|e| OpenVTCError::Config(format!("member vmc body serialize: {e}")))?;
 
     let msg_id = Uuid::new_v4();
     let now = Utc::now().timestamp().max(0) as u64;

--- a/openvtc-core/src/openpgp_card/crypt.rs
+++ b/openvtc-core/src/openpgp_card/crypt.rs
@@ -112,7 +112,7 @@ where
 
     card.verify_user_pin(user_pin.to_owned())
         .map_err(|_| OpenVTCError::TokenBadPin)?;
-    card.to_user_card(None)
+    card.as_user_card(None)
         .map_err(|e| OpenVTCError::Token(format!("Couldn't unlock user mode on token: {e}")))?;
 
     let binding = || touch_prompt.touch_notify();

--- a/openvtc-core/tests/config_encryption.rs
+++ b/openvtc-core/tests/config_encryption.rs
@@ -337,6 +337,50 @@ fn v2_blob_tampering_fails_decrypt() {
 }
 
 // ---------------------------------------------------------------------------
+// Known-answer vectors: on-disk format stability across crypto-crate upgrades
+//
+// Every other test here round-trips within a single build, so a change that
+// silently altered the stored layout — a different nonce length, a reordered
+// header, a KDF whose parameters moved — would still pass. These two blobs
+// were produced by the build before the aes-gcm 0.10 → 0.11 upgrade and are
+// checked in verbatim. They stand in for what is already sitting in a user's
+// OS keychain: if a future dependency bump makes these fail to decrypt, it
+// locks that user out of their config, and the failure belongs here rather
+// than on their machine.
+// ---------------------------------------------------------------------------
+
+fn unhex(s: &str) -> Vec<u8> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).expect("valid hex"))
+        .collect()
+}
+
+#[test]
+fn v1_blob_from_previous_release_still_decrypts() {
+    // [nonce(12) | ct+tag], key = HKDF-SHA256(ikm = unlock, salt = nonce).
+    let blob = unhex(
+        "7bf0396f20d789d71a928b217201718defc55d46ebc066bceb9ab64206bb6b71\
+         c77a7f02d3706613e9b9e8fc3f668cc62925fe1469d1aef5e88af2e6",
+    );
+    let unlock: [u8; 32] = core::array::from_fn(|i| i as u8);
+    let recovered = unlock_code_decrypt(&unlock, &blob).expect("v1 blob from previous release");
+    assert_eq!(recovered, b"openvtc format regression vector");
+}
+
+#[test]
+fn v2_blob_from_previous_release_still_decrypts() {
+    // [magic "OPV2" | salt(16) | nonce(12) | ct+tag], Argon2id over the salt.
+    let blob = unhex(
+        "4f505632b4c10d6b3333ae7cdd2fa944eb70a237e26fba713575548095ea1684\
+         3f66fc65ff46f10426d3e839f4a1888dca1b7b10a91801de9d65b8686edc1291b1",
+    );
+    let recovered = passphrase_decrypt(b"correct horse battery staple", b"kat", &blob)
+        .expect("v2 blob from previous release");
+    assert_eq!(recovered, b"openvtc v2 vector");
+}
+
+// ---------------------------------------------------------------------------
 // Export → import round-trip (task R1).
 //
 // `Config::export` writes a v2 blob (`passphrase_encrypt_v2`, OPV2 magic +

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -32,7 +32,7 @@ anyhow.workspace = true
 # spawn the binary or re-run a VTA bootstrap. The signer now ships from its
 # own repo (OpenVTC/verifiable-git-infrastructure); openvtc is a downstream
 # consumer of the published crate.
-did-git-sign = "0.1"
+did-git-sign = "0.4"
 base64.workspace = true
 byteorder.workspace = true
 chrono.workspace = true

--- a/openvtc/src/state_handler/setup_sequence/did_keys.rs
+++ b/openvtc/src/state_handler/setup_sequence/did_keys.rs
@@ -66,8 +66,8 @@ pub fn export_persona_did_keys(
 
     let mut signing_key = SecretKey::new(
         sk_pk.clone(),
-        SecretParams::Plain(PlainSecretParams::Ed25519Legacy(
-            crypto::ed25519::SecretKey::try_from_bytes(
+        SecretParams::Plain(PlainSecretParams::EdDSALegacy(
+            crypto::eddsa_legacy::SecretKey::Ed25519(crypto::ed25519::SecretKey::try_from_bytes(
                 *keys
                     .signing
                     .secret
@@ -75,7 +75,7 @@ pub fn export_persona_did_keys(
                     .first_chunk::<32>()
                     .ok_or_else(|| anyhow::anyhow!("Signing private key is not 32 bytes"))?,
                 Mode::EdDSALegacy,
-            )?,
+            )?),
         )),
     )?;
 
@@ -137,8 +137,8 @@ pub fn export_persona_did_keys(
 
     let mut auth_key = SecretSubkey::new(
         ak_pk.clone(),
-        SecretParams::Plain(PlainSecretParams::Ed25519Legacy(
-            crypto::ed25519::SecretKey::try_from_bytes(
+        SecretParams::Plain(PlainSecretParams::EdDSALegacy(
+            crypto::eddsa_legacy::SecretKey::Ed25519(crypto::ed25519::SecretKey::try_from_bytes(
                 *keys
                     .authentication
                     .secret
@@ -146,7 +146,7 @@ pub fn export_persona_did_keys(
                     .first_chunk::<32>()
                     .ok_or_else(|| anyhow::anyhow!("Authentication private key is not 32 bytes"))?,
                 Mode::EdDSALegacy,
-            )?,
+            )?),
         )),
     )?;
 
@@ -172,7 +172,7 @@ pub fn export_persona_did_keys(
         PublicKeyAlgorithm::ECDH,
         Timestamp::now(),
         None,
-        PublicParams::ECDH(EcdhPublicParams::Curve25519 {
+        PublicParams::ECDH(EcdhPublicParams::Curve25519Legacy {
             p: x25519_dalek::PublicKey::from(
                 *keys
                     .decryption
@@ -190,7 +190,7 @@ pub fn export_persona_did_keys(
     let mut dec_key = SecretSubkey::new(
         dk_pk.clone(),
         SecretParams::Plain(PlainSecretParams::ECDH(
-            crypto::ecdh::SecretKey::Curve25519(
+            crypto::ecdh::SecretKey::Curve25519Legacy(
                 StaticSecret::from(
                     *keys
                         .decryption

--- a/openvtc/src/state_handler/setup_sequence/openpgp_card.rs
+++ b/openvtc/src/state_handler/setup_sequence/openpgp_card.rs
@@ -59,7 +59,7 @@ pub fn write_keys_to_card(
             .as_ref()
             .clone(),
     )?;
-    let mut card = open_card.to_admin_card(None)?;
+    let mut card = open_card.as_admin_card(None)?;
     if let Some(last) = state.setup.token_reset.messages.last_mut() {
         *last = MessageType::Info("✓ Unlocked token in admin mode".to_string());
     }
@@ -71,7 +71,7 @@ pub fn write_keys_to_card(
     ));
     let _ = action_tx.send(state.clone());
     let uk = create_pgp_secret_packet(&keys.signing, KeyPurpose::Signing)?;
-    card.import_key(Box::new(uk), KeyType::Signing)?;
+    card.import_key(&uk, KeyType::Signing)?;
     if let Some(last) = state.setup.token_reset.messages.last_mut() {
         *last = MessageType::Info("✓ Signing key written to token".to_string());
     }
@@ -81,7 +81,7 @@ pub fn write_keys_to_card(
     ));
     let _ = action_tx.send(state.clone());
     let uk = create_pgp_secret_packet(&keys.authentication, KeyPurpose::Authentication)?;
-    card.import_key(Box::new(uk), KeyType::Authentication)?;
+    card.import_key(&uk, KeyType::Authentication)?;
     if let Some(last) = state.setup.token_reset.messages.last_mut() {
         *last = MessageType::Info("✓ Authentication key written to token".to_string());
     }
@@ -91,7 +91,7 @@ pub fn write_keys_to_card(
     ));
     let _ = action_tx.send(state.clone());
     let uk = create_pgp_secret_packet(&keys.decryption, KeyPurpose::Encryption)?;
-    card.import_key(Box::new(uk), KeyType::Decryption)?;
+    card.import_key(&uk, KeyType::Decryption)?;
     if let Some(last) = state.setup.token_reset.messages.last_mut() {
         *last = MessageType::Info("✓ Decryption key written to token".to_string());
     }
@@ -125,16 +125,18 @@ fn create_pgp_secret_packet(key: &KeyInfo, kp: KeyPurpose) -> Result<UploadableK
             )?;
 
             // Create SecretParams
-            let sp = SecretParams::Plain(PlainSecretParams::Ed25519Legacy(
-                crypto::ed25519::SecretKey::try_from_bytes(
-                    *key.secret
-                        .get_private_bytes()
-                        .first_chunk::<32>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!("Private key bytes shorter than 32 bytes")
-                        })?,
-                    Mode::EdDSALegacy,
-                )?,
+            let sp = SecretParams::Plain(PlainSecretParams::EdDSALegacy(
+                crypto::eddsa_legacy::SecretKey::Ed25519(
+                    crypto::ed25519::SecretKey::try_from_bytes(
+                        *key.secret
+                            .get_private_bytes()
+                            .first_chunk::<32>()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("Private key bytes shorter than 32 bytes")
+                            })?,
+                        Mode::EdDSALegacy,
+                    )?,
+                ),
             ));
 
             (pk, sp)
@@ -162,16 +164,18 @@ fn create_pgp_secret_packet(key: &KeyInfo, kp: KeyPurpose) -> Result<UploadableK
             )?;
 
             // Create SecretParams
-            let sp = SecretParams::Plain(PlainSecretParams::Ed25519Legacy(
-                crypto::ed25519::SecretKey::try_from_bytes(
-                    *key.secret
-                        .get_private_bytes()
-                        .first_chunk::<32>()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!("Private key bytes shorter than 32 bytes")
-                        })?,
-                    Mode::EdDSALegacy,
-                )?,
+            let sp = SecretParams::Plain(PlainSecretParams::EdDSALegacy(
+                crypto::eddsa_legacy::SecretKey::Ed25519(
+                    crypto::ed25519::SecretKey::try_from_bytes(
+                        *key.secret
+                            .get_private_bytes()
+                            .first_chunk::<32>()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("Private key bytes shorter than 32 bytes")
+                            })?,
+                        Mode::EdDSALegacy,
+                    )?,
+                ),
             ));
 
             (pk, sp)
@@ -194,7 +198,7 @@ fn create_pgp_secret_packet(key: &KeyInfo, kp: KeyPurpose) -> Result<UploadableK
                 PublicKeyAlgorithm::ECDH,
                 Timestamp::now(),
                 key.expiry.map(|e| e.num_days() as u16),
-                PublicParams::ECDH(EcdhPublicParams::Curve25519 {
+                PublicParams::ECDH(EcdhPublicParams::Curve25519Legacy {
                     p: x25519_pk,
                     hash: crypto::hash::HashAlgorithm::Sha256,
                     alg_sym: crypto::sym::SymmetricKeyAlgorithm::AES256,
@@ -204,7 +208,7 @@ fn create_pgp_secret_packet(key: &KeyInfo, kp: KeyPurpose) -> Result<UploadableK
 
             // Create SecretParams
             let sp = SecretParams::Plain(PlainSecretParams::ECDH(
-                crypto::ecdh::SecretKey::Curve25519(x25519_sk.into()),
+                crypto::ecdh::SecretKey::Curve25519Legacy(x25519_sk.into()),
             ));
 
             (pk, sp)
@@ -233,7 +237,7 @@ pub fn set_signing_touch_policy(
             .as_ref()
             .clone(),
     )?;
-    let mut card = open_card.to_admin_card(None)?;
+    let mut card = open_card.as_admin_card(None)?;
 
     state.setup.token_set_touch.messages.push(MessageType::Info(
         "Setting touch policy on signing key...".to_string(),
@@ -268,7 +272,7 @@ pub fn set_cardholder_name(
             .as_ref()
             .clone(),
     )?;
-    let mut card = open_card.to_admin_card(None)?;
+    let mut card = open_card.as_admin_card(None)?;
 
     state
         .setup


### PR DESCRIPTION
Fixes a build break, then brings the whole dependency graph to its latest
compatible release.

## 1. The build break

`cargo install --path openvtc` failed:

```
error[E0063]: missing field `request_id` in initializer of `MemberVmcBody`
  --> openvtc-core/src/members.rs:76:37
```

`cargo install --path` ignores `Cargo.lock` and re-resolves, so it picked up a
vta-sdk newer than the locked 0.20.6. Between 0.20.17 and 0.20.24 the SDK added
`protocols::members::MemberVmcBody::request_id`, leaving our struct literal
incomplete.

`request_id: None` is the correct value. The field closes an *approved join
request* as a side effect of the VMC delivery (the retired
`join-requests/accept` semantics), and neither caller is join-time — one is the
manual "issue VMC" action, the other the auto-answer to a VTC
`members/request-vmc`. Floor raised to 0.20.24.

## 2. Full dependency refresh

`cargo update` moved 48 packages: vta-sdk 0.20.24 → 0.20.30, trust-tasks-rs
0.2.43 → 0.2.51, affinidi-messaging-sdk 0.18.60 → 0.18.65, plus the resolver /
TDK / TSP / mediator crates alongside them.

Manifest floors raised:

| Crate | From | To | Source changes |
|---|---|---|---|
| `vta-service` (dev) | 0.11 | 0.13 | none |
| `did-git-sign` | 0.1 | 0.4 | none |
| `base64` | 0.22 | 0.23 | none |
| `pgp` | 0.19 | 0.20 | renames |
| `openpgp-card` | 0.6 | 0.7 | renames |
| `openpgp-card-rpgp` | 0.7 | 0.8 | renames |
| `aes-gcm` | 0.10 | 0.11 | nonce construction |

**`vta-service` 0.11 → 0.13** is what unblocked the rest. The 0.11 line pulled
vta-sdk 0.19, which calls a `TrustTasksOps::acl_set` that
affinidi-messaging-sdk 0.18.65 no longer has — that combination is why the lock
was initially held at vta-sdk 0.20.24. The MockVta harness needed no changes.

**The OpenPGP trio** moves as a set. Every call-site change is a rename:
`PlainSecretParams::Ed25519Legacy` → `EdDSALegacy` wrapping the new
`eddsa_legacy::SecretKey`; ECDH `Curve25519` → `Curve25519Legacy` on both the
public params and the secret key; `to_user_card` / `to_admin_card` → `as_*`;
`import_key` now borrows the uploadable key instead of taking a `Box`.

**`aes-gcm` 0.11** wants an RNG from the rand_core 0.9 trait set for
`AeadCore::generate_nonce`, and its `Nonce` borrows a fixed-size array rather
than a slice. Rather than split the RNG stack, the single nonce site now fills
12 bytes from `rand`'s `OsRng` directly — same OS entropy, no new dependency.

### Held back, deliberately

`rand` stays at 0.8 and `x25519-dalek` at 2.x. pgp 0.20 still declares
`rand ^0.8.6` and `x25519-dalek ^2`, and we hand it both an `OsRng` and a
`StaticSecret` directly, so the trait sets and types have to agree. The manifest
comments now carry that re-evaluation instead of the stale 2026-06-03 one.

## Format-stability tests

Two new known-answer tests in `config_encryption.rs` decrypt v1 and v2 blobs
generated by the **pre-upgrade** build. Every existing test round-trips within a
single build, so a bump that silently changed the stored layout would still have
passed — these stand in for what is already sitting in a user's OS keychain.
Both pass, so aes-gcm 0.11 is byte-compatible with what shipped.

## deny.toml

Dropped the `RUSTSEC-2026-0194` / `-0195` ignores: the update carries quick-xml
to 0.41, where both DoS advisories are fixed, and `cargo deny` now warns that
the ignores match nothing.

## Verification

- `cargo build --workspace --locked` — clean
- `cargo clippy --workspace --all-targets` — clean, no warnings
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — all pass, including the 2 new KAT tests (the 4
  ignored suites are the pre-existing `#[ignore]` mediator tests)
- `cargo deny check` — advisories / bans / licenses / sources all ok
- `cargo doc --workspace --no-deps` — no warnings
- `cargo install --path openvtc --locked` — succeeds, binary replaced

## vti-stack-development-guide pre-merge checklist

No outbound service call is added or changed — dependency versions, one struct
field, and mechanical API renames. R1.2 / R1.4 / R6.4 are unaffected. R3.6 is
what this PR is: the SDK surface moved underneath us, and the pinned lockfile
had been hiding it.
