### PR TITLE
fix(ux): prefill the community from a pasted VIC; drop the phantom setup step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A pasted invitation now fills in the community it is for, and Enter says
+  something either way.** On the join entry page a pasted VIC was routed to the
+  invitation slot and nothing else: the DID input stayed empty, so Enter — which
+  swallowed the keypress on an empty field, with no message — did nothing at
+  all. The credential in hand names its community (a VIC's issuer *is* the VTC),
+  so the operator was being asked to go and find a DID they already had, and got
+  a screen that looked frozen when they didn't.
+
+  A paste now records the issuer and prefills the input with it, and the loaded
+  invitation says which community it came from. Prefilled, not auto-submitted:
+  an invitation arrives from someone else, so the community stays visible and
+  editable before Enter commits to joining it. Anything typed by hand wins over
+  the credential, and a redraw never overwrites an edit. Enter on an empty field
+  now reports why nothing happened. (vti-setup#29)
+- **The invitation prompt is legible, and sits where it is needed.** It was dark
+  grey italic — the dimmest text on the page — below the input and below the
+  brighter examples block, and read as decoration; the reporter could not find
+  anywhere to import a VIC at all. The invitation status and any error now sit
+  directly above the input in full-contrast colours, and all of it wraps to the
+  terminal width rather than clipping its tail. (vti-setup#29)
+- **The setup wizard no longer advertises a step it will never run.** R-A-5
+  ended setup at profile security — a persona is minted later by the join flow —
+  but the breadcrumb still listed a fourth "Digital Identity" step (or "Display
+  Name" on the webvh-server path) that could never become active, so the wizard
+  appeared to skip a step on the way to Setup Complete. Setup is now shown as
+  the four steps it actually has. (vti-setup#31)
+
 - **Take `affinidi-messaging-delivery` 0.1.14, which stops the layer acking a
   message no consumer received.** An ack is a delete at the mediator, and the
   dispatcher acked unconditionally — including when its subscriber broadcast had

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -125,6 +125,15 @@ pub struct JoinState {
     /// from [`has_invitation`](Self::has_invitation), which reflects what was
     /// *loaded* on the entry page before community matching.
     pub presented_invitation: Option<PresentedInvitation>,
+    /// The community (VTC) DID that issued the invitation loaded on the entry
+    /// page. For an `InvitationCredential` the issuer *is* the community, so a
+    /// pasted VIC already names the community it is for: the entry page shows it
+    /// alongside the "invitation loaded" line and prefills the DID input with it,
+    /// rather than making the operator find and retype a DID the credential in
+    /// hand already carries. Prefilled, not auto-submitted — a VIC arrives from
+    /// someone else, so the community it points at stays visible and editable
+    /// before Enter commits to joining it.
+    pub invitation_issuer: Option<String>,
     /// True when the operator explicitly cleared a loaded VIC on the entry page,
     /// so the status text reads "joining without an invitation" rather than the
     /// generic "no VIC" tip. Distinguishes a deliberate clear from never having

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -144,12 +144,23 @@ impl StateHandler {
                             // the entry page shows "joining without an invitation".
                             state.invitation_credential = None;
                             state.join.has_invitation = false;
+                            state.join.invitation_issuer = None;
                             state.join.vic_cleared = true;
                             state.join.messages.clear();
                             let _ = self.state_tx.send(state.clone());
                         }
                         Action::JoinSubmitVtc(vtc_did) => {
                             let Some(vtc_did) = validate_join_input(&vtc_did) else {
+                                // Say why nothing happened. A keypress that
+                                // cannot proceed must not be a silent no-op —
+                                // that reads as a frozen screen (issue #29).
+                                state.join.messages.push(MessageType::Error(
+                                    "Enter the community's DID or agent name \
+                                     first — or paste an invitation credential \
+                                     (VIC) to fill it in."
+                                        .to_string(),
+                                ));
+                                let _ = self.state_tx.send(state.clone());
                                 continue;
                             };
                             // Accept an agent name (`example.com/@acme`) in place
@@ -640,7 +651,13 @@ fn load_pasted_vic(state: &mut State, text: &str, vtc_did: Option<&str>) {
         return;
     }
     let Some(vtc_did) = vtc_did else {
-        // Entry page: no community to match against yet.
+        // Entry page: no community to match against yet. The VIC's issuer *is*
+        // the community, and `validate_invitation_credential` has already
+        // guaranteed one is extractable, so record it — the page shows it and
+        // prefills the DID input from it instead of asking for a DID the
+        // credential already carries.
+        state.join.invitation_issuer =
+            openvtc_core::join::invitation_issuer(&vic).map(str::to_string);
         state.invitation_credential = Some(vic);
         state.join.has_invitation = true;
         state.join.vic_cleared = false;
@@ -1922,6 +1939,42 @@ mod tests {
         // No row is added: the invitation step has not been reached.
         assert!(state.join.invitation_options.is_empty());
         assert_eq!(first_error(&state), None);
+    }
+
+    /// The entry-page paste records the VIC's issuer, which *is* the community
+    /// being joined. The entry page prefills its DID input from this, so an
+    /// operator holding an invitation never has to find and retype a DID the
+    /// credential already carries (issue #29).
+    #[test]
+    fn an_entry_page_paste_records_the_issuing_community() {
+        let mut state = State::default();
+        load_pasted_vic(&mut state, &pasteable_vic("urn:uuid:one").to_string(), None);
+        assert_eq!(state.join.invitation_issuer.as_deref(), Some(COMMUNITY));
+    }
+
+    /// `issuer` also has an object form; both must yield the community DID, or
+    /// the prefill silently stops working for half the issuers out there.
+    #[test]
+    fn an_object_form_issuer_is_recorded_too() {
+        let mut state = State::default();
+        let mut vic = pasteable_vic("urn:uuid:one");
+        vic["issuer"] = json!({ "id": COMMUNITY, "name": "Example Community" });
+        load_pasted_vic(&mut state, &vic.to_string(), None);
+        assert_eq!(state.join.invitation_issuer.as_deref(), Some(COMMUNITY));
+    }
+
+    /// A rejected paste must not leave an issuer behind: the entry page would
+    /// prefill a community DID from a credential it refused to load, and the
+    /// operator would join without the invitation they thought they presented.
+    #[test]
+    fn a_rejected_entry_page_paste_records_no_issuer() {
+        let not_a_vic = json!({ "id": "urn:uuid:one", "type": ["VerifiableCredential"] });
+        for text in ["}{ not json", &not_a_vic.to_string()] {
+            let mut state = State::default();
+            load_pasted_vic(&mut state, text, None);
+            assert_eq!(state.join.invitation_issuer, None, "for paste {text:?}");
+            assert!(!state.join.has_invitation);
+        }
     }
 
     // ---- Pre-submit persona connect ----

--- a/openvtc/src/ui/pages/join_flow/mod.rs
+++ b/openvtc/src/ui/pages/join_flow/mod.rs
@@ -43,6 +43,13 @@ pub struct JoinFlow {
     /// survives re-renders without round-tripping through the watch channel.
     pub vtc_did: Input,
 
+    /// The issuer DID last prefilled into [`vtc_did`](Self::vtc_did) from a
+    /// pasted invitation. `move_with_state` runs on every state broadcast, so
+    /// without this the prefill would fight the operator — retyping over it on
+    /// each redraw. Comparing against it means a *new* invitation prefills once
+    /// and anything typed afterwards is left alone.
+    pub prefilled_issuer: Option<String>,
+
     // Page handlers (zero-sized — they read from `props.state`).
     pub vtc_enter_did: VtcEnterDid,
     pub invitation_choice: InvitationChoice,
@@ -66,6 +73,36 @@ impl From<&State> for Props {
     }
 }
 
+impl JoinFlow {
+    /// Fill the community-DID input from a pasted invitation's issuer.
+    ///
+    /// A VIC's issuer *is* the community that will receive the join, so once one
+    /// is loaded the DID is already in hand — asking the operator to go and find
+    /// the same DID a second time is the "pressing Enter does nothing" report in
+    /// issue #29. Prefilling (rather than submitting) keeps the community on
+    /// screen and editable: an invitation is handed to you by someone else, so
+    /// the DID it points at is worth a look before Enter commits to joining it.
+    ///
+    /// Only fills an empty field or one still holding a previous prefill —
+    /// anything typed or pasted by hand wins over the credential.
+    fn prefill_from_invitation(&mut self) {
+        let Some(issuer) = self.props.state.invitation_issuer.as_deref() else {
+            // Invitation cleared (Ctrl+L): forget the prefill so re-pasting the
+            // same VIC fills the field again.
+            self.prefilled_issuer = None;
+            return;
+        };
+        if self.prefilled_issuer.as_deref() == Some(issuer) {
+            return;
+        }
+        let current = self.vtc_did.value().trim();
+        if current.is_empty() || Some(current) == self.prefilled_issuer.as_deref() {
+            self.vtc_did = Input::new(issuer.to_string());
+        }
+        self.prefilled_issuer = Some(issuer.to_string());
+    }
+}
+
 impl Component for JoinFlow {
     fn new(state: &State, action_tx: UnboundedSender<Action>) -> Self
     where
@@ -74,6 +111,7 @@ impl Component for JoinFlow {
         JoinFlow {
             action_tx,
             vtc_did: Input::default(),
+            prefilled_issuer: None,
             vtc_enter_did: VtcEnterDid,
             invitation_choice: InvitationChoice,
             identity_choice: IdentityChoice,
@@ -87,10 +125,12 @@ impl Component for JoinFlow {
     where
         Self: Sized,
     {
-        JoinFlow {
+        let mut next = JoinFlow {
             props: Props::from(state),
             ..self
-        }
+        };
+        next.prefill_from_invitation();
+        next
     }
 
     fn handle_key_event(&mut self, key: KeyEvent) {
@@ -116,6 +156,10 @@ impl Component for JoinFlow {
                 // (VIC): hand it to the state handler to validate + stash (#3).
                 // Anything else is the VTC DID being pasted into the input.
                 if trimmed.starts_with('{') {
+                    // Re-arm the prefill: a paste is a deliberate act, so
+                    // pasting the same VIC again after clearing the input fills
+                    // it back in rather than being a no-op.
+                    self.prefilled_issuer = None;
                     let _ = self
                         .action_tx
                         .send(Action::JoinPasteVic(trimmed.to_string()));
@@ -148,5 +192,89 @@ impl ComponentRender<()> for JoinFlow {
             JoinPage::IdentityChoice => self.identity_choice.render(&self.props.state, frame),
             JoinPage::Progress => self.join_progress.render(&self.props.state, frame),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Prefilling the community-DID input from a pasted invitation (issue #29).
+    //! `move_with_state` runs on every state broadcast, so the interesting cases
+    //! are all about *not* overwriting the operator on a redraw.
+    use super::*;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    const ISSUER: &str = "did:webvh:QmRoot:community.example.com";
+
+    fn flow() -> JoinFlow {
+        let (tx, _rx) = unbounded_channel();
+        JoinFlow::new(&State::default(), tx)
+    }
+
+    /// Set an issuer on the state and push it through the same path the runtime
+    /// uses, so the tests exercise `move_with_state` rather than the helper.
+    fn broadcast(flow: JoinFlow, issuer: Option<&str>) -> JoinFlow {
+        let mut state = State::default();
+        state.join.invitation_issuer = issuer.map(str::to_string);
+        flow.move_with_state(&state)
+    }
+
+    #[test]
+    fn a_pasted_invitation_fills_the_empty_did_input() {
+        let flow = broadcast(flow(), Some(ISSUER));
+        assert_eq!(flow.vtc_did.value(), ISSUER);
+    }
+
+    /// The whole point of the guard: a redraw must not keep re-stamping the
+    /// input after the operator has edited what was prefilled.
+    #[test]
+    fn a_later_redraw_leaves_an_edited_prefill_alone() {
+        let mut flow = broadcast(flow(), Some(ISSUER));
+        flow.vtc_did = Input::new("did:webvh:somewhere.else".to_string());
+        let flow = broadcast(flow, Some(ISSUER));
+        assert_eq!(flow.vtc_did.value(), "did:webvh:somewhere.else");
+    }
+
+    /// A DID typed *before* the paste is the operator's own answer; the
+    /// credential fills a blank, it does not overrule one.
+    #[test]
+    fn a_typed_did_survives_a_paste() {
+        let mut flow = flow();
+        flow.vtc_did = Input::new("did:webvh:typed.by.hand".to_string());
+        let flow = broadcast(flow, Some(ISSUER));
+        assert_eq!(flow.vtc_did.value(), "did:webvh:typed.by.hand");
+    }
+
+    /// Clearing the invitation (Ctrl+L) drops the issuer, which re-arms the
+    /// prefill so a subsequent paste is not a no-op.
+    #[test]
+    fn clearing_the_invitation_re_arms_the_prefill() {
+        let flow = broadcast(flow(), Some(ISSUER));
+        let mut flow = broadcast(flow, None);
+        assert_eq!(flow.prefilled_issuer, None);
+        flow.vtc_did = Input::default();
+        let flow = broadcast(flow, Some(ISSUER));
+        assert_eq!(flow.vtc_did.value(), ISSUER);
+    }
+
+    /// Pasting a VIC is a deliberate act, so it re-arms the prefill: paste,
+    /// clear the field by hand, paste the same VIC again — it fills back in.
+    #[test]
+    fn re_pasting_after_clearing_the_field_fills_it_again() {
+        let mut flow = broadcast(flow(), Some(ISSUER));
+        flow.vtc_did = Input::default();
+        // The paste itself only re-arms; the fill lands on the state broadcast
+        // the handler sends back.
+        flow.handle_paste_event(r#"{"id":"urn:uuid:one"}"#);
+        let flow = broadcast(flow, Some(ISSUER));
+        assert_eq!(flow.vtc_did.value(), ISSUER);
+    }
+
+    /// Non-JSON pasted on the entry page is still the VTC DID going into the
+    /// input, untouched by any of the above.
+    #[test]
+    fn a_pasted_did_still_goes_into_the_input() {
+        let mut flow = flow();
+        flow.handle_paste_event("  did:webvh:pasted.example.com  ");
+        assert_eq!(flow.vtc_did.value(), "did:webvh:pasted.example.com");
     }
 }

--- a/openvtc/src/ui/pages/join_flow/vtc_enter_did.rs
+++ b/openvtc/src/ui/pages/join_flow/vtc_enter_did.rs
@@ -5,7 +5,8 @@
 //! sub-context + join-submit sequence. Esc cancels the whole flow.
 
 use crate::colors::{
-    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_TEXT_DEFAULT,
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
+    COLOR_TEXT_DEFAULT,
 };
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
@@ -39,10 +40,12 @@ impl VtcEnterDid {
                 let _ = state.action_tx.send(Action::Exit);
             }
             KeyCode::Enter => {
+                // Submit unconditionally, empty input included: the handler
+                // answers an empty field with an on-screen reason. Swallowing
+                // the keypress here made Enter look broken after a VIC paste,
+                // which populates the invitation but not this input (issue #29).
                 let did = state.vtc_did.value().trim().to_string();
-                if !did.is_empty() {
-                    let _ = state.action_tx.send(Action::JoinSubmitVtc(did));
-                }
+                let _ = state.action_tx.send(Action::JoinSubmitVtc(did));
             }
             KeyCode::Esc => {
                 let _ = state.action_tx.send(Action::JoinCancel);
@@ -72,29 +75,55 @@ impl VtcEnterDid {
             middle,
         );
 
+        let inner = middle.inner(Margin::new(3, 2));
+
+        // Everything the operator needs *before* typing goes above the input:
+        // the invitation status and any error. Both used to sit below it, under
+        // the examples block, where the invitation tip was the dimmest and
+        // lowest thing on the page and read as decoration (issue #29).
+        let width = inner.width as usize;
+        let mut header = wrapped(
+            "Enter the Verifiable Trust Community (VTC) DID you want to join. OpenVTC \
+             will mint a fresh persona and submit a join request on your behalf.",
+            width,
+            Style::new().fg(COLOR_DARK_GRAY),
+        );
+        header.push(Line::default());
+        header.extend(invitation_lines(state, width));
+        // Surface any pre-submit error (e.g. idempotency, empty input) inline.
+        let mut had_error = false;
+        for msg in &state.messages {
+            if let crate::state_handler::setup_sequence::MessageType::Error(err) = msg {
+                header.extend(wrapped(
+                    &format!("ERROR: {err}"),
+                    width,
+                    Style::new().fg(crate::colors::COLOR_WARNING_ACCESSIBLE_RED),
+                ));
+                had_error = true;
+            }
+        }
+        if had_error {
+            header.push(Line::default());
+        }
+        header.push(Line::styled(
+            "Enter the community's DID or agent name:",
+            Style::new().fg(COLOR_BORDER).bold(),
+        ));
+
+        // Height is the line count: every line above is already wrapped (or, for
+        // a DID, truncated) to `inner`, so the block cannot rewrap under the
+        // renderer and push the input off its row. Clamped so a terminal too
+        // short for the whole block clips the *prose* rather than the input —
+        // an unreachable input field is the one failure worth ruling out.
+        let header_height = u16::try_from(header.len())
+            .unwrap_or(u16::MAX)
+            .min(inner.height.saturating_sub(2));
         let content: [Rect; 3] =
-            Layout::vertical([Length(5), Length(2), Min(0)]).areas(middle.inner(Margin::new(3, 2)));
+            Layout::vertical([Length(header_height), Length(2), Min(0)]).areas(inner);
 
         let [prompt_col, input_col] = Layout::horizontal([Length(2), Min(0)]).areas(content[1]);
 
-        frame.render_widget(
-            Paragraph::new(vec![
-                Line::styled(
-                    "Enter the Verifiable Trust Community (VTC) DID you want to join.",
-                    Style::new().fg(COLOR_DARK_GRAY),
-                ),
-                Line::styled(
-                    "OpenVTC will mint a fresh persona and submit a join request on your behalf.",
-                    Style::new().fg(COLOR_DARK_GRAY),
-                ),
-                Line::default(),
-                Line::styled(
-                    "Enter the community's DID or agent name:",
-                    Style::new().fg(COLOR_BORDER).bold(),
-                ),
-            ]),
-            content[0],
-        );
+        frame.render_widget(Paragraph::new(header), content[0]);
 
         frame.render_widget(
             Paragraph::new(Span::styled(
@@ -105,7 +134,7 @@ impl VtcEnterDid {
         );
         render_input(input, frame, input_col);
 
-        let mut lines = vec![
+        let lines = vec![
             Line::styled("Examples:", Style::new().fg(COLOR_ORANGE).bold()),
             Line::styled(
                 "  • did:webvh:QmRoot…:community.example.com",
@@ -116,50 +145,13 @@ impl VtcEnterDid {
                 Style::new().fg(COLOR_ORANGE).italic(),
             ),
             Line::default(),
+            Line::from(vec![
+                Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(" to cancel  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+                Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(" to join", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            ]),
         ];
-        // Surface any pre-submit error (e.g. idempotency) inline.
-        for msg in &state.messages {
-            if let crate::state_handler::setup_sequence::MessageType::Error(err) = msg {
-                lines.push(Line::styled(
-                    format!("ERROR: {err}"),
-                    Style::new().fg(crate::colors::COLOR_WARNING_ACCESSIBLE_RED),
-                ));
-            }
-        }
-        // Explicit VIC state so the operator knows exactly what will be presented:
-        //   loaded   → it will ride in the join VP (community can auto-admit)
-        //   cleared  → operator dropped it; joining without one (may need review)
-        //   none     → never had one; offer the paste tip
-        if state.has_invitation {
-            lines.push(Line::styled(
-                "✓ Invitation credential loaded — it will be presented to the community.",
-                Style::new().fg(COLOR_SOFT_PURPLE).bold(),
-            ));
-            lines.push(Line::styled(
-                "[Ctrl+L] join without it   ·   paste a different VIC to replace it",
-                Style::new().fg(COLOR_DARK_GRAY).italic(),
-            ));
-            lines.push(Line::default());
-        } else if state.vic_cleared {
-            lines.push(Line::styled(
-                "Invitation cleared — joining without a credential (the community may \
-                 require manual approval). Paste a VIC to load one.",
-                Style::new().fg(COLOR_DARK_GRAY).italic(),
-            ));
-            lines.push(Line::default());
-        } else {
-            lines.push(Line::styled(
-                "Tip: paste an invitation credential (VIC) here to auto-join.",
-                Style::new().fg(COLOR_DARK_GRAY).italic(),
-            ));
-            lines.push(Line::default());
-        }
-        lines.push(Line::from(vec![
-            Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to cancel  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
-            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
-            Span::styled(" to join", Style::new().fg(COLOR_TEXT_DEFAULT)),
-        ]));
 
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), content[2]);
 
@@ -172,6 +164,87 @@ impl VtcEnterDid {
             bottom,
         );
     }
+}
+
+/// The invitation status block shown above the DID input, always ending in a
+/// blank line.
+///
+/// Explicit VIC state so the operator knows exactly what will be presented:
+///   loaded   → it will ride in the join VP (community can auto-admit)
+///   cleared  → operator dropped it; joining without one (may need review)
+///   none     → never had one; offer the paste tip
+///
+/// The "loaded" case names the issuing community. A VIC's issuer *is* the
+/// community being joined, and it is the DID prefilled into the input below —
+/// showing it is what makes the prefill checkable rather than magic, and answers
+/// "which community did this invitation come from" without leaving the page.
+///
+/// Prose is wrapped to `width` and the DID centre-truncated to it — the caller
+/// sizes the header block by line count, so nothing may rewrap later.
+fn invitation_lines(state: &JoinState, width: usize) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    if state.has_invitation {
+        lines.extend(wrapped(
+            "✓ Invitation credential loaded — it will be presented to the community.",
+            width,
+            Style::new().fg(COLOR_SUCCESS).bold(),
+        ));
+        if let Some(issuer) = &state.invitation_issuer {
+            const LABEL: &str = "  Community: ";
+            lines.push(Line::from(vec![
+                Span::styled(LABEL, Style::new().fg(COLOR_TEXT_DEFAULT)),
+                Span::styled(
+                    openvtc_core::display::truncate_did_centered(
+                        issuer,
+                        width.saturating_sub(LABEL.len()),
+                    )
+                    .into_owned(),
+                    Style::new().fg(COLOR_SOFT_PURPLE),
+                ),
+            ]));
+        }
+        lines.extend(wrapped(
+            "[Ctrl+L] join without it   ·   paste a different VIC to replace it",
+            width,
+            Style::new().fg(COLOR_DARK_GRAY).italic(),
+        ));
+    } else if state.vic_cleared {
+        lines.extend(wrapped(
+            "Invitation cleared — joining without a credential; the community may \
+             require manual approval. Paste an invitation credential (VIC) to load one.",
+            width,
+            Style::new().fg(COLOR_ORANGE),
+        ));
+    } else {
+        // The lead-in gets its own line: hanging it off a narrowed first line
+        // wraps the body into a ragged column on small terminals.
+        lines.push(Line::styled(
+            "Have an invitation?",
+            Style::new().fg(COLOR_BORDER).bold(),
+        ));
+        lines.extend(wrapped(
+            "Paste the invitation credential (VIC) JSON here — it fills in the \
+             community DID for you and rides along with the join request.",
+            width,
+            Style::new().fg(COLOR_TEXT_DEFAULT),
+        ));
+    }
+    lines.push(Line::default());
+    lines
+}
+
+/// Hard-wrap `text` to `width` and style each resulting line.
+///
+/// The header block is sized by line count, so it renders unwrapped `Line`s —
+/// which a `Paragraph` clips rather than wraps, losing the tail of anything too
+/// long. Wrapping here keeps the count honest and the text whole. Reuses the
+/// overlay wrapper, which already hard-splits DIDs and JSON (no spaces to break
+/// on) rather than overflowing them.
+fn wrapped(text: &str, width: usize, style: Style) -> Vec<Line<'static>> {
+    crate::ui::pages::main::wrap_text(text, width)
+        .into_iter()
+        .map(|l| Line::styled(l, style))
+        .collect()
 }
 
 fn render_input(input: &Input, frame: &mut Frame, area: Rect) {
@@ -187,4 +260,137 @@ fn render_input(input: &Input, frame: &mut Frame, area: Rect) {
     );
     let x = input.visual_cursor().max(scroll) - scroll;
     frame.set_cursor_position((area.x + x as u16, area.y))
+}
+
+#[cfg(test)]
+mod tests {
+    //! The invitation status block is sized by line count, not by wrapping, so
+    //! these render the page and read the buffer back — a line that wrapped
+    //! would silently push the input off its row.
+    use super::*;
+    use crate::state_handler::setup_sequence::MessageType;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    const ISSUER: &str = "did:webvh:QmRootQmRootQmRoot:community.example.com";
+
+    /// Render at `width`×24 and return the drawn rows, trailing spaces trimmed.
+    fn rows(state: &JoinState, input: &str, width: u16) -> Vec<String> {
+        let mut terminal = Terminal::new(TestBackend::new(width, 24)).expect("test terminal");
+        let input = Input::new(input.to_string());
+        terminal
+            .draw(|frame| VtcEnterDid.render(state, &input, frame))
+            .expect("render");
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|c| c.symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    fn row_of(rows: &[String], needle: &str) -> usize {
+        rows.iter()
+            .position(|r| r.contains(needle))
+            .unwrap_or_else(|| panic!("{needle:?} not drawn in:\n{}", rows.join("\n")))
+    }
+
+    /// The paste affordance is the thing an operator holding a VIC needs to
+    /// see; it belongs above the input, not below the examples (issue #29).
+    #[test]
+    fn the_paste_affordance_is_drawn_above_the_input() {
+        let drawn = rows(&JoinState::default(), "", 100);
+        assert!(
+            row_of(&drawn, "Have an invitation?") < row_of(&drawn, "Enter the community's DID"),
+            "the invitation prompt should precede the input prompt:\n{}",
+            drawn.join("\n")
+        );
+        // And still ahead of the examples that used to bury it.
+        assert!(row_of(&drawn, "Have an invitation?") < row_of(&drawn, "Examples:"));
+    }
+
+    /// A loaded invitation names the community it is for — that DID is what
+    /// gets prefilled into the input, so it has to be visible to be checkable.
+    #[test]
+    fn a_loaded_invitation_names_its_community() {
+        let state = JoinState {
+            has_invitation: true,
+            invitation_issuer: Some(ISSUER.to_string()),
+            ..JoinState::default()
+        };
+        let drawn = rows(&state, ISSUER, 100);
+        let row = &drawn[row_of(&drawn, "Community:")];
+        assert!(row.contains("community.example.com"), "got {row:?}");
+    }
+
+    /// On a terminal too small for the whole status block the prose clips, but
+    /// the input the operator has to type into stays on screen.
+    #[test]
+    fn a_cramped_terminal_still_shows_the_input() {
+        let mut terminal = Terminal::new(TestBackend::new(40, 14)).expect("test terminal");
+        let state = JoinState {
+            has_invitation: true,
+            invitation_issuer: Some(ISSUER.to_string()),
+            ..JoinState::default()
+        };
+        let input = Input::new("did:webvh:typed".to_string());
+        terminal
+            .draw(|frame| VtcEnterDid.render(&state, &input, frame))
+            .expect("render");
+        let drawn: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(drawn.contains("> did:webvh:typed"), "got:\n{drawn}");
+    }
+
+    /// The input row must stay put whatever the status block says, at a width
+    /// narrow enough that an unwrapped long DID would have spilled.
+    #[test]
+    fn the_input_keeps_its_row_across_states_and_widths() {
+        let mut with_error = JoinState {
+            has_invitation: true,
+            invitation_issuer: Some(ISSUER.to_string()),
+            ..JoinState::default()
+        };
+        with_error
+            .messages
+            .push(MessageType::Error("something went wrong".to_string()));
+        let states = [
+            JoinState::default(),
+            JoinState {
+                vic_cleared: true,
+                ..JoinState::default()
+            },
+            JoinState {
+                has_invitation: true,
+                invitation_issuer: Some(ISSUER.to_string()),
+                ..JoinState::default()
+            },
+            with_error,
+        ];
+        for width in [60, 100, 160] {
+            for (i, state) in states.iter().enumerate() {
+                let drawn = rows(state, "did:webvh:typed", width);
+                let prompt = row_of(&drawn, "Enter the community's DID");
+                let input = row_of(&drawn, "> did:webvh:typed");
+                assert_eq!(
+                    input,
+                    prompt + 1,
+                    "state {i} at width {width}: input should sit directly under its \
+                     prompt:\n{}",
+                    drawn.join("\n")
+                );
+            }
+        }
+    }
 }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -1986,7 +1986,7 @@ fn edit_text(code: KeyCode, current: &str) -> Option<String> {
 ///
 /// The hard split matters because these messages carry DIDs and JSON, which
 /// contain no spaces to break on.
-fn wrap_text(text: &str, width: usize) -> Vec<String> {
+pub(crate) fn wrap_text(text: &str, width: usize) -> Vec<String> {
     if width == 0 {
         return vec![text.to_string()];
     }

--- a/openvtc/src/ui/pages/setup_flow/mod.rs
+++ b/openvtc/src/ui/pages/setup_flow/mod.rs
@@ -356,10 +356,18 @@ impl ComponentRender<()> for SetupFlow {
 pub fn render_setup_header(frame: &mut Frame, rect: Rect, state: &SetupState) {
     let mut line1 = Line::default();
 
-    // WebVH-server flow: Get Started → DID & Keys → Profile Security → Display Name → Setup Complete
-    // Normal flow:       Get Started → Key Management → Profile Security → Digital Identity → Setup Complete
+    // WebVH-server flow: Get Started → DID & Keys → Profile Security → Setup Complete
+    // Normal flow:       Get Started → Key Management → Profile Security → Setup Complete
+    //
+    // R-A-5 ended setup at protection (`UnlockCode*` → `FinalPage`): the persona
+    // pages (`MediatorAsk`/`MediatorCustom`/`UserName`/`WebVHAddress`) are no
+    // longer reachable from State-A setup — a persona is minted later by the
+    // State-B join flow, which draws its own progress. The breadcrumb kept
+    // advertising a "Digital Identity" / "Display Name" step that could never
+    // become active, so the wizard read as skipping a step. If those pages are
+    // ever revived here, add their step back to both label lists.
     let use_server = state.vta.use_webvh_server;
-    let total_step: usize = 5;
+    let total_step: usize = 4;
 
     // Determine which step we're on
     let active = state.active_page;
@@ -399,14 +407,6 @@ pub fn render_setup_header(frame: &mut Frame, rect: Rect, state: &SetupState) {
                 | SetupPage::TokenSetCardholderName
         );
 
-    let is_identity = matches!(
-        active,
-        SetupPage::MediatorAsk
-            | SetupPage::MediatorCustom
-            | SetupPage::UserName
-            | SetupPage::WebVHAddress
-    );
-
     let is_final = matches!(active, SetupPage::FinalPage);
 
     // Step labels for each flow
@@ -415,7 +415,6 @@ pub fn render_setup_header(frame: &mut Frame, rect: Rect, state: &SetupState) {
             "Get Started",
             "DID & Keys",
             "Profile Security",
-            "Display Name",
             "Setup Complete",
         ]
     } else {
@@ -423,7 +422,6 @@ pub fn render_setup_header(frame: &mut Frame, rect: Rect, state: &SetupState) {
             "Get Started",
             "Key Management",
             "Profile Security",
-            "Digital Identity",
             "Setup Complete",
         ]
     };
@@ -435,10 +433,8 @@ pub fn render_setup_header(frame: &mut Frame, rect: Rect, state: &SetupState) {
         1
     } else if is_profile_security {
         2
-    } else if is_identity {
-        3
     } else if is_final {
-        4
+        3
     } else {
         0
     };


### PR DESCRIPTION
Fixes the three UX defects reported in [OpenVTC/vti-setup#29](https://github.com/OpenVTC/vti-setup/issues/29) and [OpenVTC/vti-setup#31](https://github.com/OpenVTC/vti-setup/issues/31). Grouped into one PR because they are all the same surface — what the operator sees on the way into a community.

## 1. A pasted VIC now fills in the community it is for (#29)

> Pressing Enter at this point does nothing. You still have to copy/paste in the VTC DID as well to continue.

Two bugs behind that one sentence.

**Enter was a silent no-op.** `VtcEnterDid::handle_key_event` only sent `JoinSubmitVtc` when the trimmed input was non-empty — otherwise the keypress vanished with no message, no error, nothing. A paste routes to `Action::JoinPasteVic` and never touches `vtc_did`, so after pasting an invitation the field is still empty and the page looks frozen. Enter now submits unconditionally and the handler answers an empty field with a reason on screen.

**The DID was already in hand.** A VIC's issuer *is* the community's VTC DID — `openvtc_core::join::invitation_issuer` says so outright, and `validate_invitation_credential` already requires the issuer to be extractable before a paste is accepted. Nothing read it: `invitation_issuer` had no callers in the TUI crate. The entry-page paste now records it, and the component prefills the input from it.

**Prefilled, not auto-submitted.** An invitation is handed to you by someone else, so the community it points at stays visible and editable before Enter commits to joining it. The loaded-invitation line now names that community, which is what makes the prefill checkable rather than magic.

The prefill is guarded so it never fights the operator: `move_with_state` runs on every state broadcast, so a `prefilled_issuer` field records what was last stamped in. A DID typed by hand survives a paste, an edited prefill survives every later redraw, and a paste re-arms the guard so clearing the field and pasting the same VIC again fills it back in.

## 2. The invitation prompt is legible and sits where it is needed (#29)

> note the hard-to-see "Tip: paste an invitation credential (VIC) here to auto-join"

It was `COLOR_DARK_GRAY` italic — deliberately the dimmest text on the page — rendered *below* the input, below the orange examples block, and below any errors. The least important content on the screen was the loudest.

The invitation status and any error now sit directly above the input in full-contrast colours, and the tip leads with a bold **Have an invitation?** rather than a dim "Tip:". Everything in that block is wrapped to the terminal width instead of clipping its tail — reusing `wrap_text`, which already hard-splits DIDs and JSON. The block is sized by line count and clamped so a terminal too short for it clips prose rather than the input field.

Worth noting for the record: as *filed*, #29 was a discoverability report — the reporter could not find anywhere to import a VIC at all. Raising the contrast and moving it above the fold is the fix here; if that is still not enough, the next step is an explicit paste row like the one `InvitationChoice` already carries.

## 3. Setup no longer advertises a step it will never run (#31)

R-A-5 ended setup at profile security (`UnlockCode*` → `FinalPage`); a persona is minted later by the State-B join flow. The persona pages are already marked `#[allow(dead_code)]` with a comment saying exactly that, and nothing anywhere navigates to `SetupPage::MediatorAsk`.

But `render_setup_header` still hardcoded `total_step = 5` and an `is_identity` group that could never match — so the wizard went 3/5 → 5/5 with an unticked "Digital Identity" in between, which is what the reporter saw. Both label lists drop to four steps: the `use_webvh_server` branch's "Display Name" (`UserName`) is reachable only via `UseDefaultMediator` from the same dead `MediatorAsk`, so it was equally stranded.

## Testing

`cargo test --workspace` green, clippy clean. New coverage:

- **Issuer capture** — string and object `issuer` forms both yield the community DID, and a rejected paste (bad JSON, not a VIC) leaves no issuer behind. That last one matters: an issuer surviving a refused paste would prefill a community DID from a credential that will not be presented.
- **Prefill guards** — fills an empty field; leaves an edited prefill alone on redraw; a typed DID survives a paste; clearing the invitation and re-pasting both re-arm it.
- **Render tests** — draw the page to a `TestBackend` and read the buffer back: the paste affordance precedes both the input and the examples, a loaded invitation names its community, the input stays directly under its prompt across all four states at three widths, and a 40×14 terminal still shows the input.

The render tests are the ones that earn their keep — the header is sized by line count, so a line that wrapped where it was assumed not to would silently push the input off its row.