### PR TITLE
feat(join): ask a community about a join it has not answered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Ask a community about a join it has not answered** — every way a `Pending`
+  join could previously resolve was the community volunteering something: a
+  verdict, a credential, a problem-report. If any of those was lost — a socket
+  down at the wrong moment, a mediator that dropped it, a decision a human took
+  days later when nothing was listening — the record sat `Pending` and this
+  client never asked. `join-requests/status/0.1` is the protocol's answer to
+  exactly that, and OpenVTC had implemented only the receiving half
+  (`handle_join_status_response` existed with nothing to trigger it).
+
+  A minute-by-minute tick now reconciles each pollable `Pending` join, starting
+  with an immediate poll at launch — a join still `Pending` when the app starts
+  is precisely the one whose answer may have been lost. Per record it then backs
+  off 1 → 2 → 4 → 8 minutes, capped at 15, with at most four polls per tick
+  across the account (R1.4), so a parked join is noticed promptly without this
+  client becoming a load source. Pacing is deliberately in memory: it is about
+  this process's politeness, and a stale on-disk backoff would suppress the poll
+  a fresh launch most wants to make. The poll takes the transport the submit took
+  — a TSP-only community would never see a DIDComm poll.
+
+- **Adopt the community's own request id when it first replies** — a join is
+  recorded against the id of the request document *we* sent, because that is the
+  only handle available until the VTC answers; the VTC mints its own and returns
+  it in the first correlated reply. The submit-receipt path already swapped the
+  id in, but a `refer` / `request_more` verdict carries `requestId` too and read
+  straight past it — correlation there is by `thid`, so nothing needed it.
+
+  A referred join is the one that then sits `Pending` for as long as a human
+  takes, so it is the one that most needs to be askable-about later, and without
+  the id there is no handle to ask with. `CommunityRecord::request_id_confirmed`
+  now records *whose* id a record holds, and is the gate on polling: quoting our
+  own placeholder would be asking about a request the community has never heard
+  of. Records written before this default to unconfirmed, which is the safe
+  reading — we cannot tell whose id they hold.
+
+  Note what this does **not** cover: a join that received *no* reply at all has
+  no confirmed id and cannot be polled. That case is not a gap here — it is
+  recovered by collecting the stored mail the reply is sitting in.
+
 ### Fixed
 
 - **Connect the applicant persona before submitting the join, not after** — a

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -226,6 +226,21 @@ pub struct CommunityRecord {
     /// that submits without going through the join flow.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub submit_transport: Option<crate::didcomm::MessagingTransport>,
+    /// Whether the `Pending` request id is the **community's** id rather than
+    /// our submit-time placeholder.
+    ///
+    /// A join is recorded against the id of the request document we sent,
+    /// because that is the only handle we have until the VTC answers; the VTC
+    /// mints its own (`Uuid::new_v4()`) and tells us in the first correlated
+    /// reply. Which of the two the record currently holds decides whether the
+    /// community can be *asked* about this join
+    /// ([`crate::join::poll_join_status`]) — a poll quoting our placeholder is
+    /// a request the VTC has never heard of, and is answered as such.
+    ///
+    /// `false` for a record written before this existed: those are never polled,
+    /// which is the safe reading (we cannot tell whose id they hold).
+    #[serde(default)]
+    pub request_id_confirmed: bool,
     /// DIDComm relationships scoped to this community.
     #[serde(default)]
     pub relationships: Relationships,
@@ -284,6 +299,8 @@ struct CommunityRecordShadow {
     #[serde(default)]
     submit_transport: Option<crate::didcomm::MessagingTransport>,
     #[serde(default)]
+    request_id_confirmed: bool,
+    #[serde(default)]
     relationships: Relationships,
     #[serde(default)]
     tasks: Tasks,
@@ -340,6 +357,7 @@ impl From<CommunityRecordShadow> for CommunityRecord {
             requested_at: shadow.requested_at,
             receipt_at: shadow.receipt_at,
             submit_transport: shadow.submit_transport,
+            request_id_confirmed: shadow.request_id_confirmed,
             relationships: shadow.relationships,
             tasks: shadow.tasks,
             vrcs_issued: shadow.vrcs_issued,
@@ -390,6 +408,10 @@ impl CommunityRecord {
             // Set by the join flow once it knows which transport carried the
             // submit; `new_pending` itself is transport-agnostic.
             submit_transport: None,
+            // `request_id` here is the id of the document we just sent. It only
+            // becomes the community's once a reply says so — see
+            // `confirm_request_id`.
+            request_id_confirmed: false,
             relationships: Relationships::default(),
             tasks: Tasks::default(),
             vrcs_issued: Vrcs::default(),
@@ -517,6 +539,36 @@ impl CommunityRecord {
         false
     }
 
+    /// Adopt the community's own request id for a still-`Pending` join, replacing
+    /// the submit-time placeholder.
+    ///
+    /// Every correlated VTC reply carries it — the submit-receipt, and the
+    /// verdict envelope (`VerdictResponse.requestId`) that a `refer` /
+    /// `request_more` arrives in. Adopting it from *whichever* lands first is
+    /// what makes a join that is parked for human review askable-about later:
+    /// the id is the only thing `join-requests/status` can name.
+    ///
+    /// Returns `true` if the record changed (the caller should persist). A no-op
+    /// once the id is confirmed and unchanged, and on a non-`Pending` record —
+    /// a terminal state has nothing left to poll for.
+    pub fn confirm_request_id(&mut self, request_id: Uuid) -> bool {
+        let CommunityStatus::Pending { request_id: held } = &self.status else {
+            return false;
+        };
+        if *held == request_id && self.request_id_confirmed {
+            return false;
+        }
+        self.status = CommunityStatus::Pending { request_id };
+        self.request_id_confirmed = true;
+        true
+    }
+
+    /// Whether the community can be asked about this join: still `Pending`, and
+    /// against the community's own request id rather than our placeholder.
+    pub fn is_pollable_pending(&self) -> bool {
+        self.request_id_confirmed && matches!(self.status, CommunityStatus::Pending { .. })
+    }
+
     /// Whether this is a `Pending` join the VTC has not acknowledged within
     /// [`PENDING_ACK_GRACE_SECS`] of submission — the signal that the submit may
     /// have been dropped (size limit / unhandled type) rather than healthily
@@ -529,6 +581,21 @@ impl CommunityRecord {
                 .requested_at
                 .is_some_and(|r| now - r >= TimeDelta::seconds(PENDING_ACK_GRACE_SECS))
     }
+}
+
+/// One `Pending` join that can be reconciled with its community, flattened out
+/// of the record so the poll can be driven without holding a `Config` borrow
+/// across the network I/O.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingPoll {
+    pub vtc_did: VtcDid,
+    pub persona_ref: PersonaId,
+    /// The **community's** request id — never our submit-time placeholder; see
+    /// [`CommunityRecord::request_id_confirmed`].
+    pub request_id: Uuid,
+    /// The transport the submit used, so the poll takes the same route. A
+    /// community reachable only over TSP would never see a DIDComm poll.
+    pub submit_transport: Option<crate::didcomm::MessagingTransport>,
 }
 
 /// The account — the OpenVTC ↔ VTA relationship (State-A bootstrap) plus its
@@ -638,6 +705,29 @@ impl Account {
         self.communities.get_mut(vtc)?.iter_mut().find(
             |c| matches!(&c.status, CommunityStatus::Pending { request_id: r } if *r == request_id),
         )
+    }
+
+    /// Every `Pending` join the community can be asked about, as the tuple a
+    /// status poll needs: which community, which persona speaks to it, the
+    /// community's request id, and the transport the submit went out on.
+    ///
+    /// Read-only and cheap — the caller (a periodic reconcile) runs this on
+    /// every tick and expects an empty vector to be the normal answer.
+    pub fn pollable_pending(&self) -> Vec<PendingPoll> {
+        self.memberships()
+            .filter(|c| c.is_pollable_pending())
+            .filter_map(|c| {
+                let CommunityStatus::Pending { request_id } = c.status else {
+                    return None;
+                };
+                Some(PendingPoll {
+                    vtc_did: c.vtc_did.clone(),
+                    persona_ref: c.persona_ref,
+                    request_id,
+                    submit_transport: c.submit_transport,
+                })
+            })
+            .collect()
     }
 
     /// Add a new membership. Callers gate on [`Self::has_live_membership`] first
@@ -869,6 +959,7 @@ mod tests {
             display_name: Some(vtc.to_string()),
             sub_context_id: format!("openvtc/{vtc}"),
             submit_transport: None,
+            request_id_confirmed: false,
             persona_ref,
             status,
             favourite: false,
@@ -1300,6 +1391,61 @@ mod tests {
         let mut active = community("v", pid, CommunityStatus::Active);
         active.requested_at = Some(now - TimeDelta::days(1));
         assert!(!active.pending_unacknowledged(now));
+    }
+
+    #[test]
+    fn confirm_request_id_adopts_the_communitys_id_only_while_pending() {
+        let pid = PersonaId::new();
+        let real = Uuid::new_v4();
+
+        let mut c = community("v", pid, pending());
+        assert!(
+            !c.is_pollable_pending(),
+            "a record still holding our submit id has nothing the VTC can look up"
+        );
+        assert!(
+            c.confirm_request_id(real),
+            "adopting is a change to persist"
+        );
+        assert!(matches!(c.status, CommunityStatus::Pending { request_id } if request_id == real));
+        assert!(c.is_pollable_pending());
+        assert!(
+            !c.confirm_request_id(real),
+            "re-confirming the same id changes nothing, so it must not force a save"
+        );
+
+        // A terminal record has nothing left to poll for, so a late reply
+        // carrying an id must not resurrect it as pollable.
+        let mut rejected = community("v", pid, CommunityStatus::Rejected);
+        assert!(!rejected.confirm_request_id(real));
+        assert!(!rejected.is_pollable_pending());
+    }
+
+    #[test]
+    fn pollable_pending_lists_only_confirmed_pending_joins() {
+        let mut acct = Account::default();
+        let pid = PersonaId::new();
+        let real = Uuid::new_v4();
+
+        // Unconfirmed pending — not askable.
+        acct.add_membership(community("unconfirmed", pid, pending()));
+        // Active — nothing to ask.
+        acct.add_membership(community("active", pid, CommunityStatus::Active));
+        // Confirmed pending — the one case.
+        let mut confirmed = community("confirmed", pid, pending());
+        confirmed.confirm_request_id(real);
+        confirmed.submit_transport = Some(crate::didcomm::MessagingTransport::Tsp);
+        acct.add_membership(confirmed);
+
+        let pollable = acct.pollable_pending();
+        assert_eq!(pollable.len(), 1);
+        assert_eq!(pollable[0].vtc_did, "confirmed");
+        assert_eq!(pollable[0].request_id, real);
+        assert_eq!(
+            pollable[0].submit_transport,
+            Some(crate::didcomm::MessagingTransport::Tsp),
+            "the poll must take the transport the submit took"
+        );
     }
 
     #[test]

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -188,6 +188,7 @@ mod tests {
             display_name: None,
             sub_context_id: format!("openvtc/{vtc}"),
             submit_transport: None,
+            request_id_confirmed: false,
             persona_ref,
             status,
             favourite: false,

--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -28,7 +28,8 @@ use serde_json::Value;
 use trust_tasks_rs::TrustTask;
 use uuid::Uuid;
 use vta_sdk::protocols::join_requests::{
-    JOIN_REQUEST_SUBMIT_TYPE, JoinRequestSubmitBody, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
+    JOIN_REQUEST_STATUS_TYPE, JOIN_REQUEST_SUBMIT_TYPE, JoinRequestStatusBody,
+    JoinRequestSubmitBody, MEMBER_SELF_REMOVE_TYPE, SelfRemoveBody,
 };
 
 use crate::errors::OpenVTCError;
@@ -94,6 +95,83 @@ pub async fn submit_join_request(
     Ok(request_id)
 }
 
+/// Ask a VTC what became of a join request we already have its id for
+/// (`join-requests/status/0.1`).
+///
+/// The applicant is proven the same way `submit` proves it — the authcrypt
+/// sender over DIDComm, the sender VID over TSP — so no holder-binding
+/// signature rides along (the VTC's `status_inner` takes `signature_hex = None`
+/// on this path). The reply is a `#response` document threaded on this
+/// message, handled asynchronously by
+/// [`crate::messaging::handle_join_status_response`]; nothing is awaited here.
+///
+/// `request_id` **must** be the community's own id, not our submit-time
+/// placeholder: the VTC looks the request up by it and answers "not found" for
+/// anything else. [`CommunityRecord::request_id_confirmed`] is the gate.
+///
+/// [`CommunityRecord::request_id_confirmed`]: crate::config::account::CommunityRecord::request_id_confirmed
+pub async fn poll_join_status(
+    atm: &ATM,
+    profile: &Arc<ATMProfile>,
+    persona_did: &str,
+    vtc_did: &str,
+    mediator_did: &str,
+    request_id: Uuid,
+    tsp_mediator_did: Option<&str>,
+) -> Result<(), OpenVTCError> {
+    let document_id = format!("urn:uuid:{}", Uuid::new_v4());
+    let payload = JoinRequestStatusBody { request_id };
+    let body = build_trust_task_document(
+        JOIN_REQUEST_STATUS_TYPE,
+        persona_did,
+        vtc_did,
+        &document_id,
+        payload,
+    )?;
+
+    match tsp_mediator_did {
+        Some(tsp_mediator) => {
+            crate::tsp::send_trust_task(atm, profile, &body, vtc_did, tsp_mediator).await?;
+        }
+        None => {
+            let now = Utc::now().timestamp().max(0) as u64;
+            let msg = Message::build(document_id, JOIN_REQUEST_STATUS_TYPE.to_string(), body)
+                .from(persona_did.to_string())
+                .to(vtc_did.to_string())
+                .created_time(now)
+                .finalize();
+            crate::pack_and_send(atm, profile, &msg, persona_did, vtc_did, mediator_did).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Wrap `payload` in the Trust Task *document* every VTC verb is dispatched
+/// from: the required `id` + `type`, plus the audience-binding `issuer` (us) and
+/// `recipient` (the community).
+///
+/// Generalised out of [`build_join_submit_document`], which had these five lines
+/// inline. The VTC rejects a bare payload as `malformedRequest` ("missing field
+/// `id`"), so this shape is not optional for any verb — a second verb writing
+/// its own copy is how one of them ends up subtly different.
+fn build_trust_task_document<T: serde::Serialize>(
+    type_uri: &str,
+    issuer_did: &str,
+    recipient_did: &str,
+    document_id: &str,
+    payload: T,
+) -> Result<Value, OpenVTCError> {
+    let type_uri = type_uri
+        .parse()
+        .map_err(|e| OpenVTCError::Config(format!("trust task type URI parse: {e}")))?;
+    let mut doc = TrustTask::new(document_id.to_string(), type_uri, payload);
+    doc.issuer = Some(issuer_did.to_string());
+    doc.recipient = Some(recipient_did.to_string());
+    doc.issued_at = Some(Utc::now());
+    serde_json::to_value(&doc)
+        .map_err(|e| OpenVTCError::Config(format!("trust task document serialize: {e}")))
+}
+
 /// Build the DIDComm body for a join-request submit: a Trust Task *document*
 /// (`trust_tasks_rs::TrustTask`) wrapping the [`JoinRequestSubmitBody`] payload.
 ///
@@ -115,18 +193,16 @@ fn build_join_submit_document(
         registry_consent: false,
         extensions: Value::Null,
     };
-    let type_uri = JOIN_REQUEST_SUBMIT_TYPE
-        .parse()
-        .map_err(|e| OpenVTCError::Config(format!("join submit type URI parse: {e}")))?;
-    // Supplied rather than minted here: on the DIDComm path this same id is the
-    // message id, which is what makes the two transports' reply threading agree
-    // (see [`submit_join_request`]).
-    let mut doc = TrustTask::new(document_id.to_string(), type_uri, payload);
-    doc.issuer = Some(persona_did.to_string());
-    doc.recipient = Some(vtc_did.to_string());
-    doc.issued_at = Some(Utc::now());
-    serde_json::to_value(&doc)
-        .map_err(|e| OpenVTCError::Config(format!("join submit document serialize: {e}")))
+    // `document_id` is supplied rather than minted here: on the DIDComm path this
+    // same id is the message id, which is what makes the two transports' reply
+    // threading agree (see [`submit_join_request`]).
+    build_trust_task_document(
+        JOIN_REQUEST_SUBMIT_TYPE,
+        persona_did,
+        vtc_did,
+        document_id,
+        payload,
+    )
 }
 
 /// Send a member self-removal (`MEMBER_SELF_REMOVE`) to a VTC over DIDComm to
@@ -406,6 +482,60 @@ pub fn validate_invitation_credential(vic: &Value) -> Result<(), String> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// The document a status poll puts on the wire. The VTC dispatches on the
+    /// document, not the payload — a bare payload is rejected as
+    /// `malformedRequest` ("missing field `id`"), which is exactly how the join
+    /// submit failed before #138 — so the envelope members are the contract:
+    /// `id`, `type`, and the audience binding (`issuer` = us, `recipient` = the
+    /// community). The `requestId` must be the community's, and must ride in
+    /// `payload` where `parse_payload` reads it.
+    #[test]
+    fn a_status_poll_is_a_well_formed_trust_task_document() {
+        let request_id = Uuid::new_v4();
+        let doc = build_trust_task_document(
+            JOIN_REQUEST_STATUS_TYPE,
+            "did:webvh:example.com:alice",
+            "did:webvh:example.com:community",
+            "urn:uuid:doc-1",
+            JoinRequestStatusBody { request_id },
+        )
+        .expect("the status document builds");
+
+        assert_eq!(doc["id"], json!("urn:uuid:doc-1"));
+        assert_eq!(doc["type"], json!(JOIN_REQUEST_STATUS_TYPE));
+        assert_eq!(doc["issuer"], json!("did:webvh:example.com:alice"));
+        assert_eq!(doc["recipient"], json!("did:webvh:example.com:community"));
+        assert_eq!(
+            doc["payload"]["requestId"],
+            json!(request_id),
+            "the community looks the join up by this id"
+        );
+    }
+
+    /// The submit document is built through the same helper, so its shape must
+    /// not have moved: the payload still nests under `payload`, and the supplied
+    /// document id is used verbatim (it doubles as the DIDComm message id, which
+    /// is what makes DIDComm and TSP reply threading agree).
+    #[test]
+    fn the_submit_document_keeps_its_shape_through_the_shared_builder() {
+        let doc = build_join_submit_document(
+            "did:webvh:example.com:alice",
+            "did:webvh:example.com:community",
+            json!({ "type": ["VerifiablePresentation"] }),
+            "urn:uuid:submit-1",
+        )
+        .expect("the submit document builds");
+
+        assert_eq!(doc["id"], json!("urn:uuid:submit-1"));
+        assert_eq!(doc["type"], json!(JOIN_REQUEST_SUBMIT_TYPE));
+        assert_eq!(doc["issuer"], json!("did:webvh:example.com:alice"));
+        assert_eq!(doc["recipient"], json!("did:webvh:example.com:community"));
+        assert_eq!(
+            doc["payload"]["vp"]["type"],
+            json!(["VerifiablePresentation"])
+        );
+    }
 
     fn sample_vic() -> Value {
         json!({

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -20,7 +20,7 @@ use vta_sdk::protocols::join_requests::{
 };
 
 use crate::config::Config;
-use crate::config::account::{Account, CommunityStatus, PersonaId};
+use crate::config::account::{Account, PersonaId};
 use crate::relationships::{RelationshipState, Relationships};
 use crate::tasks::{TaskType, Tasks};
 
@@ -201,9 +201,9 @@ pub fn handle_join_submit_receipt(
         );
         return false;
     };
-    record.status = CommunityStatus::Pending {
-        request_id: body.request_id,
-    };
+    // Adopt the VTC's id in place of our placeholder — and record that it *is*
+    // the VTC's, which is what makes this join askable-about later.
+    record.confirm_request_id(body.request_id);
     // The receipt is the VTC's acknowledgement that the submit arrived.
     record.mark_acknowledged(chrono::Utc::now());
     info!(
@@ -404,7 +404,15 @@ pub fn handle_join_verdict(
         VerdictEffect::Refer => {
             // The VTC responded — submit acknowledged — but the decision is
             // deferred to human review; stays Pending.
-            let changed = record.mark_acknowledged(chrono::Utc::now());
+            //
+            // The verdict envelope carries the VTC's own `requestId`, which this
+            // used to read past: correlation is by `thid`, so nothing needed it.
+            // A referred join is precisely the one that then sits Pending for as
+            // long as a human takes, and without adopting the id here there is
+            // no handle to ask about it with — the answer arrives only if the
+            // VTC volunteers it.
+            let changed = record.confirm_request_id(body.request_id)
+                | record.mark_acknowledged(chrono::Utc::now());
             info!(
                 vtc = %from_did,
                 queue = body.verdict.with.queue.as_deref().unwrap_or(""),
@@ -417,8 +425,10 @@ pub fn handle_join_verdict(
         }
         VerdictEffect::RequestMore => {
             // The VTC responded — submit acknowledged — but needs more evidence;
-            // stays Pending.
-            let changed = record.mark_acknowledged(chrono::Utc::now());
+            // stays Pending. Adopt its request id for the same reason `Refer`
+            // does: this join outlives the exchange that produced it.
+            let changed = record.confirm_request_id(body.request_id)
+                | record.mark_acknowledged(chrono::Utc::now());
             info!(
                 vtc = %from_did,
                 needs = ?body.verdict.with.needs,
@@ -858,6 +868,10 @@ pub fn create_finalize_message(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Asserted on throughout, but no longer named by the handlers themselves:
+    // they go through `CommunityRecord`'s transitions rather than assigning a
+    // status directly.
+    use crate::config::account::CommunityStatus;
 
     fn msg(id: &str, created: Option<u64>, expires: Option<u64>) -> Message {
         let mut m =
@@ -1271,6 +1285,78 @@ mod tests {
         let rec = only(&acct, vtc);
         assert!(matches!(rec.status, CommunityStatus::Pending { .. }));
         assert!(rec.receipt_at.is_some(), "the VTC responded — acknowledged");
+    }
+
+    /// A verdict that leaves the join `Pending` is the one case where the
+    /// community's own request id matters later: the join outlives the exchange
+    /// that produced it, and the id is the only handle
+    /// `join-requests/status` can name it by. Correlation here is by `thid`, so
+    /// nothing *needed* the id — which is exactly why it used to be read past.
+    #[test]
+    fn a_verdict_that_stays_pending_adopts_the_communitys_request_id() {
+        for effect in ["refer", "request_more"] {
+            let vtc = "did:webvh:example:vtc";
+            let placeholder = Uuid::new_v4();
+            let vtc_request_id = Uuid::new_v4();
+            let mut acct = pending_account(vtc, placeholder);
+            assert!(
+                !only(&acct, vtc).is_pollable_pending(),
+                "{effect}: before any reply we hold our own id, which the VTC has never seen"
+            );
+
+            let message = Message::build(
+                Uuid::new_v4().to_string(),
+                vta_sdk::protocols::join_requests::JOIN_REQUEST_SUBMIT_RESPONSE_TYPE.to_string(),
+                serde_json::json!({
+                    "requestId": vtc_request_id,
+                    "verdict": { "effect": effect, "with": {} },
+                }),
+            )
+            .from(vtc.to_string())
+            .thid(placeholder.to_string())
+            .finalize();
+
+            let out = handle_join_verdict(&mut acct, &message, vtc);
+            assert!(
+                out.changed,
+                "{effect}: adopting the id is a change to persist"
+            );
+
+            let rec = only(&acct, vtc);
+            match &rec.status {
+                CommunityStatus::Pending { request_id } => assert_eq!(
+                    *request_id, vtc_request_id,
+                    "{effect}: the record now names the join the way the community does"
+                ),
+                other => panic!("{effect}: expected still-Pending, got {other:?}"),
+            }
+            assert!(
+                rec.is_pollable_pending(),
+                "{effect}: with the community's id, this join can now be asked about"
+            );
+        }
+    }
+
+    /// The submit-receipt path already adopted the id; what is new is recording
+    /// that it *is* the community's, which is what the poll gates on.
+    #[test]
+    fn a_submit_receipt_makes_the_join_pollable() {
+        let vtc = "did:webvh:example:vtc";
+        let placeholder = Uuid::new_v4();
+        let real = Uuid::new_v4();
+        let mut acct = pending_account(vtc, placeholder);
+
+        let message = Message::build(
+            Uuid::new_v4().to_string(),
+            vta_sdk::protocols::join_requests::JOIN_REQUEST_SUBMIT_RECEIPT_TYPE.to_string(),
+            serde_json::json!({ "requestId": real, "status": "pending" }),
+        )
+        .from(vtc.to_string())
+        .thid(placeholder.to_string())
+        .finalize();
+
+        assert!(handle_join_submit_receipt(&mut acct, &message, vtc));
+        assert!(only(&acct, vtc).is_pollable_pending());
     }
 
     #[test]

--- a/openvtc/src/state_handler/join_status_poll.rs
+++ b/openvtc/src/state_handler/join_status_poll.rs
@@ -1,0 +1,291 @@
+//! Ask a community what became of a join it has not answered.
+//!
+//! Every other way a `Pending` join resolves is the community volunteering
+//! something: a verdict, a credential, a problem-report. If any of those is lost
+//! — a socket that was down at the wrong moment, a mediator that dropped it, a
+//! decision a human took days later and the push went nowhere — the record sits
+//! `Pending` and nothing here ever asks. `join-requests/status/0.1` is the
+//! protocol's answer to that, and OpenVTC has until now implemented only the
+//! receiving half (`messaging::handle_join_status_response`).
+//!
+//! ## What can be polled
+//!
+//! Only a join whose request id is the **community's** — see
+//! [`CommunityRecord::request_id_confirmed`]. The VTC mints its own id and tells
+//! us in the first correlated reply; until one arrives we hold the id of the
+//! document we sent, which the VTC has never heard of. So a join that never got
+//! *any* reply cannot be polled at all, and is not this module's case: it is
+//! recovered by collecting the stored mail the reply is sitting in.
+//!
+//! ## Pacing
+//!
+//! Per-record, in memory, never persisted: the first tick after launch polls
+//! (a record that survived a restart is exactly the one worth reconciling),
+//! then backs off 1 → 2 → 4 → 8 minutes, capped at [`POLL_BACKOFF_CAP`]. At most
+//! [`MAX_POLLS_PER_TICK`] go out per tick, so an account with many parked joins
+//! spreads them over several ticks instead of opening a fan of sends at one
+//! community (R1.4). Deliberately in memory: the pacing is about *this*
+//! process's politeness, and persisting it would let a stale on-disk backoff
+//! suppress the poll a fresh launch most wants to make.
+//!
+//! [`CommunityRecord::request_id_confirmed`]: openvtc_core::config::account::CommunityRecord::request_id_confirmed
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use affinidi_tdk::messaging::ATM;
+use openvtc_core::config::Config;
+use openvtc_core::config::account::{PendingPoll, PersonaId, VtcDid};
+use openvtc_core::didcomm::MessagingTransport;
+use tracing::debug;
+
+/// Backoff after the n-th consecutive poll of one record: 1, 2, 4, 8 minutes,
+/// then capped.
+const POLL_BACKOFF_BASE: Duration = Duration::from_secs(60);
+
+/// Ceiling on the per-record backoff. A join parked for human review can sit for
+/// days; a poll every quarter of an hour is enough to notice the outcome
+/// promptly without making this client a load source.
+const POLL_BACKOFF_CAP: Duration = Duration::from_secs(900);
+
+/// How many polls one tick may send, across all records.
+const MAX_POLLS_PER_TICK: usize = 4;
+
+/// The identity of a membership for pacing purposes: a community may hold
+/// several, one per persona (multi-membership), and each is polled separately.
+type PollKey = (VtcDid, PersonaId);
+
+/// How long to wait before the `attempts`-th consecutive poll of one record.
+/// `attempts == 0` (never polled) is no wait — the first tick after launch goes
+/// straight out.
+fn poll_backoff(attempts: u32) -> Duration {
+    if attempts == 0 {
+        return Duration::ZERO;
+    }
+    // The shift is clamped only to keep it from overflowing; `POLL_BACKOFF_CAP`
+    // is what actually bounds the wait, so raising the cap raises the ceiling
+    // without also having to find this shift.
+    POLL_BACKOFF_BASE
+        .checked_mul(1u32 << attempts.saturating_sub(1).min(8))
+        .unwrap_or(POLL_BACKOFF_CAP)
+        .min(POLL_BACKOFF_CAP)
+}
+
+/// Per-record poll pacing for the life of the process.
+#[derive(Debug, Default)]
+pub(crate) struct PollPacer {
+    sent: HashMap<PollKey, Sent>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Sent {
+    at: Instant,
+    attempts: u32,
+}
+
+impl PollPacer {
+    /// The records due a poll right now, newest-backoff first come first served,
+    /// capped at [`MAX_POLLS_PER_TICK`]. Marks each returned record as polled, so
+    /// a caller that then fails to send simply retries after the backoff rather
+    /// than hammering an unreachable community.
+    pub(crate) fn due(&mut self, candidates: Vec<PendingPoll>, now: Instant) -> Vec<PendingPoll> {
+        // Forget records that are no longer pending (resolved, left, expired), so
+        // a long-lived process doesn't accumulate their pacing entries and a
+        // community re-joined later starts from a clean first poll.
+        let live: std::collections::HashSet<PollKey> = candidates
+            .iter()
+            .map(|c| (c.vtc_did.clone(), c.persona_ref))
+            .collect();
+        self.sent.retain(|key, _| live.contains(key));
+
+        let mut due = Vec::new();
+        for candidate in candidates {
+            if due.len() >= MAX_POLLS_PER_TICK {
+                break;
+            }
+            let key = (candidate.vtc_did.clone(), candidate.persona_ref);
+            let attempts = match self.sent.get(&key) {
+                None => 0,
+                Some(sent) => {
+                    if now.duration_since(sent.at) < poll_backoff(sent.attempts) {
+                        continue;
+                    }
+                    sent.attempts
+                }
+            };
+            self.sent.insert(
+                key,
+                Sent {
+                    at: now,
+                    attempts: attempts.saturating_add(1),
+                },
+            );
+            due.push(candidate);
+        }
+        due
+    }
+}
+
+/// One poll, resolved against the account so the send needs no `Config` borrow
+/// and can therefore be moved into a spawned task.
+pub(crate) struct Poll {
+    applicant_did: String,
+    profile: std::sync::Arc<affinidi_tdk::messaging::profiles::ATMProfile>,
+    mediator_did: String,
+    vtc_did: String,
+    request_id: uuid::Uuid,
+    /// The submit went out over TSP, so the poll must too — a community
+    /// reachable only over TSP would never see a DIDComm poll.
+    over_tsp: bool,
+}
+
+/// Resolve each due record to a sendable [`Poll`], dropping any whose persona no
+/// longer resolves to a runtime identity (a deleted DID mid-flight): there is
+/// nothing to speak as, and the record's own repair path is elsewhere.
+pub(crate) fn build(config: &Config, due: Vec<PendingPoll>) -> Vec<Poll> {
+    due.into_iter()
+        .filter_map(|record| {
+            let Some(identity) = config.identities.get(&record.persona_ref) else {
+                debug!(
+                    vtc = %record.vtc_did,
+                    "skipping status poll: the join's persona has no runtime identity"
+                );
+                return None;
+            };
+            Some(Poll {
+                applicant_did: identity.persona_did().to_string(),
+                profile: identity.profile().clone(),
+                mediator_did: identity.mediator_did.clone().unwrap_or_default(),
+                vtc_did: record.vtc_did,
+                request_id: record.request_id,
+                over_tsp: record.submit_transport == Some(MessagingTransport::Tsp),
+            })
+        })
+        .collect()
+}
+
+/// Send each poll, one at a time. The reply is asynchronous — it arrives on the
+/// persona's own listener and is applied by the inbound dispatch — so nothing is
+/// awaited beyond the send, and a failure is logged rather than surfaced: this
+/// is background reconciliation the operator did not initiate, it retries after
+/// the backoff, and the fact it is reconciling (a `Pending` record, flagged once
+/// past the grace window) is already on screen.
+///
+/// Sequential on purpose. The cap is four per tick, these are sends to
+/// potentially the same community, and a fan of concurrent sends buys nothing
+/// against a reply path that is asynchronous either way.
+pub(crate) async fn send_all(atm: ATM, polls: Vec<Poll>) {
+    for poll in polls {
+        // TSP needs the community's *advertised* TSP mediator, resolved fresh:
+        // it is the hop the routing layer seals to, and a document may have
+        // changed since the submit.
+        let tsp_mediator = if poll.over_tsp {
+            openvtc_core::config::peer_tsp_mediator(&poll.vtc_did).await
+        } else {
+            None
+        };
+        match openvtc_core::join::poll_join_status(
+            &atm,
+            &poll.profile,
+            &poll.applicant_did,
+            &poll.vtc_did,
+            &poll.mediator_did,
+            poll.request_id,
+            tsp_mediator.as_deref(),
+        )
+        .await
+        {
+            Ok(()) => debug!(
+                vtc = %poll.vtc_did,
+                request_id = %poll.request_id,
+                "asked the community about a pending join"
+            ),
+            Err(e) => debug!(
+                vtc = %poll.vtc_did,
+                request_id = %poll.request_id,
+                error = %e,
+                "could not ask the community about a pending join; will retry after the backoff"
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn candidate(vtc: &str) -> PendingPoll {
+        PendingPoll {
+            vtc_did: vtc.to_string(),
+            persona_ref: PersonaId::new(),
+            request_id: Uuid::new_v4(),
+            submit_transport: Some(MessagingTransport::DidComm),
+        }
+    }
+
+    #[test]
+    fn the_first_tick_polls_immediately() {
+        let mut pacer = PollPacer::default();
+        let due = pacer.due(vec![candidate("did:webvh:a")], Instant::now());
+        assert_eq!(due.len(), 1, "a record never polled is due at once");
+    }
+
+    #[test]
+    fn a_second_tick_inside_the_backoff_is_not_due() {
+        let mut pacer = PollPacer::default();
+        let one = candidate("did:webvh:a");
+        let now = Instant::now();
+        assert_eq!(pacer.due(vec![one.clone()], now).len(), 1);
+        assert!(
+            pacer
+                .due(vec![one.clone()], now + Duration::from_secs(30))
+                .is_empty(),
+            "30s after the first poll is inside the 60s backoff"
+        );
+        assert_eq!(
+            pacer.due(vec![one], now + Duration::from_secs(61)).len(),
+            1,
+            "past the backoff it is due again"
+        );
+    }
+
+    #[test]
+    fn the_backoff_grows_and_then_caps() {
+        assert_eq!(poll_backoff(0), Duration::ZERO);
+        assert_eq!(poll_backoff(1), Duration::from_secs(60));
+        assert_eq!(poll_backoff(2), Duration::from_secs(120));
+        assert_eq!(poll_backoff(4), Duration::from_secs(480));
+        // Capped, and — the part worth pinning — never overflows into a wait so
+        // long the poll effectively stops.
+        assert_eq!(poll_backoff(5), POLL_BACKOFF_CAP);
+        assert_eq!(poll_backoff(u32::MAX), POLL_BACKOFF_CAP);
+    }
+
+    #[test]
+    fn one_tick_sends_no_more_than_the_cap() {
+        let mut pacer = PollPacer::default();
+        let candidates: Vec<_> = (0..10)
+            .map(|i| candidate(&format!("did:webvh:{i}")))
+            .collect();
+        let due = pacer.due(candidates.clone(), Instant::now());
+        assert_eq!(
+            due.len(),
+            MAX_POLLS_PER_TICK,
+            "a large backlog is spread over ticks, not sent at once"
+        );
+    }
+
+    #[test]
+    fn a_record_that_stops_being_pending_is_forgotten() {
+        let mut pacer = PollPacer::default();
+        let one = candidate("did:webvh:a");
+        let now = Instant::now();
+        assert_eq!(pacer.due(vec![one.clone()], now).len(), 1);
+        // It resolved: absent from the candidates, so its pacing is dropped...
+        assert!(pacer.due(vec![], now + Duration::from_secs(1)).is_empty());
+        // ...and a later join of the same community starts from a fresh poll
+        // rather than inheriting the old backoff.
+        assert_eq!(pacer.due(vec![one], now + Duration::from_secs(2)).len(), 1);
+    }
+}

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -1105,6 +1105,7 @@ mod tests {
                 display_name: display_name.map(str::to_owned),
                 sub_context_id: String::new(),
                 submit_transport: None,
+                request_id_confirmed: false,
                 persona_ref: persona_id,
                 status: CommunityStatus::Active,
                 favourite: false,

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -151,6 +151,7 @@ mod dispatch_util;
 mod inbox_actions;
 pub mod join;
 mod join_flow;
+mod join_status_poll;
 pub mod main_page;
 mod message_dispatch;
 mod relationship_actions;
@@ -778,6 +779,14 @@ impl StateHandler {
         // `agent_name_refresh_targets` finds uncached/stale DIDs, and the resolver
         // caches keep repeat sweeps quiet.
         let mut agent_name_tick = tokio::time::interval(std::time::Duration::from_secs(300));
+        // Reconcile Pending joins with their communities. The first tick fires
+        // immediately, which is the point: a join still Pending at launch is the
+        // one whose answer may have been lost, and asking is how we find out
+        // rather than waiting to be told again. Per-record backoff lives in the
+        // pacer, so a minute-by-minute tick does not mean a minute-by-minute
+        // poll; ticks over an account with no Pending join do no work at all.
+        let mut join_status_tick = tokio::time::interval(std::time::Duration::from_secs(60));
+        let mut join_status_pacer = join_status_poll::PollPacer::default();
 
         let result = loop {
             tokio::select! {
@@ -1927,6 +1936,29 @@ impl StateHandler {
                             if expired.len() == 1 { "" } else { "s" },
                         ));
                         let _ = self.state_tx.send(state.clone());
+                    }
+                },
+                _ = join_status_tick.tick() => {
+                    // Ask each community about a join it has not resolved.
+                    // Only joins recorded against the *community's* request id
+                    // are askable — see `join_status_poll` — so a join that
+                    // never got any reply is not covered here; that one is
+                    // recovered by collecting the mail its reply is sitting in.
+                    //
+                    // Spawned detached rather than through `background_dispatch`:
+                    // there is no outcome to apply on the loop thread (the reply
+                    // arrives on the persona's listener and goes through inbound
+                    // dispatch like any other), and the pacer already prevents
+                    // pile-up by marking a record polled before the send.
+                    let candidates = config.account.pollable_pending();
+                    if !candidates.is_empty()
+                        && let Some(atm) = tdk.atm.clone()
+                    {
+                        let due = join_status_pacer.due(candidates, std::time::Instant::now());
+                        let polls = join_status_poll::build(&config, due);
+                        if !polls.is_empty() {
+                            tokio::spawn(join_status_poll::send_all(atm, polls));
+                        }
                     }
                 },
                 _ = agent_name_tick.tick() => {


### PR DESCRIPTION
feat(join): ask a community about a join it has not answered

Every way a Pending join could resolve was the community volunteering
something: a verdict, a credential, a problem-report. Lose any of those —
a socket down at the wrong moment, a mediator that dropped it, a decision
a human took days later when nothing was listening — and the record sits
Pending while this client never asks. `join-requests/status/0.1` is the
protocol's answer to exactly that, and OpenVTC had implemented only the
receiving half: `handle_join_status_response` existed with nothing to
trigger it.

A 60s tick now reconciles each pollable Pending join, first poll
immediate — a join still Pending at launch is precisely the one whose
answer may have been lost — then per-record backoff 1/2/4/8 minutes
capped at 15, at most four polls per tick across the account (R1.4).
Pacing is in memory on purpose: it is about this process's politeness,
and a stale on-disk backoff would suppress the poll a fresh launch most
wants to make. The poll takes the transport the submit took, since a
TSP-only community would never see a DIDComm poll. Spawned detached
rather than through background_dispatch: there is no outcome to apply on
the loop thread (the reply arrives on the persona's listener and goes
through inbound dispatch like anything else), and the pacer prevents
pile-up by marking a record polled before the send.

The gate this needed did not exist. A join is recorded against the id of
the document WE sent — the only handle available until the VTC answers —
while the VTC mints its own (`join/mod.rs`: `id: Uuid::new_v4()`) and
returns it in the first correlated reply. The submit-receipt path already
swapped it in, but a refer/request_more verdict carries `requestId` too
and read straight past it, because correlation there is by `thid` and
nothing needed the id. A referred join is the one that then sits Pending
for as long as a human takes — the one that most needs to be
askable-about — so it is now adopted from whichever reply lands first.
`CommunityRecord::request_id_confirmed` records whose id a record holds
and gates the poll: quoting our own placeholder is asking about a request
the community has never heard of, and is answered as such. Pre-existing
records default to unconfirmed, which is the safe reading.

Scope, stated plainly: a join that received NO reply has no confirmed id
and cannot be polled. That is not a gap this can close — the id does not
exist on our side — and it is not the case for it either; that one is
recovered by collecting the stored mail its reply is sitting in.

`build_trust_task_document` is generalised out of the submit builder
rather than copied, so both verbs produce the envelope the VTC dispatches
on (a bare payload is `malformedRequest`, "missing field `id`" — how the
submit failed before #138).

  cargo test --workspace                       → 677 passed, 0 failed
  cargo test --workspace -- --include-ignored  → 690 passed, 0 failed
  cargo clippy --all-targets -- -D warnings    → clean
  cargo fmt --all                              → clean

No e2e: the round trip needs a VTC to answer, and vtc-service is not in
this workspace's test graph (vta-service is). What is covered here is
everything on this side of the wire — the document shape, the id
adoption on both reply paths, the pollable gate, and the pacer.