### PR TITLE
feat(join): attribute the submit transport, and refuse an unreachable community

### DIFF
--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -213,6 +213,19 @@ pub struct CommunityRecord {
     /// surfaced in the UI so it isn't mistaken for a healthy wait (D16).
     #[serde(default)]
     pub receipt_at: Option<DateTime<Utc>>,
+    /// Which transport carried the join submit.
+    ///
+    /// Recorded so an unacknowledged join can say *which* transport went
+    /// unanswered. Without it the warning reads identically whether the VTC
+    /// ignored us, the mediator dropped the frame, or the peer could not
+    /// decode the transport it advertised — which is exactly the ambiguity
+    /// that cost a night of log-reading against a VTC advertising `#tsp` that
+    /// its binary could not speak.
+    ///
+    /// `None` on records written before this existed, and on any future path
+    /// that submits without going through the join flow.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submit_transport: Option<crate::didcomm::MessagingTransport>,
     /// DIDComm relationships scoped to this community.
     #[serde(default)]
     pub relationships: Relationships,
@@ -269,6 +282,8 @@ struct CommunityRecordShadow {
     #[serde(default)]
     receipt_at: Option<DateTime<Utc>>,
     #[serde(default)]
+    submit_transport: Option<crate::didcomm::MessagingTransport>,
+    #[serde(default)]
     relationships: Relationships,
     #[serde(default)]
     tasks: Tasks,
@@ -324,6 +339,7 @@ impl From<CommunityRecordShadow> for CommunityRecord {
             member_since: shadow.member_since,
             requested_at: shadow.requested_at,
             receipt_at: shadow.receipt_at,
+            submit_transport: shadow.submit_transport,
             relationships: shadow.relationships,
             tasks: shadow.tasks,
             vrcs_issued: shadow.vrcs_issued,
@@ -371,6 +387,9 @@ impl CommunityRecord {
             member_since: None,
             requested_at: Some(now),
             receipt_at: None,
+            // Set by the join flow once it knows which transport carried the
+            // submit; `new_pending` itself is transport-agnostic.
+            submit_transport: None,
             relationships: Relationships::default(),
             tasks: Tasks::default(),
             vrcs_issued: Vrcs::default(),
@@ -849,6 +868,7 @@ mod tests {
             vtc_did: vtc.to_string(),
             display_name: Some(vtc.to_string()),
             sub_context_id: format!("openvtc/{vtc}"),
+            submit_transport: None,
             persona_ref,
             status,
             favourite: false,

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -726,6 +726,87 @@ pub async fn peer_tsp_mediator(peer_did: &str) -> Option<String> {
     }
 }
 
+/// The messaging transports a peer's DID document actually offers us.
+///
+/// Both halves come from **one** resolve — `resolve_vta_with_resolver` returns
+/// the TSP mediator and the DIDComm mediator together — so asking about both
+/// costs no more than asking about TSP alone.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PeerTransports {
+    /// Mediator DID from a `#tsp` / `TSPTransport` service, if advertised.
+    pub tsp_mediator: Option<String>,
+    /// Mediator DID from a `DIDCommMessaging` service, if advertised.
+    pub didcomm_mediator: Option<String>,
+}
+
+impl PeerTransports {
+    /// Whether the peer offers any transport we can send a join over.
+    ///
+    /// A peer advertising neither cannot be joined at all, and finding that out
+    /// *before* minting a persona is the difference between a clear refusal and
+    /// an orphaned identity attached to a request nobody received.
+    #[must_use]
+    pub fn any(&self) -> bool {
+        self.tsp_mediator.is_some() || self.didcomm_mediator.is_some()
+    }
+
+    /// Which transport a send would actually choose, mirroring the stack's
+    /// prefer-TSP-then-DIDComm order.
+    #[must_use]
+    pub fn preferred(&self) -> Option<crate::didcomm::MessagingTransport> {
+        if self.tsp_mediator.is_some() {
+            Some(crate::didcomm::MessagingTransport::Tsp)
+        } else if self.didcomm_mediator.is_some() {
+            Some(crate::didcomm::MessagingTransport::DidComm)
+        } else {
+            None
+        }
+    }
+}
+
+/// Ask a peer's DID document which messaging transports it offers.
+///
+/// Deliberately *not* a reachability check. It reports what the document
+/// advertises, which is all a client can know before sending — a peer that
+/// advertises a transport its binary cannot decode looks identical from here,
+/// and is the peer's defect to fix, not ours to work around. What this buys is
+/// refusing the genuinely impossible case (a peer advertising nothing) early.
+pub async fn peer_messaging_transports(peer_did: &str) -> PeerTransports {
+    let Ok(resolver) = affinidi_did_resolver_cache_sdk::DIDCacheClient::new(
+        affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
+    )
+    .await
+    else {
+        // Resolver init failure is not "the peer offers nothing" — say nothing
+        // rather than block a join on a local fault.
+        tracing::debug!(peer = %peer_did, "transport discovery resolver init failed");
+        return PeerTransports {
+            tsp_mediator: None,
+            didcomm_mediator: None,
+        };
+    };
+
+    match tokio::time::timeout(
+        TSP_DISCOVERY_TIMEOUT,
+        vta_sdk::provision_client::resolve_vta_with_resolver(peer_did, &resolver),
+    )
+    .await
+    {
+        Ok(Ok(resolved)) => PeerTransports {
+            tsp_mediator: resolved.tsp_mediator_did,
+            didcomm_mediator: resolved.mediator_did,
+        },
+        Ok(Err(e)) => {
+            tracing::debug!(peer = %peer_did, error = %e, "transport discovery failed");
+            PeerTransports::default()
+        }
+        Err(_) => {
+            tracing::debug!(peer = %peer_did, "transport discovery timed out");
+            PeerTransports::default()
+        }
+    }
+}
+
 /// What transport discovery decided about the TSP leg.
 ///
 /// Returned rather than logged-and-dropped so the decision is assertable. The
@@ -1393,5 +1474,56 @@ mod tests {
         assert_eq!(active_reverse.persona_id, active_forward.persona_id);
         assert_eq!(active_reverse.did, active_forward.did);
         assert_eq!(config_forward.persona_did(), config_reverse.persona_did());
+    }
+}
+
+#[cfg(test)]
+mod peer_transport_tests {
+    use super::*;
+    use crate::didcomm::MessagingTransport;
+
+    /// Preference order mirrors the stack's: TSP first, then DIDComm.
+    #[test]
+    fn tsp_is_preferred_when_both_are_advertised() {
+        let both = PeerTransports {
+            tsp_mediator: Some("did:web:tsp-mediator".into()),
+            didcomm_mediator: Some("did:web:didcomm-mediator".into()),
+        };
+        assert_eq!(both.preferred(), Some(MessagingTransport::Tsp));
+        assert!(both.any());
+    }
+
+    #[test]
+    fn didcomm_is_used_when_tsp_is_absent() {
+        let didcomm_only = PeerTransports {
+            tsp_mediator: None,
+            didcomm_mediator: Some("did:web:didcomm-mediator".into()),
+        };
+        assert_eq!(didcomm_only.preferred(), Some(MessagingTransport::DidComm));
+        assert!(didcomm_only.any());
+    }
+
+    /// The case the join preflight exists for: a document offering no messaging
+    /// service at all cannot be joined, and saying so before the persona mint is
+    /// the difference between a clear refusal and an orphaned identity.
+    #[test]
+    fn a_peer_advertising_nothing_is_not_joinable() {
+        let none = PeerTransports::default();
+        assert_eq!(none.preferred(), None);
+        assert!(!none.any());
+    }
+
+    /// A peer advertising only TSP is still "joinable" from here — whether it
+    /// can actually *decode* TSP is not knowable before sending, and is the
+    /// peer's defect rather than something to route around. Pinned so nobody
+    /// later turns this into a reachability probe.
+    #[test]
+    fn tsp_only_is_joinable_because_advertisement_is_all_we_can_see() {
+        let tsp_only = PeerTransports {
+            tsp_mediator: Some("did:web:tsp-mediator".into()),
+            didcomm_mediator: None,
+        };
+        assert_eq!(tsp_only.preferred(), Some(MessagingTransport::Tsp));
+        assert!(tsp_only.any());
     }
 }

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -56,6 +56,7 @@ use affinidi_tdk::messaging::profiles::ATMProfile;
 use affinidi_tdk::secrets_resolver::SecretsResolver;
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -458,21 +459,26 @@ pub fn persona_listener_id(persona_did: &str) -> String {
 /// core (it is pure) so the protocol logic there can build its own messages.
 pub use crate::messaging::build_didcomm_message;
 
-/// Which transport carried an inbound frame.
+/// Which transport carried a message — inbound or outbound.
 ///
 /// A narrowed mirror of the messaging layer's `Protocol`, kept separate on
 /// purpose: `Protocol` is `#[non_exhaustive]` and grows upstream, whereas this
-/// only ever names transports OpenVTC actually decodes. A new `Protocol`
+/// only ever names transports OpenVTC actually speaks. A new `Protocol`
 /// variant is dropped at the pump and never reaches here.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InboundTransport {
+///
+/// Serializable because it is also recorded on a `CommunityRecord`: a join that
+/// is never acknowledged needs to say *which* transport went unanswered, and
+/// that has to survive the restart you make to go looking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessagingTransport {
     /// Authcrypted DIDComm message off the mediator socket.
     DidComm,
     /// TSP frame, arriving on that *same* socket — see the pump's comment.
     Tsp,
 }
 
-impl std::fmt::Display for InboundTransport {
+impl std::fmt::Display for MessagingTransport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
             Self::DidComm => "DIDComm",
@@ -497,7 +503,7 @@ pub enum DIDCommEvent {
         /// was wrong for every TSP frame, which is the transport this stack
         /// prefers. Carrying it costs one field and makes the log able to tell
         /// the truth.
-        transport: InboundTransport,
+        transport: MessagingTransport,
     },
     /// A trust-ping was received — state handler decides whether to respond.
     TrustPingReceived {
@@ -678,14 +684,14 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
         // same shape so everything below is transport-agnostic.
         let (message, transport) = match item.message.protocol {
             Protocol::DIDComm => match serde_json::from_slice::<Message>(&item.message.payload) {
-                Ok(message) => (message, InboundTransport::DidComm),
+                Ok(message) => (message, MessagingTransport::DidComm),
                 Err(e) => {
                     debug!(error = %e, "inbound DIDComm frame is not a Message — dropped");
                     continue;
                 }
             },
             Protocol::TSP => match tsp_frame_to_message(&item) {
-                Some(message) => (message, InboundTransport::Tsp),
+                Some(message) => (message, MessagingTransport::Tsp),
                 None => continue,
             },
             // A protocol OpenVTC does not speak — DIDComm v1 today, whatever

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -187,6 +187,7 @@ mod tests {
             vtc_did: vtc.into(),
             display_name: None,
             sub_context_id: format!("openvtc/{vtc}"),
+            submit_transport: None,
             persona_ref,
             status,
             favourite: false,

--- a/openvtc-core/tests/didcomm_transport_e2e.rs
+++ b/openvtc-core/tests/didcomm_transport_e2e.rs
@@ -122,7 +122,7 @@ async fn an_openvtc_message_routes_through_the_production_transport() {
             // hardcode that label and so was wrong for every TSP frame.
             assert_eq!(
                 transport,
-                openvtc_core::didcomm::InboundTransport::DidComm,
+                openvtc_core::didcomm::MessagingTransport::DidComm,
                 "a DIDComm round trip reports DIDComm"
             );
             assert_eq!(

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -664,15 +664,20 @@ fn build_pending_record(
     persona_id: PersonaId,
     request_id: uuid::Uuid,
     now: chrono::DateTime<Utc>,
+    submit_transport: openvtc_core::didcomm::MessagingTransport,
 ) -> CommunityRecord {
-    CommunityRecord::new_pending(
+    let mut record = CommunityRecord::new_pending(
         vtc_did,
         display_name,
         sub_context_id,
         persona_id,
         request_id,
         now,
-    )
+    );
+    // Which transport carried the submit, so an unacknowledged join can name it
+    // rather than leaving every cause looking alike.
+    record.submit_transport = Some(submit_transport);
+    record
 }
 
 /// Run the automated mint → sub-context → join-submit → persist sequence.
@@ -718,6 +723,29 @@ async fn run_join_sequence(
         openvtc_core::agent_name::resolve_verified_name(tdk.did_resolver(), &vtc_did).await;
     config.set_cached_agent_name(&vtc_did, display_name.clone(), chrono::Utc::now());
     state.join.display_name = display_name.clone();
+
+    // 3. Preflight the community's transports, before anything is minted.
+    //
+    // A peer that advertises no messaging service cannot be joined at all, and
+    // discovering that after the persona mint leaves an orphaned identity
+    // attached to a request nobody could receive. This is a check on what the
+    // document *offers* — not on whether the peer can actually serve it, which
+    // no client can know before sending, and which is the peer's defect to fix
+    // rather than ours to route around.
+    let transports = openvtc_core::config::peer_messaging_transports(&vtc_did).await;
+    let Some(submit_transport) = transports.preferred() else {
+        state.join.fail(format!(
+            "This community advertises no messaging transport ({}). Its DID \
+             document offers neither a TSP nor a DIDComm service, so a join \
+             request cannot reach it. Nothing was created.",
+            state.join.display_name.as_deref().unwrap_or(&vtc_did)
+        ));
+        return;
+    };
+    state
+        .join
+        .info(format!("Community reachable over {submit_transport}."));
+    let _ = handler.state_tx.send(state.clone());
 
     let top_context_id = config.account.top_context_id.clone();
 
@@ -1090,6 +1118,7 @@ async fn run_join_sequence(
         persona_id,
         request_id,
         Utc::now(),
+        submit_transport,
     );
     config.account.add_membership(record.clone());
     if let Err(e) = save_config(config, profile) {
@@ -1299,12 +1328,18 @@ mod tests {
             persona,
             request_id,
             now,
+            openvtc_core::didcomm::MessagingTransport::Tsp,
         );
         assert_eq!(rec.vtc_did, "did:vtc:c");
         assert_eq!(rec.display_name.as_deref(), Some("Community"));
         assert_eq!(rec.sub_context_id, "top/slug");
         assert_eq!(rec.persona_ref, persona);
         assert_eq!(rec.requested_at, Some(now));
+        assert_eq!(
+            rec.submit_transport,
+            Some(openvtc_core::didcomm::MessagingTransport::Tsp),
+            "the record remembers which transport carried the submit"
+        );
         assert!(rec.is_live(), "a fresh Pending record is live");
         match rec.status {
             CommunityStatus::Pending { request_id: got } => {
@@ -1329,6 +1364,7 @@ mod tests {
             persona,
             uuid::Uuid::new_v4(),
             chrono::Utc::now(),
+            openvtc_core::didcomm::MessagingTransport::DidComm,
         );
         js.created_community = Some(rec);
         js.created_persona_did = Some("did:webvh:persona".to_string());

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -312,6 +312,13 @@ pub struct CommunitySummary {
     /// grace window — the submit may have been dropped rather than healthily
     /// awaiting a decision. Drives a warning hint on the row (D16).
     pub pending_unacknowledged: bool,
+    /// Which transport carried the join submit, when the record knows.
+    ///
+    /// Only used to qualify the unacknowledged warning. Without it the warning
+    /// reads the same whether the community ignored us or could not decode the
+    /// transport it advertised, which is the ambiguity that made a real failure
+    /// take a night to find. `None` for records written before it was recorded.
+    pub submit_transport: Option<String>,
     /// Whether this community is archived (R-C-8); only shown when "show archived"
     /// is on, with a marker.
     pub archived: bool,

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -560,6 +560,7 @@ impl MainPageState {
                     openvtc_core::config::account::CommunityStatus::Pending { .. }
                 ),
                 pending_unacknowledged: c.pending_unacknowledged(now),
+                submit_transport: c.submit_transport.map(|t| t.to_string()),
                 archived: c.archived,
                 needs_attention: c.needs_attention(),
                 persona_did: persona.map(|p| p.did.clone()).unwrap_or_default(),
@@ -1103,6 +1104,7 @@ mod tests {
                 vtc_did: vtc_did.to_string(),
                 display_name: display_name.map(str::to_owned),
                 sub_context_id: String::new(),
+                submit_transport: None,
                 persona_ref: persona_id,
                 status: CommunityStatus::Active,
                 favourite: false,

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -126,9 +126,20 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         // healthily awaiting a decision. Surface it so a stuck join is visible
         // long before the 7-day Expired (D16).
         if c.pending_unacknowledged {
+            // Name the transport the submit went out over. "No response" alone
+            // reads identically whether the community ignored the request, the
+            // mediator dropped it, or the community could not decode the
+            // transport its own document advertises — and only the last of
+            // those is fixed somewhere other than here.
+            let over = c
+                .submit_transport
+                .as_deref()
+                .map_or(String::new(), |t| format!(" (sent over {t})"));
             lines.push(Line::from(Span::styled(
-                "    ⚠ no response from the community yet — the request may not have been received"
-                    .to_string(),
+                format!(
+                    "    ⚠ no response from the community yet{over} — the request may not have \
+                     been received"
+                ),
                 Style::new().fg(COLOR_ORANGE),
             )));
         }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2868,6 +2868,7 @@ mod key_handler_tests {
             is_inactive,
             is_pending,
             pending_unacknowledged: false,
+            submit_transport: None,
             archived: false,
             needs_attention: false,
             persona_did: "did:example:persona".to_string(),


### PR DESCRIPTION
A join that is never acknowledged used to say only:

> ⚠ no response from the community yet — the request may not have been received

That reads identically whether the community ignored the request, the mediator dropped it, or the community **could not decode the transport its own DID document advertises** — and only the last of those is fixed somewhere other than here. Telling them apart cost a night of log-reading against a VTC advertising `#tsp` that its binary could not speak.

## Not a transport fallback — deliberately

Falling back is the wrong answer twice over:

1. **This repo already removed one.** #207, the commit two before this branch, is *"reopen the bootstrap transport, don't fall back to REST"* — the fallback masked a working TSP path and produced a worse failure.
2. **It would not have helped.** That VTC advertises `#vtc-rest`, `#vtc-status-list`, `#tsp` and **no `DIDCommMessaging` service at all**. There was nothing to fall back to. "Works with any combination" cannot rescue a peer offering one broken transport.

And a client that papers over a peer advertising a transport it cannot serve guarantees the peer is never fixed, while every other client — the mobile agent, the PNM/CNM CLIs — carries the same workaround. TSP and DIDComm also differ in their authentication properties, so a silent downgrade changes the security posture without telling the user.

## What this does instead

**1. Record the transport.** `CommunityRecord` gains `submit_transport`, set by the join flow from the transport discovery it already performs. Written *absent, not null*, on records that predate it — the `skip_serializing_if` habit from VTI #919, which is this same defect class one layer down.

**2. Name it in the warning.**

> ⚠ no response from the community yet (sent over TSP) — the request may not have been received

R6.4: the operator can now tell the failure modes apart at a glance.

**3. Preflight before minting.** A community whose document advertises no messaging transport cannot be joined at all, and discovering that *after* the persona mint leaves an orphaned identity attached to a request nobody could receive. `peer_messaging_transports` answers both halves from the one resolve `resolve_vta_with_resolver` already performs, and the flow refuses before anything is created:

> This community advertises no messaging transport (…). Its DID document offers neither a TSP nor a DIDComm service, so a join request cannot reach it. Nothing was created.

## Scope boundary, pinned by a test

This checks what a document **offers**, not whether the peer can serve it — no client can know that before sending. A test asserts a TSP-only peer stays joinable, so nobody later "improves" this into the reachability probe (or the fallback) it declines to be.

## Also

`InboundTransport` → `MessagingTransport`, now serialisable: one type for the concept rather than a parallel enum for the outbound direction. The compiler covered the rename.

## Verification

- `cargo test --workspace` — 16 test binaries, all green
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --check` — clean
- New tests cover the preference order, the not-joinable case, and the TSP-only boundary above; the record test asserts the transport is carried

Not covered: nothing here makes a peer that advertises a transport it cannot serve work. That fix belongs in the VTC — its DID document should not advertise `#tsp` when built without the (non-default) `tsp` feature.
