### PR TITLE
chore(deps): affinidi-messaging-delivery 0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Take `affinidi-messaging-delivery` 0.1.14, which stops the layer acking a
+  message no consumer received.** An ack is a delete at the mediator, and the
+  dispatcher acked unconditionally — including when its subscriber broadcast had
+  just reported that nobody was listening. Those messages were destroyed: no
+  subscriber is installed for a moment at startup and again on the way down, and
+  what arrives in that window is whatever the peer happened to send.
+
+  This is the layer-side half of the same defect as the unbounded event channel
+  below. That change stopped *this* client discarding messages the mediator had
+  already deleted; this one stops them being deleted before this client is
+  listening at all. Lockfile only — the requirement was already `0.1.12`, so
+  nothing but resolution moves. Verified against a live test mediator: all four
+  `didcomm_transport_e2e` cases pass, including the stored-mail pickup path.
+
 - **Inbound messages are no longer dropped when the event channel fills.** The
   DIDComm event channel was a 256-slot bounded channel whose overflow behaviour
   was log-and-drop, on the reasoning that a pathological mediator should not grow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-delivery"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10577a9de3302bc2981faefb3201a6faec788d22d8cc1a7a5dea3005c716cb"
+checksum = "7e5655cfc5cdac34b52b8de49e0297af3bd347b9989707053be8711fdd4c54f9"
 dependencies = [
  "affinidi-messaging-core",
  "async-trait",
@@ -864,7 +864,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -875,7 +875,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2364,7 +2364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2722,7 +2722,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3024,7 +3024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4920,7 +4920,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5451,7 +5451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6224,7 +6224,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6791,7 +6791,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6858,7 +6858,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7492,7 +7492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7704,7 +7704,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7717,7 +7717,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9418,7 +9418,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Takes [affinidi-tdk-rs#710](https://github.com/affinidi/affinidi-tdk-rs/pull/710) — the fix for the delivery layer acking a message no consumer received.

## Why this matters on its own

An ack is a delete at the mediator, and `run_dispatcher` acked unconditionally — including when its subscriber broadcast had just returned `Err`, meaning nobody was listening. Those messages were destroyed.

**This is the layer-side half of the same defect #224 fixed here.** That change stopped *this client* discarding messages the mediator had already deleted. This one stops them being deleted before this client is listening at all. Neither alone closes the window, and the window is exactly where membership credentials and join verdicts land — during startup and teardown, which is what #221 turned out to be.

## What changed

**Lockfile only.** The requirement was already `"0.1.12"`, so 0.1.14 satisfies it and no manifest moves. But resolution is the entire point: the fix landing upstream does nothing for a build still resolving 0.1.13 from crates.io, which is what both this repo and VTI were doing.

## Testing

Verified against a **live test mediator** rather than on the compile alone, since the change is to ack semantics:

```
running 4 tests
test a_message_stored_before_the_listener_existed_is_collected_on_connect ... ok
test an_openvtc_message_routes_through_the_production_transport ... ok
test an_unrelated_message_type_reaches_no_handler ... ok
test the_supervisor_does_not_churn_a_healthy_transport ... ok
```

The first of those drives the pickup/ack path directly. Full workspace suite and `clippy -D warnings` clean.

A companion PR does the same bump in `verifiable-trust-infrastructure`; the VTA and VTC were on 0.1.13 too.
