### PR TITLE
feat(persona): say so when a mint comes back without TSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **A persona minted without TSP now says so, at mint time.** OpenVTC always
+  requests the `#tsp` service — `create_did_via_server` sets
+  `add_tsp_service: true` on every one of the three paths that mint a persona —
+  but the VTA drops it unless it has `[services] tsp` enabled with a mediator
+  configured. That refusal was silent, and the resulting persona looks entirely
+  healthy: it resolves, it has a mediator, it messages DIDComm peers fine. It is
+  only unable to reach a TSP-only community, which surfaces much later as a join
+  that goes out and is never answered.
+
+  Since the service is written at mint time and the document is never revisited,
+  such a persona never recovers on its own — so the warning names the
+  consequence, says the DID cannot gain the service later, and names the VTA
+  setting that fixes it. Emitted as a `warn!` at the single mint point (so the
+  log always has it) and surfaced on all three user-facing surfaces: the setup
+  wizard's message list, the join flow's status line, and the persona manager's
+  progress channel. A healthy mint stays silent.
+
 - **`openvtc health` reports progress as it works.** The command is almost
   entirely network waits — a `did:webvh` resolution is an HTTPS fetch and each
   probe is bounded at 10s — so a chain with a few mediators could sit silent for

--- a/openvtc-core/src/config/did.rs
+++ b/openvtc-core/src/config/did.rs
@@ -52,6 +52,53 @@ pub fn mediator_from_document(doc: &Document) -> Option<String> {
         .filter(|m| !m.is_empty())
 }
 
+/// Whether a freshly-minted persona document actually advertises `#tsp`.
+///
+/// Matched on the service `type` (`TSPTransport`), never the `#id` fragment —
+/// the fragment is an arbitrary label and the OWF reference implementation names
+/// it `#tsp-transport` where this stack names it `#tsp`.
+pub fn advertises_tsp(document: &Document) -> bool {
+    document.service.iter().any(|s| {
+        s.type_
+            .iter()
+            .any(|t| t == vta_sdk::protocol::matching::TSP_SERVICE_TYPE)
+    })
+}
+
+/// The warning to show when a minted persona did **not** get its `#tsp`
+/// service, or `None` when it did.
+///
+/// OpenVTC always asks for it — `create_did_via_server` sets
+/// `add_tsp_service: true` unconditionally, on every one of the three paths that
+/// mint a persona. The VTA is entitled to refuse: it drops the entry unless it
+/// has `[services] tsp` enabled with a mediator configured, which is a
+/// deliberate accommodation for a DIDComm-only deployment.
+///
+/// What was wrong is that it refused **silently**. A persona minted against such
+/// a VTA looks completely healthy — it resolves, it has a mediator, it messages
+/// DIDComm peers fine — and is simply unable to reach a TSP-only community,
+/// which surfaces much later as a join that goes out and is never answered.
+/// Since the service is written at mint time and the document is never revisited,
+/// that persona will not recover on its own; the only fix is to mint another one
+/// once the VTA is configured, and the moment to say so is now, while the
+/// operator is still looking at the screen that created it.
+///
+/// Returns the message rather than logging it so the one wording is shared by
+/// all three call sites (setup wizard, join flow, and the persona manager) —
+/// three copies would drift, and this is the sentence that has to be right.
+pub fn tsp_advertisement_warning(document: &Document) -> Option<String> {
+    if advertises_tsp(document) {
+        return None;
+    }
+    Some(
+        "Note: this persona advertises DIDComm only — the VTA did not add a TSP \
+         service. It cannot join a TSP-only community, and the DID cannot gain \
+         the service later. Enable `[services] tsp` on the VTA (with a mediator \
+         configured) and mint a new persona if you need one."
+            .to_string(),
+    )
+}
+
 /// Creates a new `did:webvh` DID with key pre-rotation enabled.
 ///
 /// This builds a full DID Document containing three verification methods:
@@ -408,6 +455,76 @@ mod tests {
         let parsed = Url::parse(&normalized).expect("parse url");
         let webvh = WebVHURL::parse_url(&parsed).expect("webvh parse");
         webvh.to_did_base()
+    }
+
+    /// Build a document with the given service types, via the same
+    /// `ServiceBuilder` the minting path uses.
+    fn doc_with_services(types: &[&str]) -> Document {
+        let did = "did:webvh:QmScid:example.com:persona";
+        let mut document = Document::new(did).expect("new document");
+        for (i, type_) in types.iter().enumerate() {
+            let endpoint = Endpoint::Map(json!([{
+                "accept": ["didcomm/v2"],
+                "uri": "did:webvh:QmScid:example.com:mediator",
+            }]));
+            let id = Url::parse(&format!("{did}#svc-{i}")).expect("service id");
+            document
+                .service
+                .push(ServiceBuilder::new(*type_, endpoint).id_url(id).build());
+        }
+        document
+    }
+
+    /// The service is matched on `type`, never the `#id` fragment — the OWF
+    /// reference implementation names it `#tsp-transport` where this stack names
+    /// it `#tsp`, and both are `TSPTransport`.
+    #[test]
+    fn tsp_is_detected_by_type_not_id() {
+        assert!(advertises_tsp(&doc_with_services(&["TSPTransport"])));
+        assert!(advertises_tsp(&doc_with_services(&[
+            "DIDCommMessaging",
+            "TSPTransport"
+        ])));
+    }
+
+    /// The case this exists for: the VTA granted DIDComm and declined TSP. That
+    /// persona resolves, has a mediator, and messages DIDComm peers fine — it is
+    /// only unable to reach a TSP-only community, which is invisible until a
+    /// join goes unanswered.
+    #[test]
+    fn a_didcomm_only_mint_is_warned_about() {
+        let document = doc_with_services(&["DIDCommMessaging"]);
+        assert!(!advertises_tsp(&document));
+
+        let warning = tsp_advertisement_warning(&document).expect("must warn");
+        assert!(
+            warning.contains("TSP-only community"),
+            "the consequence must be named, not just the missing service: {warning}"
+        );
+        assert!(
+            warning.contains("cannot gain the service later"),
+            "a persona does not recover on its own — the document is written at \
+             mint time and never revisited, and an operator who thinks it will \
+             heal is the reason this warning exists: {warning}"
+        );
+        assert!(
+            warning.contains("[services] tsp"),
+            "the fix is a VTA setting; naming it is what makes this actionable: {warning}"
+        );
+    }
+
+    /// A healthy mint must stay silent. A warning shown on every persona is a
+    /// warning nobody reads by the third one.
+    #[test]
+    fn a_tsp_capable_mint_says_nothing() {
+        let document = doc_with_services(&["DIDCommMessaging", "TSPTransport"]);
+        assert_eq!(tsp_advertisement_warning(&document), None);
+    }
+
+    /// A document with no services at all is the same defect, not a special case.
+    #[test]
+    fn a_serviceless_document_is_warned_about_too() {
+        assert!(tsp_advertisement_warning(&doc_with_services(&[])).is_some());
     }
 
     #[test]

--- a/openvtc/src/state_handler/create_persona.rs
+++ b/openvtc/src/state_handler/create_persona.rs
@@ -67,6 +67,14 @@ pub(crate) async fn mint_standalone_persona(
     )
     .await?;
 
+    // The VTA may have declined the `#tsp` service we asked for. Report it
+    // through the same progress channel the caller is already showing, so a
+    // persona that cannot reach a TSP-only community says so at mint time rather
+    // than months later as a join nobody answers.
+    if let Some(warning) = openvtc_core::config::did::tsp_advertisement_warning(&document) {
+        progress(&warning);
+    }
+
     // The persona's mediator is the account's VTA mediator: the DID minted via
     // the VTA's webvh server advertises that mediator, so the persona listener
     // must use the same one (mirrors the join flow).

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -968,6 +968,15 @@ async fn run_join_sequence(
             .await
             {
                 Ok((keys, did, document, _mnemonic)) => {
+                    // A persona the VTA minted without `#tsp` can never reach a
+                    // TSP-only community — and this join may be to one. Say so
+                    // here rather than letting it surface later as a request
+                    // that goes out and is never answered.
+                    if let Some(warning) =
+                        openvtc_core::config::did::tsp_advertisement_warning(&document)
+                    {
+                        state.join.info(warning);
+                    }
                     state.setup.did_keys = Some(keys);
                     state.setup.webvh_address.did = did;
                     state.setup.webvh_address.document = document;

--- a/openvtc/src/state_handler/setup_did_actions.rs
+++ b/openvtc/src/state_handler/setup_did_actions.rs
@@ -186,6 +186,17 @@ async fn apply_server_create_result(
                 .webvh_server
                 .messages
                 .push(MessageType::Info(format!("DID created: {}", did)));
+            // Surfaced on the wizard's own message list, beside "DID created":
+            // a persona minted without `#tsp` is unable to reach a TSP-only
+            // community, and this is the last screen where the operator is still
+            // looking at the thing that created it.
+            if let Some(warning) = openvtc_core::config::did::tsp_advertisement_warning(&document) {
+                state
+                    .setup
+                    .webvh_server
+                    .messages
+                    .push(MessageType::Info(warning));
+            }
             state.setup.webvh_server.did = did.clone();
             state.setup.webvh_server.document = document.clone();
             state.setup.webvh_server.mnemonic = mnemonic;

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -266,6 +266,17 @@ pub async fn list_webvh_servers(client: &VtaClient) -> Result<Vec<WebvhServerRec
 
 /// Create a DID via a WebVH server
 /// Returns (PersonaDIDKeys, did, Document, mnemonic)
+///
+/// # Callers must surface the TSP warning
+///
+/// This requests `#tsp` unconditionally, but the VTA drops it unless it has
+/// `[services] tsp` configured with a mediator — silently, and the resulting
+/// persona looks entirely healthy while being unable to reach a TSP-only
+/// community. A `warn!` is emitted here so the log always carries it, but the
+/// operator is looking at a TUI, not a log. Pass the returned `Document` to
+/// [`tsp_advertisement_warning`] and show what it returns.
+///
+/// [`tsp_advertisement_warning`]: openvtc_core::config::did::tsp_advertisement_warning
 pub async fn create_did_via_server(
     client: &VtaClient,
     tdk: &TDK,
@@ -394,6 +405,22 @@ pub async fn create_did_via_server(
         .resolve(&did)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to resolve created DID: {e}"))?;
+
+    // We asked for `#tsp` above; the VTA is entitled to refuse (it drops the
+    // entry unless it has `[services] tsp` on with a mediator). Record here,
+    // once, whether it actually granted it — this is the only place every mint
+    // passes through, so a caller cannot forget to look. The user-facing half is
+    // each caller's activity log, via `tsp_advertisement_warning`.
+    if openvtc_core::config::did::advertises_tsp(&resolved.doc) {
+        tracing::debug!(%did, "minted persona advertises #tsp");
+    } else {
+        tracing::warn!(
+            %did,
+            "minted persona has no #tsp service — the VTA did not grant the one we \
+             requested (needs `[services] tsp` with a mediator). This persona cannot \
+             reach a TSP-only community and the document will not gain the service later."
+        );
+    }
 
     Ok((persona_keys, did, resolved.doc, mnemonic))
 }


### PR DESCRIPTION
Item 2 from the #222 follow-ups: the VTA can silently decline the `#tsp` service, and nothing on the client notices.

## The problem

OpenVTC always asks for it — `create_did_via_server` sets `add_tsp_service: true`, and all three paths that mint a persona (setup wizard, join flow, persona manager) funnel through that one call. The VTA is entitled to refuse: it drops the entry unless it has `[services] tsp` enabled with a mediator configured, which is a deliberate accommodation for a DIDComm-only deployment.

What was wrong is that it refused **silently**. The persona that comes back looks completely healthy — it resolves, it carries a mediator, it messages DIDComm peers without trouble. It is only unable to reach a TSP-only community, and nothing says so at the time.

That surfaces months later as a join that goes out and is never answered — the most expensive shape a failure takes here, and the one that cost several rounds of log-reading to diagnose in #221. It's also **permanent**: the service is written at mint time and the document is never revisited, so the persona does not heal when the VTA is later fixed. An operator who assumes otherwise waits for something that cannot happen.

This is exactly the case the health command surfaced in #222 — `persona hello-fury → VTC first-vtc: no shared transport` — but only long after the mint that caused it.

## The change

A `warn!` at the single mint point, so the log always carries it regardless of caller, plus the user-facing half on all three surfaces:

| Path | Surface |
|---|---|
| Setup wizard | `webvh_server.messages` |
| Join flow | `state.join.info` |
| Persona manager | the `progress` channel |

The message text lives in `openvtc_core::config::did::tsp_advertisement_warning` so one wording is shared rather than three that drift. It names three things, because any two leave the reader stuck:

> Note: this persona advertises DIDComm only — the VTA did not add a TSP service. It cannot join a TSP-only community, and the DID cannot gain the service later. Enable `[services] tsp` on the VTA (with a mediator configured) and mint a new persona if you need one.

A healthy mint stays silent — a warning shown on every persona is one nobody reads by the third.

Detection matches on the service `type` (`TSPTransport`), never the `#id` fragment: the OWF reference implementation names it `#tsp-transport` where this stack names it `#tsp`, and both are the same type.

## What this does not do

It does not re-mint or repair an existing persona. `hello-fury` in the #222 report is still stranded, and fixing it means a new DID with the membership rebound — a real operation that should be a deliberate decision, not a side effect of a warning. This change only stops new ones being created silently.

The obligation on callers is documented on `create_did_via_server` but not enforced by the type system; the unconditional `warn!` is the backstop if a future mint path forgets the UI half.

## Testing

- 4 new tests: type-not-id detection, the DIDComm-only warning (asserting each of the three things the message must say), silence on a healthy mint, and a serviceless document treated as the same defect rather than a special case.
- Full workspace suite, `clippy -D warnings`, `fmt`, and `cargo doc -D warnings` all green locally — the last of which is the check I missed before #222's CI failure.

Not covered: an end-to-end mint against a VTA with `[services] tsp` disabled. The detection is unit-tested against a built `Document`, but nobody has watched the warning appear on a real DIDComm-only VTA.
