### PR TITLE
chore(deps): vta-sdk 0.21.11 — provisioning speaks the 0.2 wire tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276d0db4e6424387c7340fccc0609df1c1e4e1fd12502b90d24d4ab3ceaa717d"
+checksum = "aed8bc60621324d13d4d44648433e14909c0826efecd930f6782f0393343954c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -865,7 +865,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2723,7 +2723,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3025,7 +3025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4920,7 +4920,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5451,7 +5451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6224,7 +6224,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6791,7 +6791,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6858,7 +6858,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7492,7 +7492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7704,7 +7704,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7717,7 +7717,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8746,9 +8746,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456716fe80d4a904d17fb841698db36375d53a6a70e2544c433ca0c6d4648f7"
+checksum = "a86c69345fc067ff2ec56d8e094fbfaf2a6c5e7879f80dafc11141938b9d4ad2"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8792,9 +8792,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b21d4e74ba9c75f1c2ea038d35ca4a83a992f0c43652d0f69092375c55d5107d"
+checksum = "810f97bf57e4908e6145059bada6a5208830bb405f7c0d965c121ae794ab424b"
 dependencies = [
  "aes-gcm 0.10.3",
  "affinidi-crypto",
@@ -9416,7 +9416,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,14 @@ affinidi-messaging-delivery = "0.1.12"
 # 0.1.5 the enum is exhaustively matched already and that arm is an
 # unreachable pattern, which `-D warnings` rejects.
 affinidi-messaging-core = "0.1.6"
-affinidi-messaging-sdk = "0.19.2"
+# Floor is 0.19.4 (affinidi-tdk-rs #694, shipped alongside VTI #917):
+# `live_stream_next*` held a read guard on `ws_channel_tx` across its wait while
+# `stop_websocket` needs the write guard, so an in-flight poll blocked shutdown
+# until the poll window elapsed. The delivery layer's window is 10s and its
+# inbound pump reads ahead after every frame, so quitting the TUI mid-window
+# paid the remainder. Left at `0.19.2` a clean checkout could resolve back onto
+# the stall.
+affinidi-messaging-sdk = "0.19.4"
 # `StreamExt::next` on the `BoxStream` returned by `MessagingService::subscribe`.
 futures-util = "0.3"
 # Agent names (DID shortcuts). `agent-names` carries the parse /
@@ -133,7 +140,15 @@ trust-tasks-capability-client = "0.3"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-# The 0.21 line, floored at 0.21.10: that is the release that moved its own
+# The 0.21 line, floored at 0.21.11: that release makes `BootstrapAsk`
+# serialise the `provision/integration/0.2` camelCase ask tags
+# (`adminRotation` / `templateBootstrap`). Up to 0.21.10 it emitted the 0.1
+# PascalCase spellings while submitting under the 0.2 type URI, and the VTA's
+# payload-schema gate rejected every provisioning request — setup could not get
+# past "Provision integration DID + admin credential" (VTI #917). Nothing here
+# had a lever over that casing, so the floor is the fix.
+#
+# 0.21.10 remains the floor's other reason: it is the release that moved its own
 # `trust-tasks-rs` requirement to `^0.4`. An earlier 0.21.x still asks for
 # `^0.2.55`, which would resolve a second trust-tasks in the graph alongside
 # ours and break `TrustTask` type unification across the sdk boundary.
@@ -141,7 +156,7 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # `protocols::members::MemberVmcBody`'s `request_id` field once set, and the
 # 0.20.6 floor the TSP leg set (see the `tsp` feature note below) — both
 # predate this major and neither can be un-met from here.
-vta-sdk = { version = "0.21.10", features = [
+vta-sdk = { version = "0.21.11", features = [
   "session",
   "client",
   "didcomm",


### PR DESCRIPTION
Setup could not get past **"Provision integration DID + admin credential"** — the VTA rejected every request:

```
malformed request: payload does not conform to
https://trusttasks.org/spec/provision/integration/0.2:
{"adminTemplate":{"name":"vta-admin","vars":{}},"contextHint":"openvtc",
 "note":"openvtc","type":"AdminRotation"}
is not valid under any of the schemas listed in the 'oneOf' keyword
```

`vta-sdk` submitted under the `provision/integration/**0.2**` type URI while `BootstrapAsk` still serialised the **0.1** PascalCase ask tags. The two schemas differ in exactly that constant — 0.1 requires `AdminRotation`, 0.2 requires `adminRotation` — so the VTA's payload-schema gate refused the payload before the handler ran. Nothing on this side had a lever over it: the ask is built and serialised inside `vta_sdk::provision_client`.

Fixed upstream in [VTI #917](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/917). This is the dependency bump that picks it up — no code change here, as that PR anticipated.

## What moves

| crate | | why |
|---|---|---|
| `vta-sdk` | 0.21.10 → **0.21.11** | the fix — variants get `rename_all = "camelCase"`, PascalCase kept as inbound **aliases** so a 0.1 holder that signed the old tag still verifies |
| `vta-service` (dev-dep) | 0.14.23 → **0.14.24** | the paired server: its trust-task handler now verifies the raw `doc.payload["request"]` via `verify_value` instead of re-serialising the typed struct, so client and server casing no longer have to agree. Moved so MockVta exercises the server this client is actually meant to talk to |
| `affinidi-messaging-sdk` | 0.19.3 → **0.19.4** | floor raised — see below |

`trust-tasks-rs` **stays at `0.4`**. 0.21.11 still declares `^0.4`, so the graph keeps exactly one `TrustTask` and the type unification across the sdk boundary holds. Lockfile churn is these three crates and nothing else.

### The `affinidi-messaging-sdk` floor

0.19.4 carries [affinidi-tdk-rs#694](https://github.com/affinidi/affinidi-tdk-rs/pull/694), released alongside #917: `live_stream_next*` held a **read** guard on `ws_channel_tx` across its wait while `stop_websocket` needs the **write** guard, so an in-flight poll blocked shutdown until the poll window elapsed. That window is 10s for the delivery layer, whose inbound pump issues a read-ahead after every frame — so quitting the TUI mid-window paid the remainder.

The old `0.19.2` caret already admitted 0.19.4 and the lock was on 0.19.3; raising the declared floor is what stops a clean checkout resolving back onto the stall.

## Verification

- `cargo build --workspace --all-features` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo test --workspace --all-features` ✅ (0 failures)
- `cargo fmt --all --check` ✅
- `cargo deny check` ✅ advisories / bans / licenses / sources
- `admin_rotation_provisions_against_mock_vta` (ignored, run explicitly) ✅

**But that e2e does not cover this regression, and it is worth saying so plainly.** `provision_admin_rotated_via_rest` posts to the legacy `/bootstrap/provision-integration` REST route, which never reaches `dispatch_trust_task_core` — where the schema gate lives. That is precisely why the bug shipped uncaught on this side. The failing path was the TSP-carried 0.2 trust task.

So the green e2e is not the evidence. The evidence is the wire change in the pulled crates:

- `vta-sdk-0.21.11/src/provision_integration/request.rs:90` — `#[serde(tag = "type", rename_all = "camelCase")]`, with `#[serde(alias = "AdminRotation")]` / `alias = "TemplateBootstrap"` preserved inbound.
- `vta-service-0.14.24/src/trust_tasks/provision_integration.rs:71` — `BootstrapRequest::verify_value(request_raw)`.

Real confirmation is a setup run against the redeployed VTA.

## Follow-up worth filing

The gap the e2e leaves is a genuine coverage hole, not a one-off: the only provisioning path we test end-to-end is the legacy REST route, while the path the wizard actually takes (TSP-carried trust task, through the dispatcher and its schema gate) has no e2e at all. Happy to open an issue for a MockVta trust-task provisioning test if you want it tracked.
