### PR TITLE
fix(join): a first-run join could never be answered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,69 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-15
+
+A first-run join could go out and never be answerable. This fixes the state
+machine that caused it, and adds the command that would have found it in one
+step instead of five service logs.
+
+### Fixed
+
+- **A first-run join is answerable again.** Creating a persona and then joining
+  — the ordinary first-run order — left the client in the State-A degraded loop
+  instead of handing off to the runtime. That loop has no inbound arm, so the
+  community's reply was received by the SDK, acknowledged (and therefore deleted
+  at the mediator), and dropped before any handler saw it. The join stayed
+  `Pending` forever with a clean log on both sides, and no restart could recover
+  it: the mail was gone from the mediator, and `join-requests/status` polling is
+  gated on a request id that only arrives in a reply that was never processed.
+
+  The hand-off was gated on the join having minted the account's *first*
+  identity. It never was: the degraded loop mints personas too
+  (`CreatePersonaSubmit`), and `Config::active_identity()` reports `Some` for any
+  persona at all, so the guard was false exactly when a persona had been created
+  first. It is now gated on the join alone.
+
+- **A live listener can no longer outlive its consumer.** The degraded loop
+  re-checks `list_listeners()` each iteration and hands off whenever it holds
+  one, whatever opened it. A socket this loop owns is a mailbox nobody reads, so
+  the backstop is unconditional rather than specific to the join path — the
+  failure mode it prevents is silent, permanent message loss that looks like a
+  community which never answered.
+
+### Added
+
+- **`openvtc health [--vtc <did>] [--json]`** — resolve the messaging chain and
+  print the map. For every DID involved (each persona, the VTA, every mediator,
+  each VTC) it resolves the document, prints the `service` array verbatim —
+  including entries of types this build does not recognise, since a party
+  publishing one is indistinguishable from a party publishing nothing when read
+  through the capability matcher alone — and probes any transport URLs. It then
+  runs the same TSP > DIDComm > REST negotiation a real send performs, so the
+  reported transport is the one that would actually be used, and names every
+  party behind each mediator so a split-mediator topology is visible rather than
+  assumed away.
+
+  Read-only, and deliberately usable while things are broken: it takes no
+  process lock (so it runs against a profile a stuck TUI is holding), and account
+  details are best-effort (`--vtc` alone works with no account, and a config that
+  will not decrypt is reported as a finding rather than an abort). Exits non-zero
+  if any DID fails to resolve or any pair shares no transport.
+
+### Changed
+
+- **`trust-tasks-rs` 0.4 → 0.6, `trust-tasks-capability-client` 0.3 → 0.5,
+  floor `vta-sdk` at 0.23.3.** This is a follow, not a lead: vta-sdk 0.23.3
+  declares `trust-tasks-rs ^0.6` where 0.23.0 declared `^0.4`, so holding 0.4
+  stopped matching the stack and started splitting the type — a dependency
+  refresh alone put 0.4.1 and 0.6.5 in the same binary, which is precisely what
+  the pin exists to prevent. `cargo tree -d` showing two `trust-tasks-rs` rows
+  is the check that it has drifted again.
+
+- Dependency refresh: `affinidi-messaging-sdk` 0.19.5 → 0.19.7, `vta-sdk` 0.23.0
+  → 0.23.3, `vta-service` 0.15.0 → 0.15.3, `vti-common` 0.11.39 → 0.11.40, plus
+  transitive updates.
+
 ## [0.3.0] - 2026-08-15
 
 The first tagged release since 0.2.0 (21 May). 0.2.1 was version-bumped and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.15"
+version = "0.18.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ebe160eaf8addcf13210c1bfdaf2a87df6a4f82b8cc3c84a3e38b92bd0ef81"
+checksum = "95435c2e6cc192765e0dd4d7d00aa8995869cce73040852d3035c35ca8018e53"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3994145193a940c4fce2905cfc89d85e5999c804295cdd7e7dc8c3c32d6ed018"
+checksum = "a793b4479720c074d56ab2c0e9ed272987bf679b0baa130160718512a93079c8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.49"
+version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54c01b2b939e6f96eb83d3701076267658517cd4afd25de2cf55ed7fe175b1a"
+checksum = "60b360ddb78e934a51d9ad7343e0fa0fbe25b60a4e1dabf4f40b25955bc6ceba"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -1575,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2407,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "dbus-secret-service-keyring-store"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+checksum = "7227ffd3b4896266bbc100348025cebe51d9aea94ce118a1d68f4a6463963dae"
 dependencies = [
  "dbus-secret-service",
  "keyring-core",
@@ -3029,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
 name = "euclid"
@@ -3161,9 +3161,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finl_unicode"
@@ -3185,9 +3185,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fjall"
-version = "3.1.8"
+version = "3.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420a84699b8ccbb1ed573e38e88f4f23637b45beab6432066452f834be469c57"
+checksum = "d5427b70d8592043024955a4a40b5cf44af323fdad7c1f62848a01ec7806709e"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -4498,9 +4498,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "openvtc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm 0.11.0",
  "affinidi-data-integrity",
@@ -5371,7 +5371,7 @@ dependencies = [
 
 [[package]]
 name = "openvtc-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm 0.11.0",
  "affinidi-data-integrity",
@@ -5939,9 +5939,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -8218,9 +8218,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb5938e40914d79917c4f4ae45bd898890eb782479a95ecb741c7db74a1924"
+checksum = "c5000d9bfe928a9f2a7096d8cbcfe3844219abc6635b74f5755d5fdf9b144448"
 dependencies = [
  "chrono",
  "serde",
@@ -8232,9 +8232,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d2b8d94c339d2c60fe75566ee0a7f4c6b2f7ca3f38819ec732add5c0f1f21f"
+checksum = "66aaa7b08053453cf5cdb7f8a97f4fc3cc91d7ea4cbec345231552c4d68a4e79"
 dependencies = [
  "affinidi-messaging-didcomm",
  "serde",
@@ -8246,9 +8246,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bece9c7bd60022b8cf57415f84d7f49f66ab6687848b1de3bfd66641eca1c269"
+checksum = "786a4b9f9e0f1fe25fd4c0d5e8fa4b96d53db350779dc9731a7422e7e4c2bf26"
 dependencies = [
  "axum",
  "chrono",
@@ -8265,9 +8265,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68255c485b3a9382210e91f7b4304093b57a133d288e64dd2c2aec8f57e89638"
+checksum = "6b7e476b1c5b36d26cfd74ac9a441874f7782c87f3edbb4ae08620703f9e146d"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8282,9 +8282,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.4.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8749686980d1e1ec639afce6e39cb6ae53f0662b5f7593238fc8439af36e3e"
+checksum = "d0b630d88cf3258040b38722b4dc8f99d74da84bae431277d46a9a65f1496b40"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8534,9 +8534,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",
@@ -8614,9 +8614,9 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517fd07618320badbef0e3311cb25717aed78711d2e56e6bc37cd9b91c637416"
+checksum = "18fa247cf181a490ae702539a13b4e97fab58605941fe50e7e1dfcc7b7ebf183"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2",
@@ -8641,9 +8641,9 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.10.30"
+version = "0.10.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7cbe1e37f685ac5aea64bf051f67c6c1304d5a63012d30c4d1ea9ca998f1b"
+checksum = "edc14d587f8ab7cf9fce59881ec4dec3176cd061c267cbb3e783f20c75b349b5"
 dependencies = [
  "aes-gcm 0.10.3",
  "affinidi-crypto",
@@ -8668,12 +8668,14 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91726928385cfcf35ef7599c4b40bb8c4136a8bae13ff37fece2ea722a78d45"
+checksum = "6be0b6c72a4fc1b9614bf1609de7bf17bd7f3987034823361782d6d3610ed4f3"
 dependencies = [
  "serde",
  "serde_ignored",
+ "serde_json",
+ "sha2 0.11.0",
  "toml",
  "tracing",
  "vta-sdk",
@@ -8726,9 +8728,9 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ffaad2be227325069833df384b2c1a55df48d35363cd5504ee0aa6439e0c8"
+checksum = "af715ae6f9027ee932dbf63b542abc3d488b9ddc4ca981297f15381e60a9df6b"
 dependencies = [
  "hex",
  "multibase",
@@ -8746,9 +8748,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.23.0"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8d9df250173cc4f3793f84de441616ba885cc3c1423b926ef3c19232f15a18"
+checksum = "3c9568443139159df504d84928f86c48ba5fa72cda8f27ec5f83e1a3b0499db0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8792,9 +8794,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df895d25e97ee5a46a10f17f6b23275de9c7e9e21bfdf5a96cd58ceff530b3e"
+checksum = "e7c19ca1055cb1cec43561c4c3b0cb4b42ea3d3af70126946215984dd7b220b5"
 dependencies = [
  "aes-gcm 0.10.3",
  "affinidi-crypto",
@@ -8949,9 +8951,9 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d5721815fa6971b225b549d2719b19673d1ce4d782b8fa7893dbd5bbc53ac0"
+checksum = "9bfb3f17c1677bafe37e2949620bd185d186b25b5afe49c0a7053929a8ee34bf"
 dependencies = [
  "affinidi-tdk",
  "reqwest",
@@ -8967,9 +8969,9 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.11.39"
+version = "0.11.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f87bf95ecc749f6bd3ff4b348802b7efdb30fb8062acaeecab940921f27fce"
+checksum = "d469f1da6dd071e8a6115d1bcf22c1f883484ec99924f3d86f8e725621822169"
 dependencies = [
  "aes-gcm 0.10.3",
  "affinidi-data-integrity",
@@ -9141,9 +9143,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
 dependencies = [
  "cc",
  "downcast-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "3"
 
 [workspace.package]
 description = "Open Verifiable Trust Community (OpenVTC) - First Person Protocol"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 publish = false
 authors = ["Glenn Gore <glenn@affinidi.com>"]
@@ -127,16 +127,24 @@ tokio-stream = "0.1"
 tokio-util = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Pinned to the line the VTA/VTC themselves build against, NOT the newest
-# release. `TrustTask` crosses the vta-sdk boundary in both directions — we
-# hand one to `submit`, and `capabilities` classifies the ones a VTC
-# advertises — so our copy has to be the same crate version vta-sdk resolves,
-# or the two are distinct types that do not unify. vta-sdk 0.21.10 declares
-# `trust-tasks-rs ^0.4` and verifiable-trust-infrastructure moved the whole
-# workspace to 0.4 in VTI #911. 0.5/0.6 are published but nothing in the
-# deployed stack speaks them yet; taking them here would desync us.
-trust-tasks-rs = "0.4"
-trust-tasks-capability-client = "0.3"
+# Pinned to the line the VTA/VTC themselves build against, NOT independently
+# chosen. `TrustTask` crosses the vta-sdk boundary in both directions — we hand
+# one to `submit`, and `capabilities` classifies the ones a VTC advertises — so
+# our copy has to be the same crate version vta-sdk resolves, or the two are
+# distinct types that do not unify.
+#
+# Moved 0.4 → 0.6 when vta-sdk did. This is a *follow*, not a lead: vta-sdk
+# 0.23.3 declares `trust-tasks-rs ^0.6` (0.23.0 was still on ^0.4), so holding
+# 0.4 here stopped matching the stack and started splitting the type — a
+# `cargo update` alone put 0.4.1 and 0.6.5 in the same binary, which is the
+# exact failure the paragraph above exists to prevent. `cargo tree -d` is the
+# check: two `trust-tasks-rs` rows means this pin has drifted from vta-sdk's
+# again, whichever direction it drifted.
+#
+# `trust-tasks-capability-client` moves with it (0.3 → 0.5) for the same reason
+# — it re-exports the same `TrustTask`.
+trust-tasks-rs = "0.6"
+trust-tasks-capability-client = "0.5"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
@@ -151,6 +159,10 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # workspace against the unreleased sdk before the bump, where `add_tsp_service`
 # was the sole compile error and every test still passed.
 #
+# Floor is 0.23.3 within the line: 0.23.0 declares `trust-tasks-rs ^0.4` and
+# 0.23.3 declares `^0.6`, so a checkout that resolved back to 0.23.0 while this
+# workspace is on 0.6 would put two `trust-tasks-rs` in the binary again.
+#
 # The old 0.21.x floor notes are gone with the line. Each recorded a defect this
 # repo had no lever over — 0.21.10's `trust-tasks-rs` `^0.4` requirement (type
 # unification across the sdk boundary), 0.21.11's `provision/integration/0.2`
@@ -158,7 +170,7 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # members as `null` and killing key creation over DIDComm and TSP (VTI #919).
 # All are below this floor by construction; they are kept in git history rather
 # than as a wall of satisfied constraints.
-vta-sdk = { version = "0.23", features = [
+vta-sdk = { version = "0.23.3", features = [
   "session",
   "client",
   "didcomm",

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -31,6 +31,10 @@ argon2.workspace = true
 affinidi-tdk.workspace = true
 affinidi-data-integrity.workspace = true
 affinidi-did-resolver-cache-sdk.workspace = true
+# `health` probes mediator transport URLs over HTTP: resolving a DID proves the
+# document is fetchable, not that the transport host behind it answers, and the
+# two fail independently.
+reqwest = { workspace = true }
 # `CancellationToken`, for `start_service`'s shutdown hook.
 tokio-util = { workspace = true }
 # The delivery layer this module now runs on (#189): `-delivery` is the durable

--- a/openvtc-core/src/health.rs
+++ b/openvtc-core/src/health.rs
@@ -1,0 +1,902 @@
+//! Map the messaging path between OpenVTC and a community, and say where it
+//! breaks.
+//!
+//! A join that goes out and is never answered has, from the client, exactly one
+//! symptom: nothing happens. The cause is somewhere in a chain of five or six
+//! parties — this persona, its mediator, the VTA, the VTC, *its* mediator — each
+//! of which advertises its own transports in its own DID document, and any two
+//! of which may sit behind different mediators. Reading that by hand means
+//! fetching several `did.jsonl` files and diffing service arrays.
+//!
+//! This module fetches them and prints the map. It answers four questions:
+//!
+//! 1. **Does each DID resolve?** For `did:webvh` that is a live HTTPS fetch, so
+//!    it doubles as the first reachability check.
+//! 2. **What does each advertise?** The full `service` array, verbatim — not
+//!    just the transports we recognise, because an unrecognised entry is exactly
+//!    what you want to see when a peer looks healthy and isn't.
+//! 3. **What would we actually use?** [`select_protocol`] over both sides'
+//!    capabilities, which is the same negotiation a real send performs.
+//! 4. **Is the transport host reachable?** A bounded HTTP probe of each
+//!    mediator's endpoint URL.
+//!
+//! Deliberately read-only: it resolves, negotiates and probes. It never sends a
+//! message, so it is safe to run against production while a join is stuck.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use affinidi_did_resolver_cache_sdk::DIDCacheClient;
+use serde::Serialize;
+use serde_json::Value;
+use vta_sdk::protocol::matching::{Protocol, ServiceCapabilities, select_protocol};
+
+/// Bound on any single network step. Every step is independently bounded so one
+/// unreachable host cannot stall the whole report — a partial map is the useful
+/// output here, and a hang is the least useful.
+const STEP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// What a party is in the chain. Ordering is the order they are reported in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Role {
+    /// One of our own persona DIDs — the identity a community knows us by.
+    Persona,
+    /// The Verifiable Trust Agent that custodies our keys.
+    Vta,
+    /// A community's VTC.
+    Vtc,
+    /// A mediator some other party routes through.
+    Mediator,
+}
+
+impl Role {
+    /// Lowercase display name.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Role::Persona => "persona",
+            Role::Vta => "vta",
+            Role::Vtc => "vtc",
+            Role::Mediator => "mediator",
+        }
+    }
+}
+
+/// One `service` entry, as published. `types` is a vector because DID-Core
+/// permits `type` to be a string or an array, and a party that publishes both
+/// `TSPTransport` and something else on one entry is worth seeing as-is.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ServiceEntry {
+    pub id: String,
+    pub types: Vec<String>,
+    pub endpoint: String,
+}
+
+/// Result of a bounded HTTP probe of a transport URL.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum Probe {
+    /// The host answered. Any status is reachability — a 404 from a mediator's
+    /// base path still proves DNS, TLS and routing all work, which is the thing
+    /// being tested. Reporting it as a failure would send an operator hunting a
+    /// network fault that isn't there.
+    Reachable { url: String, http_status: u16 },
+    /// No answer: DNS, TLS, connection or timeout.
+    Unreachable { url: String, error: String },
+}
+
+/// A resolved party.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Resolved {
+    /// Every `service` entry the document publishes, in document order.
+    pub services: Vec<ServiceEntry>,
+    /// The transports we recognise, by service `type`.
+    pub tsp_endpoint: Option<String>,
+    pub didcomm_endpoint: Option<String>,
+    pub rest_endpoint: Option<String>,
+    /// Probes of any `http(s)` endpoints above. Mediator DIDs are not probed
+    /// here — they are separate parties in the report and probed as themselves.
+    pub probes: Vec<Probe>,
+}
+
+/// A party in the chain, resolved or not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Party {
+    pub role: Role,
+    /// Where this DID came from — "persona", "VTC (--vtc)", "mediator of
+    /// persona joy-ahead". Carries the provenance a bare DID cannot.
+    pub label: String,
+    pub did: String,
+    /// `None` when resolution failed; `error` then says why.
+    pub resolved: Option<Resolved>,
+    pub error: Option<String>,
+}
+
+impl Party {
+    /// The capability set for negotiation, or an empty one if unresolved.
+    fn caps(&self) -> ServiceCapabilities {
+        match &self.resolved {
+            Some(r) => ServiceCapabilities {
+                tsp: r.tsp_endpoint.clone(),
+                didcomm: r.didcomm_endpoint.clone(),
+                rest: r.rest_endpoint.clone(),
+            },
+            None => ServiceCapabilities::default(),
+        }
+    }
+}
+
+/// The negotiated transport between two parties.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum LinkOutcome {
+    /// Both sides advertise it; this is what a send would pick.
+    Selected {
+        protocol: Protocol,
+        /// The peer endpoint for that protocol — a mediator DID for TSP and
+        /// DIDComm, a URL for REST.
+        peer_endpoint: String,
+    },
+    /// The advertised sets do not intersect. Both are named so the operator can
+    /// see which side to change.
+    NoCommonProtocol {
+        ours: Vec<Protocol>,
+        theirs: Vec<Protocol>,
+    },
+    /// One side did not resolve, so there is nothing to negotiate over.
+    Unknown { reason: String },
+}
+
+/// A directed pair whose transport we negotiated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Link {
+    pub from: String,
+    pub to: String,
+    #[serde(flatten)]
+    pub outcome: LinkOutcome,
+}
+
+/// The whole map.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HealthReport {
+    pub parties: Vec<Party>,
+    pub links: Vec<Link>,
+    /// Findings worth an operator's attention — split mediators, dead ends,
+    /// unresolvable parties. Empty is the healthy case.
+    pub notes: Vec<String>,
+}
+
+impl HealthReport {
+    /// Whether anything in the chain is broken enough to stop a message.
+    ///
+    /// Unresolvable parties and empty protocol intersections count; an
+    /// unreachable probe does not, because a mediator that refuses a bare GET on
+    /// its base path is normal and the DID resolution above already proved the
+    /// host answers.
+    #[must_use]
+    pub fn is_healthy(&self) -> bool {
+        self.parties.iter().all(|p| p.resolved.is_some())
+            && !self
+                .links
+                .iter()
+                .any(|l| matches!(l.outcome, LinkOutcome::NoCommonProtocol { .. }))
+    }
+}
+
+/// A DID to include in the report, with the provenance to label it by.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Subject {
+    pub role: Role,
+    pub label: String,
+    pub did: String,
+}
+
+impl Subject {
+    pub fn new(role: Role, label: impl Into<String>, did: impl Into<String>) -> Self {
+        Self {
+            role,
+            label: label.into(),
+            did: did.into(),
+        }
+    }
+}
+
+/// Resolve every subject, follow each one's mediators, negotiate every link that
+/// matters, and probe the transport hosts.
+///
+/// `subjects` is the chain as the caller knows it — our personas, our VTA, the
+/// community's VTC. Mediators are *discovered*, not passed in: which mediator a
+/// party uses is a property of its document, and taking it from local config
+/// would report what we believe rather than what is published. That difference
+/// is one of the things this command exists to expose.
+pub async fn build_report(subjects: &[Subject]) -> HealthReport {
+    let resolver = match DIDCacheClient::new(
+        affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return HealthReport {
+                parties: Vec::new(),
+                links: Vec::new(),
+                notes: vec![format!(
+                    "could not start a DID resolver ({e}) — nothing could be checked. \
+                     This is a local fault, not a fault in the chain."
+                )],
+            };
+        }
+    };
+
+    let http = reqwest::Client::builder()
+        .timeout(STEP_TIMEOUT)
+        .build()
+        .ok();
+
+    let mut parties: Vec<Party> = Vec::new();
+    for subject in subjects {
+        if subject.did.is_empty() {
+            continue;
+        }
+        if parties.iter().any(|p| p.did == subject.did) {
+            continue;
+        }
+        parties.push(resolve_party(&resolver, http.as_ref(), subject).await);
+    }
+
+    // Second pass: every mediator any resolved party routes through, resolved
+    // once and labelled with *every* party that named it and for which
+    // transports. Mapping who shares a mediator with whom is most of the point —
+    // labelling it "TSP mediator of <first party to mention it>" would hide both
+    // that it also carries that party's DIDComm and that a second party is
+    // behind the same host.
+    let referenced = mediator_references(&parties);
+    for (did, users) in referenced {
+        if parties.iter().any(|p| p.did == did) {
+            continue;
+        }
+        let subject = Subject::new(Role::Mediator, format!("mediator of {users}"), did);
+        parties.push(resolve_party(&resolver, http.as_ref(), &subject).await);
+    }
+
+    let links = negotiate_links(&parties);
+    let notes = collect_notes(&parties, &links);
+    HealthReport {
+        parties,
+        links,
+        notes,
+    }
+}
+
+/// Which mediator DIDs the resolved parties route through, and who routes to
+/// each — `did:webvh:…:mediator` → `"persona joy-ahead (TSP, DIDComm), VTC acme
+/// (DIDComm)"`.
+///
+/// Keyed by DID so a mediator shared by several parties is resolved and probed
+/// once. Only `did:` endpoints qualify: a URL endpoint *is* the transport, and
+/// belongs to (and was probed on) the party that published it.
+///
+/// `BTreeMap` throughout for a stable report; the protocol list is a `Vec` built
+/// in preference order rather than a set, because "TSP, DIDComm" reads as the
+/// negotiation order and "DIDComm, TSP" (alphabetical) does not.
+fn mediator_references(parties: &[Party]) -> std::collections::BTreeMap<String, String> {
+    let mut refs: std::collections::BTreeMap<String, Vec<(String, Vec<&'static str>)>> =
+        std::collections::BTreeMap::new();
+
+    for party in parties {
+        let Some(resolved) = &party.resolved else {
+            continue;
+        };
+        for (protocol, endpoint) in [
+            ("TSP", resolved.tsp_endpoint.as_deref()),
+            ("DIDComm", resolved.didcomm_endpoint.as_deref()),
+        ] {
+            let Some(endpoint) = endpoint else { continue };
+            if !endpoint.starts_with("did:") {
+                continue;
+            }
+            let users = refs.entry(endpoint.to_string()).or_default();
+            match users.iter_mut().find(|(label, _)| *label == party.label) {
+                Some((_, protocols)) => protocols.push(protocol),
+                None => users.push((party.label.clone(), vec![protocol])),
+            }
+        }
+    }
+
+    refs.into_iter()
+        .map(|(did, users)| {
+            let described = users
+                .into_iter()
+                .map(|(label, protocols)| format!("{label} ({})", protocols.join(", ")))
+                .collect::<Vec<_>>()
+                .join(", ");
+            (did, described)
+        })
+        .collect()
+}
+
+/// Resolve one DID and read everything the report needs off its document.
+async fn resolve_party(
+    resolver: &DIDCacheClient,
+    http: Option<&reqwest::Client>,
+    subject: &Subject,
+) -> Party {
+    let fail = |error: String| Party {
+        role: subject.role,
+        label: subject.label.clone(),
+        did: subject.did.clone(),
+        resolved: None,
+        error: Some(error),
+    };
+
+    let resolved = match tokio::time::timeout(STEP_TIMEOUT, resolver.resolve(&subject.did)).await {
+        Ok(Ok(resolved)) => resolved,
+        Ok(Err(e)) => return fail(e.to_string()),
+        Err(_) => {
+            return fail(format!(
+                "resolution timed out after {}s",
+                STEP_TIMEOUT.as_secs()
+            ));
+        }
+    };
+    let doc = match serde_json::to_value(&resolved.doc) {
+        Ok(doc) => doc,
+        Err(e) => return fail(format!("document could not be re-serialised: {e}")),
+    };
+
+    let caps = ServiceCapabilities::from_did_document(&doc);
+    let services = service_entries(&doc);
+
+    // Probe only endpoints that are URLs. A DID endpoint is a mediator, which
+    // becomes its own party and is probed there — following it here would probe
+    // the same host once per party that names it.
+    let mut probes = Vec::new();
+    if let Some(client) = http {
+        let urls: BTreeSet<&str> = services
+            .iter()
+            .map(|s| s.endpoint.as_str())
+            .filter(|e| e.starts_with("http://") || e.starts_with("https://"))
+            .collect();
+        for url in urls {
+            probes.push(probe(client, url).await);
+        }
+    }
+
+    Party {
+        role: subject.role,
+        label: subject.label.clone(),
+        did: subject.did.clone(),
+        resolved: Some(Resolved {
+            services,
+            tsp_endpoint: caps.tsp,
+            didcomm_endpoint: caps.didcomm,
+            rest_endpoint: caps.rest,
+            probes,
+        }),
+        error: None,
+    }
+}
+
+/// Read the `service` array verbatim.
+///
+/// Deliberately not filtered to the types we understand: a party that publishes
+/// a transport this build does not know about looks, through
+/// [`ServiceCapabilities`] alone, exactly like a party that publishes nothing —
+/// and telling those two apart is most of the value of a map.
+fn service_entries(doc: &Value) -> Vec<ServiceEntry> {
+    let Some(services) = doc.get("service").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    services
+        .iter()
+        .map(|svc| {
+            let id = svc
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("<no id>")
+                .to_string();
+            let types = match svc.get("type") {
+                Some(Value::String(s)) => vec![s.clone()],
+                Some(Value::Array(arr)) => arr
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_string)
+                    .collect(),
+                _ => Vec::new(),
+            };
+            let endpoint = svc
+                .get("serviceEndpoint")
+                .and_then(endpoint_uri)
+                .unwrap_or_else(|| "<unreadable>".to_string());
+            ServiceEntry {
+                id,
+                types,
+                endpoint,
+            }
+        })
+        .collect()
+}
+
+/// The three shapes a `serviceEndpoint` may take: a string, an object with
+/// `uri`, or an array of either. Mirrors `vta_sdk`'s private `endpoint_uri`.
+fn endpoint_uri(endpoint: &Value) -> Option<String> {
+    match endpoint {
+        Value::String(s) => Some(s.clone()),
+        Value::Object(map) => map.get("uri")?.as_str().map(str::to_string),
+        Value::Array(arr) => arr.iter().find_map(endpoint_uri),
+        _ => None,
+    }
+}
+
+/// A bounded GET. Any HTTP answer is reachability — see [`Probe::Reachable`].
+async fn probe(client: &reqwest::Client, url: &str) -> Probe {
+    match client.get(url).send().await {
+        Ok(response) => Probe::Reachable {
+            url: url.to_string(),
+            http_status: response.status().as_u16(),
+        },
+        Err(e) => Probe::Unreachable {
+            url: url.to_string(),
+            error: e.to_string(),
+        },
+    }
+}
+
+/// Negotiate the pairs that decide whether a join can complete: each persona
+/// against each VTA and VTC.
+///
+/// Mediator-to-party pairs are deliberately absent. A mediator is a hop, not a
+/// counterparty — nothing negotiates a protocol *with* it — and listing those
+/// pairs would bury the two that matter.
+fn negotiate_links(parties: &[Party]) -> Vec<Link> {
+    let personas: Vec<&Party> = parties.iter().filter(|p| p.role == Role::Persona).collect();
+    let peers: Vec<&Party> = parties
+        .iter()
+        .filter(|p| matches!(p.role, Role::Vta | Role::Vtc))
+        .collect();
+
+    let mut links = Vec::new();
+    for persona in &personas {
+        for peer in &peers {
+            let outcome = if persona.resolved.is_none() {
+                LinkOutcome::Unknown {
+                    reason: format!("{} did not resolve", persona.label),
+                }
+            } else if peer.resolved.is_none() {
+                LinkOutcome::Unknown {
+                    reason: format!("{} did not resolve", peer.label),
+                }
+            } else {
+                match select_protocol(&persona.caps(), &peer.caps(), &peer.did) {
+                    Ok(m) => LinkOutcome::Selected {
+                        protocol: m.protocol,
+                        peer_endpoint: m.peer_endpoint,
+                    },
+                    Err(_) => LinkOutcome::NoCommonProtocol {
+                        ours: persona.caps().advertised(),
+                        theirs: peer.caps().advertised(),
+                    },
+                }
+            };
+            links.push(Link {
+                from: persona.label.clone(),
+                to: peer.label.clone(),
+                outcome,
+            });
+        }
+    }
+    links
+}
+
+/// Turn the map into the handful of sentences an operator acts on.
+fn collect_notes(parties: &[Party], links: &[Link]) -> Vec<String> {
+    let mut notes = Vec::new();
+
+    for party in parties {
+        if let Some(error) = &party.error {
+            notes.push(format!(
+                "{} ({}) did not resolve: {error}",
+                party.label, party.did
+            ));
+            continue;
+        }
+        let Some(resolved) = &party.resolved else {
+            continue;
+        };
+        if resolved.services.is_empty() {
+            notes.push(format!(
+                "{} publishes no service endpoints at all — nothing can route to it.",
+                party.label
+            ));
+        } else if resolved.tsp_endpoint.is_none()
+            && resolved.didcomm_endpoint.is_none()
+            && party.role != Role::Mediator
+        {
+            notes.push(format!(
+                "{} advertises no TSP or DIDComm transport (services present, but none of a \
+                 recognised type) — it cannot be messaged.",
+                party.label
+            ));
+        }
+        for probe in &resolved.probes {
+            if let Probe::Unreachable { url, error } = probe {
+                notes.push(format!("{}: {url} is unreachable ({error}).", party.label));
+            }
+        }
+    }
+
+    for link in links {
+        match &link.outcome {
+            LinkOutcome::NoCommonProtocol { ours, theirs } => notes.push(format!(
+                "{} and {} share no transport: we offer [{}], they offer [{}]. A message \
+                 between them cannot be sent until one side adds the other's.",
+                link.from,
+                link.to,
+                join_protocols(ours),
+                join_protocols(theirs),
+            )),
+            LinkOutcome::Unknown { reason } => notes.push(format!(
+                "{} → {}: transport could not be determined ({reason}).",
+                link.from, link.to
+            )),
+            LinkOutcome::Selected { .. } => {}
+        }
+    }
+
+    // Split mediators are legal and often deliberate, but they are also the
+    // thing an operator most often does not realise is true of their
+    // deployment — so it is stated, not warned about.
+    let mediators: BTreeSet<&str> = parties
+        .iter()
+        .filter(|p| p.role == Role::Mediator)
+        .map(|p| p.did.as_str())
+        .collect();
+    if mediators.len() > 1 {
+        notes.push(format!(
+            "{} distinct mediators are in play; messages cross between them. This is \
+             supported, but it means a delivery problem can live in either.",
+            mediators.len()
+        ));
+    }
+
+    notes
+}
+
+fn join_protocols(protocols: &[Protocol]) -> String {
+    if protocols.is_empty() {
+        return "none".to_string();
+    }
+    protocols
+        .iter()
+        .map(|p| p.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn resolved_party(role: Role, label: &str, did: &str, doc: &Value) -> Party {
+        let caps = ServiceCapabilities::from_did_document(doc);
+        Party {
+            role,
+            label: label.to_string(),
+            did: did.to_string(),
+            resolved: Some(Resolved {
+                services: service_entries(doc),
+                tsp_endpoint: caps.tsp,
+                didcomm_endpoint: caps.didcomm,
+                rest_endpoint: caps.rest,
+                probes: Vec::new(),
+            }),
+            error: None,
+        }
+    }
+
+    /// The shape a persona minted by the VTA's webvh server actually publishes —
+    /// taken from a real document, including the `#vta-didcomm` id, because the
+    /// matcher must key on `type` and never on the id fragment.
+    fn persona_doc(mediator: &str) -> Value {
+        json!({
+            "service": [
+                {
+                    "id": "did:webvh:scid:example:persona#tsp",
+                    "type": "TSPTransport",
+                    "serviceEndpoint": mediator,
+                },
+                {
+                    "id": "did:webvh:scid:example:persona#vta-didcomm",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": [{ "uri": mediator, "accept": ["didcomm/v2"] }],
+                },
+            ]
+        })
+    }
+
+    #[test]
+    fn services_are_read_verbatim_including_unrecognised_types() {
+        let doc = json!({
+            "service": [
+                { "id": "#tsp", "type": "TSPTransport", "serviceEndpoint": "did:webvh:m" },
+                { "id": "#odd", "type": "SomeFutureTransport", "serviceEndpoint": "https://x/y" },
+            ]
+        });
+        let entries = service_entries(&doc);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[1].types, vec!["SomeFutureTransport".to_string()]);
+        assert_eq!(
+            entries[1].endpoint, "https://x/y",
+            "an unrecognised transport must still be shown — a party that publishes \
+             one looks empty through ServiceCapabilities alone, and telling that \
+             apart from publishing nothing is the point of the map"
+        );
+    }
+
+    /// DID-Core allows `type` as an array and `serviceEndpoint` in three shapes.
+    #[test]
+    fn endpoint_and_type_shapes_are_all_read() {
+        assert_eq!(endpoint_uri(&json!("https://a")), Some("https://a".into()));
+        assert_eq!(
+            endpoint_uri(&json!({"uri": "did:webvh:m"})),
+            Some("did:webvh:m".into())
+        );
+        assert_eq!(
+            endpoint_uri(&json!([{"uri": "did:webvh:m"}])),
+            Some("did:webvh:m".into())
+        );
+
+        let doc = json!({
+            "service": [{
+                "id": "#both", "type": ["DIDCommMessaging", "Other"],
+                "serviceEndpoint": [{ "uri": "did:webvh:m" }],
+            }]
+        });
+        assert_eq!(service_entries(&doc)[0].types.len(), 2);
+    }
+
+    /// Both sides on TSP: the negotiated protocol is TSP, and the endpoint is
+    /// the *peer's* mediator (the hop a routed send seals to), not ours.
+    #[test]
+    fn a_shared_transport_negotiates_and_names_the_peer_mediator() {
+        let parties = vec![
+            resolved_party(
+                Role::Persona,
+                "persona",
+                "did:webvh:p",
+                &persona_doc("did:webvh:our-mediator"),
+            ),
+            resolved_party(
+                Role::Vtc,
+                "VTC",
+                "did:webvh:v",
+                &persona_doc("did:webvh:their-mediator"),
+            ),
+        ];
+        let links = negotiate_links(&parties);
+        assert_eq!(links.len(), 1);
+        match &links[0].outcome {
+            LinkOutcome::Selected {
+                protocol,
+                peer_endpoint,
+            } => {
+                assert_eq!(*protocol, Protocol::Tsp, "TSP outranks DIDComm");
+                assert_eq!(peer_endpoint, "did:webvh:their-mediator");
+            }
+            other => panic!("expected a selected protocol, got {other:?}"),
+        }
+    }
+
+    /// The case worth catching before a send: no intersection. Both sides'
+    /// advertised sets must survive into the note, because "add TSP" and "add
+    /// DIDComm" are different instructions to different operators.
+    #[test]
+    fn a_disjoint_pair_reports_both_sides() {
+        let tsp_only = json!({
+            "service": [{ "id": "#tsp", "type": "TSPTransport", "serviceEndpoint": "did:webvh:m1" }]
+        });
+        let didcomm_only = json!({
+            "service": [{
+                "id": "#dc", "type": "DIDCommMessaging",
+                "serviceEndpoint": [{ "uri": "did:webvh:m2" }],
+            }]
+        });
+        let parties = vec![
+            resolved_party(Role::Persona, "persona", "did:webvh:p", &tsp_only),
+            resolved_party(Role::Vtc, "VTC", "did:webvh:v", &didcomm_only),
+        ];
+        let links = negotiate_links(&parties);
+        assert!(matches!(
+            links[0].outcome,
+            LinkOutcome::NoCommonProtocol { .. }
+        ));
+
+        let notes = collect_notes(&parties, &links);
+        let note = notes
+            .iter()
+            .find(|n| n.contains("share no transport"))
+            .expect("a disjoint pair must produce a note");
+        assert!(note.contains("tsp"), "our side must be named: {note}");
+        assert!(note.contains("didcomm"), "their side must be named: {note}");
+        assert!(
+            !HealthReport {
+                parties,
+                links,
+                notes,
+            }
+            .is_healthy()
+        );
+    }
+
+    /// An unresolvable party is a dead end, not a negotiation failure — the note
+    /// must say which DID failed and why, since that is the whole diagnosis.
+    #[test]
+    fn an_unresolvable_peer_is_named_with_its_reason() {
+        let parties = vec![
+            resolved_party(
+                Role::Persona,
+                "persona",
+                "did:webvh:p",
+                &persona_doc("did:webvh:m"),
+            ),
+            Party {
+                role: Role::Vtc,
+                label: "VTC".into(),
+                did: "did:webvh:missing".into(),
+                resolved: None,
+                error: Some("404 fetching did.jsonl".into()),
+            },
+        ];
+        let links = negotiate_links(&parties);
+        assert!(matches!(links[0].outcome, LinkOutcome::Unknown { .. }));
+
+        let notes = collect_notes(&parties, &links);
+        assert!(
+            notes
+                .iter()
+                .any(|n| n.contains("did:webvh:missing") && n.contains("404")),
+            "the failing DID and its reason must both appear: {notes:?}"
+        );
+        assert!(
+            !HealthReport {
+                parties,
+                links,
+                notes
+            }
+            .is_healthy()
+        );
+    }
+
+    /// A mediator carrying both transports for a party must say so, and one
+    /// shared by two parties must be resolved once and name both.
+    ///
+    /// Labelling it after the first protocol and the first party to mention it
+    /// hid exactly the two facts the map exists to show: that the host carries
+    /// both legs, and who else is behind it.
+    #[test]
+    fn a_shared_mediator_names_every_party_and_transport() {
+        let parties = vec![
+            resolved_party(
+                Role::Persona,
+                "persona joy-ahead",
+                "did:webvh:p",
+                &persona_doc("did:webvh:shared"),
+            ),
+            resolved_party(
+                Role::Vtc,
+                "VTC acme",
+                "did:webvh:v",
+                &json!({
+                    "service": [{
+                        "id": "#dc", "type": "DIDCommMessaging",
+                        "serviceEndpoint": [{ "uri": "did:webvh:shared" }],
+                    }]
+                }),
+            ),
+        ];
+
+        let refs = mediator_references(&parties);
+        assert_eq!(refs.len(), 1, "one host, resolved once: {refs:?}");
+        let label = &refs["did:webvh:shared"];
+        assert_eq!(
+            label, "persona joy-ahead (TSP, DIDComm), VTC acme (DIDComm)",
+            "both parties, and TSP before DIDComm (negotiation order, not \
+             alphabetical): {label}"
+        );
+    }
+
+    /// A URL endpoint is the transport itself, not a mediator to follow.
+    #[test]
+    fn a_url_endpoint_is_not_followed_as_a_mediator() {
+        let parties = vec![resolved_party(
+            Role::Mediator,
+            "mediator",
+            "did:webvh:m",
+            &json!({
+                "service": [{
+                    "id": "#tsp", "type": "TSPTransport",
+                    "serviceEndpoint": "https://mediator.example/mediator/v1",
+                }]
+            }),
+        )];
+        assert!(
+            mediator_references(&parties).is_empty(),
+            "following a transport URL as a DID would resolve nothing and add a \
+             bogus party to the map"
+        );
+    }
+
+    /// Two mediators is legal. It must be *stated* (it is the thing operators
+    /// most often don't know is true of their deployment) but must not make the
+    /// report unhealthy.
+    #[test]
+    fn split_mediators_are_reported_without_being_called_a_fault() {
+        let parties = vec![
+            resolved_party(
+                Role::Persona,
+                "persona",
+                "did:webvh:p",
+                &persona_doc("did:webvh:m1"),
+            ),
+            resolved_party(
+                Role::Vtc,
+                "VTC",
+                "did:webvh:v",
+                &persona_doc("did:webvh:m2"),
+            ),
+            resolved_party(
+                Role::Mediator,
+                "mediator of persona",
+                "did:webvh:m1",
+                &json!({}),
+            ),
+            resolved_party(
+                Role::Mediator,
+                "mediator of VTC",
+                "did:webvh:m2",
+                &json!({}),
+            ),
+        ];
+        let links = negotiate_links(&parties);
+        let notes = collect_notes(&parties, &links);
+        assert!(
+            notes.iter().any(|n| n.contains("distinct mediators")),
+            "split mediators must be surfaced: {notes:?}"
+        );
+        assert!(
+            HealthReport {
+                parties,
+                links,
+                notes
+            }
+            .is_healthy(),
+            "two mediators is a supported topology, not a failure"
+        );
+    }
+
+    /// A mediator with no recognised transport is normal (its own document
+    /// carries a URL, not a mediator DID), so it must not draw the
+    /// "cannot be messaged" note that a VTC or persona would.
+    #[test]
+    fn a_mediator_is_not_faulted_for_advertising_no_mediator() {
+        let mediator_doc = json!({
+            "service": [{
+                "id": "#tsp", "type": "TSPTransport",
+                "serviceEndpoint": "https://mediator.example/mediator/v1",
+            }]
+        });
+        let parties = vec![resolved_party(
+            Role::Mediator,
+            "mediator of persona",
+            "did:webvh:m",
+            &mediator_doc,
+        )];
+        let notes = collect_notes(&parties, &[]);
+        assert!(
+            !notes.iter().any(|n| n.contains("cannot be messaged")),
+            "a mediator publishing a transport URL is healthy: {notes:?}"
+        );
+    }
+}

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod config;
 pub mod didcomm;
 pub mod display;
 pub mod errors;
+pub mod health;
 pub mod identity;
 pub mod join;
 pub mod logs;

--- a/openvtc/src/cli.rs
+++ b/openvtc/src/cli.rs
@@ -36,6 +36,43 @@ pub fn cli() -> Command {
                 ),
         ])
         .subcommand(Command::new("setup").about("Initial configuration of the openvtc tool"))
+        .subcommand(
+            Command::new("health")
+                .about(
+                    "Resolve the messaging chain (personas, VTA, mediators, VTCs) and \
+                     report what each DID advertises, which transport each pair would \
+                     negotiate, and whether the hosts answer",
+                )
+                .long_about(
+                    "Map the messaging path between this client and a community.\n\n\
+                     For every DID involved — each persona, the VTA, every mediator, and \
+                     each VTC — this resolves the DID document, prints its service \
+                     definitions verbatim, and probes any transport URLs. It then runs \
+                     the same TSP > DIDComm > REST negotiation a real send performs, so \
+                     the reported transport is the one that would actually be used.\n\n\
+                     Parties may sit behind different mediators; that is supported and \
+                     is reported rather than assumed away.\n\n\
+                     Read-only: nothing is sent, so it is safe to run against a live \
+                     deployment while a join is stuck. Exits non-zero if any DID fails \
+                     to resolve or any pair shares no transport.",
+                )
+                .args([
+                    Arg::new("vtc")
+                        .long("vtc")
+                        .value_name("DID")
+                        .action(clap::ArgAction::Append)
+                        .help(
+                            "A community VTC DID to include. Repeatable. Communities \
+                             already in the account are included automatically; use this \
+                             to check one before joining, or when the account cannot be \
+                             loaded.",
+                        ),
+                    Arg::new("json")
+                        .long("json")
+                        .action(clap::ArgAction::SetTrue)
+                        .help("Emit the report as JSON instead of a rendered map"),
+                ]),
+        )
 }
 
 #[cfg(feature = "openpgp-card")]

--- a/openvtc/src/health_cmd.rs
+++ b/openvtc/src/health_cmd.rs
@@ -1,0 +1,262 @@
+//! `openvtc health` — resolve the messaging chain and print the map.
+//!
+//! The command exists for one question: a join went out, nothing came back,
+//! and every service involved logged a clean run. Answering it means knowing
+//! which DIDs resolve, what each one advertises, which transport any two of
+//! them would actually negotiate, and whether they even share a mediator. That
+//! is four `did.jsonl` fetches and a service-array diff done by hand, which is
+//! why it usually isn't done.
+//!
+//! Config loading is **best-effort by design**. `--vtc` alone produces a useful
+//! report against a community you have not joined (and against one whose join is
+//! stuck), and a config that will not decrypt is itself a finding rather than a
+//! reason to refuse to run.
+
+use anyhow::Result;
+use console::style;
+use openvtc_core::config::{Config, KeyBackend};
+use openvtc_core::health::{HealthReport, LinkOutcome, Party, Probe, Role, Subject, build_report};
+
+use crate::colors::{CLI_BLUE, CLI_ORANGE, CLI_PURPLE, CLI_RED};
+
+/// Build the subject list and render the report.
+///
+/// `config` is `None` when the account could not be loaded; the report then
+/// covers only the `--vtc` DIDs given on the command line.
+pub async fn run(config: Option<&Config>, vtc_args: &[String], as_json: bool) -> Result<()> {
+    let mut subjects: Vec<Subject> = Vec::new();
+
+    if let Some(config) = config {
+        for identity in config.identities.values() {
+            subjects.push(Subject::new(
+                Role::Persona,
+                format!("persona {}", short_tail(&identity.did)),
+                identity.did.clone(),
+            ));
+        }
+        if let KeyBackend::Vta { vta_did, .. } = &config.key_backend
+            && vta_did.starts_with("did:")
+        {
+            subjects.push(Subject::new(Role::Vta, "VTA", vta_did.clone()));
+        }
+        for community in config.account.memberships() {
+            let did = community.vtc_did.to_string();
+            subjects.push(Subject::new(
+                Role::Vtc,
+                format!("VTC {} (joined)", short_tail(&did)),
+                did,
+            ));
+        }
+    }
+
+    // Command-line VTCs last: `build_report` de-duplicates by DID and keeps the
+    // first label, so a community already in the config keeps its "(joined)"
+    // label rather than being relabelled by the flag that also named it.
+    for did in vtc_args {
+        subjects.push(Subject::new(
+            Role::Vtc,
+            format!("VTC {} (--vtc)", short_tail(did)),
+            did.clone(),
+        ));
+    }
+
+    if subjects.is_empty() {
+        anyhow::bail!(
+            "nothing to check: no account could be loaded and no --vtc was given. \
+             Pass --vtc <did> to check a community directly."
+        );
+    }
+
+    let report = build_report(&subjects).await;
+
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        render(&report, config.is_none());
+    }
+
+    // A broken chain is a failed check: exit non-zero so this is usable in a
+    // script or a CI smoke test, not only by eye.
+    if report.is_healthy() {
+        Ok(())
+    } else {
+        std::process::exit(1);
+    }
+}
+
+/// The last path segment of a `did:webvh`, which is the part humans recognise
+/// (`…:dids.example.dev:legend-swear` → `legend-swear`). Falls back to the whole
+/// string for DID methods with no path.
+fn short_tail(did: &str) -> String {
+    did.rsplit(':').next().unwrap_or(did).to_string()
+}
+
+fn render(report: &HealthReport, config_missing: bool) {
+    if config_missing {
+        println!(
+            "{}",
+            style(
+                "No account loaded — reporting only the DIDs given with --vtc. \
+                 Persona, VTA and mediator legs are not covered."
+            )
+            .color256(CLI_ORANGE)
+        );
+        println!();
+    }
+
+    println!("{}", style("PARTIES").color256(CLI_BLUE).bold());
+    for party in &report.parties {
+        render_party(party);
+    }
+
+    if !report.links.is_empty() {
+        println!();
+        println!(
+            "{}",
+            style("NEGOTIATED TRANSPORT").color256(CLI_BLUE).bold()
+        );
+        for link in &report.links {
+            let arrow = format!("  {} → {}", link.from, link.to);
+            match &link.outcome {
+                LinkOutcome::Selected {
+                    protocol,
+                    peer_endpoint,
+                } => println!(
+                    "{arrow}: {} via {}",
+                    style(protocol.as_str()).color256(CLI_PURPLE).bold(),
+                    style(peer_endpoint).color256(CLI_PURPLE),
+                ),
+                LinkOutcome::NoCommonProtocol { ours, theirs } => println!(
+                    "{arrow}: {} (we offer [{}], they offer [{}])",
+                    style("no shared transport").color256(CLI_RED).bold(),
+                    protocols(ours),
+                    protocols(theirs),
+                ),
+                LinkOutcome::Unknown { reason } => println!(
+                    "{arrow}: {} ({reason})",
+                    style("unknown").color256(CLI_ORANGE)
+                ),
+            }
+        }
+    }
+
+    println!();
+    if report.notes.is_empty() {
+        println!(
+            "{}",
+            style("No problems found in the messaging chain.").color256(CLI_BLUE)
+        );
+    } else {
+        println!("{}", style("FINDINGS").color256(CLI_ORANGE).bold());
+        for note in &report.notes {
+            println!("  • {note}");
+        }
+    }
+}
+
+fn render_party(party: &Party) {
+    println!();
+    println!(
+        "  {} {}",
+        style(format!("[{}]", party.role.as_str())).color256(CLI_PURPLE),
+        style(&party.label).bold(),
+    );
+    println!("    did: {}", style(&party.did).color256(CLI_PURPLE));
+
+    let Some(resolved) = &party.resolved else {
+        println!(
+            "    {}: {}",
+            style("UNRESOLVED").color256(CLI_RED).bold(),
+            party.error.as_deref().unwrap_or("unknown error"),
+        );
+        return;
+    };
+
+    if resolved.services.is_empty() {
+        println!("    services: {}", style("none").color256(CLI_RED));
+    } else {
+        println!("    services:");
+        for service in &resolved.services {
+            let types = if service.types.is_empty() {
+                "<no type>".to_string()
+            } else {
+                service.types.join(", ")
+            };
+            // The `#id` fragment is shown but never matched on — an operator
+            // comparing two deployments needs to see that one names it `#tsp`
+            // and the other `#tsp-transport` while both are `TSPTransport`.
+            println!(
+                "      {:<28} {:<22} → {}",
+                fragment(&service.id),
+                style(types).color256(CLI_BLUE),
+                service.endpoint,
+            );
+        }
+    }
+
+    for probe in &resolved.probes {
+        match probe {
+            Probe::Reachable { url, http_status } => println!(
+                "    probe {url} → {} (HTTP {http_status})",
+                style("reachable").color256(CLI_BLUE),
+            ),
+            Probe::Unreachable { url, error } => println!(
+                "    probe {url} → {} ({error})",
+                style("unreachable").color256(CLI_RED).bold(),
+            ),
+        }
+    }
+}
+
+/// Just the `#fragment` of a service id when it has one — the full DID prefix is
+/// already printed above and repeating it per row buries the part that differs.
+fn fragment(id: &str) -> String {
+    match id.rsplit_once('#') {
+        Some((_, frag)) => format!("#{frag}"),
+        None => id.to_string(),
+    }
+}
+
+fn protocols(list: &[vta_sdk::protocol::matching::Protocol]) -> String {
+    if list.is_empty() {
+        return "none".to_string();
+    }
+    list.iter()
+        .map(|p| p.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_tail_names_a_webvh_persona_by_its_path() {
+        assert_eq!(
+            short_tail("did:webvh:QmScid:dids.example.dev:legend-swear"),
+            "legend-swear"
+        );
+    }
+
+    /// A DID with no path must not render as an empty label.
+    #[test]
+    fn short_tail_falls_back_for_pathless_dids() {
+        assert_eq!(short_tail("did:key:z6Mkabc"), "z6Mkabc");
+        assert_eq!(short_tail("notadid"), "notadid");
+    }
+
+    /// The fragment is what distinguishes two service entries; the DID prefix is
+    /// printed once above and repeating it per row hides the difference.
+    #[test]
+    fn service_ids_render_as_their_fragment() {
+        assert_eq!(fragment("did:webvh:QmScid:example:x#tsp"), "#tsp");
+        assert_eq!(
+            fragment("did:webvh:QmScid:example:x#tsp-transport"),
+            "#tsp-transport",
+            "the OWF reference impl names it differently from ours; both are \
+             TSPTransport, and an operator comparing deployments must see which"
+        );
+        assert_eq!(fragment("no-fragment"), "no-fragment");
+    }
+}

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -24,8 +24,94 @@ use tokio::sync::broadcast;
 mod cli;
 mod clipboard;
 mod colors;
+mod health_cmd;
 mod state_handler;
 mod ui;
+
+/// Load the full account for `openvtc health`, or `None` if it cannot be had.
+///
+/// Every failure here is soft. A profile that does not exist, will not decrypt,
+/// or whose VTA is unreachable still leaves a useful report to run against the
+/// `--vtc` DIDs — and "the account would not load" is itself a finding worth
+/// printing rather than an error worth aborting on. The reason is surfaced on
+/// stderr so it is not swallowed.
+///
+/// The admin VTA session `load_step2` hands back is shut down immediately: this
+/// command reads DID documents, and holding a live mediator connection open for
+/// that would add a second socket for the profile the running TUI may already
+/// own.
+async fn load_config_for_health(profile: &str, unlock_code_arg: Option<&str>) -> Option<Config> {
+    let deferred = match load_fast(profile, unlock_code_arg) {
+        Ok(deferred) => deferred,
+        Err(OpenVTCError::ConfigNotFound(_, _)) => return None,
+        Err(e) => {
+            eprintln!(
+                "{} {}",
+                style("Account not loaded:").color256(CLI_ORANGE),
+                redact_paths(&e.to_string()),
+            );
+            return None;
+        }
+    };
+
+    let mut tdk = match affinidi_tdk::TDK::new(
+        affinidi_tdk::common::config::TDKConfig::builder()
+            .with_load_environment(false)
+            .build()
+            .ok()?,
+        None,
+    )
+    .await
+    {
+        Ok(tdk) => tdk,
+        Err(e) => {
+            eprintln!(
+                "{} {e}",
+                style("Account not loaded (TDK init failed):").color256(CLI_ORANGE)
+            );
+            return None;
+        }
+    };
+
+    #[cfg(feature = "openpgp-card")]
+    struct TouchPrompt;
+    #[cfg(feature = "openpgp-card")]
+    impl openvtc_core::config::TokenInteractions for TouchPrompt {
+        fn touch_notify(&self) {
+            eprintln!("Touch your security token to continue…");
+        }
+        fn touch_completed(&self) {}
+    }
+
+    match Config::load_step2(
+        &mut tdk,
+        profile,
+        deferred.public_config,
+        deferred.unlock_passphrase.as_ref(),
+        #[cfg(feature = "openpgp-card")]
+        &deferred.user_pin,
+        #[cfg(feature = "openpgp-card")]
+        &TouchPrompt,
+        None,
+    )
+    .await
+    {
+        Ok((config, admin_session)) => {
+            if let Some(session) = admin_session {
+                session.shutdown().await;
+            }
+            Some(config)
+        }
+        Err(e) => {
+            eprintln!(
+                "{} {}",
+                style("Account not loaded:").color256(CLI_ORANGE),
+                redact_paths(&e.to_string()),
+            );
+            None
+        }
+    }
+}
 
 /// Register the platform-specific keyring-core credential store as the
 /// process default. Must run before any `keyring_core::Entry::new` call.
@@ -178,6 +264,23 @@ async fn main() -> Result<()> {
             style(&profile).color256(CLI_ORANGE)
         );
         bail!("Profile name may only contain [A-Za-z0-9._-] and must not contain '..'");
+    }
+
+    // `health` runs before the duplicate-instance check and never takes the
+    // lock. The report is read-only, and the moment you most want it is while a
+    // TUI is sitting on a join that never came back — refusing to run because
+    // that TUI holds the profile would deny the diagnosis to the one situation
+    // it exists for. Account details are best-effort for the same reason (see
+    // `health_cmd::run`): a locked or undecryptable profile degrades the report
+    // rather than aborting it.
+    if let Some(("health", health_args)) = matches.subcommand() {
+        let vtc_dids: Vec<String> = health_args
+            .get_many::<String>("vtc")
+            .map(|values| values.cloned().collect())
+            .unwrap_or_default();
+        let as_json = health_args.get_flag("json");
+        let config = load_config_for_health(&profile, unlock_code_arg.as_deref()).await;
+        return health_cmd::run(config.as_ref(), &vtc_dids, as_json).await;
     }
 
     // Check if profile is currently active elsewhere?

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -2763,10 +2763,25 @@ impl StateHandler {
     /// ordering note in `run`. The early load-failure callers pass `None`; they
     /// cannot join at all.
     ///
-    /// Returns [`DegradedOutcome::Joined`] when an in-session join mints the
-    /// account's first persona (State-A → member). The caller then installs the
-    /// remaining listeners without a restart (hot-start). All other exits
-    /// return [`DegradedOutcome::Exit`] after closing the admin session.
+    /// Returns [`DegradedOutcome::Joined`] when an in-session join succeeds
+    /// (State-A → member). The caller then installs the remaining listeners
+    /// without a restart (hot-start). All other exits return
+    /// [`DegradedOutcome::Exit`] after closing the admin session.
+    ///
+    /// # Invariant: this loop must never own a live listener across an iteration
+    ///
+    /// Its `select!` has exactly two arms — `action_rx` and `interrupt_rx`. There
+    /// is **no inbound arm**: nothing here drains the DIDComm event channel that
+    /// `dispatch_inbound` feeds. A listener opened here is therefore a socket
+    /// whose mail the SDK acknowledges (and the mediator then deletes) while no
+    /// consumer runs — inbound survives only as far as the channel's 256-slot
+    /// buffer, and only until the runtime loop drains it.
+    ///
+    /// So every path that opens a listener must exit via
+    /// [`DegradedOutcome::Joined`] in the same iteration. The `StartJoin` arm
+    /// enforces this for itself *and* re-checks `list_listeners()` as a backstop,
+    /// because the cost of getting it wrong is silent, permanent message loss
+    /// that looks like a community that never answered.
     async fn run_degraded_loop(
         &self,
         action_rx: &mut UnboundedReceiver<Action>,
@@ -2818,15 +2833,10 @@ impl StateHandler {
                         }
                     }
                     Action::StartJoin => {
-                        // Set when the join minted our first persona: the loop
-                        // then breaks `Joined` so `run()` can start messaging.
-                        let mut joined_with_identity = false;
+                        // Set when a join succeeded: the loop then breaks `Joined`
+                        // so `run()` can start messaging.
+                        let mut joined_a_community = false;
                         if let Some(ctx) = join_ctx.as_mut() {
-                            // A State-A account has no identity yet; a successful
-                            // join flips this None→Some. (An account that already
-                            // had one — the messaging-startup-failure path — never
-                            // transitions here.)
-                            let had_identity = ctx.config.active_identity().is_some();
                             match self
                                 .join_flow(
                                     action_rx,
@@ -2846,17 +2856,30 @@ impl StateHandler {
                                 )
                                 .await
                             {
-                                // The joined session is ignored here: a first join
-                                // from State A flips `joined_with_identity`, breaking
+                                // The joined session is ignored here: a join from
+                                // State A flips `joined_a_community`, breaking
                                 // `Joined` so `run()` restarts into the full pipeline,
                                 // whose startup registration (`IdentityRegistry`)
                                 // brings the new session up (R-B-5). Live in-loop
                                 // registration is only needed in the runtime loop.
-                                Ok(join_flow::JoinExit::Returned(_)) => {
+                                Ok(join_flow::JoinExit::Returned(joined)) => {
                                     // Back on the main page; resume the degraded loop.
                                     state.active_page = state::ActivePage::Main;
-                                    joined_with_identity =
-                                        !had_identity && ctx.config.active_identity().is_some();
+                                    // Gated on the *join*, never on whether it minted
+                                    // the account's first identity. This used to read
+                                    // `!had_identity && …`, on the assumption that the
+                                    // only way to already hold an identity here was the
+                                    // messaging-startup-failure path. It is not: the
+                                    // `CreatePersonaSubmit` arm below mints one in this
+                                    // very loop, and `active_identity()` falls back to
+                                    // the first persona in the map — so the ordinary
+                                    // first-run order (create persona, *then* join)
+                                    // left `had_identity` true, skipped the hand-off,
+                                    // and stranded the account in a loop that has no
+                                    // inbound arm. The community's reply was ACKed by
+                                    // the SDK, deleted at the mediator, and dropped.
+                                    joined_a_community =
+                                        joined.is_some() && ctx.config.active_identity().is_some();
                                 }
                                 Ok(join_flow::JoinExit::Exit(interrupted)) => {
                                     if let Err(e) = terminator.terminate(interrupted.clone()) {
@@ -2879,15 +2902,29 @@ impl StateHandler {
                         // Hot-start: the borrow on `join_ctx` has ended, so take
                         // the context and hand it back to `run()`, which brings up
                         // the new persona's DIDComm listener without a restart.
-                        if joined_with_identity {
-                            state
-                                .main_page
-                                .log("Joined — starting secure messaging…");
+                        //
+                        // `holds_listener` is the backstop for the same class of
+                        // bug the condition above fixes: this loop has no inbound
+                        // arm, so *any* live listener it owns is a mailbox nobody
+                        // reads. Whatever opened one — this join, or some future
+                        // arm — the only safe move is to hand off to the runtime
+                        // loop that drains the event channel. See the invariant on
+                        // `run_degraded_loop`.
+                        let holds_listener = match messaging {
+                            Some(m) => !m.list_listeners().await.is_empty(),
+                            None => false,
+                        };
+                        if must_hand_off(joined_a_community, holds_listener, join_ctx.is_some()) {
+                            state.main_page.log(if joined_a_community {
+                                "Joined — starting secure messaging…"
+                            } else {
+                                "Starting secure messaging…"
+                            });
                             let _ = self.state_tx.send(state.clone());
                             break DegradedOutcome::Joined(Box::new(
                                 join_ctx
                                     .take()
-                                    .expect("join_ctx present when join succeeded"),
+                                    .expect("join_ctx present, just checked is_some"),
                             ));
                         }
                     }
@@ -3366,6 +3403,26 @@ async fn deregister_inactive_community(
     }
 }
 
+/// Whether a degraded-loop iteration must hand its runtime context back to
+/// `run()` — see the invariant on [`StateHandler::run_degraded_loop`].
+///
+/// Two independent reasons, either sufficient:
+///
+/// - **`joined_a_community`** — a join succeeded, so a reply is coming to a loop
+///   that cannot receive it. Deliberately *not* "…and this was the account's
+///   first identity": that extra clause is what broke the ordinary first-run
+///   order (create persona → join), because `Config::active_identity()` reports
+///   `Some` for any persona at all, including one minted moments earlier by this
+///   same loop's `CreatePersonaSubmit` arm.
+/// - **`holds_listener`** — the messaging runtime owns a socket whatever opened
+///   it. A listener with no consumer loses mail permanently, so this is a
+///   hand-off condition in its own right.
+///
+/// `has_ctx` gates both: there is nothing to hand back without a runtime context.
+fn must_hand_off(joined_a_community: bool, holds_listener: bool, has_ctx: bool) -> bool {
+    (joined_a_community || holds_listener) && has_ctx
+}
+
 async fn register_joined_session(
     session_manager: &mut session_manager::SessionManager,
     service: &openvtc_core::didcomm::Messaging,
@@ -3482,6 +3539,51 @@ fn build_trust_pong(
 mod tests {
     use super::*;
     use crate::state_handler::main_page::menu::MainMenu;
+
+    /// The regression this function exists for.
+    ///
+    /// The degraded loop has no inbound arm, so a join made there must hand off
+    /// to the runtime loop or the community's reply is ACKed by the SDK, deleted
+    /// at the mediator, and dropped — leaving the join `Pending` forever with a
+    /// clean log on both sides.
+    ///
+    /// The old condition also required the join to have minted the account's
+    /// *first* identity. Creating a persona and then joining — the ordinary
+    /// first-run order, and both actions the degraded loop serves — made that
+    /// false and silently disabled the hand-off. Only the join matters.
+    #[test]
+    fn a_join_hands_off_even_when_a_persona_already_existed() {
+        assert!(
+            must_hand_off(true, false, true),
+            "a successful join must hand off; whether a persona already existed \
+             (CreatePersonaSubmit ran first) is irrelevant — requiring it to be \
+             the first identity is the bug this test pins"
+        );
+    }
+
+    /// The backstop: a live listener is a mailbox with no reader, whatever
+    /// opened it.
+    #[test]
+    fn a_live_listener_alone_forces_the_hand_off() {
+        assert!(
+            must_hand_off(false, true, true),
+            "a listener this loop cannot drain must force the hand-off even with \
+             no join, so a future arm that opens one cannot silently lose mail"
+        );
+    }
+
+    /// Nothing open, nothing joined: stay in the loop.
+    #[test]
+    fn an_idle_iteration_stays_in_the_degraded_loop() {
+        assert!(!must_hand_off(false, false, true));
+    }
+
+    /// No runtime context, nothing to hand back — must not break out (the
+    /// `join_ctx.take().expect(..)` below would panic).
+    #[test]
+    fn no_context_never_hands_off() {
+        assert!(!must_hand_off(true, true, false));
+    }
 
     /// Lifecycle log lines name the listener by its verified agent name. These
     /// showed raw `did:webvh:` strings because the logger task is detached and


### PR DESCRIPTION
## What this fixes

A first-run join could go out and never be answerable. Create a persona, then join — the ordinary first-run order — and the community's reply was received by the SDK, acknowledged (so deleted at the mediator), and dropped before any handler saw it. The join sat `Pending` forever with a clean log on **both** sides, and no restart could recover it.

Found while diagnosing a stuck join against a live deployment, where four services' logs all showed a clean run and the client's activity log simply stopped after "Join request sent over TSP".

## Why it happened

The State-A degraded loop can send but cannot receive: its `select!` has exactly two arms, `action_rx` and `interrupt_rx`, and nothing there drains the event channel `dispatch_inbound` feeds. That is fine by design, because a successful join is meant to leave immediately via `DegradedOutcome::Joined` and let the runtime loop take over.

The gate on that hand-off was:

```rust
joined_with_identity = !had_identity && ctx.config.active_identity().is_some();
```

`!had_identity` assumed the only way to already hold an identity there was the messaging-startup-failure path. It isn't — the `CreatePersonaSubmit` arm mints one in the same loop, and `Config::active_identity()` falls back to `identities.values().next()`, so it reports `Some` for any persona at all. Create one first and the guard is false exactly when the hand-off matters most.

It is also unrecoverable rather than merely late: the mail is gone from the mediator, and `join-requests/status` polling is gated on `request_id_confirmed`, which only flips when a correlated reply is *processed*. The recovery paths from #218 and #219 share that blind spot, so both fail together.

## Changes

**`fix(join)`** — gate the hand-off on the join alone. Beside it, a `list_listeners()` check as a backstop: whatever opens a socket in this loop is a mailbox with no reader, so holding one is a hand-off condition in its own right and a future arm cannot reintroduce this silently. The decision moves into `must_hand_off` so both halves are named and tested, and the invariant is written on `run_degraded_loop` where the next person to add an arm will read it.

**`feat(health)`** — `openvtc health [--vtc <did>] [--json]`, because the diagnosis above took four services' logs and several `did.jsonl` fetches by hand.

For every DID in the chain it resolves the document, prints the `service` array **verbatim** (deliberately unfiltered — a party advertising a transport this build doesn't know is indistinguishable through `ServiceCapabilities` from one advertising nothing), runs the real `select_protocol` negotiation so the reported transport is the one a send would pick, and probes each transport URL. Mediators are discovered from the documents rather than read from local config, resolved once, and labelled with every party behind them and which transports each uses — so a split-mediator topology is visible rather than assumed away.

Built to be usable while things are broken: no process lock (runs against a profile a stuck TUI holds), best-effort account loading (`--vtc` alone works with no account; a config that won't decrypt is a finding, not an abort), every network step independently bounded, read-only throughout. Exits non-zero when a DID fails to resolve or a pair shares no transport.

```
  [vtc] VTC legend-swear (--vtc)
    services:
      #tsp              TSPTransport      → did:webvh:QmS53…:firstperson-mediator
      #vta-didcomm      DIDCommMessaging  → did:webvh:QmS53…:firstperson-mediator
      #whois            LinkedVerifiablePresentation → …/whois.vp
    probe https://dids.firstperson.dev/legend-swear → reachable (HTTP 200)

  [mediator] mediator of VTC legend-swear (--vtc) (TSP, DIDComm)
      #tsp              TSPTransport      → https://mediator.firstperson.dev/mediator/v1
      #service          DIDCommMessaging  → https://mediator.firstperson.dev/mediator/v1
    probe https://mediator.firstperson.dev/mediator/v1 → reachable (HTTP 404)
```

**`chore(release)`** — 0.3.1, and `trust-tasks-rs` 0.4 → 0.6.

## ⚠️ The dependency change needs a real check

A dependency refresh alone put `trust-tasks-rs` 0.4.1 **and** 0.6.5 in the same binary — precisely the split the pin exists to prevent. vta-sdk 0.23.3 declares `^0.6` where 0.23.0 declared `^0.4`, so the `"0.4"` requirement had stopped tracking the stack it was written to track. Moved to 0.6 with `trust-tasks-capability-client` 0.3 → 0.5, and vta-sdk floored at 0.23.3 so a clean checkout can't resolve back onto the fork. `cargo tree -d` is now clean for all three.

**This is wire-adjacent and the deployments in the field are on the 0.4 line.** The types unify and the suite is green, but the check that matters is a join round-trip against a scratch community, not a green build. Please don't merge this ahead of that.

## Testing

- Full workspace suite green (`cargo test --workspace`), `clippy -D warnings` and `fmt` clean.
- 4 new tests pinning the hand-off invariant, including `a_join_hands_off_even_when_a_persona_already_existed` — the exact ordering that broke.
- 9 new tests on the health report: shared/split mediators, disjoint protocol sets, unresolvable peers, all three `serviceEndpoint` shapes, and unrecognised service types surviving into the map.
- `openvtc health` exercised live against `dids.firstperson.dev` / `mediator.firstperson.dev`, both healthy (exit 0) and unresolvable-DID (exit 1) paths.

Not covered: a real first-run join round-trip on the fixed binary. Worth doing alongside the dependency check above.
