### PR TITLE
fix(messaging): collect stored mail on connect, and start messaging before the first join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Collect the messages the mediator is holding, instead of waiting to be
+  pushed** — every inbound message OpenVTC has ever received arrived by live
+  delivery. A mediator live-streams a message only to a recipient connected at
+  the instant it lands; everything else is stored, and a stored inbox is
+  redelivered **only** when a new websocket *displaces* an existing one for the
+  same DID (`websocket_streaming.rs`, `if replacing`). Enabling live delivery
+  drains nothing. So a listener that connects for the first time — the applicant
+  persona during a join, a community's session after a restart, any identity
+  whose socket was down when a reply arrived — was never told what was already
+  waiting for it, and nothing in this client ever asked.
+
+  That is the join that sits `Pending` while the community's outbox reports
+  `Sent`, and it is why relaunching the app appeared to fix it: the new process's
+  socket displaced the old one, and *that* is what made the mediator redelivery
+  fire. The recovery was a side effect of how the previous process happened to
+  exit.
+
+  `Messaging::pickup_stored` now collects a listener's stored mail over
+  message-pickup 3.0 and hands each message to the state handler on the same
+  channel a live frame uses, and `pickup_on_connect` runs it on every connect —
+  first connect and reconnect alike, since a reconnect is exactly when something
+  may have landed with nobody attached. Messages are acknowledged **after**
+  handoff, never before, the same discipline the delivery layer's own dispatcher
+  follows; a frame that could not be unsealed, mapped, or queued is deliberately
+  *not* acked, so nothing is deleted unread. Bounded at 200 messages per connect
+  (R1.4), with the remainder logged rather than silently dropped.
+
+  Classification is shared with the live dispatcher rather than copied
+  (`classify_inbound`), so the two paths cannot drift into admitting different
+  message types — and the authcrypt sender binding is applied to a collected
+  message too, because these carry membership decisions and credentials and must
+  not be the one path where a spoofed `from` is believed.
+
+  Delivery is at-least-once by design (a message may also arrive live); the
+  runtime loop's `SeenMessages` is what makes that harmless.
+
+- **Start messaging before the first join, not after it** — a State-A account
+  (no persona yet) ran its join with no messaging runtime at all, so the
+  applicant had no socket for the entire ceremony. A community auto-admitting an
+  invited join answers in under a second, so its reply was stored rather than
+  streamed — and since the hot-start's listener was a *first* connect, the
+  mediator never redelivered it either. The first join a new operator makes was
+  the one join with no live recipient.
+
+  The runtime now comes up **before** the State-A branch and empty
+  (`start_empty_service`; `Messaging::start` runs its dispatcher before the first
+  transport exists, so this is a supported state, not a stub), and the degraded
+  loop hands it to `join_flow`. A State-A join therefore connects its applicant
+  before submitting, exactly as the runtime-loop join already does.
+  `install_listeners` then adds whatever is missing, skipping any the join
+  already brought up — one websocket per DID.
+
+  The durable join record also now states whether the applicant was connected at
+  submit. A join sent from an unconnected persona is still valid, but it is the
+  one that takes the collect-on-connect path, and an operator reading the log
+  later could not otherwise tell that from a community that never answered.
+
 - **Connect the applicant persona before submitting the join, not after** — a
   join over an accepted invitation is auto-admitted in well under a second, and
   the community pushes the membership credential (VMC) and role credential (VEC)

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -46,6 +46,9 @@ use affinidi_messaging_delivery::{
     Delivery, InMemoryOutboxStore, MessagingService, OutboxStore, drain_loop_via,
 };
 use affinidi_messaging_sdk::DidCommTransport;
+/// A picked-up frame, tagged by protocol — the stored-mail counterpart of the
+/// live stream's `Protocol`-tagged `Inbound`.
+use affinidi_messaging_sdk::protocols::message_pickup::InboundFrame;
 use affinidi_tdk::common::TDKSharedState;
 use affinidi_tdk::common::config::TDKConfig;
 use affinidi_tdk::common::profiles::TDKProfile;
@@ -191,6 +194,17 @@ const REBUILD_BACKOFF_CAP: std::time::Duration = std::time::Duration::from_secs(
 /// How often the supervisor evaluates transports.
 const SUPERVISOR_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// How many stored messages one pickup round asks the mediator for. The SDK
+/// caps a delivery-request at 100; 50 keeps a single `delivery` response small
+/// while still clearing a normal mailbox in one round trip.
+const PICKUP_PAGE: usize = 50;
+
+/// Ceiling on one pickup's total (R1.4 — a loop over a peer's data is bounded).
+/// A mailbox larger than this is a pathology, not a backlog; the remainder stays
+/// stored and is collected on the next connect rather than flooding the event
+/// channel in one go.
+const PICKUP_MAX: usize = 200;
+
 /// Backoff before the `attempts`-th consecutive rebuild: 5 s, 10 s, 20 s, 40 s,
 /// then capped at 60 s. `attempts == 0` (none yet) is no wait.
 fn rebuild_backoff(attempts: u32) -> std::time::Duration {
@@ -238,6 +252,11 @@ struct DownSince {
 /// hid this behind `send_message(listener_id, …)`.
 struct IdentityWire {
     atm: ATM,
+    /// The ATM profile the wire speaks through. Held because message-pickup is a
+    /// profile-scoped operation (`send_delivery_request_frames`,
+    /// `send_messages_received`), and the transport does not surface the profile
+    /// it was bound to.
+    profile: Arc<ATMProfile>,
     did: String,
     /// Kept so the supervisor can rebuild this identity's wire from scratch.
     ///
@@ -292,6 +311,14 @@ struct MessagingInner {
     /// `affinidi-messaging-delivery` 0.1.12).
     outbox: Arc<dyn OutboxStore>,
     identities: tokio::sync::RwLock<HashMap<String, IdentityWire>>,
+    /// Where [`Messaging::pickup_stored`] hands a stored message off. The live
+    /// dispatcher owns its own clone; this one exists because a pickup emits the
+    /// *same* events by the *same* route, so a consumer cannot tell (and must
+    /// not have to) whether a message was streamed or collected.
+    event_tx: mpsc::Sender<DIDCommEvent>,
+    /// Listener ids with a pickup currently running, so a flapping socket
+    /// cannot stack overlapping drains of the same mailbox.
+    pickup_in_flight: std::sync::Mutex<std::collections::HashSet<String>>,
     /// Dispatcher + per-identity drains, aborted on [`Messaging::shutdown`].
     tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
@@ -311,6 +338,8 @@ impl Messaging {
             status_tx: status_tx.clone(),
             outbox,
             identities: tokio::sync::RwLock::new(HashMap::new()),
+            event_tx: event_tx.clone(),
+            pickup_in_flight: std::sync::Mutex::new(std::collections::HashSet::new()),
             tasks: std::sync::Mutex::new(Vec::new()),
         });
 
@@ -325,12 +354,13 @@ impl Messaging {
         let messaging = Self { inner };
         let supervised = messaging.clone();
         let supervisor = tokio::spawn(async move { supervise_transports(supervised).await });
-        messaging
-            .inner
-            .tasks
-            .lock()
-            .expect("tasks mutex")
-            .push(supervisor);
+        let collecting = messaging.clone();
+        let collector = tokio::spawn(async move { pickup_on_connect(collecting).await });
+        {
+            let mut tasks = messaging.inner.tasks.lock().expect("tasks mutex");
+            tasks.push(supervisor);
+            tasks.push(collector);
+        }
 
         messaging
     }
@@ -403,6 +433,153 @@ impl Messaging {
                 _ => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
             }
         }
+    }
+
+    /// Collect the messages the mediator is **holding** for `listener_id` and
+    /// hand them to the state handler on the same channel a live frame uses.
+    /// Returns how many were handed off.
+    ///
+    /// ## Why this exists
+    ///
+    /// A mediator live-streams a message only to a recipient that is connected
+    /// at the instant it lands. Everything else is stored — and stored is where
+    /// it stays: the mediator redelivers a stored inbox **only** when a new
+    /// socket *displaces* an existing one for the same DID
+    /// (`websocket_streaming.rs`, `if replacing`), and enabling live delivery
+    /// does not drain anything. So a listener that connects for the first time —
+    /// the applicant persona during a join, a community's session coming up
+    /// after a restart, any identity whose socket was down when a reply arrived
+    /// — hears nothing about what is already waiting for it.
+    ///
+    /// That is the shape of the join that sits `Pending` with the community's
+    /// outbox reporting `Sent`, and it is why relaunching the app "fixes" it:
+    /// the new process's socket displaces the old one and the mediator finally
+    /// redelivers. Collecting explicitly makes that recovery ours rather than a
+    /// side effect of how the previous process happened to exit.
+    ///
+    /// ## Contract
+    ///
+    /// Message-pickup 3.0 delivery-request, then `messages-received` for what
+    /// was handed off — ack **after** handoff, never before, which is the same
+    /// discipline the delivery layer's own dispatcher follows. A frame that
+    /// could not be unsealed, mapped, or queued is deliberately **not** acked:
+    /// it stays in the mailbox rather than being deleted unread, and the drain
+    /// stops there (a stuck frame at the head of the queue would otherwise be
+    /// re-fetched forever). Bounded at [`PICKUP_MAX`] messages per call (R1.4);
+    /// the remainder is left for the next connect and logged rather than
+    /// silently dropped.
+    ///
+    /// Delivery is at-least-once by design: a message may also arrive live. The
+    /// runtime loop's `SeenMessages` is what makes that harmless.
+    pub async fn pickup_stored(&self, listener_id: &str) -> Result<usize, MessagingError> {
+        let (atm, profile) = {
+            let identities = self.inner.identities.read().await;
+            let wire = identities
+                .get(listener_id)
+                .ok_or_else(|| MessagingError::UnknownListener(listener_id.to_string()))?;
+            (wire.atm.clone(), wire.profile.clone())
+        };
+        let fail = |reason: String| MessagingError::Listener {
+            listener_id: listener_id.to_string(),
+            reason,
+        };
+
+        let mut handed_off = 0usize;
+        while handed_off < PICKUP_MAX {
+            let batch = atm
+                .message_pickup()
+                .send_delivery_request_frames(&profile, Some(PICKUP_PAGE), true)
+                .await
+                .map_err(|e| fail(format!("delivery-request failed: {e}")))?;
+            if batch.is_empty() {
+                break;
+            }
+            let requested = batch.len();
+
+            let mut acks: Vec<String> = Vec::with_capacity(requested);
+            for (frame, attachment_id) in batch {
+                // An attachment the mediator could not hand over: there is
+                // nothing to deliver, but it must still be acked or every future
+                // pickup re-fetches the same dead entry.
+                let Some(frame) = frame else {
+                    acks.push(attachment_id);
+                    continue;
+                };
+                let Some((message, transport, from)) =
+                    frame_to_message(&atm, &profile, frame).await
+                else {
+                    continue;
+                };
+                let events = classify_inbound(message, transport, from, listener_id.to_string());
+                // An unroutable type is *handled* — the live path drops it too —
+                // so ack it rather than leaving it to be re-fetched forever.
+                if events.is_empty() {
+                    acks.push(attachment_id);
+                    continue;
+                }
+                let mut queued = true;
+                for event in events {
+                    if let Err(e) = self.inner.event_tx.try_send(event) {
+                        tracing::warn!(
+                            error = %e,
+                            "DIDComm event channel saturated during pickup — leaving the message stored"
+                        );
+                        queued = false;
+                        break;
+                    }
+                }
+                if queued {
+                    handed_off += 1;
+                    acks.push(attachment_id);
+                }
+            }
+
+            if !acks.is_empty() {
+                let acked = acks.len();
+                if let Err(e) = atm
+                    .message_pickup()
+                    // `wait_for_response`: the reply is the mediator's status
+                    // after the delete, so waiting is what makes a failed ack
+                    // visible here instead of showing up as the same messages
+                    // arriving again on the next connect.
+                    .send_messages_received(&profile, &acks, true)
+                    .await
+                {
+                    // The messages are already with the state handler; failing to
+                    // ack only means the mediator serves them again, which
+                    // `SeenMessages` absorbs. Not worth failing the pickup over.
+                    tracing::warn!(
+                        listener = %crate::display::truncate_did(listener_id, 32),
+                        acked,
+                        error = %e,
+                        "could not acknowledge picked-up messages; they will be offered again"
+                    );
+                }
+            }
+
+            // Only continue once a *whole* full page was accounted for. A frame
+            // left unacked stays at the head of the queue, so another round would
+            // fetch the same page again — this is what makes the loop terminate
+            // without ever deleting something we could not read.
+            if acks.len() < requested || requested < PICKUP_PAGE {
+                break;
+            }
+        }
+
+        if handed_off >= PICKUP_MAX {
+            tracing::warn!(
+                listener = %crate::display::truncate_did(listener_id, 32),
+                limit = PICKUP_MAX,
+                "stored-message pickup hit its per-connect limit; the rest stays in the mailbox"
+            );
+        } else if handed_off > 0 {
+            tracing::info!(
+                listener = %crate::display::truncate_did(listener_id, 32),
+                count = handed_off,
+                "collected messages the mediator was holding"
+            );
+        }
+        Ok(handed_off)
     }
 
     /// Stop every drain and the dispatcher, and drop all transports.
@@ -629,7 +806,7 @@ pub async fn add_listener(service: &Messaging, spec: &ListenerSpec) -> Result<()
         .await
         .map_err(|e| fail(format!("mediator connect: {e}")))?;
     let transport: Arc<dyn MessageTransport> = Arc::new(
-        DidCommTransport::new(atm.clone(), profile)
+        DidCommTransport::new(atm.clone(), profile.clone())
             .await
             .map_err(|e| fail(format!("transport bind: {e}")))?,
     );
@@ -642,6 +819,7 @@ pub async fn add_listener(service: &Messaging, spec: &ListenerSpec) -> Result<()
         spec.id.clone(),
         IdentityWire {
             atm,
+            profile,
             did: spec.did.clone(),
             spec: spec.clone(),
         },
@@ -667,14 +845,6 @@ pub async fn add_listener(service: &Messaging, spec: &ListenerSpec) -> Result<()
 /// `vtc-service` made when it cut over. Acking is **not** done here: the service's
 /// own dispatcher acks after handoff, never before.
 async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender<DIDCommEvent>) {
-    let catch_all = match regex::Regex::new(&format!("^(?:{OPENVTC_CATCH_ALL_PATTERN})$")) {
-        Ok(re) => re,
-        Err(e) => {
-            tracing::error!(error = %e, "catch-all pattern failed to compile — inbound dispatch is dead");
-            return;
-        }
-    };
-
     let mut inbound = service.subscribe();
     while let Some(item) = inbound.next().await {
         // Both protocols arrive on this one stream — `DidCommTransport` owns the
@@ -707,51 +877,160 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
         // The transport authenticated the sender; the plaintext `from` header is
         // sender-controlled. Prefer the cryptographically-bound one.
         let from = item.message.sender.clone().or_else(|| message.from.clone());
-        let listener_id = item.message.recipient.clone();
 
-        let event = if message.typ == TRUST_PING_TYPE {
-            // Not auto-answered: the state handler pongs only after checking the
-            // sender has a relationship.
-            DIDCommEvent::TrustPingReceived {
-                from,
-                listener_id,
-                message_id: message.id.clone(),
+        for event in classify_inbound(message, transport, from, item.message.recipient.clone()) {
+            if let Err(e) = event_tx.try_send(event) {
+                tracing::warn!(error = %e, "DIDComm event channel saturated — dropping inbound message");
             }
-        } else if message.typ == TRUST_PONG_TYPE {
-            // Forwarded as both: InboundMessage drives task removal, the pong
-            // event drives the activity log.
-            let _ = event_tx
-                .try_send(DIDCommEvent::TrustPongReceived { from: from.clone() })
-                .inspect_err(|e| tracing::warn!(error = %e, "dropping trust-pong log event"));
-            DIDCommEvent::InboundMessage {
-                from,
-                message: Box::new(message),
-                transport,
-            }
-        } else if catch_all.is_match(&message.typ) {
-            tracing::info!(
-                listener = %crate::display::truncate_did(&item.message.recipient, 32),
-                msg_type = %message.typ,
-                from = ?from.as_deref().map(|d| crate::display::truncate_did(d, 32)),
-                thid = ?message.thid,
-                "inbound OpenVTC message received"
-            );
-            DIDCommEvent::InboundMessage {
-                from,
-                message: Box::new(message),
-                transport,
-            }
-        } else {
-            // Pickup-status heartbeats and anything else: dropped, as the
-            // framework's ignore-handler and fallback did.
-            debug!(typ = %message.typ, "unhandled message type — dropped");
-            continue;
-        };
-
-        if let Err(e) = event_tx.try_send(event) {
-            tracing::warn!(error = %e, "DIDComm event channel saturated — dropping inbound message");
         }
     }
+}
+
+/// Unseal one picked-up frame into the shape [`classify_inbound`] takes, with
+/// the cryptographically-bound sender the live path would have carried.
+///
+/// The live stream arrives pre-mapped by the SDK's transport adapter; a frame
+/// collected from storage has not been through it, so the same two unsealings
+/// happen here — DIDComm was already unpacked by the delivery-request handler
+/// (which is where the metadata comes from), TSP is unsealed by `atm.tsp()`,
+/// exactly as `tsp_to_inbound` does on the live path.
+async fn frame_to_message(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    frame: InboundFrame,
+) -> Option<(Message, MessagingTransport, Option<String>)> {
+    match frame {
+        InboundFrame::DidComm(message, meta) => {
+            let from = authenticated_sender(&message, &meta);
+            Some((*message, MessagingTransport::DidComm, from))
+        }
+        InboundFrame::Tsp(packed) => {
+            // `unpack` authenticates the sender VID (resolve + verify), so
+            // `sender` here is proven, not self-asserted — the same guarantee
+            // the live path's `Inbound.message.sender` carries.
+            let (payload, sender) = match atm.tsp().unpack(profile, &packed).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "could not unpack a stored TSP frame — leaving it in the mailbox");
+                    return None;
+                }
+            };
+            // The mediator keys a stored TSP frame on `sha256(packed)`, which is
+            // the id the live path falls back to when the document carries none.
+            let fallback_id = {
+                use sha2::{Digest, Sha256};
+                hex::encode(Sha256::digest(packed.as_bytes()))
+            };
+            let recipient = profile.inner.did.clone();
+            let message =
+                tsp_document_to_message(&payload, Some(&sender), &recipient, &fallback_id)?;
+            Some((message, MessagingTransport::Tsp, Some(sender)))
+        }
+        // `InboundFrame` is `#[non_exhaustive]`: a protocol OpenVTC does not
+        // speak. Left in the mailbox rather than acked — the same handling the
+        // live dispatcher gives an unsupported `Protocol`, minus the deletion.
+        other => {
+            debug!(frame = ?std::mem::discriminant(&other), "picked-up frame on an unsupported protocol — left stored");
+            None
+        }
+    }
+}
+
+/// The DID that actually authcrypted a picked-up DIDComm message, or `None`
+/// when there is none.
+///
+/// A mirror of the SDK transport adapter's `authenticated_sender`, which is
+/// private to that crate. The plaintext `from` header is sender-controlled: an
+/// attacker can authcrypt with their own key (so `authenticated` is true) while
+/// claiming a victim's `from`, and only the `from == DID(encrypted_from_kid)`
+/// check rejects that. The live path gets this for free; a picked-up message
+/// must not be the one place where it is skipped, because these messages carry
+/// membership decisions and credentials.
+///
+/// Belongs upstream on `InboundFrame` rather than here — see the note in
+/// [`Messaging::pickup_stored`].
+fn authenticated_sender(
+    message: &Message,
+    meta: &affinidi_messaging_sdk::messages::compat::UnpackMetadata,
+) -> Option<String> {
+    if !meta.authenticated || meta.anonymous_sender {
+        return None;
+    }
+    let kid = meta.encrypted_from_kid.as_deref()?;
+    let key_did = kid.split_once('#').map(|(did, _)| did).unwrap_or(kid);
+    match message.from.as_deref() {
+        Some(from) if from == key_did => Some(from.to_string()),
+        _ => None,
+    }
+}
+
+/// The routing gate, compiled once and shared by the live dispatcher and the
+/// stored-message pickup so the two admit **exactly** the same set.
+///
+/// It used to be compiled inside `dispatch_inbound`, where a compile failure
+/// silently killed inbound dispatch for the process. The pattern is a `const`
+/// covered by `catch_all_tests`, so a failure is a build-time bug; treating it
+/// as one here is what lets both call sites share a single compiled regex
+/// without either carrying an unreachable error path.
+static CATCH_ALL: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+    regex::Regex::new(&format!("^(?:{OPENVTC_CATCH_ALL_PATTERN})$"))
+        .expect("OPENVTC_CATCH_ALL_PATTERN is a constant, and `catch_all_tests` compiles it")
+});
+
+/// Classify one already-decoded inbound message into the events the state
+/// handler consumes. Returns **zero or more**: an unroutable type yields none, a
+/// trust-pong yields two (the log event and the message itself).
+///
+/// Peeled out of [`dispatch_inbound`] so [`Messaging::pickup_stored`] admits the
+/// same messages by the same rules. A message the mediator stored while nobody
+/// was listening is not a different kind of message, and a second copy of this
+/// decision would be free to drift from the live one — which is the failure that
+/// is invisible until a specific reply type stops arriving on one path only.
+fn classify_inbound(
+    message: Message,
+    transport: MessagingTransport,
+    from: Option<String>,
+    listener_id: String,
+) -> Vec<DIDCommEvent> {
+    if message.typ == TRUST_PING_TYPE {
+        // Not auto-answered: the state handler pongs only after checking the
+        // sender has a relationship.
+        return vec![DIDCommEvent::TrustPingReceived {
+            from,
+            listener_id,
+            message_id: message.id.clone(),
+        }];
+    }
+    if message.typ == TRUST_PONG_TYPE {
+        // Forwarded as both: InboundMessage drives task removal, the pong
+        // event drives the activity log.
+        return vec![
+            DIDCommEvent::TrustPongReceived { from: from.clone() },
+            DIDCommEvent::InboundMessage {
+                from,
+                message: Box::new(message),
+                transport,
+            },
+        ];
+    }
+    if CATCH_ALL.is_match(&message.typ) {
+        tracing::info!(
+            listener = %crate::display::truncate_did(&listener_id, 32),
+            msg_type = %message.typ,
+            from = ?from.as_deref().map(|d| crate::display::truncate_did(d, 32)),
+            thid = ?message.thid,
+            "inbound OpenVTC message received"
+        );
+        return vec![DIDCommEvent::InboundMessage {
+            from,
+            message: Box::new(message),
+            transport,
+        }];
+    }
+    // Pickup-status heartbeats and anything else: dropped, as the framework's
+    // ignore-handler and fallback did.
+    debug!(typ = %message.typ, "unhandled message type — dropped");
+    Vec::new()
 }
 
 /// Normalise an inbound TSP frame into the [`Message`] shape the dispatcher and
@@ -782,7 +1061,31 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
 /// warning rather than guessed at: unlike DIDComm there is no envelope to fall
 /// back on, and inventing a type would route it to the wrong handler.
 fn tsp_frame_to_message(item: &affinidi_messaging_core::transport::Inbound) -> Option<Message> {
-    let doc: serde_json::Value = match serde_json::from_slice(&item.message.payload) {
+    tsp_document_to_message(
+        &item.message.payload,
+        item.message.sender.as_deref(),
+        &item.message.recipient,
+        &item.message.id,
+    )
+}
+
+/// The mapping itself, over an already-unsealed TSP payload.
+///
+/// Split from [`tsp_frame_to_message`] because the two ways a TSP frame reaches
+/// us differ only in *who* unsealed it: the live stream arrives as an `Inbound`
+/// the SDK's transport adapter already unpacked, while a frame picked up from
+/// storage ([`Messaging::pickup_stored`]) is unsealed by this crate. The
+/// document-to-`Message` rules above must not be written twice.
+///
+/// `fallback_id` is the frame hash — the id the SDK substitutes when the
+/// document carries none.
+fn tsp_document_to_message(
+    payload: &[u8],
+    sender: Option<&str>,
+    recipient: &str,
+    fallback_id: &str,
+) -> Option<Message> {
+    let doc: serde_json::Value = match serde_json::from_slice(payload) {
         Ok(doc) => doc,
         Err(e) => {
             tracing::warn!(error = %e, "inbound TSP frame is not JSON — dropped");
@@ -803,7 +1106,7 @@ fn tsp_frame_to_message(item: &affinidi_messaging_core::transport::Inbound) -> O
     let id = doc
         .get("id")
         .and_then(|i| i.as_str())
-        .unwrap_or(&item.message.id)
+        .unwrap_or(fallback_id)
         .to_string();
 
     let mut builder = Message::build(id, typ.to_string(), doc.clone());
@@ -814,10 +1117,10 @@ fn tsp_frame_to_message(item: &affinidi_messaging_core::transport::Inbound) -> O
     if let Some(thid) = doc.get("threadId").and_then(|t| t.as_str()) {
         builder = builder.thid(thid.to_string());
     }
-    if let Some(sender) = item.message.sender.as_deref() {
+    if let Some(sender) = sender {
         builder = builder.from(sender.to_string());
     }
-    Some(builder.to(item.message.recipient.clone()).finalize())
+    Some(builder.to(recipient.to_string()).finalize())
 }
 
 /// Catch-all pattern for OpenVTC protocol messages + VTC Trust-Task
@@ -1140,6 +1443,59 @@ pub fn spawn_lifecycle_logger(
 ///
 /// A rebuild **removes before it adds**, because the mediator permits one websocket
 /// per DID and rejects a second with `duplicate-channel`.
+/// Collect a listener's stored mail every time its socket comes up.
+///
+/// Subscribes to the same connection transitions the session manager and the
+/// activity log read, so "connected" means the one thing here it means
+/// everywhere else. Every connect qualifies, not just the first: a reconnect is
+/// exactly when a message may have landed with nobody attached.
+///
+/// Each pickup runs detached — the drain is network I/O and must not hold up the
+/// next transition — and at most one per listener is in flight, so a flapping
+/// socket cannot stack overlapping drains of the same mailbox.
+async fn pickup_on_connect(service: Messaging) {
+    let mut transitions = service.subscribe();
+    loop {
+        let listener_id = match transitions.recv().await {
+            Ok(ListenerStatus::Connected { listener_id }) => listener_id,
+            Ok(ListenerStatus::Disconnected { .. }) => continue,
+            // Lagged: transitions were missed, not the mailbox. The next connect
+            // collects whatever accumulated, and a listener that is up *now* is
+            // covered by the supervisor's own reconnect path.
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+        };
+
+        {
+            let mut in_flight = service.inner.pickup_in_flight.lock().expect("pickup mutex");
+            if !in_flight.insert(listener_id.clone()) {
+                continue;
+            }
+        }
+
+        let collector = service.clone();
+        tokio::spawn(async move {
+            if let Err(e) = collector.pickup_stored(&listener_id).await {
+                // Never fatal: the socket is up and live delivery is on, so this
+                // costs only what was already waiting. Named rather than
+                // generic (R6.4) so an operator can tell an unreachable mediator
+                // from a listener that was torn down mid-pickup.
+                tracing::warn!(
+                    listener = %crate::display::truncate_did(&listener_id, 32),
+                    error = %e,
+                    "could not collect stored messages after connect"
+                );
+            }
+            collector
+                .inner
+                .pickup_in_flight
+                .lock()
+                .expect("pickup mutex")
+                .remove(&listener_id);
+        });
+    }
+}
+
 async fn supervise_transports(service: Messaging) {
     let mut down: HashMap<String, DownSince> = HashMap::new();
 
@@ -1307,22 +1663,24 @@ pub async fn start_service(
     event_tx: mpsc::Sender<DIDCommEvent>,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> Result<Messaging, MessagingError> {
-    let service = Messaging::start(event_tx);
+    let service = start_empty_service(event_tx, shutdown);
+    install_listeners(&service, config, tdk).await;
+    Ok(service)
+}
 
-    // Listeners are installed one at a time rather than handed over as a set: each
-    // is an independent mediator connect, and one persona whose mediator is down
-    // must not stop the others coming up. A failure is logged and skipped — the
-    // panel reports per-listener state, so a missing one is visible rather than
-    // silent, and `reconnect_persona_listener_io` is the recovery path.
-    for spec in build_listener_configs(config, tdk).await {
-        if let Err(e) = add_listener(&service, &spec).await {
-            tracing::warn!(
-                listener = %crate::display::truncate_did(&spec.id, 32),
-                error = %e,
-                "listener failed to come up; continuing without it"
-            );
-        }
-    }
+/// Stand the runtime up with **no** listeners, honouring `shutdown`.
+///
+/// Separated from [`start_service`] because a State-A account has no identity to
+/// install a listener for, yet still needs the runtime live: the join flow can
+/// then bring the applicant persona's socket up *before* it submits, which is
+/// the whole of what stops a fast community reply from being stored unread.
+/// `Messaging::start` is built for this — its dispatcher runs before the first
+/// transport exists — so an empty service is a supported state, not a stub.
+pub fn start_empty_service(
+    event_tx: mpsc::Sender<DIDCommEvent>,
+    shutdown: tokio_util::sync::CancellationToken,
+) -> Messaging {
+    let service = Messaging::start(event_tx);
 
     // The framework owned the shutdown token; now it is ours to honour. Dropping
     // every transport on cancel is what stops a stale socket racing the next
@@ -1333,7 +1691,34 @@ pub async fn start_service(
         on_cancel.shutdown().await;
     });
 
-    Ok(service)
+    service
+}
+
+/// Install every listener `config` describes that is not already running.
+///
+/// Idempotent by listener id, because it is called after a path that may have
+/// installed one already: a State-A join brings its own persona up mid-ceremony,
+/// and re-adding that id would error on the duplicate (and, worse, race a second
+/// socket against the live one for the same DID).
+///
+/// Listeners are installed one at a time rather than handed over as a set: each
+/// is an independent mediator connect, and one persona whose mediator is down
+/// must not stop the others coming up. A failure is logged and skipped — the
+/// panel reports per-listener state, so a missing one is visible rather than
+/// silent, and `reconnect_persona_listener_io` is the recovery path.
+pub async fn install_listeners(service: &Messaging, config: &Config, tdk: &affinidi_tdk::TDK) {
+    for spec in build_listener_configs(config, tdk).await {
+        if service.has_listener(&spec.id).await {
+            continue;
+        }
+        if let Err(e) = add_listener(service, &spec).await {
+            tracing::warn!(
+                listener = %crate::display::truncate_did(&spec.id, 32),
+                error = %e,
+                "listener failed to come up; continuing without it"
+            );
+        }
+    }
 }
 
 /// Produce a short, collision-resistant identifier from a DID for listener IDs.

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -465,7 +465,7 @@ impl Messaging {
     /// could not be unsealed, mapped, or queued is deliberately **not** acked:
     /// it stays in the mailbox rather than being deleted unread, and the drain
     /// stops there (a stuck frame at the head of the queue would otherwise be
-    /// re-fetched forever). Bounded at [`PICKUP_MAX`] messages per call (R1.4);
+    /// re-fetched forever). Bounded at `PICKUP_MAX` messages per call (R1.4);
     /// the remainder is left for the next connect and logged rather than
     /// silently dropped.
     ///

--- a/openvtc-core/tests/didcomm_transport_e2e.rs
+++ b/openvtc-core/tests/didcomm_transport_e2e.rs
@@ -189,6 +189,133 @@ async fn an_unrelated_message_type_reaches_no_handler() {
     );
 }
 
+/// A message that arrived while its recipient had **no listener at all** is
+/// collected when one comes up.
+///
+/// This is the join that sits `Pending` forever, reduced to its essentials. A
+/// mediator live-streams only to a recipient connected at the instant the
+/// message lands; everything else is stored, and a stored inbox is redelivered
+/// *only* to a socket that displaces an existing one for the same DID. Bob here
+/// has never connected, so there is nothing to displace: without
+/// `pickup_stored`, this message is unreachable until some future process
+/// happens to replace a socket, which is why relaunching the app "fixed" it.
+///
+/// Deliberately sends **before** bob has any transport — not merely before he is
+/// connected — so no amount of live-stream timing luck can make it pass.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "slow: spawns a real mediator (~1s)"]
+async fn a_message_stored_before_the_listener_existed_is_collected_on_connect() {
+    init_test_tracing();
+    let mediator = MockMediator::start().await.expect("mediator start");
+    let alice = mediator.profile("alice").expect("alice");
+    let bob = mediator.profile("bob").expect("bob");
+    let alice_did = alice.did.clone();
+    let bob_did = bob.did.clone();
+
+    // Sender only. Bob has no service, no transport, no socket.
+    let (alice_tx, _alice_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (alice_service, alice_listener) = start_production_service(alice, &bob_did, alice_tx).await;
+    alice_service
+        .wait_connected(&alice_listener, Duration::from_secs(20))
+        .await
+        .expect("alice listener connects");
+
+    let message = Message::build(
+        Uuid::new_v4().to_string(),
+        OPENVTC_TYPE.to_string(),
+        serde_json::json!({ "hello": "stored" }),
+    )
+    .from(alice_did.clone())
+    .to(bob_did.clone())
+    .finalize();
+
+    send_message_via(&alice_service, &message, &alice_listener, &bob_did)
+        .await
+        .expect("production send delivers to the mediator");
+
+    // Let the mediator finish storing it with no recipient attached. Without
+    // this the send and the connect are milliseconds apart, and the frame is
+    // simply live-delivered to a socket that came up while it was still in
+    // flight — which passes whether or not anything collects stored mail.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Now bring bob up. The connect transition is what triggers the pickup.
+    let (bob_tx, mut bob_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (bob_service, bob_listener) = start_production_service(bob, &alice_did, bob_tx).await;
+    bob_service
+        .wait_connected(&bob_listener, Duration::from_secs(20))
+        .await
+        .expect("bob listener connects");
+
+    let event = tokio::time::timeout(Duration::from_secs(20), bob_rx.recv())
+        .await
+        .expect("bob collects the stored message within 20s")
+        .expect("event channel still open");
+
+    match event {
+        DIDCommEvent::InboundMessage {
+            message,
+            from,
+            transport,
+        } => {
+            assert_eq!(message.typ, OPENVTC_TYPE);
+            assert_eq!(
+                transport,
+                openvtc_core::didcomm::MessagingTransport::DidComm,
+                "a collected DIDComm message still reports DIDComm"
+            );
+            // The anti-spoof binding survives the pickup path: `from` is the DID
+            // that authcrypted the envelope, not the plaintext header. A
+            // collected message carries membership decisions and credentials, so
+            // this must not be the one path where that check is skipped.
+            assert_eq!(
+                from.as_deref(),
+                Some(alice_did.as_str()),
+                "the cryptographically-bound sender survives collection"
+            );
+            assert_eq!(
+                message.body.get("hello").and_then(|v| v.as_str()),
+                Some("stored"),
+            );
+        }
+        other => panic!("expected InboundMessage, got {other:?}"),
+    }
+
+    // A collected message is acknowledged, so it is gone from the mailbox. Were
+    // it not, every connect would re-deliver it — and the *next* connect is a
+    // replacement, which is exactly when the mediator redelivers the whole
+    // undelivered inbox. Replacing bob's transport and hearing nothing is the
+    // assertion that the ack landed.
+    //
+    // The ack is issued after the handoff this test just observed, so tearing
+    // the transport down the instant the event arrives would cancel the ack
+    // in flight and assert a race rather than the behaviour. Give the round trip
+    // room against an in-process mediator.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    bob_service.remove_listener(&bob_listener).await;
+    let (bob_tx2, mut bob_rx2) = mpsc::channel::<DIDCommEvent>(16);
+    let (bob_service2, bob_listener2) =
+        start_production_service(mediator.profile("bob").expect("bob"), &alice_did, bob_tx2).await;
+    bob_service2
+        .wait_connected(&bob_listener2, Duration::from_secs(20))
+        .await
+        .expect("bob reconnects");
+
+    // Anything the *mediator* says about the swap is expected and irrelevant —
+    // replacing a socket earns a `w.websocket.duplicate-channel` problem-report
+    // addressed to the terminated one. The claim is only that the collected
+    // message itself does not come back.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while let Ok(Some(event)) = tokio::time::timeout_at(deadline, bob_rx2.recv()).await {
+        if let DIDCommEvent::InboundMessage { message, .. } = event {
+            assert_ne!(
+                message.typ, OPENVTC_TYPE,
+                "an already-collected message must not be delivered a second time"
+            );
+        }
+    }
+}
+
 /// The supervisor must leave a **healthy** transport alone.
 ///
 /// A rebuild tears the websocket down and builds a new one, so a supervisor that

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -1288,7 +1288,7 @@ async fn run_join_sequence(
     };
     // Last gate before the request goes out: the socket started above has had
     // the invitation + VP work to come up, so this is normally already true.
-    await_persona_online(handler, state, messaging, &applicant_did).await;
+    let applicant_online = await_persona_online(handler, state, messaging, &applicant_did).await;
 
     let request_id = match openvtc_core::join::submit_join_request(
         atm,
@@ -1362,13 +1362,26 @@ async fn run_join_sequence(
     // Durable, unlike the ceremony commentary in `state.join`, which is
     // transient UI and gone on the next launch. A submitted join is the thing
     // you most want a record of when it does not complete.
+    //
+    // Whether the applicant was connected is part of that record. A join
+    // submitted from an unconnected persona is still valid — the community
+    // admits, and `Messaging::pickup_stored` collects the reply when the socket
+    // comes up — but it is the one that takes the slow path, and an operator
+    // reading this log later cannot otherwise tell that from a community that
+    // never answered.
     config.public.logs.insert(
         LogFamily::Community,
         format!(
-            "Join request sent to ({}) as persona ({}) over {} — Pending, not yet acknowledged.",
+            "Join request sent to ({}) as persona ({}) over {} — Pending, not yet acknowledged.{}",
             state.join.display_name.as_deref().unwrap_or(&vtc_did),
             persona_did,
-            submit_transport
+            submit_transport,
+            if applicant_online {
+                ""
+            } else {
+                " The applicant was not connected at submit; a reply that arrives before it \
+                 connects is collected from the mediator rather than streamed."
+            }
         ),
     );
     state.main_page.log(format!(
@@ -1467,21 +1480,25 @@ async fn start_persona_listener(
 /// answer is normally already `Connected` and it returns at once. A persona with
 /// no listener at all (State-A, or an install that failed) is nothing to wait
 /// for, and the submit proceeds either way.
+/// Returns whether the applicant was live at the moment of the submit — which
+/// the durable join record then states, because "sent while offline" is the one
+/// fact that explains a join taking the slow (collect-on-connect) path, and it
+/// has to survive the relaunch you make to go looking.
 async fn await_persona_online(
     handler: &StateHandler,
     state: &mut State,
     messaging: Option<&Messaging>,
     applicant_did: &str,
-) {
+) -> bool {
     let Some(service) = messaging else {
-        return;
+        return false;
     };
     let listener_id = openvtc_core::didcomm::persona_listener_id(applicant_did);
     if !service.has_listener(&listener_id).await {
-        return;
+        return false;
     }
 
-    match service
+    let online = match service
         .wait_connected(&listener_id, PERSONA_CONNECT_TIMEOUT)
         .await
     {
@@ -1489,6 +1506,7 @@ async fn await_persona_online(
             state
                 .join
                 .info("Persona connected — ready to receive the community's reply.");
+            true
         }
         Err(e) => {
             // Installed but not up yet. The listener's own restart policy keeps
@@ -1498,9 +1516,11 @@ async fn await_persona_online(
                 "The persona's mediator session is still connecting — submitting now; the \
                  community's reply will be collected once it is up.",
             );
+            false
         }
-    }
+    };
     let _ = handler.state_tx.send(state.clone());
+    online
 }
 
 /// Persist the config, abstracting over the openpgp-card touch prompt.

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -557,18 +557,42 @@ impl StateHandler {
         // Enter. Dismissing the loading screen (Enter) reveals the main page.
         state.loading_complete = true;
 
+        // The messaging runtime comes up HERE, before the State-A branch, and
+        // empty: `Messaging::start` runs its dispatcher before the first
+        // transport exists, so a service with no listeners is a supported state.
+        //
+        // The ordering is the point. A State-A join used to run with no messaging
+        // at all, so the applicant persona had no socket while the community
+        // decided — and a community auto-admitting an invited join answers in
+        // under a second. Its reply was therefore stored, not streamed, and the
+        // mediator only ever redelivers a stored inbox to a socket that
+        // *displaces* another one, so the hot-start below never heard about it.
+        // That is the first join a new operator makes, which is the worst
+        // possible place for it. Starting the runtime first lets `join_flow`
+        // connect the applicant before it submits, exactly as the runtime-loop
+        // join already does.
+        //
+        // Bounded so a misbehaving mediator can't grow our memory without limit;
+        // overflows surface as `try_send` warnings and the message is left in the
+        // mailbox for `Messaging::pickup_stored` to collect on the next connect.
+        let (didcomm_event_tx, mut didcomm_event_rx) =
+            mpsc::channel(didcomm::DIDCOMM_EVENT_CHANNEL_CAPACITY);
+        let shutdown_token = tokio_util::sync::CancellationToken::new();
+        let didcomm_service =
+            didcomm::start_empty_service(didcomm_event_tx.clone(), shutdown_token.clone());
+
         // A State-A account has no persona/community yet (R-A-5): there is no
-        // DID to open a DIDComm session for. Skip the persona listener entirely
-        // and run the responsive degraded loop so the user can still navigate,
-        // open the Communities page, and start a join.
+        // DID to open a DIDComm session for *yet*. Run the responsive degraded
+        // loop so the user can still navigate, open the Communities page, and
+        // start a join — with the live (empty) messaging runtime, so a join made
+        // there gets its applicant socket up before submitting.
         //
         // Hot-start: if the user *joins* a community in the degraded loop, the
         // join mints a persona into `config.identities` (so `active_identity()`
         // flips None→Some). The degraded loop detects that and hands the runtime
         // context back as `DegradedOutcome::Joined` instead of looping, so we
-        // fall through to the messaging setup below and bring up the persona
-        // listener immediately — no process restart needed to receive the
-        // approval credential.
+        // fall through to the messaging setup below — no process restart needed
+        // to receive the approval credential.
         let (tdk, mut config, admin_vta) = if config.active_identity().is_none() {
             state.connection.status = state::MediatorStatus::NoActiveCommunity;
             let _ = self.state_tx.send(state.clone());
@@ -589,10 +613,16 @@ impl StateHandler {
                     &mut terminator,
                     &mut state,
                     Some(join_ctx),
+                    Some(&didcomm_service),
                 )
                 .await?
             {
-                DegradedOutcome::Exit(interrupted) => return Ok(interrupted),
+                DegradedOutcome::Exit(interrupted) => {
+                    // Drop every socket the State-A join may have opened, rather
+                    // than leaving one racing the next process for the same DID.
+                    shutdown_token.cancel();
+                    return Ok(interrupted);
+                }
                 DegradedOutcome::Joined(ctx) => {
                     state.main_page.sync_from_config(&ctx.config);
                     (ctx.tdk, ctx.config, ctx.admin_vta)
@@ -619,50 +649,10 @@ impl StateHandler {
         state.connection.status = state::MediatorStatus::Connecting;
         let _ = self.state_tx.send(state.clone());
 
-        // Start the DIDComm service (connection lifecycle, message dispatch, sending).
-        // Bounded so a misbehaving mediator can't grow our memory without limit;
-        // overflows surface as `try_send` warnings and the message is dropped
-        // (the mediator pickup protocol will redeliver once we drain).
-        let (didcomm_event_tx, mut didcomm_event_rx) =
-            mpsc::channel(didcomm::DIDCOMM_EVENT_CHANNEL_CAPACITY);
-        let shutdown_token = tokio_util::sync::CancellationToken::new();
-
-        let didcomm_service = match didcomm::start_service(
-            &config,
-            &tdk,
-            didcomm_event_tx.clone(),
-            shutdown_token.clone(),
-        )
-        .await
-        {
-            Ok(svc) => svc,
-            Err(e) => {
-                state.connection.status =
-                    state::MediatorStatus::Failed(format!("DIDComm service: {e:#}"));
-                state
-                    .main_page
-                    .log_error("DIDComm service failed to start", &e);
-                let _ = self.state_tx.send(state.clone());
-                // Messaging is down but the admin VTA session may still be live;
-                // hand it to the degraded loop so the user can still join a
-                // community (State-B path). The loop closes the session on exit.
-                let join_ctx = DegradedJoinContext {
-                    tdk,
-                    config,
-                    admin_vta,
-                    profile: self.profile.clone(),
-                };
-                return self
-                    .run_degraded_loop_terminal(
-                        &mut action_rx,
-                        &mut interrupt_rx,
-                        &mut terminator,
-                        &mut state,
-                        Some(join_ctx),
-                    )
-                    .await;
-            }
-        };
+        // Install this account's listeners on the runtime started above. Skips
+        // any that already exist, so a State-A join's own persona listener is
+        // bound to rather than duplicated (one websocket per DID).
+        didcomm::install_listeners(&didcomm_service, &config, &tdk).await;
 
         // Process-lifetime LRU of inbound message IDs. Backstop for replay
         // and mediator-pickup duplicates beyond what the TDK already filters.
@@ -2734,9 +2724,16 @@ impl StateHandler {
     /// load-failure callers have no loaded config, so they pass `None` and
     /// `StartJoin` is a no-op there.
     ///
+    /// `messaging` is the live (initially listener-less) DIDComm runtime, so a
+    /// join started here can bring the applicant persona's socket up **before**
+    /// it submits. Without it the first join an account ever makes is also the
+    /// one join with no live recipient while the community decides — see the
+    /// ordering note in `run`. The early load-failure callers pass `None`; they
+    /// cannot join at all.
+    ///
     /// Returns [`DegradedOutcome::Joined`] when an in-session join mints the
-    /// account's first persona (State-A → member). The caller then brings up the
-    /// persona's DIDComm listener without a restart (hot-start). All other exits
+    /// account's first persona (State-A → member). The caller then installs the
+    /// remaining listeners without a restart (hot-start). All other exits
     /// return [`DegradedOutcome::Exit`] after closing the admin session.
     async fn run_degraded_loop(
         &self,
@@ -2745,6 +2742,7 @@ impl StateHandler {
         terminator: &mut Terminator,
         state: &mut State,
         mut join_ctx: Option<DegradedJoinContext>,
+        messaging: Option<&didcomm::Messaging>,
     ) -> Result<DegradedOutcome> {
         // R11: the degraded loop persists only via `remove_community` (State-A
         // community withdrawal); `join_flow` saves itself synchronously. Coalesce
@@ -2806,12 +2804,13 @@ impl StateHandler {
                                     &mut ctx.config,
                                     ctx.admin_vta.as_ref(),
                                     ctx.profile.as_str(),
-                                    // State-A: messaging never started (or just
-                                    // failed to). The loop breaks `Joined` on a
-                                    // first join so `run()` restarts into the
-                                    // full pipeline, and startup registration
-                                    // brings the persona's listener up there.
-                                    None,
+                                    // The live runtime, so the applicant persona
+                                    // is connected before the submit goes out and
+                                    // an auto-admitted join's reply is streamed
+                                    // rather than stored unread. `None` only for
+                                    // the early load-failure callers, which
+                                    // cannot reach a join anyway.
+                                    messaging,
                                 )
                                 .await
                             {
@@ -2946,10 +2945,11 @@ impl StateHandler {
         Ok(result)
     }
 
-    /// Run the degraded loop for a path that cannot hot-start (no loaded config,
-    /// or messaging already failed for an existing member), collapsing the
-    /// outcome to an [`Interrupted`]. `DegradedOutcome::Joined` is unreachable
-    /// for these callers — only the State-A entry can transition None→Some.
+    /// Run the degraded loop for a path that cannot hot-start (no loaded config),
+    /// collapsing the outcome to an [`Interrupted`]. `DegradedOutcome::Joined` is
+    /// unreachable for these callers — only the State-A entry can transition
+    /// None→Some. They have no messaging runtime either, and no config to build
+    /// one from.
     async fn run_degraded_loop_terminal(
         &self,
         action_rx: &mut UnboundedReceiver<Action>,
@@ -2959,7 +2959,7 @@ impl StateHandler {
         join_ctx: Option<DegradedJoinContext>,
     ) -> Result<Interrupted> {
         match self
-            .run_degraded_loop(action_rx, interrupt_rx, terminator, state, join_ctx)
+            .run_degraded_loop(action_rx, interrupt_rx, terminator, state, join_ctx, None)
             .await?
         {
             DegradedOutcome::Exit(interrupted) => Ok(interrupted),


### PR DESCRIPTION
fix(messaging): collect stored mail on connect, and start messaging before the first join

Every inbound message this client has ever received arrived by live
delivery. A mediator live-streams a message only to a recipient connected
at the instant it lands; everything else is stored — and a stored inbox is
redelivered ONLY when a new websocket displaces an existing one for the
same DID (`websocket_streaming.rs`, `if replacing`). Enabling live
delivery drains nothing. So a listener connecting for the first time was
never told what was already waiting for it, and nothing here ever asked.

That is the join that sits Pending while the community's outbox reports
Sent. It is also why relaunching "fixed" it: the new process's socket
displaced the old one, and that is what made the mediator redelivery fire.
The recovery was a side effect of how the previous process happened to
exit — #217 closed the window for the runtime-loop join, but left every
residual case depending on that accident.

`Messaging::pickup_stored` collects a listener's stored mail over
message-pickup 3.0 and hands each message to the state handler on the same
channel a live frame uses; `pickup_on_connect` runs it on every connect,
first and subsequent alike, since a reconnect is exactly when something
may have landed with nobody attached. Ack is after handoff, never before —
the delivery layer's own discipline — and a frame that could not be
unsealed, mapped or queued is deliberately NOT acked, so nothing is
deleted unread; that also terminates the drain, since an unacked frame at
the head of the queue would otherwise be refetched forever. Bounded at 200
per connect (R1.4) with the remainder logged, not silently dropped.

Classification is shared with the live dispatcher (`classify_inbound`)
rather than copied, so the two paths cannot drift into admitting different
types, and the authcrypt sender binding is applied to a collected message
too: these carry membership decisions and credentials and must not be the
one path where a spoofed `from` is believed.

Second half: a State-A account ran its join with no messaging runtime at
all (`join_flow(.., None)`), so the applicant had no socket for the whole
ceremony — and the hot-start's listener was a *first* connect, which the
mediator does not redeliver to. The first join a new operator makes was
the one join with no live recipient. The runtime now starts before the
State-A branch and empty (`start_empty_service`), the degraded loop hands
it to `join_flow`, and `install_listeners` adds what is missing afterwards
without duplicating the socket the join already opened. The removed
"DIDComm service failed to start" fallback was unreachable: `start_service`
never returned `Err`.

The durable join record now also states whether the applicant was
connected at submit — a join sent offline is valid but takes the
collect-on-connect path, which the log could not previously distinguish
from a community that never answered.

  cargo test --workspace                       → 666 passed, 0 failed
  cargo test --workspace -- --include-ignored  → 680 passed, 0 failed
  cargo clippy --all-targets -- -D warnings    → clean
  cargo fmt --all                              → clean

The new e2e (`a_message_stored_before_the_listener_existed_is_collected_on_connect`)
was verified to fail with the pickup disabled: the message is stored, bob
connects, enables live delivery, and hears nothing. Its first draft passed
without the fix because the send and the connect were milliseconds apart —
the frame was still in flight — so it now waits out a real offline window
before connecting the recipient.