### PR TITLE
fix(logs): say what arrived, over which transport, and keep the record

### DIFF
--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -458,6 +458,29 @@ pub fn persona_listener_id(persona_did: &str) -> String {
 /// core (it is pure) so the protocol logic there can build its own messages.
 pub use crate::messaging::build_didcomm_message;
 
+/// Which transport carried an inbound frame.
+///
+/// A narrowed mirror of the messaging layer's `Protocol`, kept separate on
+/// purpose: `Protocol` is `#[non_exhaustive]` and grows upstream, whereas this
+/// only ever names transports OpenVTC actually decodes. A new `Protocol`
+/// variant is dropped at the pump and never reaches here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InboundTransport {
+    /// Authcrypted DIDComm message off the mediator socket.
+    DidComm,
+    /// TSP frame, arriving on that *same* socket — see the pump's comment.
+    Tsp,
+}
+
+impl std::fmt::Display for InboundTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::DidComm => "DIDComm",
+            Self::Tsp => "TSP",
+        })
+    }
+}
+
 /// Events sent from DIDComm router handlers to the state handler main loop.
 #[derive(Debug)]
 pub enum DIDCommEvent {
@@ -466,6 +489,15 @@ pub enum DIDCommEvent {
         message: Box<Message>,
         #[allow(dead_code)]
         from: Option<String>,
+        /// Which transport actually carried this frame.
+        ///
+        /// The pump knows — it matches on `Protocol` to decode the payload —
+        /// but used to drop it here, so every consumer that wanted to say how a
+        /// message arrived had to guess. The activity log guessed "DIDComm" and
+        /// was wrong for every TSP frame, which is the transport this stack
+        /// prefers. Carrying it costs one field and makes the log able to tell
+        /// the truth.
+        transport: InboundTransport,
     },
     /// A trust-ping was received — state handler decides whether to respond.
     TrustPingReceived {
@@ -644,16 +676,16 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
         // payload is the `Message` JSON (`to_inbound` in the SDK adapter); a TSP
         // frame's is a bare Trust Task document, which is normalised into the
         // same shape so everything below is transport-agnostic.
-        let message = match item.message.protocol {
+        let (message, transport) = match item.message.protocol {
             Protocol::DIDComm => match serde_json::from_slice::<Message>(&item.message.payload) {
-                Ok(message) => message,
+                Ok(message) => (message, InboundTransport::DidComm),
                 Err(e) => {
                     debug!(error = %e, "inbound DIDComm frame is not a Message — dropped");
                     continue;
                 }
             },
             Protocol::TSP => match tsp_frame_to_message(&item) {
-                Some(message) => message,
+                Some(message) => (message, InboundTransport::Tsp),
                 None => continue,
             },
             // A protocol OpenVTC does not speak — DIDComm v1 today, whatever
@@ -688,6 +720,7 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
             DIDCommEvent::InboundMessage {
                 from,
                 message: Box::new(message),
+                transport,
             }
         } else if catch_all.is_match(&message.typ) {
             tracing::info!(
@@ -700,6 +733,7 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
             DIDCommEvent::InboundMessage {
                 from,
                 message: Box::new(message),
+                transport,
             }
         } else {
             // Pickup-status heartbeats and anything else: dropped, as the

--- a/openvtc-core/src/display.rs
+++ b/openvtc-core/src/display.rs
@@ -79,9 +79,81 @@ pub fn display_identifier<'a>(name: Option<&'a str>, did: &'a str, max_len: usiz
     }
 }
 
+/// A short, human-meaningful label for a message type URI.
+///
+/// The obvious implementation — take the last path segment — is wrong for every
+/// Trust Task, because a Trust Task URI *ends in its version*:
+///
+/// ```text
+/// https://trusttasks.org/spec/credential-exchange/issue/0.1
+///                                                      ^^^ last segment
+/// ```
+///
+/// The activity log did exactly that and rendered every inbound message as
+/// `Inbound: 0.1`. It went unnoticed because legacy DIDComm types end in the
+/// action (`…/relationship/1.0/request` → `request`), so the label only became
+/// useless once the stack moved to Trust Tasks — precisely when the log became
+/// worth reading.
+///
+/// This keeps the part that identifies the task, dropping the scheme, the host
+/// and the `spec/` prefix, so the example above renders as
+/// `credential-exchange/issue/0.1`.
+#[must_use]
+pub fn task_label(type_uri: &str) -> String {
+    // Canonical Trust Task shape: strip everything up to and including `/spec/`.
+    if let Some((_, tail)) = type_uri.split_once("/spec/")
+        && !tail.is_empty()
+    {
+        return tail.to_string();
+    }
+
+    // Anything else (legacy DIDComm types, bare strings): keep the last two
+    // segments, which is the action plus enough context to disambiguate it.
+    let segments: Vec<&str> = type_uri.rsplit('/').take(2).collect();
+    match segments.len() {
+        0 => type_uri.to_string(),
+        1 => segments[0].to_string(),
+        _ => format!("{}/{}", segments[1], segments[0]),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The defect this exists for: a Trust Task URI ends in its version, so the
+    /// last-segment label named the version and nothing else.
+    #[test]
+    fn a_trust_task_label_names_the_task_not_its_version() {
+        assert_eq!(
+            task_label("https://trusttasks.org/spec/credential-exchange/issue/0.1"),
+            "credential-exchange/issue/0.1"
+        );
+        assert_eq!(
+            task_label("https://trusttasks.org/spec/keys/create/0.1"),
+            "keys/create/0.1"
+        );
+    }
+
+    /// Legacy DIDComm types end in the action, and still read correctly.
+    #[test]
+    fn a_legacy_didcomm_label_keeps_its_action() {
+        assert_eq!(
+            task_label("https://didcomm.org/trust-ping/2.0/ping"),
+            "2.0/ping"
+        );
+    }
+
+    /// No panics and no empty labels on degenerate input — this runs on
+    /// whatever a peer put in `typ`, which is not ours to trust.
+    #[test]
+    fn a_degenerate_type_still_produces_something() {
+        assert_eq!(task_label("bare"), "bare");
+        assert_eq!(task_label(""), "");
+        // A trailing `/spec/` with nothing after it falls through to the
+        // segment path rather than returning an empty label.
+        assert!(!task_label("https://trusttasks.org/spec/").is_empty());
+    }
 
     #[test]
     fn truncate_did_passes_through_short_input() {

--- a/openvtc-core/src/logs.rs
+++ b/openvtc-core/src/logs.rs
@@ -64,14 +64,31 @@ pub struct Logs {
     /// Log entries in insertion order (oldest first).
     pub messages: VecDeque<LogMessage>,
     /// Maximum number of entries to retain.
+    ///
+    /// **Not persisted**, deliberately. It is a policy constant — nothing sets
+    /// it but [`Default`] — and serializing it meant every config written
+    /// before a change pinned the *old* value forever: raising the default
+    /// would have silently done nothing for existing users, who are the only
+    /// ones with logs to lose. `skip` makes it come from code on every load.
+    ///
+    /// A stored `limit` in an older config is simply ignored (nothing here
+    /// denies unknown fields), so no migration is needed.
+    #[serde(skip, default = "default_limit")]
     pub limit: usize,
+}
+
+/// Retained-entry ceiling. Raised 100 → 200: at 100, a single busy session's
+/// inbound traffic could evict the community-lifecycle entries that are the
+/// reason to keep a log at all.
+fn default_limit() -> usize {
+    200
 }
 
 impl Default for Logs {
     fn default() -> Self {
         Self {
             messages: VecDeque::new(),
-            limit: 100,
+            limit: default_limit(),
         }
     }
 }
@@ -102,7 +119,7 @@ mod tests {
             logs.messages.is_empty(),
             "Default Logs should have no messages"
         );
-        assert_eq!(logs.limit, 100, "Default limit should be 100");
+        assert_eq!(logs.limit, 200, "Default limit should be 200");
     }
 
     #[test]
@@ -142,5 +159,33 @@ mod tests {
         assert_eq!(format!("{}", LogFamily::Contact), "CONTACT");
         assert_eq!(format!("{}", LogFamily::Task), "TASK");
         assert_eq!(format!("{}", LogFamily::Config), "CONFIG");
+        assert_eq!(format!("{}", LogFamily::Community), "COMMUNITY");
+    }
+
+    /// An existing config picks up the current ceiling rather than the one it
+    /// was written with.
+    ///
+    /// This is the whole reason `limit` is `skip`ped. It used to serialize, so
+    /// every config already on disk carried `"limit": 100` — and raising the
+    /// default would have changed nothing for exactly the users who had logs to
+    /// lose, while passing every test written against a fresh `Default`.
+    #[test]
+    fn a_stored_limit_does_not_pin_an_old_ceiling() {
+        let stored = r#"{"messages": [], "limit": 100}"#;
+        let logs: Logs = serde_json::from_str(stored).expect("an older config still parses");
+        assert_eq!(
+            logs.limit, 200,
+            "the ceiling comes from code, not from what the config was written with"
+        );
+    }
+
+    /// And it is no longer written back out, so this cannot regress.
+    #[test]
+    fn the_limit_is_not_persisted() {
+        let json = serde_json::to_value(Logs::default()).expect("serialises");
+        assert!(
+            json.get("limit").is_none(),
+            "limit is policy, not user data — persisting it is what caused the bug above"
+        );
     }
 }

--- a/openvtc-core/src/logs.rs
+++ b/openvtc-core/src/logs.rs
@@ -20,6 +20,14 @@ pub enum LogFamily {
     Task,
     /// Configuration changes.
     Config,
+    /// Community membership lifecycle: join submitted, admitted, rejected,
+    /// withdrawn, left; the credentials that carry those transitions.
+    ///
+    /// Added because none of the families above covered the ceremony that
+    /// matters most. A join produced a detailed running commentary on the join
+    /// screen and *nothing* durable, so after a restart there was no record
+    /// that it had ever been attempted — which is exactly when you go looking.
+    Community,
 }
 
 impl Display for LogFamily {
@@ -29,6 +37,7 @@ impl Display for LogFamily {
             LogFamily::Contact => "CONTACT",
             LogFamily::Task => "TASK",
             LogFamily::Config => "CONFIG",
+            LogFamily::Community => "COMMUNITY",
         };
         write!(f, "{}", s)
     }

--- a/openvtc-core/tests/didcomm_transport_e2e.rs
+++ b/openvtc-core/tests/didcomm_transport_e2e.rs
@@ -108,10 +108,22 @@ async fn an_openvtc_message_routes_through_the_production_transport() {
         .expect("event channel still open");
 
     match event {
-        DIDCommEvent::InboundMessage { message, from } => {
+        DIDCommEvent::InboundMessage {
+            message,
+            from,
+            transport,
+        } => {
             assert_eq!(
                 message.typ, OPENVTC_TYPE,
                 "the catch-all pattern routed this type"
+            );
+            // The reported transport is the one that actually carried the
+            // frame, not a guess. This leg is DIDComm; the activity log used to
+            // hardcode that label and so was wrong for every TSP frame.
+            assert_eq!(
+                transport,
+                openvtc_core::didcomm::InboundTransport::DidComm,
+                "a DIDComm round trip reports DIDComm"
             );
             assert_eq!(
                 from.as_deref(),

--- a/openvtc-core/tests/logs.rs
+++ b/openvtc-core/tests/logs.rs
@@ -4,10 +4,10 @@ use openvtc_core::logs::{LogFamily, Logs};
 use std::collections::VecDeque;
 
 #[test]
-fn default_logs_is_empty_with_limit_100() {
+fn default_logs_is_empty_with_the_current_limit() {
     let logs = Logs::default();
     assert!(logs.messages.is_empty());
-    assert_eq!(logs.limit, 100);
+    assert_eq!(logs.limit, 200);
 }
 
 #[test]

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -66,7 +66,15 @@ async fn main() -> Result<()> {
     //   OPENVTC_DEBUG_LOG=/tmp/openvtc.log cargo run -p openvtc
     // Log level defaults to "debug" but can be overridden with RUST_LOG.
     if let Ok(log_path) = env::var("OPENVTC_DEBUG_LOG") {
-        match std::fs::File::create(&log_path) {
+        // Append, never truncate. `File::create` truncated on every launch, so
+        // the evidence from a failed run was destroyed by the restart used to
+        // reproduce it — the exact workflow this variable exists to serve.
+        // Each run announces itself below, so runs stay separable in one file.
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+        {
             Ok(log_file) => {
                 let filter = tracing_subscriber::EnvFilter::try_from_default_env()
                     .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("debug"));
@@ -75,7 +83,13 @@ async fn main() -> Result<()> {
                     .with_writer(std::sync::Mutex::new(log_file))
                     .with_ansi(false)
                     .init();
-                tracing::info!("Debug logging enabled → {log_path}");
+                // A run banner, because the file now spans runs: without a
+                // marker, two appended runs read as one continuous session and
+                // a restart becomes invisible in the middle of a trace.
+                tracing::info!(
+                    version = env!("CARGO_PKG_VERSION"),
+                    "───── openvtc run started ─────  (appending to {log_path})"
+                );
             }
             Err(e) => {
                 eprintln!(

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -20,6 +20,7 @@ use openvtc_core::config::{
     account::{CommunityRecord, PersonaId, VtcDid},
     context_path::build_sub_context_id,
 };
+use openvtc_core::logs::LogFamily;
 use tokio::sync::{broadcast, mpsc::UnboundedReceiver};
 use tracing::debug;
 use vta_sdk::{client::VtaClient, protocols::did_management::create::WebvhPathMode};
@@ -1100,6 +1101,17 @@ async fn run_join_sequence(
 
     // 10. Success — refresh the communities panel and surface the relaunch prompt.
     state.main_page.sync_from_config(config);
+    // Durable, unlike the ceremony commentary in `state.join`, which is
+    // transient UI and gone on the next launch. A submitted join is the thing
+    // you most want a record of when it does not complete.
+    config.public.logs.insert(
+        LogFamily::Community,
+        format!(
+            "Join request submitted to ({}) as persona ({}) — Pending.",
+            state.join.display_name.as_deref().unwrap_or(&vtc_did),
+            persona_did
+        ),
+    );
     state
         .main_page
         .log("Join request submitted — Pending in your Communities list.");

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -267,11 +267,32 @@ pub async fn process_inbound_message(
     // VEC as separate `credential-exchange/issue` messages. Store each on the
     // community and flip Pending -> Active when the membership credential lands.
     if message.typ == CREDENTIAL_ISSUE_TYPE {
-        return Ok(handle_credential_issue(
-            &mut config.account,
-            message,
-            &from_did,
-        ));
+        // Snapshot before, so the log can say what *changed* rather than that a
+        // message arrived. An issued membership credential is the moment a join
+        // completes — the single most consequential inbound message there is,
+        // and it used to be indistinguishable from any other in the log.
+        let was_active = config
+            .account
+            .memberships_for(&from_did)
+            .iter()
+            .any(|m| m.status.is_active());
+        let changed = handle_credential_issue(&mut config.account, message, &from_did);
+        if changed {
+            let now_active = config
+                .account
+                .memberships_for(&from_did)
+                .iter()
+                .any(|m| m.status.is_active());
+            config.public.logs.insert(
+                LogFamily::Community,
+                if now_active && !was_active {
+                    format!("Admitted to community ({from_did}) — membership is now Active.")
+                } else {
+                    format!("Credential received from community ({from_did}).")
+                },
+            );
+        }
+        return Ok(changed);
     }
 
     // VTC join-requests submit `#response`: the synchronous admission verdict in

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1627,7 +1627,7 @@ impl StateHandler {
                 // DIDComm inbound message events
                 Some(event) = didcomm_event_rx.recv() => {
                     match event {
-                        didcomm::DIDCommEvent::InboundMessage { message, .. } => {
+                        didcomm::DIDCommEvent::InboundMessage { message, transport, .. } => {
                             // Capture message info before processing for detailed logging
                             let msg_type = message.typ.clone();
                             let msg_from = message.from.clone().unwrap_or_else(|| "unknown".into());
@@ -1671,12 +1671,11 @@ impl StateHandler {
                                         .await;
                                     }
                                     state.main_page.sync_from_config(&config);
-                                    // Extract short type name for summary
-                                    let short_type = msg_type.rsplit('/').next().unwrap_or(&msg_type);
+                                    let short_type = openvtc_core::display::task_label(&msg_type);
                                     state.main_page.log_detailed(
-                                        format!("Inbound: {short_type}"),
+                                        format!("Inbound {transport}: {short_type}"),
                                         format!(
-                                            "Inbound DIDComm Message\n\
+                                            "Inbound {transport} Message\n\
                                              ───────────────────────\n\
                                              Type:    {msg_type}\n\
                                              From:    {msg_from}\n\


### PR DESCRIPTION
Five defects, all found while debugging a join that was **in fact succeeding**.

## The log named the version, not the task

The inbound summary took the last path segment of the type URI. A Trust Task URI *ends in its version*:

```
https://trusttasks.org/spec/credential-exchange/issue/0.1
                                                     ^^^ last segment
```

So every inbound message rendered as `Inbound: 0.1`. It went unnoticed because legacy DIDComm types end in the action (`…/trust-ping/2.0/ping` → `ping`) — the label only became useless once the stack moved to Trust Tasks, which is exactly when the log became worth reading.

New `display::task_label` keeps the part that identifies the task, so a VTC's membership credential now reads `credential-exchange/issue/0.1`.

## It claimed DIDComm for everything

The detail pane hardcoded `"Inbound DIDComm Message"`. The pump *knows* the transport — it matches on `Protocol` to decode the payload — but `DIDCommEvent::InboundMessage` dropped it before any consumer could see it, so the log guessed. It guessed wrong for every TSP frame, and TSP is the transport this stack prefers and the one the VTC advertises. The event now carries `InboundTransport`, and the existing DIDComm transport e2e asserts it.

## `OPENVTC_DEBUG_LOG` truncated on every launch

`File::create` meant the restart used to reproduce a failure destroyed the evidence from the run that failed — the exact workflow the variable exists to serve. Now appends, with a run banner so restarts stay visible within one file.

## A join left no durable trace

The ceremony's running commentary lives in `state.join` — transient UI, gone on the next launch. Nothing in the join or membership path wrote to the *persisted* log, because no family covered it. After a restart there was no record a join had been attempted at all.

Adds `LogFamily::Community` and writes two entries that survive: the submitted join, and the credential that admits you — distinguishing "membership is now Active" from a later credential by comparing status either side of the handler, so the log says what *changed* rather than that a message arrived.

## Retention raised to 200 — and the ceiling stopped being persisted

At 100, one busy session's inbound traffic could evict the community events that are the reason to keep a log at all.

Raising the default alone would not have worked. `limit` was a **serialized** field, so every config already on disk carried `"limit": 100` and would have kept using it. The raise would have silently applied only to users with no config yet — precisely the ones with no logs to lose — while passing every test written against a fresh `Default`.

Nothing ever sets `limit` but `Default`; it is policy, not user data. It is now `#[serde(skip)]` with an explicit `default_limit()`, so the ceiling comes from code on every load, and a stored `limit` in an older config is ignored (nothing here denies unknown fields) — no migration needed.

## Why this mattered

The middle two are what made the live debugging harder than it needed to be. The VTC **was** answering, with `credential-exchange/issue/0.1` — the membership credential — and the activity log rendered it as `Inbound: 0.1`, indistinguishable from anything else.

## Verification

- `cargo test --workspace` — 16 test binaries, all green
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --check` — clean
- Tests pin: the label behaviour including the version-suffix case that caused this and degenerate (peer-controlled) input; that an older config with `"limit": 100` loads at 200; and that `limit` is no longer written back out
