### PR TITLE
fix(join): say the request was sent, not that the community received it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.11"
+version = "0.18.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f623c27d6f0ce96bb765a7a1ec8590030aeccbe93b8c70798d05a8c0db3385"
+checksum = "49fb3bf7087fca7d9b10025f1ef03a6526aaa3abbe8f491b7860000f364e968b"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -395,7 +395,6 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk",
 ]
 
 [[package]]
@@ -450,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aed8bc60621324d13d4d44648433e14909c0826efecd930f6782f0393343954c"
+checksum = "3994145193a940c4fce2905cfc89d85e5999c804295cdd7e7dc8c3c32d6ed018"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -865,7 +864,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -876,7 +875,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2365,7 +2364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2723,7 +2722,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3025,7 +3024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3797,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4920,7 +4919,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5008,9 +5007,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -5451,7 +5450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5751,7 +5750,7 @@ dependencies = [
  "aes-gcm 0.10.3",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -6224,7 +6223,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6791,7 +6790,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6858,7 +6857,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6869,9 +6868,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7492,7 +7491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7704,7 +7703,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7717,7 +7716,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9416,7 +9415,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -1177,7 +1177,23 @@ async fn run_join_sequence(
         return;
     }
 
-    // 10. Success — refresh the communities panel and surface the relaunch prompt.
+    // 10. Sent — refresh the communities panel and surface the relaunch prompt.
+    //
+    // "Sent", not "delivered". Every word below is deliberately about what this
+    // client actually witnessed: `submit_join_request` resolves `Ok` when *our
+    // own mediator* accepts the frame, which says nothing about whether the
+    // community's mediator received it or the community ever read it. Claiming
+    // otherwise is R1.1 — a send `Ok` is not a delivery — and it is the reason a
+    // join that died two hops away read here as an unqualified success while the
+    // community's log showed no trace of it.
+    //
+    // The acknowledgement is asynchronous and cannot be waited for here: the
+    // join flow's `select!` loop reads UI actions only, so the inbound dispatch
+    // that reconciles a receipt (`CommunityRecord::receipt_at`) does not run
+    // until this sequence returns. `pending_unacknowledged` flags the record in
+    // the communities panel if nothing arrives within `PENDING_ACK_GRACE_SECS`,
+    // so the honest thing to do here is name what is still outstanding and point
+    // at where the answer will show up.
     state.main_page.sync_from_config(config);
     // Durable, unlike the ceremony commentary in `state.join`, which is
     // transient UI and gone on the next launch. A submitted join is the thing
@@ -1185,20 +1201,23 @@ async fn run_join_sequence(
     config.public.logs.insert(
         LogFamily::Community,
         format!(
-            "Join request submitted to ({}) as persona ({}) — Pending.",
+            "Join request sent to ({}) as persona ({}) over {} — Pending, not yet acknowledged.",
             state.join.display_name.as_deref().unwrap_or(&vtc_did),
-            persona_did
+            persona_did,
+            submit_transport
         ),
     );
-    state
-        .main_page
-        .log("Join request submitted — Pending in your Communities list.");
+    state.main_page.log(format!(
+        "Join request sent over {submit_transport} — Pending in your Communities list, awaiting \
+         the community's acknowledgement."
+    ));
     state.join.created_community = Some(record);
     state.join.created_persona_did = Some(persona_did.clone());
     state.join.completed = Completion::CompletedOK;
-    state
-        .join
-        .info("Join request submitted — it's now Pending in your Communities list.");
+    state.join.info(format!(
+        "Join request sent over {submit_transport}. Waiting for the community to acknowledge it — \
+         it's Pending in your Communities list, which will flag it if no response arrives."
+    ));
 }
 
 /// Persist the config, abstracting over the openpgp-card touch prompt.

--- a/openvtc/src/ui/pages/join_flow/join_progress.rs
+++ b/openvtc/src/ui/pages/join_flow/join_progress.rs
@@ -93,8 +93,14 @@ impl JoinProgress {
             }
             Completion::CompletedOK => {
                 lines.push(Line::default());
+                // "Sent", not "submitted" or "delivered". What completed is our
+                // half: the request left this client and our mediator accepted
+                // it. Whether the community received it is a separate, later
+                // fact, carried by the acknowledgement (`receipt_at`) — and
+                // wording this as an accomplished submit is what let a join that
+                // never reached its community read here as a success.
                 lines.push(Line::styled(
-                    "Join request submitted.",
+                    "Join request sent.",
                     Style::new().fg(COLOR_SUCCESS).bold(),
                 ));
                 if let Some(rec) = &state.created_community {
@@ -119,8 +125,21 @@ impl JoinProgress {
                     }
                     lines.push(Line::from(vec![
                         Span::styled("  Status:        ", Style::new().fg(COLOR_SUCCESS)),
-                        Span::styled("Pending", Style::new().fg(COLOR_ORANGE)),
+                        Span::styled(
+                            "Pending  ·  not yet acknowledged",
+                            Style::new().fg(COLOR_ORANGE),
+                        ),
                     ]));
+                    // Which wire carried it. When a join goes unanswered this is
+                    // the first thing worth knowing, and reading it off the
+                    // record means it names the transport actually used rather
+                    // than the one the community advertises.
+                    if let Some(transport) = &rec.submit_transport {
+                        lines.push(Line::from(vec![
+                            Span::styled("  Sent over:     ", Style::new().fg(COLOR_SUCCESS)),
+                            Span::styled(transport.to_string(), Style::new().fg(COLOR_SOFT_PURPLE)),
+                        ]));
+                    }
                     // Whether an invitation was actually presented (auto-admit
                     // path) or this is an open request (manual approval) — the
                     // distinction that determines what happens next.
@@ -162,6 +181,12 @@ impl JoinProgress {
                     "It's now in your Communities list, marked Pending — it will update \
                      there as the community responds.",
                     Style::new().fg(COLOR_SUCCESS),
+                ));
+                lines.push(Line::styled(
+                    "The community hasn't acknowledged it yet. That normally takes seconds; \
+                     if it doesn't arrive, the Communities list will flag the request as \
+                     possibly not received.",
+                    Style::new().fg(COLOR_DARK_GRAY),
                 ));
             }
             Completion::CompletedFail => {


### PR DESCRIPTION
A join whose submit died two hops away — swallowed by a mediator that
could not turn the community's DID-shaped `#didcomm` endpoint into a URL,
and stored locally instead of relayed — reported here as an unqualified
success: a bold green "Join request submitted.", a durable log line
saying the same, and a completion message that mentioned only the Pending
state. Nothing in the flow had witnessed the community receive anything.

`submit_join_request` resolves `Ok` when *our own mediator* accepts the
frame. That is the R1.1 rule in the stack development guide — a send `Ok`
is not a delivery — and this is the surface where the lie is most
expensive, because it is the one the operator reads before walking away.

The acknowledgement can't be awaited here: the join flow's `select!` loop
reads UI actions only, so the inbound dispatch that reconciles a receipt
(`CommunityRecord::receipt_at`) doesn't run until the sequence returns. So
this doesn't invent a wait — it says what was and wasn't established, and
points at where the answer lands.

- "Join request sent", not "submitted", everywhere the flow reports the
  outcome: the progress banner, the transient completion message, the
  main-page log, and the durable community log.
- Status reads `Pending · not yet acknowledged`, and the banner says the
  Communities list will flag the request if no response arrives — which
  is `pending_unacknowledged` past `PENDING_ACK_GRACE_SECS`, already
  built but never previewed at the moment it becomes relevant.
- Show the transport that carried the submit, read off the record so it
  names the wire actually used rather than what the community advertises.
  When a join goes unanswered that is the first thing worth knowing.

Signed-off-by: Glenn Gore <glenn.g@affinidi.com>

---

## Why

A join whose submit died two hops away reported here as an unqualified success. The actual failure was in the mediator (affinidi/affinidi-tdk-rs#705): the community's `#didcomm` endpoint names its mediator by DID, the sending mediator had no rule for that shape, so it stored the forward locally and answered 200. Nothing this client saw was wrong — it just reported far more than it knew.

## What changed

Wording and one new field on the completion screen. No behavioural change to the ceremony.

| Before | After |
|---|---|
| **Join request submitted.** | **Join request sent.** |
| Status: Pending | Status: Pending · not yet acknowledged |
| — | Sent over: DIDComm |
| "Join request submitted to (X) as persona (Y) — Pending." | "Join request sent to (X) as persona (Y) over DIDComm — Pending, not yet acknowledged." |

Plus a line on the banner saying the Communities list will flag the request if no response arrives — which `pending_unacknowledged` already does past `PENDING_ACK_GRACE_SECS`, but only two minutes later, in a panel the operator has usually left by then.

## Why not just wait for the acknowledgement

Considered and rejected: the join flow's `select!` loop reads UI actions only, so the inbound dispatch that reconciles a receipt does not run until `run_join_sequence` returns. A wait there would time out 100% of the time.

## Second commit

`chore(deps)`: the semver-compatible half of `cargo update`. The VTI crates are held back — vta-service 0.14.37 wants vta-sdk 0.22 while this repo requires 0.21, and the resulting two-copies graph stops the dev-dependency harness compiling. That crossing is its own change.

## Test plan

- `cargo test` — all suites pass (306 + 260 + the rest, 0 failures).
- `cargo clippy --all-targets` — clean.
- `cargo fmt --all --check` — clean.