### PR TITLE
fix(messaging): never drop an inbound message we have already acked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Inbound messages are no longer dropped when the event channel fills.** The
+  DIDComm event channel was a 256-slot bounded channel whose overflow behaviour
+  was log-and-drop, on the reasoning that a pathological mediator should not grow
+  memory without bound. That missed what a dropped event costs: by the time an
+  event reaches this channel the delivery layer has already acked the message,
+  and an ack is a delete at the mediator. A dropped event was therefore not a
+  deferred message but a **permanently destroyed** one — carrying membership
+  credentials and join verdicts — with one `warn!` line as the only record.
+
+  Backpressure was never actually on offer. Blocking on a full channel would
+  stall the consumer, the delivery layer's subscriber broadcast would overflow
+  instead, and its `subscribe()` stream swallows that as `Lagged` **silently** —
+  strictly worse than the warned drop. The only real choice was where the loss
+  happens, so the channel is now unbounded and the answer is nowhere.
+
+  `pickup_stored` keeps its ack-after-handoff ordering: a message that cannot be
+  taken stays stored at the mediator and is offered again.
+
 ### Added
 
 - **A persona minted without TSP now says so, at mint time.** OpenVTC always

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -315,7 +315,7 @@ struct MessagingInner {
     /// dispatcher owns its own clone; this one exists because a pickup emits the
     /// *same* events by the *same* route, so a consumer cannot tell (and must
     /// not have to) whether a message was streamed or collected.
-    event_tx: mpsc::Sender<DIDCommEvent>,
+    event_tx: mpsc::UnboundedSender<DIDCommEvent>,
     /// Listener ids with a pickup currently running, so a flapping socket
     /// cannot stack overlapping drains of the same mailbox.
     pickup_in_flight: std::sync::Mutex<std::collections::HashSet<String>>,
@@ -329,7 +329,7 @@ impl Messaging {
     /// Listeners are added with [`add_listener`]; starting empty is what lets the
     /// dispatcher be running before the first transport connects, so no inbound
     /// frame is missed on a listener that comes up quickly.
-    pub fn start(event_tx: mpsc::Sender<DIDCommEvent>) -> Self {
+    pub fn start(event_tx: mpsc::UnboundedSender<DIDCommEvent>) -> Self {
         let outbox: Arc<dyn OutboxStore> = Arc::new(InMemoryOutboxStore::new());
         let service = Arc::new(MessagingService::empty(outbox.clone()));
         let (status_tx, _) = tokio::sync::broadcast::channel(LISTENER_STATUS_CAPACITY);
@@ -517,12 +517,16 @@ impl Messaging {
                     acks.push(attachment_id);
                     continue;
                 }
+                // Ack only after the handoff succeeds, so a message we could not
+                // take stays stored at the mediator and is offered again. The
+                // channel is unbounded, so the only failure left is a departed
+                // receiver (shutdown) — in which case leaving it stored is
+                // exactly right: the next run collects it.
                 let mut queued = true;
                 for event in events {
-                    if let Err(e) = self.inner.event_tx.try_send(event) {
-                        tracing::warn!(
-                            error = %e,
-                            "DIDComm event channel saturated during pickup — leaving the message stored"
+                    if self.inner.event_tx.send(event).is_err() {
+                        tracing::debug!(
+                            "state handler has gone away during pickup — leaving the message stored"
                         );
                         queued = false;
                         break;
@@ -694,11 +698,38 @@ pub enum DIDCommEvent {
     TrustPongReceived { from: Option<String> },
 }
 
-/// Capacity of the DIDComm event channel. Backpressure target: a
-/// pathological mediator pushing messages faster than the state handler
-/// can drain them gets `try_send` failures (logged + dropped), instead
-/// of growing memory without bound. 256 is enough headroom that normal
-/// operator activity doesn't ever overflow.
+/// The DIDComm event channel is **unbounded**, deliberately.
+///
+/// It used to be a 256-slot bounded channel whose overflow behaviour was
+/// `try_send` → log → drop, on the reasoning that a pathological mediator should
+/// not be able to grow memory without bound. That reasoning missed what a
+/// dropped event costs here.
+///
+/// By the time an event reaches this channel the delivery layer has already
+/// acked the message — `run_dispatcher` in `affinidi-messaging-delivery` acks
+/// immediately after handing off to its subscriber broadcast — and an ack is a
+/// delete at the mediator. So a dropped event is not a deferred message, it is a
+/// **permanently destroyed** one, with a single `warn!` line as the only record.
+/// These carry membership credentials and join verdicts; #221 is what that looks
+/// like from the outside, and it took four services' logs to find.
+///
+/// Backpressure was never really available anyway. Blocking on a full channel
+/// would stall this consumer, the layer's broadcast buffer would overflow
+/// instead, and `subscribe()` swallows that as `Lagged` **silently** — strictly
+/// worse than the warned drop it replaced. The only choice actually on offer is
+/// where the loss happens, so we choose nowhere.
+///
+/// The memory concern is bounded in practice by the mediator: events arrive only
+/// as fast as it delivers, the consumer is the state handler's `select!` (always
+/// draining unless mid-await), and the payloads are small. Unbounded growth
+/// requires a consumer stalled indefinitely, which is a bug that would strand the
+/// UI too — visible, unlike the silent credential loss this replaces.
+///
+/// Kept as a named constant for the historical record and for anyone who goes
+/// looking for the old capacity; nothing reads it.
+#[deprecated(
+    note = "the event channel is unbounded; this value is retained only to document what it was"
+)]
 pub const DIDCOMM_EVENT_CHANNEL_CAPACITY: usize = 256;
 
 /// Reason string included in a "Reconnect failed" log entry, plus the
@@ -844,7 +875,10 @@ pub async fn add_listener(service: &Messaging, spec: &ListenerSpec) -> Result<()
 /// dispatch — a consumer matches on the message itself — which is the same move
 /// `vtc-service` made when it cut over. Acking is **not** done here: the service's
 /// own dispatcher acks after handoff, never before.
-async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender<DIDCommEvent>) {
+async fn dispatch_inbound(
+    service: Arc<MessagingService>,
+    event_tx: mpsc::UnboundedSender<DIDCommEvent>,
+) {
     let mut inbound = service.subscribe();
     while let Some(item) = inbound.next().await {
         // Both protocols arrive on this one stream — `DidCommTransport` owns the
@@ -879,8 +913,14 @@ async fn dispatch_inbound(service: Arc<MessagingService>, event_tx: mpsc::Sender
         let from = item.message.sender.clone().or_else(|| message.from.clone());
 
         for event in classify_inbound(message, transport, from, item.message.recipient.clone()) {
-            if let Err(e) = event_tx.try_send(event) {
-                tracing::warn!(error = %e, "DIDComm event channel saturated — dropping inbound message");
+            // Unbounded: `send` fails only when the receiver is gone, which means
+            // the state handler has shut down and there is nothing left to
+            // deliver to. It can no longer fail because the channel is full —
+            // see `DIDCOMM_EVENT_CHANNEL_CAPACITY` for why dropping there was
+            // destroying messages the mediator had already deleted.
+            if event_tx.send(event).is_err() {
+                tracing::debug!("state handler has gone away — ending inbound dispatch");
+                return;
             }
         }
     }
@@ -1660,7 +1700,7 @@ pub async fn persona_listener_config_for(
 pub async fn start_service(
     config: &Config,
     tdk: &affinidi_tdk::TDK,
-    event_tx: mpsc::Sender<DIDCommEvent>,
+    event_tx: mpsc::UnboundedSender<DIDCommEvent>,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> Result<Messaging, MessagingError> {
     let service = start_empty_service(event_tx, shutdown);
@@ -1677,7 +1717,7 @@ pub async fn start_service(
 /// `Messaging::start` is built for this — its dispatcher runs before the first
 /// transport exists — so an empty service is a supported state, not a stub.
 pub fn start_empty_service(
-    event_tx: mpsc::Sender<DIDCommEvent>,
+    event_tx: mpsc::UnboundedSender<DIDCommEvent>,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> Messaging {
     let service = Messaging::start(event_tx);

--- a/openvtc-core/tests/didcomm_transport_e2e.rs
+++ b/openvtc-core/tests/didcomm_transport_e2e.rs
@@ -46,7 +46,7 @@ const OPENVTC_TYPE: &str = "https://linuxfoundation.org/openvtc/test/1.0/ping";
 async fn start_production_service(
     profile: common::TestProfile,
     remote_did: &str,
-    event_tx: mpsc::Sender<DIDCommEvent>,
+    event_tx: mpsc::UnboundedSender<DIDCommEvent>,
 ) -> (Messaging, String) {
     let listener = relationship_listener_config_from_secrets(
         &profile.did,
@@ -75,14 +75,14 @@ async fn an_openvtc_message_routes_through_the_production_transport() {
     let bob_did = bob.did.clone();
 
     // Receiver first: a listener that is not yet polling would miss the frame.
-    let (bob_tx, mut bob_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (bob_tx, mut bob_rx) = mpsc::unbounded_channel::<DIDCommEvent>();
     let (bob_service, bob_listener) = start_production_service(bob, &alice_did, bob_tx).await;
     bob_service
         .wait_connected(&bob_listener, Duration::from_secs(20))
         .await
         .expect("bob listener connects");
 
-    let (alice_tx, _alice_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (alice_tx, _alice_rx) = mpsc::unbounded_channel::<DIDCommEvent>();
     let (alice_service, alice_listener) = start_production_service(alice, &bob_did, alice_tx).await;
     alice_service
         .wait_connected(&alice_listener, Duration::from_secs(20))
@@ -154,14 +154,14 @@ async fn an_unrelated_message_type_reaches_no_handler() {
     let alice_did = alice.did.clone();
     let bob_did = bob.did.clone();
 
-    let (bob_tx, mut bob_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (bob_tx, mut bob_rx) = mpsc::unbounded_channel::<DIDCommEvent>();
     let (bob_service, bob_listener) = start_production_service(bob, &alice_did, bob_tx).await;
     bob_service
         .wait_connected(&bob_listener, Duration::from_secs(20))
         .await
         .expect("bob listener connects");
 
-    let (alice_tx, _alice_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (alice_tx, _alice_rx) = mpsc::unbounded_channel::<DIDCommEvent>();
     let (alice_service, alice_listener) = start_production_service(alice, &bob_did, alice_tx).await;
     alice_service
         .wait_connected(&alice_listener, Duration::from_secs(20))
@@ -213,7 +213,7 @@ async fn a_message_stored_before_the_listener_existed_is_collected_on_connect() 
     let bob_did = bob.did.clone();
 
     // Sender only. Bob has no service, no transport, no socket.
-    let (alice_tx, _alice_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (alice_tx, _alice_rx) = mpsc::unbounded_channel::<DIDCommEvent>();
     let (alice_service, alice_listener) = start_production_service(alice, &bob_did, alice_tx).await;
     alice_service
         .wait_connected(&alice_listener, Duration::from_secs(20))
@@ -240,7 +240,7 @@ async fn a_message_stored_before_the_listener_existed_is_collected_on_connect() 
     tokio::time::sleep(Duration::from_secs(3)).await;
 
     // Now bring bob up. The connect transition is what triggers the pickup.
-    let (bob_tx, mut bob_rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (bob_tx, mut bob_rx) = mpsc::unbounded_channel::<DIDCommEvent>();
     let (bob_service, bob_listener) = start_production_service(bob, &alice_did, bob_tx).await;
     bob_service
         .wait_connected(&bob_listener, Duration::from_secs(20))
@@ -293,7 +293,7 @@ async fn a_message_stored_before_the_listener_existed_is_collected_on_connect() 
     // room against an in-process mediator.
     tokio::time::sleep(Duration::from_secs(3)).await;
     bob_service.remove_listener(&bob_listener).await;
-    let (bob_tx2, mut bob_rx2) = mpsc::channel::<DIDCommEvent>(16);
+    let (bob_tx2, mut bob_rx2) = mpsc::unbounded_channel::<DIDCommEvent>();
     let (bob_service2, bob_listener2) =
         start_production_service(mediator.profile("bob").expect("bob"), &alice_did, bob_tx2).await;
     bob_service2
@@ -335,7 +335,7 @@ async fn the_supervisor_does_not_churn_a_healthy_transport() {
     let alice = mediator.profile("alice").expect("alice");
     let bob_did = mediator.profile("bob").expect("bob").did;
 
-    let (tx, _rx) = mpsc::channel::<DIDCommEvent>(16);
+    let (tx, _rx) = mpsc::unbounded_channel::<DIDCommEvent>();
     let (service, listener_id) = start_production_service(alice, &bob_did, tx).await;
     service
         .wait_connected(&listener_id, Duration::from_secs(20))

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -1978,7 +1978,7 @@ mod tests {
         // `test_config` has no identities, so any persona id is unresolvable.
         let config = test_config();
         let tdk = test_tdk().await;
-        let (event_tx, _event_rx) = tokio::sync::mpsc::channel(1);
+        let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
         let service = Messaging::start(event_tx);
 
         let claimed = start_persona_listener(

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -576,8 +576,7 @@ impl StateHandler {
         // Bounded so a misbehaving mediator can't grow our memory without limit;
         // overflows surface as `try_send` warnings and the message is left in the
         // mailbox for `Messaging::pickup_stored` to collect on the next connect.
-        let (didcomm_event_tx, mut didcomm_event_rx) =
-            mpsc::channel(didcomm::DIDCOMM_EVENT_CHANNEL_CAPACITY);
+        let (didcomm_event_tx, mut didcomm_event_rx) = mpsc::unbounded_channel();
         let shutdown_token = tokio_util::sync::CancellationToken::new();
         let didcomm_service =
             didcomm::start_empty_service(didcomm_event_tx.clone(), shutdown_token.clone());


### PR DESCRIPTION
First change from the messaging robustness review. This is **P2** from the #221 triage — the one correctness bug in the inbound path that openvtc can fix on its own.

## The bug

The DIDComm event channel was bounded at 256, with log-and-drop on overflow (`didcomm.rs:882`):

```rust
if let Err(e) = event_tx.try_send(event) {
    tracing::warn!(error = %e, "DIDComm event channel saturated — dropping inbound message");
}
```

The justification was backpressure against a pathological mediator growing memory without bound. It missed what a dropped event costs.

**By the time an event reaches this channel, the message is already gone.** `run_dispatcher` in `affinidi-messaging-delivery` acks immediately after handing off to its subscriber broadcast, and an ack is a delete at the mediator. So the drop wasn't deferral — it was destruction, of membership credentials and join verdicts, recorded by one `warn!` line.

#221 is what that looks like from the outside: a join `Pending` forever, clean logs on both sides, four services' logs to find it.

## Backpressure was never actually available

Worth stating because it's the obvious objection. Blocking on a full channel stalls this consumer → the delivery layer's broadcast buffer overflows in its place → and `subscribe()` handles that as:

```rust
Err(broadcast::error::RecvError::Lagged(_)) => continue,
```

Silently. So blocking trades a *warned* drop for a *silent* one. The only choice actually on offer is where the loss lands; this makes it land nowhere.

## Why unbounded is the right trade

Events arrive only as fast as the mediator delivers them, the consumer is the state handler's `select!` (always draining unless mid-await), and payloads are small. Unbounded growth requires a consumer stalled indefinitely — a bug that would strand the UI too, and therefore be visible, unlike the silent credential loss it replaces.

`pickup_stored` keeps its ack-after-handoff ordering, which was already correct: a message it cannot take stays stored at the mediator and is offered again. Its send can now only fail on a departed receiver, where leaving it stored is exactly right.

## Testing

- All four `didcomm_transport_e2e` cases pass against a **live test mediator**, including `a_message_stored_before_the_listener_existed_is_collected_on_connect` — the pickup/ack path this touches.
- Full workspace suite, `clippy -D warnings`, `fmt`, `cargo doc -D warnings` green.

**No new unit test, deliberately.** The property is type-level: `UnboundedSender` cannot fail for capacity, and reverting means changing the signature in five places plus the state-handler wiring — a deliberate act, with the rationale on `DIDCOMM_EVENT_CHANNEL_CAPACITY` (kept, deprecated, as the historical record). A test constructing its own channel would guard nothing about the production wiring, and I'd rather not ship one that implies otherwise.

## Found but not fixed here

**The root defect is upstream.** `affinidi-messaging-delivery`'s `run_dispatcher` acks after `inner.subscribers.send(item)` — a `tokio::sync::broadcast` send, which returns as soon as the item is in a fixed-size buffer that can be silently overwritten, and returns `Err` when there are *no* subscribers (the item is dropped, then acked anyway). Its own doc says "acks it once after handoff… never ack-before-handoff", and the transport adapter sets `auto_delete = false` specifically to support that contract — but a broadcast buffer is not a durable handoff. Worth raising against that crate; nothing in openvtc can close it.

**P3 is still open and needs a protocol change.** `join_status_poll` is gated on `request_id_confirmed`, which only flips when a correlated reply is *processed*; its module doc says the never-got-a-reply case is recovered by `pickup_stored` instead, but if mail was acked and deleted without dispatch, both fail together. The VTC does know the request id — it returns it in the duplicate-submit conflict — but only inside a free-text error string, which is too brittle to parse. The clean fix is a status query keyed by applicant DID, which is a `vtc-service` change.
