### PR TITLE
fix(setup): reopen the bootstrap transport, don't fall back to REST

### DIFF
--- a/openvtc/src/state_handler/setup_sequence/mod.rs
+++ b/openvtc/src/state_handler/setup_sequence/mod.rs
@@ -161,14 +161,16 @@ pub struct VtaSetupState {
     /// `admin_did` becomes the new `credential_did` and the matching private
     /// key is what `challenge_response` re-authenticates with.
     pub admin_credential: Option<AdminCredentialReply>,
-    /// Transport the bootstrap actually used. `Some(Protocol::DidComm)` means
-    /// downstream calls must reuse DIDComm (the VTA may not advertise REST at
-    /// all); `Some(Protocol::Rest)` means REST. `None` until provisioning
-    /// completes.
+    /// Transport the bootstrap actually used. `Some(Protocol::Tsp)` /
+    /// `Some(Protocol::DidComm)` mean downstream calls must reuse that
+    /// transport — the VTA may advertise no REST service at all, in which case
+    /// there is no URL to fall back to; `Some(Protocol::Rest)` means REST.
+    /// `None` until provisioning completes.
     pub protocol: Option<Protocol>,
-    /// DIDComm mediator DID, captured from `VtaEvent::Connected` when the
-    /// chosen transport is DIDComm. Required to open further DIDComm sessions
-    /// post-bootstrap.
+    /// Mediator DID that carried the bootstrap, captured from
+    /// `VtaEvent::Connected`: the `#tsp` mediator when the chosen transport is
+    /// TSP, the `#DIDCommMessaging` one when it is DIDComm. Required to open
+    /// further sessions on either transport post-bootstrap; `None` on REST.
     pub mediator_did: Option<String>,
 }
 

--- a/openvtc/src/state_handler/setup_vta_actions.rs
+++ b/openvtc/src/state_handler/setup_vta_actions.rs
@@ -24,6 +24,42 @@ fn vta_url_override() -> Option<String> {
     normalize_url_override(std::env::var(VTA_URL_OVERRIDE_ENV).ok())
 }
 
+/// How the post-bootstrap `VtaClient` must authenticate, given the transport
+/// the bootstrap actually completed on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PostBootstrapAuth {
+    /// Reopen the mediator-backed session (TSP or DIDComm) as the rotated admin
+    /// DID. The session's proven sender identity *is* the authentication.
+    Session(Protocol),
+    /// REST challenge-response against the advertised base URL.
+    Rest,
+    /// REST with nothing to talk to — the VTA advertises no `#vta-rest`
+    /// service, so there is no base URL to authenticate against.
+    RestWithoutUrl,
+}
+
+/// Pure core of the post-bootstrap transport decision.
+///
+/// Deliberately matches `Protocol` exhaustively, with no wildcard arm: a
+/// wildcard is what silently routed the TSP bootstrap into REST auth, where the
+/// empty base URL became reqwest's opaque "builder error". Adding a transport
+/// upstream should break this build, not quietly fall back to REST.
+fn post_bootstrap_auth(protocol: Option<Protocol>, has_rest_url: bool) -> PostBootstrapAuth {
+    match protocol {
+        Some(Protocol::Tsp) => PostBootstrapAuth::Session(Protocol::Tsp),
+        Some(Protocol::DidComm) => PostBootstrapAuth::Session(Protocol::DidComm),
+        // `None` means provisioning never reported a transport. It only reaches
+        // here on the URL-direct override path, which is REST by construction.
+        Some(Protocol::Rest) | None => {
+            if has_rest_url {
+                PostBootstrapAuth::Rest
+            } else {
+                PostBootstrapAuth::RestWithoutUrl
+            }
+        }
+    }
+}
+
 /// Pure core of [`vta_url_override`]: trim and drop blank/whitespace-only
 /// values so an exported-but-empty env var reads as unset.
 fn normalize_url_override(raw: Option<String>) -> Option<String> {
@@ -304,27 +340,34 @@ pub(crate) async fn handle_vta_start_provision(
     state.setup.vta.mediator_did = connect_mediator_did;
 
     // Build the post-bootstrap VtaClient on the same transport the bootstrap
-    // chose. REST → challenge-response auth + bearer token. DIDComm → open a
-    // fresh DIDComm session as the rotated admin DID; the session itself is
-    // the auth, so no separate token round-trip is needed (and indeed there
-    // may be no REST endpoint at all on a DIDComm-only VTA).
-    let client = match connect_protocol {
-        Some(Protocol::DidComm) => {
+    // chose. TSP and DIDComm → open a fresh session as the rotated admin DID;
+    // the session itself is the auth (both carry a proven sender identity the
+    // VTA resolves straight to its ACL grant), so no separate token round-trip
+    // is needed. REST → challenge-response auth + bearer token.
+    //
+    // Both mediator-backed transports MUST be handled explicitly. Falling
+    // through to the REST arm on a VTA that advertises no `#vta-rest` service
+    // leaves `vta_url` empty, and the SDK's `format!("{base_url}/auth/challenge")`
+    // then yields the relative `/auth/challenge`, which reqwest rejects as an
+    // opaque "builder error" — the bootstrap succeeds and the very next step
+    // fails with no hint that the transport was the problem.
+    let client = match post_bootstrap_auth(connect_protocol, !state.setup.vta.vta_url.is_empty()) {
+        PostBootstrapAuth::Session(transport) => {
+            let label = transport.label();
             let mediator = match state.setup.vta.mediator_did.clone() {
                 Some(m) => m,
                 None => {
-                    state.setup.vta.messages.push(MessageType::Error(
-                        "DIDComm transport selected but no mediator DID was advertised."
-                            .to_string(),
-                    ));
+                    state.setup.vta.messages.push(MessageType::Error(format!(
+                        "{label} transport selected but no mediator DID was advertised."
+                    )));
                     state.setup.vta.completed = Completion::CompletedFail;
                     let _ = state_tx.send(state.clone());
                     return Ok(None);
                 }
             };
-            state.setup.vta.messages.push(MessageType::Info(
-                "Opening DIDComm session as rotated admin DID…".to_string(),
-            ));
+            state.setup.vta.messages.push(MessageType::Info(format!(
+                "Opening {label} session as rotated admin DID…"
+            )));
             let _ = state_tx.send(state.clone());
 
             let rest_fallback = if state.setup.vta.vta_url.is_empty() {
@@ -332,26 +375,37 @@ pub(crate) async fn handle_vta_start_provision(
             } else {
                 Some(state.setup.vta.vta_url.clone())
             };
-            match VtaClient::connect_didcomm(
-                &admin.admin_did,
-                &admin.admin_private_key_mb,
-                &vta_did,
-                &mediator,
-                rest_fallback,
-            )
-            .await
-            {
+            let opened = if transport == Protocol::Tsp {
+                VtaClient::connect_tsp(
+                    &admin.admin_did,
+                    &admin.admin_private_key_mb,
+                    &vta_did,
+                    &mediator,
+                    rest_fallback,
+                )
+                .await
+            } else {
+                VtaClient::connect_didcomm(
+                    &admin.admin_did,
+                    &admin.admin_private_key_mb,
+                    &vta_did,
+                    &mediator,
+                    rest_fallback,
+                )
+                .await
+            };
+            match opened {
                 Ok(c) => {
                     state.setup.vta.authenticated = true;
                     state.setup.vta.admin_credential = Some(admin.clone());
-                    state.setup.vta.messages.push(MessageType::Info(
-                        "DIDComm session established with VTA.".to_string(),
-                    ));
+                    state.setup.vta.messages.push(MessageType::Info(format!(
+                        "{label} session established with VTA."
+                    )));
                     c
                 }
                 Err(e) => {
                     state.setup.vta.messages.push(MessageType::Error(format!(
-                        "DIDComm session open failed: {e}"
+                        "{label} session open failed: {e}"
                     )));
                     state.setup.vta.completed = Completion::CompletedFail;
                     let _ = state_tx.send(state.clone());
@@ -359,7 +413,20 @@ pub(crate) async fn handle_vta_start_provision(
                 }
             }
         }
-        _ => {
+        PostBootstrapAuth::RestWithoutUrl => {
+            // Say this plainly rather than letting the SDK build a relative
+            // `/auth/challenge` and surface reqwest's "builder error", which
+            // names neither the URL nor the transport.
+            state.setup.vta.messages.push(MessageType::Error(
+                "REST transport selected but the VTA DID document advertises no \
+                 `#vta-rest` service, so there is no URL to authenticate against."
+                    .to_string(),
+            ));
+            state.setup.vta.completed = Completion::CompletedFail;
+            let _ = state_tx.send(state.clone());
+            return Ok(None);
+        }
+        PostBootstrapAuth::Rest => {
             state
                 .setup
                 .vta
@@ -507,7 +574,66 @@ pub(crate) async fn handle_vta_create_keys(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_url_override;
+    use super::{PostBootstrapAuth, Protocol, normalize_url_override, post_bootstrap_auth};
+
+    /// The regression: a TSP bootstrap must reopen a TSP session, never fall
+    /// back to REST auth. It used to land in the REST arm, and on a VTA with no
+    /// `#vta-rest` service the empty base URL produced reqwest's "builder
+    /// error" at `/auth/challenge` immediately after provisioning succeeded.
+    #[test]
+    fn tsp_bootstrap_reopens_a_tsp_session() {
+        assert_eq!(
+            post_bootstrap_auth(Some(Protocol::Tsp), false),
+            PostBootstrapAuth::Session(Protocol::Tsp)
+        );
+    }
+
+    /// A mediator-backed transport is authenticated by the session itself, so
+    /// the presence of a REST URL must not divert it — the URL is only ever a
+    /// fallback handed to the client, never a reason to switch transports.
+    #[test]
+    fn an_advertised_rest_url_does_not_divert_a_session_transport() {
+        assert_eq!(
+            post_bootstrap_auth(Some(Protocol::Tsp), true),
+            PostBootstrapAuth::Session(Protocol::Tsp)
+        );
+        assert_eq!(
+            post_bootstrap_auth(Some(Protocol::DidComm), true),
+            PostBootstrapAuth::Session(Protocol::DidComm)
+        );
+    }
+
+    #[test]
+    fn didcomm_bootstrap_reopens_a_didcomm_session() {
+        assert_eq!(
+            post_bootstrap_auth(Some(Protocol::DidComm), false),
+            PostBootstrapAuth::Session(Protocol::DidComm)
+        );
+    }
+
+    #[test]
+    fn rest_uses_challenge_response_when_a_url_was_advertised() {
+        assert_eq!(
+            post_bootstrap_auth(Some(Protocol::Rest), true),
+            PostBootstrapAuth::Rest
+        );
+        // `None` is the URL-direct override path, REST by construction.
+        assert_eq!(post_bootstrap_auth(None, true), PostBootstrapAuth::Rest);
+    }
+
+    /// REST with no advertised URL is a distinct, nameable failure rather than
+    /// an attempt that dies inside reqwest.
+    #[test]
+    fn rest_without_a_url_is_its_own_outcome() {
+        assert_eq!(
+            post_bootstrap_auth(Some(Protocol::Rest), false),
+            PostBootstrapAuth::RestWithoutUrl
+        );
+        assert_eq!(
+            post_bootstrap_auth(None, false),
+            PostBootstrapAuth::RestWithoutUrl
+        );
+    }
 
     #[test]
     fn override_unset_is_none() {


### PR DESCRIPTION
Bootstrap over TSP succeeded — admin DID rotated, bundle sealed, the VTA logging `TSP trust-task dispatched … status=200 OK` — and setup died on the very next step:

```
✔ Provision integration DID + admin credential — admin DID rotated: did:key:z6MktZ… (via vta-admin)

  Authenticating with VTA…
  ERROR: Authentication failed: VTA authentication failed:
         could not connect to VTA at /auth/challenge: builder error
```

## What was wrong

The post-bootstrap `VtaClient` is built by matching on the transport the bootstrap actually completed with — but only `Protocol::DidComm` had an arm:

```rust
let client = match connect_protocol {
    Some(Protocol::DidComm) => { /* reopen the session */ }
    _ => { /* REST challenge-response against vta.vta_url */ }   // ← TSP landed here
};
```

`Protocol::Tsp` fell through the wildcard into the REST branch. This VTA advertises no `#vta-rest` service (the diagnostics row reads `TSP: yes, REST: no`), so `VtaEvent::Connected` carried `rest_url: None`, `vta_url` stayed empty, and the SDK's `format!("{base_url}/auth/challenge")` produced the relative `/auth/challenge` — which reqwest rejects as an opaque **`builder error`**, naming neither the missing host nor the transport.

The bootstrap had already done the hard part over TSP. Only the step that reuses that transport was unaware TSP existed.

## The fix

- **TSP reopens a TSP session** as the rotated admin DID via `VtaClient::connect_tsp`, exactly as DIDComm already did. Neither needs a token round-trip: both carry a cryptographically proven sender identity that the VTA resolves straight to its ACL grant — which is precisely why a VTA reachable over them need not expose REST at all.
- **The wildcard is gone**, because the wildcard *is* the defect. `post_bootstrap_auth` is a pure function that matches `Protocol` exhaustively; adding a transport upstream now breaks this build instead of quietly routing it to REST.
- **`RestWithoutUrl` is a named outcome.** "REST chosen, no endpoint advertised" now fails with a sentence saying so, rather than dying inside reqwest — [R1.2/R6.4](../design-docs/vti-stack-development-guide.md): an operator must be able to tell a missing endpoint from an unreachable one.
- Corrects the `protocol` / `mediator_did` doc comments, which predated TSP and described a DIDComm-or-REST world.

## Tests

Five new cases against `post_bootstrap_auth`, the pure decision core:

| test | pins |
|---|---|
| `tsp_bootstrap_reopens_a_tsp_session` | the exact regression — TSP, no REST URL |
| `an_advertised_rest_url_does_not_divert_a_session_transport` | a REST URL is a fallback to hand the client, never a reason to switch transports |
| `didcomm_bootstrap_reopens_a_didcomm_session` | the arm that already worked stays working |
| `rest_uses_challenge_response_when_a_url_was_advertised` | REST, and the `None` URL-direct override path |
| `rest_without_a_url_is_its_own_outcome` | the failure is nameable, not a reqwest error |

Full run: build ✅, `clippy --all-targets --all-features -D warnings` ✅, `fmt --check` ✅, `cargo test --workspace --all-features` ✅ (16 binaries, 0 failures).

## What this does not cover

**The tests cover the routing decision, not the live TSP session open.** The only provisioning e2e in this repo drives `provision_admin_rotated_via_rest`, which posts to the legacy `/bootstrap/provision-integration` REST route — so no test here exercises a TSP bootstrap end to end.

That is the same gap called out in #206, and this is now the second transport-layer bug it has let through to a live setup run. Worth closing with a MockVta test that provisions over the trust-task path; happy to open an issue.

Real confirmation is a setup run against a TSP-only VTA.
