### PR TITLE
fix(join): choose TSP only when our own mediator can carry it

### DIFF
--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -878,8 +878,13 @@ pub(crate) async fn mediator_tsp_carriage(
 /// Whether the mediator we would post through carries TSP.
 ///
 /// `Some(true)` / `Some(false)` are answers; `None` means we could not ask, and
-/// a caller must not read it as either — see [`TspCarriage`]. Exposed publicly
-/// because the ceremony call sites live in the binary crate, matching
+/// a caller must not read it as either.
+///
+// Not an intra-doc link: `TspCarriage` is private, and a public item linking to
+// it fails `rustdoc -D warnings` — the same trap `peer_tsp_mediator` above
+// carries this note for.
+/// The three-way distinction it collapses lives on `TspCarriage`. Exposed
+/// publicly because the ceremony call sites live in the binary crate, matching
 /// [`peer_tsp_mediator`] beside it.
 pub async fn our_mediator_carries_tsp(mediator_did: &str) -> Option<bool> {
     if mediator_did.is_empty() {

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -807,6 +807,118 @@ pub async fn peer_messaging_transports(peer_did: &str) -> PeerTransports {
     }
 }
 
+/// Whether **our own** mediator can carry a TSP frame at all.
+///
+/// The other half of the transport decision, and the half a peer's document
+/// cannot answer. A TSP send is an HTTP POST of raw CESR bytes to *our*
+/// mediator's `/inbound` (`affinidi_messaging_sdk::protocols::TspOps::send_raw`)
+/// — the peer's advertised mediator is only the hop the routing layer is sealed
+/// to, and never sees the request. A mediator built without its `tsp` cargo
+/// feature has no protocol sniff compiled in, so it hands the frame to the
+/// DIDComm JSON parser and answers `400 w.m.message.deserialize`, before the
+/// community is reached and with the peer's mediator named in the error.
+///
+/// [`TspCarriage::Unknown`] is kept distinct from [`TspCarriage::Absent`] for
+/// the same reason [`TspDiscovery`] keeps them apart (R6.4): "your mediator does
+/// not do TSP" is worth acting on, "we could not ask" is not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TspCarriage {
+    /// The mediator's own document advertises `TSPTransport` — it speaks TSP.
+    Serves,
+    /// Resolved fine; the mediator advertises no TSP transport. Not a fault of
+    /// ours, and the reason to stay on DIDComm.
+    Absent,
+    /// Could not determine (resolve error, or the bounded wait elapsed).
+    Unknown(String),
+}
+
+/// Ask a mediator's own DID document whether it carries TSP.
+///
+/// Split from applying the result so it is testable against a seeded resolver,
+/// exactly as [`discover_tsp_mediator`] is.
+///
+/// Deliberately **not** `resolve_vta_with_resolver`: that helper keeps a `#tsp`
+/// endpoint only when it is a DID, because a *peer's* `#tsp` advertises its
+/// mediator by DID. A mediator's own `#tsp` carries the transport URL instead
+/// (`https://mediator.example/mediator/v1`), so the VTA-shaped helper drops it
+/// and would report every mediator as TSP-less. `ServiceCapabilities` is the
+/// workspace's one service-type matcher and reads either shape — and matches on
+/// the service `type`, never the `#id` fragment.
+pub(crate) async fn mediator_tsp_carriage(
+    mediator_did: &str,
+    resolver: &affinidi_did_resolver_cache_sdk::DIDCacheClient,
+) -> TspCarriage {
+    let resolved =
+        match tokio::time::timeout(TSP_DISCOVERY_TIMEOUT, resolver.resolve(mediator_did)).await {
+            Ok(Ok(resolved)) => resolved,
+            Ok(Err(e)) => return TspCarriage::Unknown(e.to_string()),
+            Err(_) => {
+                return TspCarriage::Unknown(format!(
+                    "timed out after {}s",
+                    TSP_DISCOVERY_TIMEOUT.as_secs()
+                ));
+            }
+        };
+
+    let doc = match serde_json::to_value(&resolved.doc) {
+        Ok(doc) => doc,
+        Err(e) => return TspCarriage::Unknown(format!("could not re-serialize document: {e}")),
+    };
+
+    if vta_sdk::protocol::matching::ServiceCapabilities::from_did_document(&doc)
+        .tsp
+        .is_some()
+    {
+        TspCarriage::Serves
+    } else {
+        TspCarriage::Absent
+    }
+}
+
+/// Whether the mediator we would post through carries TSP.
+///
+/// `Some(true)` / `Some(false)` are answers; `None` means we could not ask, and
+/// a caller must not read it as either — see [`TspCarriage`]. Exposed publicly
+/// because the ceremony call sites live in the binary crate, matching
+/// [`peer_tsp_mediator`] beside it.
+pub async fn our_mediator_carries_tsp(mediator_did: &str) -> Option<bool> {
+    if mediator_did.is_empty() {
+        return None;
+    }
+    let resolver = match affinidi_did_resolver_cache_sdk::DIDCacheClient::new(
+        affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
+    )
+    .await
+    {
+        Ok(resolver) => resolver,
+        Err(e) => {
+            tracing::debug!(
+                mediator = %mediator_did,
+                "TSP carriage resolver init failed ({e})"
+            );
+            return None;
+        }
+    };
+    match mediator_tsp_carriage(mediator_did, &resolver).await {
+        TspCarriage::Serves => Some(true),
+        TspCarriage::Absent => {
+            tracing::debug!(
+                mediator = %mediator_did,
+                "our mediator advertises no TSPTransport — TSP sends would be rejected"
+            );
+            Some(false)
+        }
+        TspCarriage::Unknown(reason) => {
+            tracing::warn!(
+                mediator = %mediator_did,
+                reason = %reason,
+                "could not determine whether our mediator carries TSP"
+            );
+            None
+        }
+    }
+}
+
 /// What transport discovery decided about the TSP leg.
 ///
 /// Returned rather than logged-and-dropped so the decision is assertable. The
@@ -1125,6 +1237,105 @@ mod tsp_discovery_tests {
             discover_tsp_mediator(VTA, &resolver).await,
             TspDiscovery::NotAdvertised,
         );
+    }
+}
+
+/// Whether *our own* mediator carries TSP — the leg a peer's document cannot
+/// answer, and the one that actually refused a live join.
+///
+/// The failure these pin: a community advertising `#tsp` at a TSP-capable
+/// mediator, joined from a persona whose own mediator was built without the
+/// feature. The send posts to *our* mediator, which fed the CESR frame to its
+/// DIDComm JSON parser and answered `400 w.m.message.deserialize` — while the
+/// error named the community's mediator, which never saw the request.
+#[cfg(test)]
+mod mediator_tsp_carriage_tests {
+    use super::{TspCarriage, mediator_tsp_carriage};
+    use affinidi_did_resolver_cache_sdk::{DIDCacheClient, config::DIDCacheConfigBuilder};
+    use serde_json::json;
+
+    const MEDIATOR: &str = "did:web:mediator.example";
+
+    async fn resolver_serving(services: serde_json::Value) -> DIDCacheClient {
+        let mut client = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("local DID cache");
+        let doc = json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": MEDIATOR,
+            "service": services,
+        });
+        client
+            .add_did_document(
+                MEDIATOR,
+                serde_json::from_value(doc).expect("fixture document"),
+            )
+            .await;
+        client
+    }
+
+    /// A mediator's own `#tsp` carries a transport **URL**, not a mediator DID —
+    /// the shape `resolve_vta_with_resolver` discards, and the reason this check
+    /// reads the document through `ServiceCapabilities` instead.
+    #[tokio::test]
+    async fn a_tsp_mediator_serves() {
+        let resolver = resolver_serving(json!([
+            { "id": format!("{MEDIATOR}#tsp"), "type": "TSPTransport", "serviceEndpoint": "https://mediator.example/mediator/v1" },
+            { "id": format!("{MEDIATOR}#service"), "type": ["DIDCommMessaging"], "serviceEndpoint": [{ "uri": "https://mediator.example/mediator/v1", "accept": ["didcomm/v2"] }] },
+        ]))
+        .await;
+
+        assert_eq!(
+            mediator_tsp_carriage(MEDIATOR, &resolver).await,
+            TspCarriage::Serves,
+        );
+    }
+
+    /// The live shape that broke the join: DIDComm and Authentication, no TSP.
+    /// `Absent` rather than `Unknown`, because the document answered — which is
+    /// what lets the caller downgrade to DIDComm instead of guessing.
+    #[tokio::test]
+    async fn a_didcomm_only_mediator_is_absent_not_unknown() {
+        let resolver = resolver_serving(json!([
+            { "id": format!("{MEDIATOR}#service"), "type": ["DIDCommMessaging"], "serviceEndpoint": [{ "uri": "https://mediator.example/mediator/v1", "accept": ["didcomm/v2"] }] },
+            { "id": format!("{MEDIATOR}#auth"), "type": ["Authentication"], "serviceEndpoint": "https://mediator.example/mediator/v1/authenticate" },
+        ]))
+        .await;
+
+        assert_eq!(
+            mediator_tsp_carriage(MEDIATOR, &resolver).await,
+            TspCarriage::Absent,
+        );
+    }
+
+    /// Matching is on the service `type`, never the `#id` fragment — the OWF
+    /// reference implementation names it `#tsp-transport` where ours says `#tsp`.
+    #[tokio::test]
+    async fn carriage_is_matched_on_type_not_id_fragment() {
+        let resolver = resolver_serving(json!([
+            { "id": format!("{MEDIATOR}#tsp-transport"), "type": "TSPTransport", "serviceEndpoint": "https://mediator.example/mediator/v1" },
+        ]))
+        .await;
+
+        assert_eq!(
+            mediator_tsp_carriage(MEDIATOR, &resolver).await,
+            TspCarriage::Serves,
+        );
+    }
+
+    /// A mediator we could not ask is `Unknown` — never `Absent`. Conflating
+    /// them would report "your mediator does not do TSP" about one we simply
+    /// failed to resolve, and silently downgrade a healthy TSP deployment.
+    #[tokio::test]
+    async fn an_unresolvable_mediator_is_unknown() {
+        let resolver = DIDCacheClient::new(DIDCacheConfigBuilder::default().build())
+            .await
+            .expect("local DID cache");
+
+        assert!(matches!(
+            mediator_tsp_carriage("did:example:nothing-seeded", &resolver).await,
+            TspCarriage::Unknown(_)
+        ));
     }
 }
 

--- a/openvtc-core/src/tsp.rs
+++ b/openvtc-core/src/tsp.rs
@@ -65,9 +65,18 @@ use crate::errors::OpenVTCError;
 /// # Errors
 ///
 /// Returns [`OpenVTCError`] if the document will not serialise, or if the
-/// mediator did not accept the frame. The message names both the peer and the
-/// mediator (R6.4), so an operator can tell a wrong advertised mediator from a
-/// refused send from an unreachable hop.
+/// mediator did not accept the frame. The message names the peer, the routing
+/// hop, **and the mediator the frame was actually posted to** (R6.4), so an
+/// operator can tell a wrong advertised mediator from a refused send from an
+/// unreachable hop.
+///
+/// Naming all three is not belt-and-braces. `send_routed` posts to the
+/// *profile's* mediator — `route[0]` is sealed into the frame, not dialled — so
+/// a rejection quoting only the advertised mediator sends an operator to inspect
+/// a host that never received the request. That happened: a mediator built
+/// without its `tsp` feature answered `400 w.m.message.deserialize` (it fed the
+/// CESR frame to the DIDComm JSON parser), under an error naming the peer's
+/// perfectly healthy TSP mediator.
 pub async fn send_trust_task(
     atm: &ATM,
     profile: &Arc<ATMProfile>,
@@ -83,8 +92,16 @@ pub async fn send_trust_task(
         .send_routed(profile, &route, &payload)
         .await
         .map_err(|e| {
+            // Best-effort: a profile that cannot name its own mediator is not a
+            // reason to lose the send error we actually have to report.
+            let our_mediator = profile
+                .dids()
+                .map(|(_, mediator)| mediator.to_string())
+                .unwrap_or_else(|_| "unknown".to_string());
             OpenVTCError::Config(format!(
-                "TSP send to {to_did} via advertised mediator {tsp_mediator_did}: {e}"
+                "TSP send to {to_did} (routed via its advertised mediator \
+                 {tsp_mediator_did}, posted through our own mediator \
+                 {our_mediator}): {e}"
             ))
         })
 }

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -733,7 +733,7 @@ async fn run_join_sequence(
     // no client can know before sending, and which is the peer's defect to fix
     // rather than ours to route around.
     let transports = openvtc_core::config::peer_messaging_transports(&vtc_did).await;
-    let Some(submit_transport) = transports.preferred() else {
+    let Some(peer_preferred) = transports.preferred() else {
         state.join.fail(format!(
             "This community advertises no messaging transport ({}). Its DID \
              document offers neither a TSP nor a DIDComm service, so a join \
@@ -742,9 +742,12 @@ async fn run_join_sequence(
         ));
         return;
     };
+    // What the community *offers* — not yet the wire the submit goes out on.
+    // That needs our own leg too, and is settled at step 8 once the persona (and
+    // so the mediator we post through) is known.
     state
         .join
-        .info(format!("Community reachable over {submit_transport}."));
+        .info(format!("Community reachable over {peer_preferred}."));
     let _ = handler.state_tx.send(state.clone());
 
     let top_context_id = config.account.top_context_id.clone();
@@ -1085,10 +1088,56 @@ async fn run_join_sequence(
         state.invitation_credential.as_ref(),
         linkage.as_ref(),
     );
-    // Does this community accept Trust Tasks over TSP? `None` — not advertised,
-    // or discovery could not answer — sends over DIDComm exactly as before, so a
-    // VTC that has not been flipped is unaffected.
-    let vtc_tsp_mediator = openvtc_core::config::peer_tsp_mediator(&vtc_did).await;
+    // Settle the wire. TSP needs **both** legs, which is the workspace rule that
+    // the protocol is the highest-preference one present in *both* parties'
+    // documents — and here it is not a formality. A TSP send posts the raw CESR
+    // frame to *our* mediator's `/inbound`; the community's advertised mediator
+    // is only the hop the routing layer is sealed to and never sees the request.
+    // A mediator without its `tsp` feature therefore rejects the frame as an
+    // unparseable DIDComm envelope, and does so while the error names the *other*
+    // mediator — an hour of debugging for a question answerable up front.
+    //
+    // `None` at either end sends over DIDComm exactly as before, so a community
+    // that has not been flipped is unaffected.
+    let vtc_tsp_mediator = match openvtc_core::config::peer_tsp_mediator(&vtc_did).await {
+        None => None,
+        Some(peer_mediator) => {
+            match openvtc_core::config::our_mediator_carries_tsp(&persona_mediator).await {
+                Some(true) => Some(peer_mediator),
+                // Our mediator does not carry TSP. Prefer DIDComm where the
+                // community offers it — a working join beats a correct-looking
+                // one. With TSP the community's *only* transport there is
+                // nothing to fall back to, so send it and let the mediator
+                // answer; refusing here would only replace one failure with
+                // another, minus the evidence.
+                Some(false) if transports.didcomm_mediator.is_some() => {
+                    state.join.info(
+                        "Your mediator does not carry TSP — submitting over DIDComm instead.",
+                    );
+                    let _ = handler.state_tx.send(state.clone());
+                    None
+                }
+                Some(false) => {
+                    state.join.info(
+                        "This community offers TSP only, and your mediator does not \
+                         advertise it — attempting the submit over TSP anyway.",
+                    );
+                    let _ = handler.state_tx.send(state.clone());
+                    Some(peer_mediator)
+                }
+                // Could not ask. Unknown is not "no": take the community's
+                // preference where it has an alternative, since DIDComm is the
+                // transport that worked before TSP existed.
+                None if transports.didcomm_mediator.is_some() => None,
+                None => Some(peer_mediator),
+            }
+        }
+    };
+    let submit_transport = if vtc_tsp_mediator.is_some() {
+        openvtc_core::didcomm::MessagingTransport::Tsp
+    } else {
+        openvtc_core::didcomm::MessagingTransport::DidComm
+    };
     let request_id = match openvtc_core::join::submit_join_request(
         atm,
         &persona_profile,


### PR DESCRIPTION
A join request to a TSP-advertising community died at the first hop:

```
ERROR: Failed to submit join request: Config Error: TSP send to did:webvh:…:dids.ada.ic3.dev:vtc
via advertised mediator did:webvh:…:dids.ada.ic3.dev:mediator: Transport (HTTP(S)) error:
Mediator rejected TSP message: status(400 Bad Request),
body({… "code":"w.m.message.deserialize",
      "comment":"Couldn't parse DIDComm message envelope. Reason: {1}",
      "args":["expected value at line 1 column 1"] …})
```

Every word of that error points at the community's mediator. **It never received the request.**

## The mediator that rejected the frame is ours

A TSP send is an HTTP POST of raw CESR bytes to `profile.get_mediator_rest_endpoint()` — *our own* mediator's `/inbound` (`affinidi_messaging_sdk::protocols::TspOps::send_raw`). The peer's advertised `#tsp` mediator is `route[0]`: the hop the routing layer is **sealed to**, and never dialled by us. So the 400 came from the persona's own mediator, under a message naming a host two domains away.

That mediator was built without its `tsp` cargo feature, which is **not** a default (`mediator` ships `default = ["didcomm", "redis-backend", "jemalloc"]`). Without it the protocol sniff is not compiled in at all, so the CESR frame falls through to `serde_json::from_slice` and comes back as an unparseable DIDComm envelope.

Confirmed at the wire — `/inbound` accepts anonymous posts, so this needs no keys:

```bash
printf '\xf8\x45\x00\x00probe' | curl -s -X POST \
  -H "Content-Type: application/tsp" --data-binary @- \
  https://<host>/mediator/v1/inbound
```

| Mediator | Answer to a TSP frame | |
|---|---|---|
| `…:dids.firstperson.dev:firstperson-mediator` (the persona's) | `19` · `w.m.message.deserialize` | no TSP compiled in |
| `…:dids.ada.ic3.dev:mediator` (the community's) | `37` · `e.m.message.tsp.malformed` | sniffed it as TSP; rejected only the fake magic bytes |

The community's mediator was healthy throughout.

## We only asked one end

`join_flow` chose the wire from `peer_tsp_mediator(&vtc_did)` — the community's document alone. The workspace rule is that the protocol is the highest-preference one present in **both** parties' documents, and here that was not a formality: the persona's own document advertises `DIDCommMessaging` and nothing else. The intersection was DIDComm all along, and the join would have succeeded.

The comment on `peer_messaging_transports` explains why we deliberately do not probe the peer — *"a peer that advertises a transport its binary cannot decode … is the peer's defect to fix, not ours to route around"*. That reasoning is sound and #210 pinned it with a test. It just silently covered the **local** hop too, which is not the peer's defect and is something a client can check before committing to a transport.

## What this does

**1. Gate TSP on our own mediator.** New `config::our_mediator_carries_tsp`, reading our mediator's own DID document for a `TSPTransport` service via `vta_sdk::protocol::matching::ServiceCapabilities` — matched on the service `type`, never the `#id` fragment.

Deliberately not `resolve_vta_with_resolver`: that helper keeps a `#tsp` endpoint only when it is a DID, because a *peer's* `#tsp` advertises its mediator by DID. A mediator's own `#tsp` carries the transport URL instead, so the VTA-shaped helper drops it and would report **every** mediator as TSP-less.

**2. Keep "could not ask" distinct from "does not carry"** (R6.4), the same split `TspDiscovery` already makes. Unknown takes the community's preference wherever DIDComm exists, so a resolver hiccup cannot silently downgrade a healthy TSP deployment.

**3. Degrade only where there is somewhere to degrade to.** Our mediator lacks TSP and the community offers DIDComm → DIDComm, with a visible note. The community offers TSP *only* → send it anyway and let the mediator answer; refusing would replace one failure with another, minus the evidence.

This is not the transport fallback #207 removed and #210 declined: nothing here retries a failed send on another wire, and nothing papers over a **peer** advertising what it cannot serve — that boundary and its test are untouched. This is the transport *choice*, made with both halves of the information instead of one.

**4. Say which transport was actually used.** `submit_transport` on the record and the operator line now report the wire chosen, not the community's advertisement.

**5. Name the mediator we actually posted to.** The send error carries the peer, the routing hop, *and* our own mediator, so a rejection stops sending an operator to inspect a host that never saw the request.

## Verification

- `cargo test --workspace` — 16 test binaries, all green
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --check` — clean
- Four new tests against a seeded resolver: a TSP mediator (URL-shaped `#tsp` — the shape the VTA-helper drops), the live DIDComm-only shape that broke this join, `#tsp-transport` as the id fragment (the OWF reference spelling, to pin type-matching), and unresolvable ⇒ `Unknown` rather than `Absent`

Against the deployment above this turns the failure into a successful DIDComm join with no config change anywhere.

## Not fixed here

Two gaps on the VTI side, neither of which this can reach:

- `did_webvh/document.rs`'s `add_mediator_service` injects only a `DIDCommMessaging` service, so a **VTA-minted persona can never advertise `#tsp`** regardless of how the VTA is configured. Persona-shaped identities are DIDComm-only by construction today.
- The mediator's `tsp` feature being off by default means a stock build silently lacks the sniff, and answers a TSP frame with an error that names DIDComm and never mentions TSP.
