### PR TITLE
feat(join): advertise TSP on a minted persona, on vta-sdk 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -875,7 +875,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2364,7 +2364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2633,7 +2633,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vgi-core",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -2722,7 +2722,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3024,7 +3024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4919,7 +4919,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5362,7 +5362,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.23.0",
  "windows-native-keyring-store",
  "x25519-dalek 2.0.1",
  "zeroize",
@@ -5421,7 +5421,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.23.0",
  "vta-service",
  "wiremock",
  "x25519-dalek 2.0.1",
@@ -5450,7 +5450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5750,7 +5750,7 @@ dependencies = [
  "aes-gcm 0.10.3",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -6223,7 +6223,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6790,7 +6790,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6857,7 +6857,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7491,7 +7491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7703,7 +7703,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7716,7 +7716,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8607,7 +8607,7 @@ checksum = "eb5e1abb91d5393d5e094232fce0ad8e384167ce7e4b68359b96c4a87800a495"
 dependencies = [
  "tracing",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vti-common",
 ]
 
@@ -8632,7 +8632,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vta-support",
  "vti-common",
  "zeroize",
@@ -8660,7 +8660,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vti-common",
  "x25519-dalek 3.0.0",
 ]
@@ -8675,7 +8675,7 @@ dependencies = [
  "serde_ignored",
  "toml",
  "tracing",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vti-common",
  "vti-secrets",
 ]
@@ -8707,7 +8707,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vti-common",
  "vti-secrets",
  "x25519-dalek 3.0.0",
@@ -8739,7 +8739,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vti-common",
 ]
 
@@ -8756,7 +8756,6 @@ dependencies = [
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk",
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-secrets-resolver",
@@ -8784,6 +8783,48 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "utoipa",
+ "uuid",
+ "x25519-dalek 3.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b8d9df250173cc4f3793f84de441616ba885cc3c1423b926ef3c19232f15a18"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-data-integrity",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-messaging-sdk",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-secrets-resolver",
+ "affinidi-tdk",
+ "affinidi-vc",
+ "base64 0.22.1",
+ "chrono",
+ "ciborium",
+ "curve25519-dalek 5.0.0",
+ "didwebvh-rs",
+ "ed25519-dalek 3.0.0",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hpke",
+ "multibase",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "trust-tasks-rs",
+ "url",
  "uuid",
  "x25519-dalek 3.0.0",
  "zeroize",
@@ -8868,7 +8909,7 @@ dependencies = [
  "vta-keys",
  "vta-keyspaces",
  "vta-policy",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vta-support",
  "vta-sweepers",
  "vta-vault",
@@ -8899,7 +8940,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vti-common",
 ]
 
@@ -8942,7 +8983,7 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vti-common",
 ]
 
@@ -8959,7 +9000,7 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "vti-common",
  "zeroize",
 ]
@@ -9002,7 +9043,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.21.12",
  "webauthn-rs",
  "zeroize",
 ]
@@ -9415,7 +9456,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,37 +140,25 @@ trust-tasks-capability-client = "0.3"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-# The 0.21 line, floored at 0.21.12. Each floor below is a defect this repo had
-# no lever over, kept in order because none of them can be un-met from here.
+# The 0.23 line. Moved off 0.21.12 for `CreateDidWebvhRequest.add_tsp_service`
+# (VTI #959), which is what lets a minted persona advertise `#tsp` at all — see
+# the call site in `setup_sequence/vta.rs`. Without it a persona's document
+# carries one `DIDCommMessaging` entry, so a peer's both-ends transport match
+# can never resolve to TSP however much TSP the rest of the stack speaks.
 #
-# 0.21.11 makes `BootstrapAsk`
-# serialise the `provision/integration/0.2` camelCase ask tags
-# (`adminRotation` / `templateBootstrap`). Up to 0.21.10 it emitted the 0.1
-# PascalCase spellings while submitting under the 0.2 type URI, and the VTA's
-# payload-schema gate rejected every provisioning request — setup could not get
-# past "Provision integration DID + admin credential" (VTI #917). Nothing here
-# had a lever over that casing, so the floor is the fix.
+# Two minors were crossed (0.22 and 0.23, each breaking under 0.x semver) and the only
+# thing that broke here was the new field itself: verified by building this
+# workspace against the unreleased sdk before the bump, where `add_tsp_service`
+# was the sole compile error and every test still passed.
 #
-# 0.21.10 remains the floor's other reason: it is the release that moved its own
-# `trust-tasks-rs` requirement to `^0.4`. An earlier 0.21.x still asks for
-# `^0.2.55`, which would resolve a second trust-tasks in the graph alongside
-# ours and break `TrustTask` type unification across the sdk boundary.
-# It supersedes the 0.20.24 floor that
-# `protocols::members::MemberVmcBody`'s `request_id` field once set, and the
-# 0.20.6 floor the TSP leg set (see the `tsp` feature note below) — both
-# predate this major and neither can be un-met from here.
-#
-# 0.21.12 is the current floor, and it is the same class of defect one layer
-# down: `CreateKeyBody` serialized its unset members as `null`, and
-# `keys/create/0.1` types them `"string"`, so the VTA refused every key
-# creation over DIDComm and TSP (VTI #919). Joining a community mints a
-# persona's signing key first, so a join died on its first round-trip with
-# `malformedRequest … null is not of type "string"` and rolled back. REST was
-# unaffected — it serializes a different struct, which already skipped its
-# `None`s — so only the transports this CLI actually prefers were broken.
-# Nothing here had a lever over that either: the payload is built inside the
-# sdk's own `create_key`.
-vta-sdk = { version = "0.21.12", features = [
+# The old 0.21.x floor notes are gone with the line. Each recorded a defect this
+# repo had no lever over — 0.21.10's `trust-tasks-rs` `^0.4` requirement (type
+# unification across the sdk boundary), 0.21.11's `provision/integration/0.2`
+# camelCase ask tags (VTI #917), 0.21.12's `CreateKeyBody` serialising unset
+# members as `null` and killing key creation over DIDComm and TSP (VTI #919).
+# All are below this floor by construction; they are kept in git history rather
+# than as a wall of satisfied constraints.
+vta-sdk = { version = "0.23", features = [
   "session",
   "client",
   "didcomm",

--- a/openvtc-core/tests/mockvta_bootstrap_e2e.rs
+++ b/openvtc-core/tests/mockvta_bootstrap_e2e.rs
@@ -156,6 +156,9 @@ async fn persona_did_webvh_mint_round_trips() {
             label: None,
             portable: false,
             add_mediator_service: false,
+            // This harness asserts the bootstrap round-trip, not document
+            // shape; no mediator service is requested, so no TSP entry either.
+            add_tsp_service: false,
             additional_services: None,
             pre_rotation_count: 0,
             did_document: None,

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -297,6 +297,21 @@ pub async fn create_did_via_server(
             label: None,
             portable: true,
             add_mediator_service: true,
+            // Advertise `#tsp` at the same mediator, so a peer's both-ends
+            // transport match can actually resolve to TSP for this persona.
+            // Without it the document carries one `DIDCommMessaging` entry and
+            // the intersection is DIDComm however much TSP the rest of the
+            // stack speaks — which is what #211 diagnosed and could only work
+            // around by degrading.
+            //
+            // Safe to assert unconditionally from here, from both sides:
+            // ours, because a persona's inbound TSP arrives on the mediator
+            // socket `DidCommTransport` already owns and surfaces by protocol
+            // (see `openvtc_core::tsp`) — we can read what we advertise; and
+            // the VTA's, because it drops the entry unless it has `[services]
+            // tsp` on with a mediator configured, so a DIDComm-only VTA still
+            // mints exactly the document it minted before.
+            add_tsp_service: true,
             additional_services: None,
             pre_rotation_count: 1,
             did_document: None,


### PR DESCRIPTION
The half of #211 that #211 could not do.

A persona's DID document carried exactly one service entry:

```json
"service": [{ "id": "…#vta-didcomm", "type": "DIDCommMessaging",
              "serviceEndpoint": [{ "uri": "did:webvh:…:mediator" }] }]
```

That is what `create_did_via_server` gets when it asks the VTA for its mediator, because until now the VTA had no way to add anything else. So the both-ends transport rule — the protocol is the highest-preference one present in **both** documents — could never resolve to TSP for a persona, however much TSP the rest of the stack spoke. #211 diagnosed that from the failing side and could only degrade around it. [VTI #959](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/959) added the wire field; this asks for it.

## Why `true` unconditionally

VTI #959 made this opt-in deliberately: a DID advertising a transport its **holder** cannot decode is unreachable over that transport, and only the caller knows whether the client behind the DID reads TSP frames. Both sides of that question are settled here:

- **Ours.** A persona's inbound TSP arrives on the mediator socket `DidCommTransport` already owns and surfaces by protocol (`openvtc_core::tsp`). We can read what we advertise.
- **The VTA's.** It drops the entry unless it has `[services] tsp` on with a mediator configured, so a DIDComm-only VTA still mints exactly the document it minted before. Nobody has to coordinate a rollout.

## The bump: 0.21.12 → 0.23

Two minors, each breaking under 0.x semver, and `add_tsp_service` was the only thing that broke. Verified *before* 0.23 was published by pointing `[patch.crates-io]` at a local VTI checkout: sole compile error, all 660+ tests green. Re-verified against the real 0.23.0 from crates.io.

The 0.21.x floor notes go with the line. Each recorded a defect this repo had no lever over — 0.21.10's `trust-tasks-rs` `^0.4` requirement, 0.21.11's `provision/integration/0.2` camelCase ask tags (VTI #917), 0.21.12's `CreateKeyBody` serialising unset members as `null` (VTI #919). All sit below this floor by construction, and git history keeps them better than a wall of satisfied constraints.

## Dependency refresh: targeted, and here is why

A blanket `cargo update` does not survive. It moves the published VTI crates in the dev-dependency graph and `vta-service` then fails to compile, at ten call sites:

```
error[E0308]: mismatched types
  --> vta-service-0.14.37/src/messaging/handlers.rs:823
    expected `vti_common::acl::ApproveScope`, found `vta_sdk::acl::ApproveScope`
```

Equally at 0.14.37 and at the 0.14.24 we were on — so it is the crates moving underneath it, not the version bump. That is an upstream packaging problem in the published VTI crates, worth reporting there rather than absorbing here. `cargo outdated --root-deps-only` finds nothing else stale: the only entry it lists is that same `vta-service` dev-dep, and it is lockfile-only (the requirement is already `"0.14"`).

## Two vta-sdk nodes, for now

`did-git-sign` 0.4.2 requires `vta-sdk = "^0.21.10"`, so the lockfile carries 0.21.12 for it alongside 0.23.0 for `openvtc-core`. Verified that this compiles and the full suite passes — no type crosses that boundary today. A `did-git-sign` release accepting 0.23 collapses it, and is being prepared; this PR does not wait on it, and can pick up the bump before merge.

## Verification

- `cargo test --workspace` — 16 test binaries, all green, against the published `vta-sdk` 0.23.0
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt` — clean

## What this does not do

It does not make any *existing* persona advertise TSP — DID documents are minted once, and this changes the mint. Nor does it help a persona whose mediator was built without the `tsp` cargo feature: that mediator rejects the frame at `/inbound`, which is what [tdk#704](https://github.com/affinidi/affinidi-tdk-rs/pull/704) made say so out loud.
