### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-15
+
+The first tagged release since 0.2.0 (21 May). 0.2.1 was version-bumped and
+written up but never tagged or published, so everything under it ships here too.
+
+The theme is the join ceremony's asynchronous half: a community's reply now
+reaches the applicant whether or not it happened to be connected when the reply
+was sent, and a join left unresolved is reconciled by asking rather than by
+waiting.
+
 ### Added
 
 - **Ask a community about a join it has not answered** — every way a `Pending`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "openvtc"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm 0.11.0",
  "affinidi-data-integrity",
@@ -5371,7 +5371,7 @@ dependencies = [
 
 [[package]]
 name = "openvtc-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "aes-gcm 0.11.0",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [workspace.package]
 description = "Open Verifiable Trust Community (OpenVTC) - First Person Protocol"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 publish = false
 authors = ["Glenn Gore <glenn@affinidi.com>"]
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 repository = "https://github.com/LF-Decentralized-Trust-labs/openvtc"
 
 [workspace.dependencies]
-openvtc-core = { version = "0.2", path = "openvtc-core", default-features = false }
+openvtc-core = { version = "0.3", path = "openvtc-core", default-features = false }
 
 # Decentralized Trust Graph Credentials.
 #


### PR DESCRIPTION
chore(release): 0.3.0

First tagged release since 0.2.0 (21 May). 0.2.1 was version-bumped and
written up in the changelog but never tagged or published, so everything
under it ships here too — this is the first artifact to carry it.

Minor, not patch: #219 adds an outbound protocol verb
(`join-requests/status/0.1`, previously receive-only) and #218 changes
runtime behaviour materially — every listener connect now collects the
mail the mediator was holding. Pre-1.0 that is a minor bump.

The workspace version is inherited by both crates (`version.workspace =
true`), so `[workspace.package] version` is the only place it is written
— except that `openvtc-core`'s own path-dependency requirement has to
move with it. Left at `"0.2"` the workspace stops resolving outright:

  error: failed to select a version for the requirement `openvtc-core = "^0.2"`
  candidate versions found which didn't match: 0.3.0

No config migration: the one persisted-model addition this release makes
(`CommunityRecord::request_id_confirmed`) is `#[serde(default)]`, so an
existing config loads unchanged and reads as "we hold our own request
id", which is the safe interpretation.

  cargo test --workspace                       → 677 passed, 0 failed
  cargo test --workspace -- --include-ignored  → 691 passed, 0 failed
  cargo clippy --all-targets -- -D warnings    → clean
  cargo fmt --all                              → clean
  RUSTDOCFLAGS='-D warnings' cargo doc         → clean