### PR TITLE
feat(health): live progress, quieter probes; fix duplicate `c` in Communities footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`openvtc health` reports progress as it works.** The command is almost
+  entirely network waits — a `did:webvh` resolution is an HTTPS fetch and each
+  probe is bounded at 10s — so a chain with a few mediators could sit silent for
+  most of a run that took 14 seconds. Each step now announces itself *before* the
+  wait and reports the time it actually took, which makes the slow step visible
+  while it is slow rather than inferable afterwards (it isn't: the finished
+  report has no timings). Progress goes to stderr and the report to stdout, so
+  `openvtc health --json > report.json` still pipes cleanly while showing the
+  operator what is being waited on.
+
+### Changed
+
+- **`openvtc health` no longer probes `#files` and `#whois`.** Both are served by
+  the DID host the report just fetched `did.jsonl` from, so resolving the DID had
+  already proven that host answers — and `#files` points at the directory rather
+  than the document, so the probe reported a 404 for a path that never serves a
+  bare GET. Four such lines per party buried the transport probes that carry
+  information. Implemented as a skip-list of the two document-adjacent service
+  types rather than an allow-list of known transports, so a transport type this
+  build has never heard of is still probed.
+
+- **A probe's verdict now agrees with its status code.** "reachable (HTTP 404)"
+  read as a contradiction — the word claimed health, the number denied it, and
+  nothing told the reader which to believe. Statuses are graded: 2xx/3xx is `ok`,
+  4xx is `responding` (the normal answer from an endpoint that takes POSTs and
+  websockets rather than GETs), and 5xx is `server error`. Only the last is
+  raised as a finding, which is a case the flat "reachable" actively hid: the
+  host is up and the service behind it is failing.
+
+- **A DIDComm-only persona against a TSP-only community now says what to do.**
+  The advertised sets alone (`we offer [didcomm], they offer [tsp]`) do not tell
+  an operator which side to change. A persona minted before the client requested
+  `#tsp` cannot reach a TSP-only community and will never gain the service on its
+  own — the document is written at mint time and not revisited — so the finding
+  now says that, and that re-minting is the fix. Scoped to that one direction:
+  re-minting our persona does not fix a DIDComm-only community.
+
+### Fixed
+
+- **The Communities footer no longer advertises `c` twice.** It listed every
+  binding unconditionally, so `c: capabilities` and `c: cancel` appeared side by
+  side and read as a collision. It never was one — `c` is capabilities on an
+  Active row and cancel on a Pending one, and the states are mutually exclusive.
+  The footer now shows what the selected row actually accepts, which also removes
+  four silent no-ops it was advertising: `l`/`m` on a Pending or Inactive row and
+  `x`/`d` on an Active one. The two panel-level keys (`j`, `v`) stay listed
+  always, including when nothing is selected.
+
 ## [0.3.1] - 2026-08-15
 
 A first-run join could go out and never be answerable. This fixes the state

--- a/openvtc-core/src/health.rs
+++ b/openvtc-core/src/health.rs
@@ -220,10 +220,14 @@ impl HealthReport {
 
 /// A step the report is taking, emitted as it starts and as it finishes.
 ///
+// Not an intra-doc link: `STEP_TIMEOUT` is private, and a public item linking
+// to it fails `rustdoc -D warnings` — the same trap `config::peer_tsp_mediator`
+// carries a note for.
 /// The report is mostly waiting on the network — a `did:webvh` resolution is an
-/// HTTPS fetch and each probe is bounded at [`STEP_TIMEOUT`], so a chain with a
-/// few mediators and one dead host can sit silent for the better part of a
-/// minute. Silence during that is indistinguishable from a hang, and the step
+/// HTTPS fetch and each probe is bounded by the module's per-step timeout, so a
+/// chain with a few mediators and one dead host can sit silent for the better
+/// part of a minute. Silence during that is indistinguishable from a hang, and
+/// the step
 /// that is slow is itself a finding: a resolution that takes nine seconds and
 /// then succeeds says something a report listing only the outcome does not.
 ///

--- a/openvtc-core/src/health.rs
+++ b/openvtc-core/src/health.rs
@@ -77,13 +77,47 @@ pub struct ServiceEntry {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "status", rename_all = "lowercase")]
 pub enum Probe {
-    /// The host answered. Any status is reachability — a 404 from a mediator's
-    /// base path still proves DNS, TLS and routing all work, which is the thing
-    /// being tested. Reporting it as a failure would send an operator hunting a
-    /// network fault that isn't there.
+    /// The host answered. **Any** status counts as the host being up — a 404 or
+    /// 405 from a mediator's base path proves DNS, TLS and routing all work,
+    /// which is what is being tested; those endpoints take POSTs and websockets,
+    /// not bare GETs. Calling that a failure would send an operator hunting a
+    /// network fault that is not there.
+    ///
+    /// The status is still classified for display ([`Self::grade`]) because
+    /// "reachable (HTTP 404)" read as a contradiction: the word promised health
+    /// and the number said otherwise, and a reader cannot be expected to know
+    /// which one to believe. A 5xx *is* worth flagging — the host is up and its
+    /// application is broken, which is a different thing from both.
     Reachable { url: String, http_status: u16 },
     /// No answer: DNS, TLS, connection or timeout.
     Unreachable { url: String, error: String },
+}
+
+/// How to read a probe's status code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeGrade {
+    /// 2xx/3xx — the endpoint served the request.
+    Ok,
+    /// 4xx — the host answered and declined, which is the normal answer from an
+    /// endpoint that takes POSTs or websockets rather than GETs.
+    Responding,
+    /// 5xx — the host is up and its application is failing. Worth surfacing.
+    ServerError,
+}
+
+impl Probe {
+    /// Classify a reachable probe's status; `None` when nothing answered.
+    #[must_use]
+    pub fn grade(&self) -> Option<ProbeGrade> {
+        match self {
+            Probe::Reachable { http_status, .. } => Some(match http_status {
+                200..=399 => ProbeGrade::Ok,
+                400..=499 => ProbeGrade::Responding,
+                _ => ProbeGrade::ServerError,
+            }),
+            Probe::Unreachable { .. } => None,
+        }
+    }
 }
 
 /// A resolved party.
@@ -184,6 +218,61 @@ impl HealthReport {
     }
 }
 
+/// A step the report is taking, emitted as it starts and as it finishes.
+///
+/// The report is mostly waiting on the network — a `did:webvh` resolution is an
+/// HTTPS fetch and each probe is bounded at [`STEP_TIMEOUT`], so a chain with a
+/// few mediators and one dead host can sit silent for the better part of a
+/// minute. Silence during that is indistinguishable from a hang, and the step
+/// that is slow is itself a finding: a resolution that takes nine seconds and
+/// then succeeds says something a report listing only the outcome does not.
+///
+/// Each `…ing` variant is emitted *before* the wait so the operator sees what is
+/// being waited on, and each result variant carries the `elapsed` it actually
+/// took. Deliberately structured rather than pre-formatted strings: the CLI owns
+/// presentation, and `--json` consumers can ignore the stream entirely.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum Step {
+    /// Bringing up the DID resolver (cheap, but it can fail and that failure
+    /// stops everything).
+    ResolverStarting,
+    /// About to resolve a party.
+    Resolving {
+        role: Role,
+        label: String,
+        did: String,
+    },
+    /// A party resolved.
+    Resolved {
+        label: String,
+        services: usize,
+        transports: Vec<Protocol>,
+        elapsed: Duration,
+    },
+    /// A party did not resolve. Not fatal — the report records the dead end.
+    ResolveFailed {
+        label: String,
+        error: String,
+        elapsed: Duration,
+    },
+    /// Moving on to the mediators discovered from the parties above.
+    FollowingMediators { count: usize },
+    /// About to probe a transport URL.
+    Probing { url: String },
+    /// A probe finished.
+    Probed { probe: Probe, elapsed: Duration },
+    /// Resolution done; negotiating transports (local, fast).
+    Negotiating { pairs: usize },
+    /// The whole report is built.
+    Finished { elapsed: Duration },
+}
+
+/// Where [`build_report_with_progress`] reports to. `&dyn` rather than a
+/// generic so threading it through the helpers costs no monomorphisation and no
+/// type parameter on every signature.
+pub type ProgressFn<'a> = &'a (dyn Fn(Step) + Send + Sync);
+
 /// A DID to include in the report, with the provenance to label it by.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Subject {
@@ -211,6 +300,19 @@ impl Subject {
 /// would report what we believe rather than what is published. That difference
 /// is one of the things this command exists to expose.
 pub async fn build_report(subjects: &[Subject]) -> HealthReport {
+    build_report_with_progress(subjects, &|_| {}).await
+}
+
+/// [`build_report`], reporting each step to `progress` as it happens.
+///
+/// The work is almost entirely network waits, so a caller that shows nothing
+/// until the end shows nothing for most of the run. See [`Step`].
+pub async fn build_report_with_progress(
+    subjects: &[Subject],
+    progress: ProgressFn<'_>,
+) -> HealthReport {
+    let started = std::time::Instant::now();
+    progress(Step::ResolverStarting);
     let resolver = match DIDCacheClient::new(
         affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
     )
@@ -242,7 +344,7 @@ pub async fn build_report(subjects: &[Subject]) -> HealthReport {
         if parties.iter().any(|p| p.did == subject.did) {
             continue;
         }
-        parties.push(resolve_party(&resolver, http.as_ref(), subject).await);
+        parties.push(resolve_party(&resolver, http.as_ref(), subject, progress).await);
     }
 
     // Second pass: every mediator any resolved party routes through, resolved
@@ -252,16 +354,22 @@ pub async fn build_report(subjects: &[Subject]) -> HealthReport {
     // that it also carries that party's DIDComm and that a second party is
     // behind the same host.
     let referenced = mediator_references(&parties);
-    for (did, users) in referenced {
-        if parties.iter().any(|p| p.did == did) {
-            continue;
-        }
+    let fresh: Vec<(String, String)> = referenced
+        .into_iter()
+        .filter(|(did, _)| !parties.iter().any(|p| p.did == *did))
+        .collect();
+    progress(Step::FollowingMediators { count: fresh.len() });
+    for (did, users) in fresh {
         let subject = Subject::new(Role::Mediator, format!("mediator of {users}"), did);
-        parties.push(resolve_party(&resolver, http.as_ref(), &subject).await);
+        parties.push(resolve_party(&resolver, http.as_ref(), &subject, progress).await);
     }
 
     let links = negotiate_links(&parties);
+    progress(Step::Negotiating { pairs: links.len() });
     let notes = collect_notes(&parties, &links);
+    progress(Step::Finished {
+        elapsed: started.elapsed(),
+    });
     HealthReport {
         parties,
         links,
@@ -321,13 +429,28 @@ async fn resolve_party(
     resolver: &DIDCacheClient,
     http: Option<&reqwest::Client>,
     subject: &Subject,
+    progress: ProgressFn<'_>,
 ) -> Party {
-    let fail = |error: String| Party {
+    let started = std::time::Instant::now();
+    progress(Step::Resolving {
         role: subject.role,
         label: subject.label.clone(),
         did: subject.did.clone(),
-        resolved: None,
-        error: Some(error),
+    });
+
+    let fail = |error: String| {
+        progress(Step::ResolveFailed {
+            label: subject.label.clone(),
+            error: error.clone(),
+            elapsed: started.elapsed(),
+        });
+        Party {
+            role: subject.role,
+            label: subject.label.clone(),
+            did: subject.did.clone(),
+            resolved: None,
+            error: Some(error),
+        }
     };
 
     let resolved = match tokio::time::timeout(STEP_TIMEOUT, resolver.resolve(&subject.did)).await {
@@ -347,19 +470,38 @@ async fn resolve_party(
 
     let caps = ServiceCapabilities::from_did_document(&doc);
     let services = service_entries(&doc);
+    progress(Step::Resolved {
+        label: subject.label.clone(),
+        services: services.len(),
+        transports: caps.advertised(),
+        elapsed: started.elapsed(),
+    });
 
-    // Probe only endpoints that are URLs. A DID endpoint is a mediator, which
-    // becomes its own party and is probed there — following it here would probe
-    // the same host once per party that names it.
+    // Probe only endpoints that are URLs *and* routable. A DID endpoint is a
+    // mediator, which becomes its own party and is probed there — following it
+    // here would probe the same host once per party that names it. And a
+    // non-routable entry (see `is_routable`) is served by the DID host we just
+    // resolved through, so probing it re-tests what resolution already proved
+    // and reports a 404 for a path that was never meant to answer a bare GET.
     let mut probes = Vec::new();
     if let Some(client) = http {
         let urls: BTreeSet<&str> = services
             .iter()
+            .filter(|s| is_routable(s))
             .map(|s| s.endpoint.as_str())
             .filter(|e| e.starts_with("http://") || e.starts_with("https://"))
             .collect();
         for url in urls {
-            probes.push(probe(client, url).await);
+            progress(Step::Probing {
+                url: url.to_string(),
+            });
+            let probe_started = std::time::Instant::now();
+            let result = probe(client, url).await;
+            progress(Step::Probed {
+                probe: result.clone(),
+                elapsed: probe_started.elapsed(),
+            });
+            probes.push(result);
         }
     }
 
@@ -376,6 +518,31 @@ async fn resolve_party(
         }),
         error: None,
     }
+}
+
+/// DID-document service types that are **not** routes: entries describing where
+/// the document and its attachments live, rather than somewhere a message goes.
+///
+/// `relativeRef` (`#files`) and `LinkedVerifiablePresentation` (`#whois`) are
+/// both served by the same DID host we just fetched `did.jsonl` from, so
+/// resolving the DID has already proven that host answers. Probing them again
+/// only re-tests a working host and reports a 404 for a path that never serves a
+/// bare GET — `#files` points at the *directory*, not `…/did.jsonl`. Four such
+/// lines per party drowned the transport probes that do carry information.
+const NON_ROUTABLE_SERVICE_TYPES: [&str; 2] = ["relativeRef", "LinkedVerifiablePresentation"];
+
+/// Whether a service entry names somewhere a message or request actually goes.
+///
+/// A skip-list rather than an allow-list, deliberately: a transport type this
+/// build has never heard of should still be probed (the whole point of printing
+/// services verbatim is that unknown types matter), whereas the two
+/// document-adjacent types are a closed set defined by the DID spec and the
+/// webvh hosting convention.
+fn is_routable(service: &ServiceEntry) -> bool {
+    !service
+        .types
+        .iter()
+        .any(|t| NON_ROUTABLE_SERVICE_TYPES.contains(&t.as_str()))
 }
 
 /// Read the `service` array verbatim.
@@ -520,22 +687,57 @@ fn collect_notes(parties: &[Party], links: &[Link]) -> Vec<String> {
             ));
         }
         for probe in &resolved.probes {
-            if let Probe::Unreachable { url, error } = probe {
-                notes.push(format!("{}: {url} is unreachable ({error}).", party.label));
+            match probe {
+                Probe::Unreachable { url, error } => {
+                    notes.push(format!("{}: {url} is unreachable ({error}).", party.label));
+                }
+                // A 5xx is the case a bare "reachable" hid: the host is up and
+                // its application is failing, which no other line in the report
+                // would reveal. 4xx is not flagged — that is the expected answer
+                // from a POST/websocket endpoint asked for a GET.
+                Probe::Reachable { url, http_status }
+                    if probe.grade() == Some(ProbeGrade::ServerError) =>
+                {
+                    notes.push(format!(
+                        "{}: {url} answered HTTP {http_status} — the host is up but the \
+                         service behind it is failing.",
+                        party.label
+                    ));
+                }
+                Probe::Reachable { .. } => {}
             }
         }
     }
 
     for link in links {
         match &link.outcome {
-            LinkOutcome::NoCommonProtocol { ours, theirs } => notes.push(format!(
-                "{} and {} share no transport: we offer [{}], they offer [{}]. A message \
-                 between them cannot be sent until one side adds the other's.",
-                link.from,
-                link.to,
-                join_protocols(ours),
-                join_protocols(theirs),
-            )),
+            LinkOutcome::NoCommonProtocol { ours, theirs } => {
+                let mut note = format!(
+                    "{} and {} share no transport: we offer [{}], they offer [{}]. A message \
+                     between them cannot be sent until one side adds the other's.",
+                    link.from,
+                    link.to,
+                    join_protocols(ours),
+                    join_protocols(theirs),
+                );
+                // The specific case this keeps catching, and the one an operator
+                // cannot diagnose from the sets alone: a persona minted before
+                // the client requested `#tsp` can never reach a TSP-only
+                // community, and nothing about it will change on its own — the
+                // service is written at mint time and old documents are not
+                // revisited. Saying only "no shared transport" leaves the reader
+                // to guess whether to change the community, the persona, or the
+                // client.
+                if ours.as_slice() == [Protocol::Didcomm] && theirs.as_slice() == [Protocol::Tsp] {
+                    note.push_str(
+                        " This persona's document predates `#tsp` being requested at mint \
+                         time, so it advertises DIDComm only; a persona minted by a current \
+                         client carries both. Re-minting a persona for this community is the \
+                         fix — the existing document will not gain the service on its own.",
+                    );
+                }
+                notes.push(note);
+            }
             LinkOutcome::Unknown { reason } => notes.push(format!(
                 "{} → {}: transport could not be determined ({reason}).",
                 link.from, link.to
@@ -804,6 +1006,179 @@ mod tests {
             label, "persona joy-ahead (TSP, DIDComm), VTC acme (DIDComm)",
             "both parties, and TSP before DIDComm (negotiation order, not \
              alphabetical): {label}"
+        );
+    }
+
+    /// `#files` and `#whois` live on the DID host we just resolved through, so
+    /// probing them re-tests a host already proven and reports a 404 for a path
+    /// that never serves a bare GET. Four such lines per party buried the
+    /// transport probes that carry information.
+    #[test]
+    fn document_adjacent_services_are_not_probed() {
+        let files = ServiceEntry {
+            id: "#files".into(),
+            types: vec!["relativeRef".into()],
+            endpoint: "https://webvh.storm.ws/army-provide".into(),
+        };
+        let whois = ServiceEntry {
+            id: "#whois".into(),
+            types: vec!["LinkedVerifiablePresentation".into()],
+            endpoint: "https://webvh.storm.ws/army-provide/whois.vp".into(),
+        };
+        assert!(
+            !is_routable(&files),
+            "#files is the document host, not a route"
+        );
+        assert!(
+            !is_routable(&whois),
+            "#whois is not somewhere a message goes"
+        );
+    }
+
+    /// The skip-list must not swallow transports — including one this build has
+    /// never heard of, which is exactly the case worth probing.
+    #[test]
+    fn transports_and_unknown_types_are_still_probed() {
+        for types in [
+            vec!["TSPTransport".to_string()],
+            vec!["DIDCommMessaging".to_string()],
+            vec!["Authentication".to_string()],
+            vec!["SomeFutureTransport".to_string()],
+        ] {
+            let entry = ServiceEntry {
+                id: "#x".into(),
+                types: types.clone(),
+                endpoint: "https://example/x".into(),
+            };
+            assert!(
+                is_routable(&entry),
+                "{types:?} names a route (or might); it must be probed"
+            );
+        }
+    }
+
+    /// "reachable (HTTP 404)" read as a contradiction. The grade is what lets
+    /// the word agree with the number.
+    #[test]
+    fn probe_status_is_graded_not_flattened() {
+        let at = |status| Probe::Reachable {
+            url: "https://m/x".into(),
+            http_status: status,
+        };
+        assert_eq!(at(200).grade(), Some(ProbeGrade::Ok));
+        assert_eq!(
+            at(405).grade(),
+            Some(ProbeGrade::Responding),
+            "a POST/websocket endpoint declining a GET is the host working"
+        );
+        assert_eq!(at(404).grade(), Some(ProbeGrade::Responding));
+        assert_eq!(
+            at(503).grade(),
+            Some(ProbeGrade::ServerError),
+            "host up, application failing — the case a flat `reachable` hid"
+        );
+        assert_eq!(
+            Probe::Unreachable {
+                url: "https://m/x".into(),
+                error: "dns".into()
+            }
+            .grade(),
+            None
+        );
+    }
+
+    /// A 5xx earns a finding; a 4xx does not.
+    #[test]
+    fn only_a_server_error_becomes_a_finding() {
+        let with_probe = |probe: Probe| {
+            let mut party = resolved_party(
+                Role::Mediator,
+                "mediator",
+                "did:webvh:m",
+                &json!({"service": [{
+                    "id": "#tsp", "type": "TSPTransport",
+                    "serviceEndpoint": "https://m/x",
+                }]}),
+            );
+            party.resolved.as_mut().expect("resolved").probes = vec![probe];
+            collect_notes(&[party], &[])
+        };
+
+        let five_hundred = with_probe(Probe::Reachable {
+            url: "https://m/x".into(),
+            http_status: 502,
+        });
+        assert!(
+            five_hundred.iter().any(|n| n.contains("502")),
+            "a 5xx must surface: {five_hundred:?}"
+        );
+
+        let four_oh_four = with_probe(Probe::Reachable {
+            url: "https://m/x".into(),
+            http_status: 404,
+        });
+        assert!(
+            four_oh_four.is_empty(),
+            "a 4xx on a non-GET endpoint is normal and must stay quiet: {four_oh_four:?}"
+        );
+    }
+
+    /// The stranded-persona case: DIDComm-only against TSP-only. The sets alone
+    /// don't tell an operator which side to change, so the note must.
+    #[test]
+    fn a_didcomm_only_persona_is_told_why_it_cannot_reach_a_tsp_community() {
+        let didcomm_only = json!({"service": [{
+            "id": "#vta-didcomm", "type": "DIDCommMessaging",
+            "serviceEndpoint": [{"uri": "did:webvh:m"}],
+        }]});
+        let tsp_only = json!({"service": [{
+            "id": "#tsp", "type": "TSPTransport", "serviceEndpoint": "did:webvh:m",
+        }]});
+        let parties = vec![
+            resolved_party(
+                Role::Persona,
+                "persona hello-fury",
+                "did:webvh:p",
+                &didcomm_only,
+            ),
+            resolved_party(Role::Vtc, "VTC first-vtc", "did:webvh:v", &tsp_only),
+        ];
+        let links = negotiate_links(&parties);
+        let notes = collect_notes(&parties, &links);
+        let note = notes
+            .iter()
+            .find(|n| n.contains("share no transport"))
+            .expect("disjoint pair must be reported");
+        assert!(
+            note.contains("predates") && note.contains("Re-minting"),
+            "the note must say why this persona is stuck and what fixes it, not \
+             just list the two sets: {note}"
+        );
+    }
+
+    /// The added guidance is specific to that one direction — a TSP-only *us*
+    /// against a DIDComm-only *them* is a different problem with a different fix.
+    #[test]
+    fn the_remint_advice_is_not_given_for_the_reverse_mismatch() {
+        let didcomm_only = json!({"service": [{
+            "id": "#dc", "type": "DIDCommMessaging",
+            "serviceEndpoint": [{"uri": "did:webvh:m"}],
+        }]});
+        let tsp_only = json!({"service": [{
+            "id": "#tsp", "type": "TSPTransport", "serviceEndpoint": "did:webvh:m",
+        }]});
+        let parties = vec![
+            resolved_party(Role::Persona, "persona", "did:webvh:p", &tsp_only),
+            resolved_party(Role::Vtc, "VTC", "did:webvh:v", &didcomm_only),
+        ];
+        let notes = collect_notes(&parties, &negotiate_links(&parties));
+        let note = notes
+            .iter()
+            .find(|n| n.contains("share no transport"))
+            .expect("still reported");
+        assert!(
+            !note.contains("Re-minting"),
+            "re-minting our persona does not fix a DIDComm-only community: {note}"
         );
     }
 

--- a/openvtc/src/health_cmd.rs
+++ b/openvtc/src/health_cmd.rs
@@ -15,7 +15,10 @@
 use anyhow::Result;
 use console::style;
 use openvtc_core::config::{Config, KeyBackend};
-use openvtc_core::health::{HealthReport, LinkOutcome, Party, Probe, Role, Subject, build_report};
+use openvtc_core::health::{
+    HealthReport, LinkOutcome, Party, Probe, ProbeGrade, Role, Step, Subject,
+    build_report_with_progress,
+};
 
 use crate::colors::{CLI_BLUE, CLI_ORANGE, CLI_PURPLE, CLI_RED};
 
@@ -67,7 +70,11 @@ pub async fn run(config: Option<&Config>, vtc_args: &[String], as_json: bool) ->
         );
     }
 
-    let report = build_report(&subjects).await;
+    // Progress goes to stderr, the report to stdout. That keeps
+    // `openvtc health --json > report.json` piping cleanly while still showing
+    // the operator what is being waited on — and progress *is* wanted under
+    // `--json`, since that is the run most likely to be watched rather than read.
+    let report = build_report_with_progress(&subjects, &|step| trace(&step)).await;
 
     if as_json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -89,6 +96,142 @@ pub async fn run(config: Option<&Config>, vtc_args: &[String], as_json: bool) ->
 /// string for DID methods with no path.
 fn short_tail(did: &str) -> String {
     did.rsplit(':').next().unwrap_or(did).to_string()
+}
+
+/// Render one [`Step`] to stderr, unbuffered.
+///
+/// `eprintln!` flushes per call, which is what makes this live rather than a
+/// batch dumped at exit — the whole point is that the operator sees the slow
+/// step *while* it is slow.
+///
+/// Each wait is announced before it starts and its result carries the time it
+/// took, because a chain that pauses nine seconds on one mediator and then
+/// succeeds has told you something the final report cannot: the outcome is fine
+/// and the host is struggling.
+fn trace(step: &Step) {
+    // `dim` rather than a palette colour: these lines are scaffolding the
+    // operator reads past on a healthy run, and they must not compete with the
+    // report that follows on stdout.
+    let dim = |s: String| style(s).dim().to_string();
+    match step {
+        Step::ResolverStarting => {
+            eprintln!("{}", dim("  · starting DID resolver…".into()));
+        }
+        Step::Resolving { role, label, did } => {
+            eprintln!(
+                "{}",
+                dim(format!(
+                    "  · resolving {} {label} ({})…",
+                    role.as_str(),
+                    truncate_did(did)
+                ))
+            );
+        }
+        Step::Resolved {
+            label,
+            services,
+            transports,
+            elapsed,
+        } => {
+            let transports = if transports.is_empty() {
+                style("no known transport").color256(CLI_ORANGE).to_string()
+            } else {
+                style(protocols(transports))
+                    .color256(CLI_PURPLE)
+                    .to_string()
+            };
+            eprintln!(
+                "    {} {label} — {services} service{}, {transports} {}",
+                style("✓").color256(CLI_BLUE),
+                if *services == 1 { "" } else { "s" },
+                dim(secs(elapsed)),
+            );
+        }
+        Step::ResolveFailed {
+            label,
+            error,
+            elapsed,
+        } => {
+            eprintln!(
+                "    {} {label} — {error} {}",
+                style("✗").color256(CLI_RED).bold(),
+                dim(secs(elapsed)),
+            );
+        }
+        Step::FollowingMediators { count } => {
+            if *count > 0 {
+                eprintln!(
+                    "{}",
+                    dim(format!(
+                        "  · following {count} discovered mediator{}…",
+                        if *count == 1 { "" } else { "s" }
+                    ))
+                );
+            }
+        }
+        Step::Probing { url } => {
+            eprintln!("{}", dim(format!("  · probing {url}…")));
+        }
+        Step::Probed { probe, elapsed } => match probe {
+            Probe::Reachable { url, http_status } => {
+                let (word, colour) = probe_words(probe);
+                let mark = if probe.grade() == Some(ProbeGrade::ServerError) {
+                    style("!").color256(CLI_ORANGE).bold()
+                } else {
+                    style("✓").color256(CLI_BLUE)
+                };
+                eprintln!(
+                    "    {mark} {url} — {} (HTTP {http_status}) {}",
+                    style(word).color256(colour),
+                    dim(secs(elapsed)),
+                );
+            }
+            Probe::Unreachable { url, error } => eprintln!(
+                "    {} {url} — {error} {}",
+                style("✗").color256(CLI_RED).bold(),
+                dim(secs(elapsed)),
+            ),
+        },
+        Step::Negotiating { pairs } => {
+            if *pairs > 0 {
+                eprintln!(
+                    "{}",
+                    dim(format!(
+                        "  · negotiating {pairs} pair{}…",
+                        if *pairs == 1 { "" } else { "s" }
+                    ))
+                );
+            }
+        }
+        Step::Finished { elapsed } => {
+            eprintln!(
+                "{}",
+                dim(format!("  · done in {:.1}s", elapsed.as_secs_f64()))
+            );
+            eprintln!();
+        }
+        // `Step` is `#[non_exhaustive]`: a variant added upstream should be
+        // silent here rather than stopping the build of a diagnostic tool.
+        _ => {}
+    }
+}
+
+/// A duration at the precision that matters for a network wait — tenths.
+/// Anything finer is noise next to a 10s timeout.
+fn secs(elapsed: &std::time::Duration) -> String {
+    format!("({:.1}s)", elapsed.as_secs_f64())
+}
+
+/// Shorten a DID for a progress line: the method, an ellipsis, and the trailing
+/// path segment that identifies it. A full `did:webvh` is ~110 characters and
+/// wraps the terminal, which is what makes a live trace unreadable.
+fn truncate_did(did: &str) -> String {
+    if did.len() <= 48 {
+        return did.to_string();
+    }
+    let tail = short_tail(did);
+    let head: String = did.chars().take(20).collect();
+    format!("{head}…{tail}")
 }
 
 fn render(report: &HealthReport, config_missing: bool) {
@@ -196,15 +339,34 @@ fn render_party(party: &Party) {
 
     for probe in &resolved.probes {
         match probe {
-            Probe::Reachable { url, http_status } => println!(
-                "    probe {url} → {} (HTTP {http_status})",
-                style("reachable").color256(CLI_BLUE),
-            ),
+            Probe::Reachable { url, http_status } => {
+                let (word, colour) = probe_words(probe);
+                println!(
+                    "    probe {url} → {} (HTTP {http_status})",
+                    style(word).color256(colour),
+                );
+            }
             Probe::Unreachable { url, error } => println!(
                 "    probe {url} → {} ({error})",
                 style("unreachable").color256(CLI_RED).bold(),
             ),
         }
+    }
+}
+
+/// The verdict word and colour for a probe.
+///
+/// "reachable (HTTP 404)" read as a contradiction — the word claimed health and
+/// the number denied it, and nothing told the reader which to believe. The word
+/// now carries the grade, so a mediator base path answering 404 says
+/// "responding", which is exactly what it is: the host is there and that path
+/// does not serve GETs.
+fn probe_words(probe: &Probe) -> (&'static str, u8) {
+    match probe.grade() {
+        Some(ProbeGrade::Ok) => ("ok", CLI_BLUE),
+        Some(ProbeGrade::Responding) => ("responding", CLI_BLUE),
+        Some(ProbeGrade::ServerError) => ("server error", CLI_ORANGE),
+        None => ("unreachable", CLI_RED),
     }
 }
 

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -237,21 +237,62 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
             .bold(),
         );
     } else {
-        let archived_hint = if state.show_archived {
-            "v: hide archived"
-        } else {
-            "v: show archived"
-        };
-        lines.push(
-            Line::from(format!(
-                "↑/↓ navigate   ⏎ open   f: ★   a: acknowledge   m: issue VMC   c: capabilities   \
-                 l: leave   c: cancel   x: archive   d: delete   j: join   {archived_hint}"
-            ))
-            .fg(COLOR_DARK_GRAY),
-        );
+        lines.push(Line::from(key_hints(state)).fg(COLOR_DARK_GRAY));
     }
 
     lines
+}
+
+/// The key hints for the selected row, gated exactly as the key handler gates
+/// the keys themselves (`ui::pages::main::handle_communities_key`).
+///
+/// This used to be one unconditional string listing every binding, which
+/// advertised `c` twice — `c: capabilities` and `c: cancel` — and read as a
+/// collision. It never was one: `c` is capabilities on an Active row and cancel
+/// on a Pending one, and the two states are mutually exclusive. The footer was
+/// simply describing a keymap that does not exist.
+///
+/// `c` was the visible symptom; every state-gated key had the same defect.
+/// `l`/`m` do nothing on a Pending or Inactive row and `x`/`d` do nothing on an
+/// Active one, yet all four were offered on all three. Showing what the current
+/// row actually accepts fixes the duplicate and the four silent no-ops together,
+/// which is why this is gated per row rather than by special-casing `c`.
+///
+/// The two ungated keys (`j: join`, `v: show/hide archived`) are always listed:
+/// they act on the panel, not the selection, and stay available when nothing is
+/// selected at all.
+fn key_hints(state: &CommunitiesState) -> String {
+    let selected = state.items.get(state.selected_index);
+    let mut hints = vec!["↑/↓ navigate".to_string()];
+
+    if let Some(community) = selected {
+        hints.push("⏎ open".to_string());
+        hints.push("f: ★".to_string());
+        hints.push("a: acknowledge".to_string());
+        if community.is_active {
+            hints.push("m: issue VMC".to_string());
+            hints.push("c: capabilities".to_string());
+            hints.push("l: leave".to_string());
+        }
+        if community.is_pending {
+            hints.push("c: cancel".to_string());
+        }
+        if community.is_inactive {
+            hints.push("x: archive".to_string());
+            hints.push("d: delete".to_string());
+        }
+    }
+
+    hints.push("j: join".to_string());
+    hints.push(
+        if state.show_archived {
+            "v: hide archived"
+        } else {
+            "v: show archived"
+        }
+        .to_string(),
+    );
+    hints.join("   ")
 }
 
 /// Empty state (R-C-5): a welcoming nudge to go find a community, not a dry
@@ -274,4 +315,120 @@ fn render_empty(mut lines: Vec<Line<'static>>) -> Vec<Line<'static>> {
     lines.push(Line::from(""));
     lines.push(Line::from("Press  j  to join your first community.").fg(COLOR_ORANGE));
     lines
+}
+
+#[cfg(test)]
+mod key_hint_tests {
+    use super::*;
+    use crate::state_handler::main_page::content::CommunitySummary;
+    use std::sync::Arc;
+
+    fn row(is_active: bool, is_inactive: bool, is_pending: bool) -> CommunitySummary {
+        CommunitySummary {
+            display_name: "acme".to_string(),
+            status_label: String::new(),
+            persona_label: String::new(),
+            member_since: String::new(),
+            favourite: false,
+            is_active,
+            is_inactive,
+            is_pending,
+            pending_unacknowledged: false,
+            submit_transport: None,
+            archived: false,
+            needs_attention: false,
+            persona_did: String::new(),
+            persona_agent_name: None,
+            vtc_did: String::new(),
+            vtc_agent_name: None,
+            sub_context_id: String::new(),
+            request_id: String::new(),
+            has_membership_credential: false,
+            has_role_credential: false,
+        }
+    }
+
+    fn hints_for(community: CommunitySummary) -> String {
+        key_hints(&CommunitiesState {
+            items: Arc::from(vec![community]),
+            selected_index: 0,
+            ..CommunitiesState::default()
+        })
+    }
+
+    /// The reported bug: the footer advertised `c` twice. It can never be
+    /// ambiguous now, because the two meanings live on mutually exclusive row
+    /// states and the footer follows the state.
+    #[test]
+    fn c_is_never_offered_twice() {
+        for (active, inactive, pending) in [
+            (true, false, false),
+            (false, true, false),
+            (false, false, true),
+        ] {
+            let hints = hints_for(row(active, inactive, pending));
+            assert_eq!(
+                hints.matches("c: ").count(),
+                usize::from(active || pending),
+                "`c` must appear at most once, and only where it does something: {hints}"
+            );
+        }
+    }
+
+    /// An Active row: capabilities, not cancel — and the leave/VMC pair that
+    /// only Active accepts.
+    #[test]
+    fn an_active_row_offers_capabilities_and_leave() {
+        let hints = hints_for(row(true, false, false));
+        assert!(hints.contains("c: capabilities"), "{hints}");
+        assert!(hints.contains("l: leave"), "{hints}");
+        assert!(hints.contains("m: issue VMC"), "{hints}");
+        assert!(!hints.contains("c: cancel"), "{hints}");
+        assert!(
+            !hints.contains("x: archive") && !hints.contains("d: delete"),
+            "archive/delete are inactive-only and would be silent no-ops here: {hints}"
+        );
+    }
+
+    /// A Pending row: `c` is cancel, and capabilities is gone.
+    #[test]
+    fn a_pending_row_offers_cancel_not_capabilities() {
+        let hints = hints_for(row(false, false, true));
+        assert!(hints.contains("c: cancel"), "{hints}");
+        assert!(!hints.contains("c: capabilities"), "{hints}");
+        assert!(!hints.contains("l: leave"), "{hints}");
+    }
+
+    /// An Inactive row: archive/delete, and none of the Active-only keys.
+    #[test]
+    fn an_inactive_row_offers_archive_and_delete() {
+        let hints = hints_for(row(false, true, false));
+        assert!(
+            hints.contains("x: archive") && hints.contains("d: delete"),
+            "{hints}"
+        );
+        assert!(!hints.contains("c: "), "{hints}");
+        assert!(!hints.contains("l: leave"), "{hints}");
+    }
+
+    /// `j` and `v` act on the panel rather than the selection, so they survive
+    /// an empty list — where every selection-gated key must be absent.
+    #[test]
+    fn panel_level_keys_survive_an_empty_selection() {
+        let hints = key_hints(&CommunitiesState::default());
+        assert!(hints.contains("j: join"), "{hints}");
+        assert!(hints.contains("v: show archived"), "{hints}");
+        assert!(!hints.contains("⏎ open"), "nothing is selected: {hints}");
+        assert!(!hints.contains("c: "), "nothing is selected: {hints}");
+    }
+
+    /// The archived toggle reflects the current state, as it did before.
+    #[test]
+    fn the_archived_hint_tracks_the_toggle() {
+        let hints = key_hints(&CommunitiesState {
+            show_archived: true,
+            ..CommunitiesState::default()
+        });
+        assert!(hints.contains("v: hide archived"), "{hints}");
+    }
 }


### PR DESCRIPTION
Follow-ups from running `openvtc health` against a live deployment for the first time, plus a reported UI bug.

## `openvtc health` looked like it had hung

It is almost entirely network waits — a `did:webvh` resolution is an HTTPS fetch, each probe is bounded at 10s — and it printed nothing until all of them finished. A run measured while writing this took **14.4s**, of which 7.4s was a single probe and 5.4s a single resolution. All silent.

Each step now announces itself *before* the wait and reports what it took. Which step is slow is itself a finding, and the finished report cannot carry it:

```
  · starting DID resolver…
  · resolving vtc VTC legend-swear (--vtc) (did:webvh:QmWF6C8L6b…legend-swear)…
    ✓ VTC legend-swear (--vtc) — 4 services, tsp, didcomm (5.4s)
  · following 1 discovered mediator…
    ✓ mediator of VTC legend-swear (TSP, DIDComm) — 5 services, tsp, didcomm (0.9s)
  · probing https://mediator.firstperson.dev/mediator/v1…
    ✓ https://mediator.firstperson.dev/mediator/v1 — responding (HTTP 404) (7.4s)
  · done in 14.4s
```

Progress goes to **stderr**, the report to **stdout**, so `openvtc health --json > report.json` still pipes cleanly while the operator watches the run.

## Half the probes tested nothing

`#files` and `#whois` are served by the DID host the report just fetched `did.jsonl` from — resolution had already proven that host answers. Probing them re-tested a working host and reported `404` for a path that never serves a bare GET (`#files` points at the directory, not the document). Four such lines per party buried the transport probes that carry information. Live output went from 6 probes to 2.

Implemented as a skip-list of the two document-adjacent service types, not an allow-list of known transports: an unrecognised transport type is exactly the case worth probing, and printing services verbatim would be pointless if the probe then ignored them.

## `reachable (HTTP 404)` was a contradiction

The word promised health, the number denied it, and nothing told the reader which to believe. Statuses are graded now:

| Status | Verdict | Finding? |
|---|---|---|
| 2xx/3xx | `ok` | no |
| 4xx | `responding` — normal for a POST/websocket endpoint asked for a GET | no |
| 5xx | `server error` | **yes** |

The 5xx case is what the flat "reachable" actively hid: the host is up and the service behind it is failing, which no other line in the report reveals.

## A stranded persona now says what to do

The live report found a real one: `persona hello-fury → VTC first-vtc: no shared transport (we offer [didcomm], they offer [tsp])`.

The sets alone don't tell an operator which side to change. A persona minted before the client requested `#tsp` cannot reach a TSP-only community and will never gain the service on its own — the document is written at mint time and not revisited — so the finding now says that, and names re-minting as the fix. Scoped to that direction only; re-minting our persona does nothing about a DIDComm-only community.

**This is not a minting bug.** All three persona-minting paths (`create_persona`, `join_flow`, `setup_did_actions`) funnel through `vta::create_did_via_server`, which sets `add_tsp_service: true` unconditionally. The affected persona simply predates that. Worth noting separately: the VTA silently drops the entry unless it has `[services] tsp` configured, and nothing on the client notices — a persona can be minted today, look fine, and be unable to reach a TSP-only community. Not addressed here.

## Communities footer advertised `c` twice

Reported: the footer showed `c: capabilities` and `c: cancel` side by side.

It was never ambiguous — `c` is capabilities on an Active row and cancel on a Pending one, and the states are mutually exclusive. The footer was describing a keymap that does not exist, because it listed every binding unconditionally.

`c` was the visible symptom of a wider defect: `l`/`m` do nothing on a Pending or Inactive row and `x`/`d` do nothing on an Active one, yet all four were offered on all three. Gating the hints per row the way the handler gates the keys fixes the duplicate and the four silent no-ops together. `j: join` and the archived toggle stay listed always — they act on the panel, not the selection.

## Testing

- Full workspace suite green, `clippy -D warnings` and `fmt` clean.
- 6 new tests on the footer, including `c_is_never_offered_twice` across all three row states.
- 6 new tests on health: probe grading, the skip-list (and that unknown transport types survive it), 5xx-only findings, and the re-mint advice appearing in one direction but not the reverse.
- Exercised live against `dids.firstperson.dev` / `mediator.firstperson.dev`; stdout/stderr split verified by redirecting each to a separate file.
