### PR TITLE
fix(deps): vta-sdk 0.21.12 — key creation works over DIDComm and TSP again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -876,7 +876,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2723,7 +2723,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3025,7 +3025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4920,7 +4920,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5451,7 +5451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6224,7 +6224,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6791,7 +6791,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6858,7 +6858,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7492,7 +7492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7704,7 +7704,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7717,7 +7717,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8746,9 +8746,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86c69345fc067ff2ec56d8e094fbfaf2a6c5e7879f80dafc11141938b9d4ad2"
+checksum = "63a3d95e4178a0b0c6d71a5191d08b8deee14bcc736678f445c0a540917c4f17"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9416,7 +9416,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,10 @@ trust-tasks-capability-client = "0.3"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-# The 0.21 line, floored at 0.21.11: that release makes `BootstrapAsk`
+# The 0.21 line, floored at 0.21.12. Each floor below is a defect this repo had
+# no lever over, kept in order because none of them can be un-met from here.
+#
+# 0.21.11 makes `BootstrapAsk`
 # serialise the `provision/integration/0.2` camelCase ask tags
 # (`adminRotation` / `templateBootstrap`). Up to 0.21.10 it emitted the 0.1
 # PascalCase spellings while submitting under the 0.2 type URI, and the VTA's
@@ -156,7 +159,18 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # `protocols::members::MemberVmcBody`'s `request_id` field once set, and the
 # 0.20.6 floor the TSP leg set (see the `tsp` feature note below) — both
 # predate this major and neither can be un-met from here.
-vta-sdk = { version = "0.21.11", features = [
+#
+# 0.21.12 is the current floor, and it is the same class of defect one layer
+# down: `CreateKeyBody` serialized its unset members as `null`, and
+# `keys/create/0.1` types them `"string"`, so the VTA refused every key
+# creation over DIDComm and TSP (VTI #919). Joining a community mints a
+# persona's signing key first, so a join died on its first round-trip with
+# `malformedRequest … null is not of type "string"` and rolled back. REST was
+# unaffected — it serializes a different struct, which already skipped its
+# `None`s — so only the transports this CLI actually prefers were broken.
+# Nothing here had a lever over that either: the payload is built inside the
+# sdk's own `create_key`.
+vta-sdk = { version = "0.21.12", features = [
   "session",
   "client",
   "didcomm",


### PR DESCRIPTION
Joining a community died on its first round-trip:

```text
INFO: Joining did:webvh:QmXi1PZD4NEvcvjfErAzVoCGtBFEv7dhXZQJHvcFY4U83F:webvh.storm.ws:first-vtc…
INFO: Creating persona keys (signing, authentication, encryption)…
ERROR: Failed to create persona keys: Failed to create signing key: protocol error:
trust task failed [malformedRequest]: malformed request: payload does not conform to
https://trusttasks.org/spec/keys/create/0.1: payload failed schema validation:
null is not of type "string"

Join failed. Nothing was activated.
```

`CreateKeyBody` serialized its unset members as `null`, and `keys/create/0.1` types `mnemonic` / `label` / `contextId` as `"string"` — none of which accepts null. The VTA's payload-schema gate therefore refused **every** key creation that did not carry a BIP-39 phrase, which is every one this CLI makes. A join mints a persona's signing key before anything else, so it failed there and rolled back.

REST was unaffected: that leg serializes `CreateKeyRequest`, which already skipped its `None`s. Only the transports this CLI actually prefers were broken, which is why this surfaced now rather than earlier.

Nothing here had a lever over it — the payload is built inside the sdk's own `create_key`. Fixed upstream in **VTI #919** (vta-sdk 0.21.12 + vta-service 0.14.25); this is the floor bump that picks it up.

## Why a floor and not just a lockfile move

The `^0.21.11` requirement already admitted 0.21.12, so a `cargo update` alone would have fixed a working copy and left a clean checkout free to resolve back onto the broken release. The floor is the fix, same as the 0.21.11 (provisioning casing, VTI #917) and 0.21.10 (`trust-tasks-rs ^0.4` unification) floors above it. The dependency comment now records all three in order.

## Verification

- `cargo build --release` — resolves 0.21.12 from crates.io with a checksum, no `[patch]`
- `cargo test` — full workspace, all green
- `cargo clippy --all-targets --all-features` — clean
- `cargo fmt --check` — clean

Not yet re-run against the live VTA; the join that produced the error above is the real check, and the same tree built with a local patch of the fix is what I have been testing with.

## Upstream follow-up

VTI #921 (stacked on #919) adds the two checks that would have caught this without a person hitting it: a source census over every wire type, and a producer census that drives the sdk's client methods with every optional argument unset and validates what they emit. The second found a further live defect on its first run.
