### PR TITLE
fix(vta): load the VIC list off the loop, and stop dropping keys silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The VTA Service panel stops feeling frozen.** Tab into the Invitation
+  Credentials list ran a credential-vault query *before* the focus change, and
+  the state handler services actions one at a time — so a two-line in-memory
+  focus move waited on a network round-trip with a 30-second timeout, and
+  nothing on screen explained the pause. The listing now runs off the loop:
+  focus moves immediately, the panel says a query is in flight, and "No
+  invitation credentials" is only claimed once the vault has actually answered.
+  A refresh asked for while one is running is deferred rather than dropped, so a
+  just-archived credential is never left rendered as active.
+- **`g` opens the agent-name manager whichever list is focused.** It was bound
+  only to the Context Identities list, so pressing it after a Tab produced
+  nothing at all — no action, no message — which is indistinguishable from a
+  dead keyboard and had people restarting the app. Two more silent no-ops
+  behind the same report are fixed with it: a persona selection left pointing
+  past the end of a rebuilt list disabled every key scoped to that list (and
+  restarting "fixed" it only because the selection resets to the first row), and
+  both lists drew a "◀ focus" marker from their own focus alone — so a panel the
+  keyboard could not reach still claimed focus and advertised keys that were
+  being discarded. It now points at the key that gets you there.
+- **A claimed agent name is no longer reported as no name at all.** When the
+  claim succeeded but the read-back that follows it failed, the overlay rendered
+  "No agent names yet." directly above "Applied, but could not reload the list"
+  — the prominent half saying the opposite of what had happened, for a name the
+  DID document already carried. A registry that could not be read is now shown
+  as unknown rather than empty.
+
 - **A pasted invitation now fills in the community it is for, and Enter says
   something either way.** On the join entry page a pasted VIC was routed to the
   invitation slot and nothing else: the DID input stayed empty, so Enter — which

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3640,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -164,7 +164,8 @@ pub(crate) enum DispatchOutcome {
     /// advertises, or the reason the probe could not tell. Display-only — it
     /// touches no `Config`, so it never marks the config dirty.
     VtaTransports(crate::state_handler::main_page::content::AdvertisedTransports),
-    /// A VIC list refresh finished. [`VicRefreshOutcome::apply`] swaps in the
+    /// A VIC list refresh finished. [`VicRefreshOutcome::apply`](crate::state_handler::vic::VicRefreshOutcome::apply)
+    /// swaps in the
     /// listing (or logs why it could not be read); display-only, so it touches
     /// no `Config` and never marks it dirty.
     Vic(crate::state_handler::vic::VicRefreshOutcome),

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -73,6 +73,12 @@ pub(crate) enum DispatchDomain {
     /// VTA transport probe: resolve the VTA's DID document to learn which
     /// transports it advertises. Read-only, one resolve, off the loop.
     VtaTransports,
+    /// Invitation-credential (VIC) list refresh: one credential-vault query
+    /// against the always-on admin VTA session (30 s timeout in the SDK).
+    /// Read-only. Backgrounded because it is bound to *navigation* — Tab into
+    /// the VIC list, `i` to flip the filter — and an inline await made the
+    /// focus change itself wait on the round-trip, which read as a frozen key.
+    Vic,
 }
 
 impl DispatchDomain {
@@ -85,6 +91,7 @@ impl DispatchDomain {
             DispatchDomain::Did => "Identity deletion",
             DispatchDomain::AgentName => "Agent name refresh",
             DispatchDomain::VtaTransports => "VTA transport probe",
+            DispatchDomain::Vic => "Invitation credential refresh",
         }
     }
 }
@@ -157,6 +164,10 @@ pub(crate) enum DispatchOutcome {
     /// advertises, or the reason the probe could not tell. Display-only — it
     /// touches no `Config`, so it never marks the config dirty.
     VtaTransports(crate::state_handler::main_page::content::AdvertisedTransports),
+    /// A VIC list refresh finished. [`VicRefreshOutcome::apply`] swaps in the
+    /// listing (or logs why it could not be read); display-only, so it touches
+    /// no `Config` and never marks it dirty.
+    Vic(crate::state_handler::vic::VicRefreshOutcome),
     /// A spawned dispatch job panicked (or was cancelled) and so never produced a
     /// real outcome. Synthesised by [`spawn_dispatch`] from the `JoinError` so the
     /// domain's busy-flag is still cleared (a panicking job that sent nothing would
@@ -166,8 +177,10 @@ pub(crate) enum DispatchOutcome {
 }
 
 impl DispatchOutcome {
-    /// The domain whose busy-flag this outcome releases.
-    fn domain(&self) -> DispatchDomain {
+    /// The domain whose busy-flag this outcome releases. `pub(crate)` because
+    /// the degraded (State-A) loop has to free the flag directly on the one path
+    /// where it cannot apply an outcome — see its dispatch arm.
+    pub(crate) fn domain(&self) -> DispatchDomain {
         match self {
             DispatchOutcome::MediatorReconnect(_) => DispatchDomain::Mediator,
             DispatchOutcome::Relationship(_) => DispatchDomain::Relationship,
@@ -175,6 +188,7 @@ impl DispatchOutcome {
             DispatchOutcome::Did(_) => DispatchDomain::Did,
             DispatchOutcome::AgentName(_) => DispatchDomain::AgentName,
             DispatchOutcome::VtaTransports(_) => DispatchDomain::VtaTransports,
+            DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::Panicked(domain) => *domain,
         }
     }
@@ -292,6 +306,7 @@ pub(crate) fn apply_outcome(
             // from `Config` and would drop a field the config does not hold.
             state.main_page.content_panel.vta.transports.advertised = Some(advertised);
         }
+        DispatchOutcome::Vic(outcome) => outcome.apply(state, config),
         DispatchOutcome::Panicked(domain) => {
             // The job panicked and produced no real outcome. Surface a generic
             // failure so the user isn't left staring at a stuck "in progress"; the

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -227,6 +227,16 @@ pub struct AgentNameManagerState {
     pub phase: AgentNameManagerPhase,
     /// Transient status / error line.
     pub message: Option<String>,
+    /// The registry could not be read, so [`names`](Self::names) is not known to
+    /// be the host's current answer.
+    ///
+    /// Only the empty case is actually dangerous, and it is why this flag
+    /// exists: a claim that succeeded and a reload that then failed left the
+    /// overlay rendering "No agent names yet." directly above "Applied, but
+    /// could not reload the list" — the two lines contradict each other, and the
+    /// prominent one says the opposite of what happened. The name was claimed,
+    /// and the DID document proved it.
+    pub list_stale: bool,
     /// Armed remove confirmation: `Some(row)` while awaiting `y`/Enter to
     /// release that name (a destructive op — the name becomes free for anyone to
     /// reclaim). Any other key cancels. `None` when nothing is armed.
@@ -414,6 +424,17 @@ pub struct VtaState {
     /// Whether the VIC list includes archived + soft-deleted entries (the
     /// `include_archived` / `include_deleted` query modifiers). Toggled with `i`.
     pub vic_show_inactive: bool,
+    /// A vault query is in flight. The list load is a network round-trip that no
+    /// longer blocks the loop, so the panel says so rather than showing a stale
+    /// (or empty) list with no sign that an answer is coming.
+    pub vic_loading: bool,
+    /// A refresh was asked for while one was already in flight, and must be
+    /// re-run once it lands. Set by the spawn helper when the busy-guard rejects
+    /// it: the in-flight query was issued *before* the mutation (or filter flip)
+    /// that prompted this request, so its result is already stale — dropping the
+    /// request instead would leave an archived VIC rendered as active until the
+    /// next manual refresh.
+    pub vic_refresh_queued: bool,
     /// Which of the two manageable lists (Context Identities vs Invitation
     /// Credentials) has keyboard focus, so `↑/↓` and the verbs apply to it.
     pub focus: VtaFocus,

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -496,7 +496,18 @@ impl MainPageState {
             })
             .collect();
         context_dids.sort_by(|a, b| a.did.cmp(&b.did));
-        self.content_panel.vta.context_dids = context_dids.into();
+        // Clamp the selection to the rebuilt list. Nothing else does: the list is
+        // rebuilt wholesale on every sync, so deleting a persona (or loading a
+        // profile with fewer than the last one had) could leave the index past
+        // the end — where the panel draws no cursor and every list-scoped key
+        // (`d`, and until it moved, `g`) silently does nothing, since each is
+        // guarded on `did_selected < did_count`. Restarting "fixed" it only
+        // because the index starts at 0.
+        let vta = &mut self.content_panel.vta;
+        vta.did_selected_index = vta
+            .did_selected_index
+            .min(context_dids.len().saturating_sub(1));
+        vta.context_dids = context_dids.into();
 
         // The VIC list is not derived from `Config` (it comes from the VTA
         // credential vault), so it is annotated rather than rebuilt here.
@@ -1621,6 +1632,30 @@ mod tests {
         assert_eq!(row.agent_name.as_deref(), Some("example.com/@alice"));
         assert_eq!(row.did, ALICE_DID);
         assert_eq!(row.label, "Work me");
+    }
+
+    /// A selection left pointing past the end of a shrunken persona list is
+    /// clamped back onto a real row.
+    ///
+    /// Nothing else did this: the list is rebuilt wholesale on every sync, and a
+    /// stale index disables every list-scoped key (each is guarded on
+    /// `did_selected < did_count`) while drawing no cursor to show why — a
+    /// keyboard that looks broken until the next restart resets the index to 0.
+    #[test]
+    fn syncing_clamps_a_stale_persona_selection() {
+        let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
+        let config = config_with_membership(ALICE_DID, Some("Work me"), vtc_did, None);
+
+        let mut page = MainPageState::default();
+        // What a deletion (or a smaller profile) leaves behind.
+        page.content_panel.vta.did_selected_index = 4;
+        page.sync_from_config(&config);
+
+        assert_eq!(page.content_panel.vta.context_dids.len(), 1);
+        assert_eq!(
+            page.content_panel.vta.did_selected_index, 0,
+            "the selection must land on a row that exists"
+        );
     }
 
     // --- VTA panel key counts ---

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1380,18 +1380,19 @@ impl StateHandler {
                         .await;
                     },
                     Action::VicRefresh => {
-                        self.refresh_vics(&mut state, admin_vta.as_ref(), Some(&config))
-                            .await;
+                        // Off the loop: this is Tab into the VIC list, and the
+                        // focus change queued behind it must not wait on a vault
+                        // round-trip.
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
                     },
                     Action::VicToggleInactive => {
                         state.main_page.content_panel.vta.vic_show_inactive =
                             !state.main_page.content_panel.vta.vic_show_inactive;
-                        self.refresh_vics(&mut state, admin_vta.as_ref(), Some(&config))
-                            .await;
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
                     },
                     Action::AddVicSubmit => {
-                        self.run_add_vic(&mut state, admin_vta.as_ref(), Some(&config))
-                            .await;
+                        self.run_add_vic(&mut state, admin_vta.as_ref()).await;
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
                     },
                     Action::VicArchive(i)
                     | Action::VicUnarchive(i)
@@ -1401,11 +1402,11 @@ impl StateHandler {
                         self.run_vic_lifecycle(
                             &mut state,
                             admin_vta.as_ref(),
-                            Some(&config),
                             &action,
                             i,
                         )
                         .await;
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
                     },
                     Action::CreatePersonaCopy => {
                         if let Some(did) = state
@@ -1822,6 +1823,12 @@ impl StateHandler {
                         &mut in_flight,
                         outcome,
                     );
+                    // A refresh asked for while the vault was busy is re-issued
+                    // here, now that the domain is free — see `vic_refresh_queued`.
+                    if state.main_page.content_panel.vta.vic_refresh_queued {
+                        state.main_page.content_panel.vta.vic_refresh_queued = false;
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
+                    }
                 },
                 // Lifecycle log messages from the Messaging
                 Some(event) = lifecycle_log_rx.recv() => {
@@ -2216,6 +2223,13 @@ impl StateHandler {
             .get(index)
             .cloned()
         else {
+            // No persona under the selection: the account has none yet, or the
+            // index outlived the row it pointed at. Either way say so — an
+            // unexplained no-op here is what makes `g` look broken.
+            state
+                .main_page
+                .log("No persona selected — create or select a persona DID first.");
+            let _ = self.state_tx.send(state.clone());
             return;
         };
         state.main_page.agent_names = Some(AgentNameManagerState {
@@ -2237,11 +2251,16 @@ impl StateHandler {
         };
         match agent_name_manage::list_names(admin_vta, &persona.did).await {
             Ok(names) => self.apply_agent_name_list(state, names, AgentNameManagerPhase::Ready),
-            Err(e) => self.set_agent_name_message(
-                state,
-                AgentNameManagerPhase::Ready,
-                format!("Could not load agent names: {e:#}"),
-            ),
+            Err(e) => {
+                if let Some(o) = state.main_page.agent_names.as_mut() {
+                    o.list_stale = true;
+                }
+                self.set_agent_name_message(
+                    state,
+                    AgentNameManagerPhase::Ready,
+                    format!("Could not load agent names: {e:#}"),
+                )
+            }
         }
     }
 
@@ -2414,11 +2433,18 @@ impl StateHandler {
                 state.main_page.sync_from_config(config);
                 self.apply_agent_name_list(state, names, AgentNameManagerPhase::Ready);
             }
-            Err(e) => self.set_agent_name_message(
-                state,
-                AgentNameManagerPhase::Ready,
-                format!("Applied, but could not reload the list: {e:#}"),
-            ),
+            Err(e) => {
+                // The mutation landed — only the read-back failed. Mark the list
+                // unknown so the overlay stops presenting it as the registry.
+                if let Some(o) = state.main_page.agent_names.as_mut() {
+                    o.list_stale = true;
+                }
+                self.set_agent_name_message(
+                    state,
+                    AgentNameManagerPhase::Ready,
+                    format!("Applied, but could not reload the list: {e:#}"),
+                )
+            }
         }
     }
 
@@ -2482,6 +2508,7 @@ impl StateHandler {
             o.selected = o.selected.min(o.names.len().saturating_sub(1));
             o.phase = phase;
             o.message = None;
+            o.list_stale = false;
         }
         let _ = self.state_tx.send(state.clone());
     }
@@ -2500,49 +2527,11 @@ impl StateHandler {
         let _ = self.state_tx.send(state.clone());
     }
 
-    /// (Re)load the VIC list from the VTA credential vault into the VTA panel,
-    /// honouring the "show inactive" toggle. Best-effort: a query failure logs
-    /// and leaves the previous list in place. Called when the operator focuses
-    /// the VIC list, toggles inactive, and after every mutation.
-    ///
-    /// `config` (when available) supplies the verified agent names for the
-    /// issuer DIDs: the vault descriptors carry only DIDs, so the freshly loaded
-    /// list is annotated here rather than waiting for the next
-    /// `sync_from_config`.
-    async fn refresh_vics(
-        &self,
-        state: &mut State,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-        config: Option<&Config>,
-    ) {
-        let Some(admin_vta) = admin_vta else { return };
-        let include_inactive = state.main_page.content_panel.vta.vic_show_inactive;
-        match vic::list_vics(admin_vta, include_inactive).await {
-            Ok(list) => {
-                let vta = &mut state.main_page.content_panel.vta;
-                vta.vic_selected_index = vta.vic_selected_index.min(list.len().saturating_sub(1));
-                vta.vics = list.into();
-                if let Some(config) = config {
-                    state.main_page.sync_vic_agent_names(config);
-                }
-            }
-            Err(e) => {
-                state
-                    .main_page
-                    .log_error("Listing invitation credentials failed", &e);
-            }
-        }
-        let _ = self.state_tx.send(state.clone());
-    }
-
-    /// Validate + store the pasted VIC from the add-VIC overlay, then refresh the
-    /// list. Mirrors `run_create_persona`'s phase handling.
-    async fn run_add_vic(
-        &self,
-        state: &mut State,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-        config: Option<&Config>,
-    ) {
+    /// Validate + store the pasted VIC from the add-VIC overlay. Mirrors
+    /// `run_create_persona`'s phase handling. The caller re-lists the vault
+    /// afterwards — see [`spawn_vic_refresh`], which owns every load so a stale
+    /// in-flight query can never overwrite a fresh one.
+    async fn run_add_vic(&self, state: &mut State, admin_vta: Option<&vta_sdk::client::VtaClient>) {
         use crate::state_handler::main_page::content::AddVicPhase;
 
         let json = match state.main_page.add_vic.as_ref() {
@@ -2578,7 +2567,6 @@ impl StateHandler {
                     o.messages.push("Invitation credential stored.".to_string());
                 }
                 state.main_page.log("Stored an invitation credential.");
-                self.refresh_vics(state, Some(admin_vta), config).await;
             }
             Err(e) => {
                 // A validation error keeps the operator on the input phase so they
@@ -2596,13 +2584,13 @@ impl StateHandler {
     }
 
     /// Run a VIC lifecycle verb (archive / unarchive / restore / soft-delete /
-    /// purge) against the selected VIC, clearing any confirmation arm, then
-    /// refresh the list. `index` is into the displayed VIC list.
+    /// purge) against the selected VIC, clearing any confirmation arm. `index`
+    /// is into the displayed VIC list. The caller re-lists the vault afterwards
+    /// (see [`spawn_vic_refresh`]).
     async fn run_vic_lifecycle(
         &self,
         state: &mut State,
         admin_vta: Option<&vta_sdk::client::VtaClient>,
-        config: Option<&Config>,
         action: &Action,
         index: usize,
     ) {
@@ -2638,7 +2626,6 @@ impl StateHandler {
                 .main_page
                 .log_error(format!("VIC {} failed", verb.to_lowercase()), &e),
         }
-        self.refresh_vics(state, Some(admin_vta), config).await;
     }
 
     /// Remove the community at `index` in the Communities display list: withdraw
@@ -2792,6 +2779,15 @@ impl StateHandler {
         // community withdrawal); `join_flow` saves itself synchronously. Coalesce
         // here too and force-flush on every exit path so a withdrawal isn't lost.
         let mut save = save_coalesce::SaveScheduler::new(self.profile.clone());
+        // State A reaches the VTA panel too (an account with no community still
+        // manages personas and VICs there), so it needs the same off-loop path
+        // for the vault query — otherwise Tab is responsive after the first join
+        // and sluggish before it, on the very screen a new account lives in.
+        // Only the VIC domain is dispatched here; every other network action is
+        // inert in this loop.
+        let (dispatch_tx, mut dispatch_rx) =
+            tokio::sync::mpsc::unbounded_channel::<background_dispatch::DispatchOutcome>();
+        let mut in_flight = background_dispatch::InFlight::default();
         let result = loop {
             tokio::select! {
                 Some(action) = action_rx.recv() => match action {
@@ -2947,20 +2943,18 @@ impl StateHandler {
                     }
                     Action::VicRefresh => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        let cfg = join_ctx.as_ref().map(|c| &*c.config);
-                        self.refresh_vics(state, av, cfg).await;
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
                     }
                     Action::VicToggleInactive => {
                         state.main_page.content_panel.vta.vic_show_inactive =
                             !state.main_page.content_panel.vta.vic_show_inactive;
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        let cfg = join_ctx.as_ref().map(|c| &*c.config);
-                        self.refresh_vics(state, av, cfg).await;
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
                     }
                     Action::AddVicSubmit => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        let cfg = join_ctx.as_ref().map(|c| &*c.config);
-                        self.run_add_vic(state, av, cfg).await;
+                        self.run_add_vic(state, av).await;
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
                     }
                     Action::VicArchive(i)
                     | Action::VicUnarchive(i)
@@ -2968,8 +2962,8 @@ impl StateHandler {
                     | Action::DeleteVic(i)
                     | Action::PurgeVic(i) => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        let cfg = join_ctx.as_ref().map(|c| &*c.config);
-                        self.run_vic_lifecycle(state, av, cfg, &action, i).await;
+                        self.run_vic_lifecycle(state, av, &action, i).await;
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
                     }
                     Action::CreatePersonaCopy => {
                         if let Some(did) = state
@@ -2991,6 +2985,28 @@ impl StateHandler {
                     // catch-all with now go through `handle_nav_action` above.
                     _ => {}
                 },
+                Some(outcome) = dispatch_rx.recv() => {
+                    // Applying needs the config the outcome is annotated against.
+                    // It lives in `join_ctx`, which is `take`n on hand-off to the
+                    // runtime loop — a listing that lands in that window has
+                    // nowhere to go, but its domain must still be freed or the
+                    // guard stays set for the life of the loop.
+                    match join_ctx.as_mut() {
+                        Some(ctx) => background_dispatch::apply_outcome(
+                            state,
+                            &mut ctx.config,
+                            &mut save,
+                            &mut in_flight,
+                            outcome,
+                        ),
+                        None => in_flight.finish(outcome.domain()),
+                    }
+                    if state.main_page.content_panel.vta.vic_refresh_queued {
+                        state.main_page.content_panel.vta.vic_refresh_queued = false;
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
+                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
+                    }
+                }
                 Ok(interrupted) = interrupt_rx.recv() => {
                     break DegradedOutcome::Exit(interrupted);
                 }
@@ -3124,6 +3140,74 @@ fn apply_capability_replies(
             }
         }
     }
+}
+
+/// Record what a refresh request does to the panel, and answer whether the
+/// caller should actually start a job. Split out from [`spawn_vic_refresh`]
+/// so the guard rules are testable without a live `VtaClient`.
+///
+/// The three outcomes, and why each is what it is, are documented on
+/// [`spawn_vic_refresh`].
+fn begin_vic_refresh(
+    in_flight: &mut background_dispatch::InFlight,
+    state: &mut State,
+    has_session: bool,
+) -> bool {
+    if !has_session {
+        state.main_page.content_panel.vta.vic_loading = false;
+        return false;
+    }
+    if !in_flight.try_begin(background_dispatch::DispatchDomain::Vic) {
+        state.main_page.content_panel.vta.vic_refresh_queued = true;
+        return false;
+    }
+    state.main_page.content_panel.vta.vic_loading = true;
+    true
+}
+
+/// Start a background VIC-list refresh, shared by both loops.
+///
+/// The vault query is a trust task with a 30 s SDK timeout. It used to run
+/// inline in the action arm, which meant the `VicFocusToggle` queued behind it
+/// — a two-line in-memory change — could not be applied until the network
+/// answered: Tab into the Invitation Credentials list took as long as the round
+/// trip, with nothing on screen to say why. Here the loop only *starts* the
+/// query, so the focus change lands on the next frame and the list fills in
+/// when it arrives.
+///
+/// Guarding rules, in the order they apply:
+///
+/// * **No session, no query.** Without the always-on admin VTA session there is
+///   no vault to read; the loading flag is cleared so the panel doesn't claim a
+///   query is running.
+/// * **One in flight per domain** ([`background_dispatch::InFlight`]), so
+///   leaning on Tab cannot open an unbounded fan of vault queries (VTI R1.4).
+/// * **Rejected means deferred, not dropped.** The in-flight query was issued
+///   before whatever prompted this one (a lifecycle mutation, an `i` filter
+///   flip), so its result is already stale. The request is remembered in
+///   `vic_refresh_queued` and re-issued by the dispatch arm once the domain
+///   frees — silently discarding it would leave, say, a just-archived VIC
+///   rendered as active until the operator refreshed by hand.
+fn spawn_vic_refresh(
+    dispatch_tx: &tokio::sync::mpsc::UnboundedSender<background_dispatch::DispatchOutcome>,
+    in_flight: &mut background_dispatch::InFlight,
+    state: &mut State,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
+) {
+    if !begin_vic_refresh(in_flight, state, admin_vta.is_some()) {
+        return;
+    }
+    let admin_vta = admin_vta.expect("checked by begin_vic_refresh").clone();
+    let include_inactive = state.main_page.content_panel.vta.vic_show_inactive;
+    background_dispatch::spawn_dispatch(
+        dispatch_tx.clone(),
+        background_dispatch::DispatchDomain::Vic,
+        async move {
+            background_dispatch::DispatchOutcome::Vic(
+                vic::VicRefreshOutcome::run(admin_vta, include_inactive).await,
+            )
+        },
+    );
 }
 
 /// Apply a pure navigation action to `state`, shared by the runtime loop and the
@@ -3945,5 +4029,43 @@ mod tests {
             &Action::CloseCommunitySwitcher
         ));
         assert!(state.main_page.switcher.is_none());
+    }
+
+    /// The refresh guard's three outcomes.
+    ///
+    /// The middle one is the interesting one: a request that arrives while the
+    /// vault is busy is *deferred*, not dropped. The in-flight query was issued
+    /// before whatever prompted this request — a lifecycle mutation, or an `i`
+    /// filter flip — so its answer is already stale, and discarding the new
+    /// request would leave, say, a just-archived VIC rendered as active until
+    /// someone refreshed by hand.
+    #[test]
+    fn vic_refresh_guard_defers_rather_than_drops() {
+        let mut state = State::default();
+        let mut in_flight = background_dispatch::InFlight::default();
+
+        // No admin session: nothing to query, and the panel must not be left
+        // claiming a load is under way.
+        state.main_page.content_panel.vta.vic_loading = true;
+        assert!(!begin_vic_refresh(&mut in_flight, &mut state, false));
+        assert!(!state.main_page.content_panel.vta.vic_loading);
+        assert!(!in_flight.is_busy(background_dispatch::DispatchDomain::Vic));
+
+        // First request with a session: claims the domain and starts loading.
+        assert!(begin_vic_refresh(&mut in_flight, &mut state, true));
+        assert!(state.main_page.content_panel.vta.vic_loading);
+        assert!(in_flight.is_busy(background_dispatch::DispatchDomain::Vic));
+
+        // Second while that one is in flight: not started, but remembered.
+        assert!(!begin_vic_refresh(&mut in_flight, &mut state, true));
+        assert!(
+            state.main_page.content_panel.vta.vic_refresh_queued,
+            "a rejected refresh must be re-issued once the domain frees"
+        );
+
+        // Once the outcome lands the domain is free and the queued request runs.
+        in_flight.finish(background_dispatch::DispatchDomain::Vic);
+        state.main_page.content_panel.vta.vic_refresh_queued = false;
+        assert!(begin_vic_refresh(&mut in_flight, &mut state, true));
     }
 }

--- a/openvtc/src/state_handler/vic.rs
+++ b/openvtc/src/state_handler/vic.rs
@@ -11,6 +11,8 @@ use anyhow::Result;
 use vta_sdk::client::VtaClient;
 
 use crate::state_handler::main_page::content::VicSummary;
+use crate::state_handler::state::State;
+use openvtc_core::config::Config;
 
 /// Reason string stamped on lifecycle mutations (shows in the VTA audit log).
 const REASON: &str = "via OpenVTC";
@@ -79,4 +81,176 @@ pub(crate) async fn restore_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
 pub(crate) async fn purge_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
     admin_vta.cred_vault_purge(id, Some(REASON)).await?;
     Ok(())
+}
+
+// ****************************************************************************
+// Background refresh
+// ****************************************************************************
+
+/// The result of one backgrounded VIC-list refresh, carried back to the runtime
+/// loop as a [`DispatchOutcome::Vic`](crate::state_handler::background_dispatch::DispatchOutcome::Vic).
+///
+/// Data only — the job does the vault round-trip and nothing else, so every
+/// mutation still happens on the loop thread in [`Self::apply`] (the
+/// single-mutator invariant). The error is pre-formatted here because the job
+/// cannot hand an `anyhow::Error` across the channel and the loop has no way to
+/// re-derive the cause once the client is out of scope.
+pub(crate) struct VicRefreshOutcome {
+    /// The listing, or the failure text (`{e:#}`, so an anyhow cause chain
+    /// survives — R6.4: "vault unreachable" must not read like "no VICs").
+    result: Result<Vec<VicSummary>, String>,
+    /// Whether the query asked for archived/deleted entries too. Recorded so the
+    /// applied list can be discarded when the operator has flipped `i` since the
+    /// job was spawned, rather than briefly showing the wrong set.
+    include_inactive: bool,
+}
+
+impl VicRefreshOutcome {
+    /// Run the vault query. The whole body of the spawned job — no state, no
+    /// config, no mutation.
+    pub(crate) async fn run(admin_vta: VtaClient, include_inactive: bool) -> Self {
+        Self {
+            result: list_vics(&admin_vta, include_inactive)
+                .await
+                .map_err(|e| format!("{e:#}")),
+            include_inactive,
+        }
+    }
+
+    /// Apply the listing on the loop thread: swap the list in, clamp the
+    /// selection, and re-annotate issuers with their verified agent names.
+    ///
+    /// A result whose `include_inactive` no longer matches the panel is dropped:
+    /// the operator pressed `i` while it was in flight, so a fresh job for the
+    /// new filter is already queued behind this one and applying the stale set
+    /// would flash the wrong rows.
+    pub(crate) fn apply(self, state: &mut State, config: &Config) {
+        state.main_page.content_panel.vta.vic_loading = false;
+        if self.include_inactive != state.main_page.content_panel.vta.vic_show_inactive {
+            return;
+        }
+        match self.result {
+            Ok(list) => {
+                let vta = &mut state.main_page.content_panel.vta;
+                vta.vic_selected_index = vta.vic_selected_index.min(list.len().saturating_sub(1));
+                vta.vics = list.into();
+                state.main_page.sync_vic_agent_names(config);
+            }
+            Err(e) => state
+                .main_page
+                .log_error("Listing invitation credentials failed", e.as_str()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+    use crate::state_handler::main_page::content::VicLifecycle;
+
+    fn summary(id: &str) -> VicSummary {
+        VicSummary {
+            id: id.to_string(),
+            issuer: "did:webvh:example.com:vtc".to_string(),
+            issuer_agent_name: None,
+            status: "valid".to_string(),
+            lifecycle: VicLifecycle::Active,
+            valid_until: String::new(),
+        }
+    }
+
+    /// The happy path: the listing replaces the panel's list and clears the
+    /// loading flag, so the "reading the vault…" affordance can't outlive the
+    /// query that set it.
+    #[test]
+    fn apply_swaps_in_the_listing_and_clears_loading() {
+        let mut state = State::default();
+        let config = test_config();
+        state.main_page.content_panel.vta.vic_loading = true;
+
+        VicRefreshOutcome {
+            result: Ok(vec![summary("urn:vic:1"), summary("urn:vic:2")]),
+            include_inactive: false,
+        }
+        .apply(&mut state, &config);
+
+        let vta = &state.main_page.content_panel.vta;
+        assert_eq!(vta.vics.len(), 2);
+        assert!(
+            !vta.vic_loading,
+            "the loading flag must not outlive the job"
+        );
+    }
+
+    /// A selection pointing past the end of the new listing is clamped, so the
+    /// lifecycle verbs (which index into it) can't act on a row that is gone.
+    #[test]
+    fn apply_clamps_a_selection_past_the_end() {
+        let mut state = State::default();
+        let config = test_config();
+        state.main_page.content_panel.vta.vic_selected_index = 5;
+
+        VicRefreshOutcome {
+            result: Ok(vec![summary("urn:vic:1")]),
+            include_inactive: false,
+        }
+        .apply(&mut state, &config);
+
+        assert_eq!(state.main_page.content_panel.vta.vic_selected_index, 0);
+    }
+
+    /// A result for a filter the operator has since flipped is discarded rather
+    /// than flashed: `i` toggles inactive visibility, and a listing in flight
+    /// when it was pressed answers the *old* question. The refresh queued behind
+    /// it carries the right one.
+    #[test]
+    fn apply_drops_a_listing_for_a_superseded_filter() {
+        let mut state = State::default();
+        let config = test_config();
+        state.main_page.content_panel.vta.vics = vec![summary("urn:vic:keep")].into();
+        // The panel now wants inactive entries; this job asked without them.
+        state.main_page.content_panel.vta.vic_show_inactive = true;
+        state.main_page.content_panel.vta.vic_loading = true;
+
+        VicRefreshOutcome {
+            result: Ok(vec![summary("urn:vic:stale-1"), summary("urn:vic:stale-2")]),
+            include_inactive: false,
+        }
+        .apply(&mut state, &config);
+
+        let vta = &state.main_page.content_panel.vta;
+        assert_eq!(vta.vics.len(), 1, "the superseded listing must not apply");
+        assert_eq!(vta.vics[0].id, "urn:vic:keep");
+        assert!(!vta.vic_loading);
+    }
+
+    /// A failed query leaves the previous list in place and logs the reason —
+    /// the panel must not render "no invitation credentials" for a vault it
+    /// could not reach (VTI R6.4).
+    #[test]
+    fn apply_keeps_the_previous_list_on_failure() {
+        let mut state = State::default();
+        let config = test_config();
+        state.main_page.content_panel.vta.vics = vec![summary("urn:vic:1")].into();
+        state.main_page.content_panel.vta.vic_loading = true;
+
+        VicRefreshOutcome {
+            result: Err("vault unreachable: connection refused".to_string()),
+            include_inactive: false,
+        }
+        .apply(&mut state, &config);
+
+        let vta = &state.main_page.content_panel.vta;
+        assert_eq!(vta.vics.len(), 1, "a failed read must not empty the list");
+        assert!(!vta.vic_loading);
+        assert!(
+            state
+                .main_page
+                .activity_log
+                .iter()
+                .any(|e| e.summary.contains("connection refused")),
+            "the failure reason must reach the log"
+        );
+    }
 }

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -328,7 +328,7 @@ pub fn render(state: &VtaState, panel_focused: bool) -> Vec<Line<'static>> {
 /// Three states, not two: the list has the keyboard, the *other* list has it
 /// (Tab switches between them), or the content panel is not focused at all — in
 /// which case Tab does not reach these lists and the operator needs the panel
-/// first. Collapsing the last two into "[Tab] focus" pointed at the wrong key.
+/// first. Collapsing the last two into "\[Tab\] focus" pointed at the wrong key.
 fn focus_hint(focused: bool, panel_focused: bool) -> &'static str {
     match (focused, panel_focused) {
         (true, _) => "   ◀ focus",

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -31,12 +31,20 @@ impl Panel for VtaPanel {
         state: &ContentPanelState,
         _connection: &ConnectionState,
     ) -> Vec<Line<'static>> {
-        render(&state.vta)
+        render(&state.vta, state.selected)
     }
 }
 
 /// Render the VTA service information panel.
-pub fn render(state: &VtaState) -> Vec<Line<'static>> {
+///
+/// `panel_focused` is whether the *content panel* holds keyboard focus (as
+/// opposed to the menu on the left). Both lists here draw a focus affordance,
+/// and without this they drew it from `state.focus` alone — so a panel the
+/// keyboard could not reach still announced "◀ focus" and advertised its verbs.
+/// Every one of those keys is dropped in that state (content keys are only
+/// routed when the content panel is selected), which is exactly the "the key
+/// does nothing" report.
+pub fn render(state: &VtaState, panel_focused: bool) -> Vec<Line<'static>> {
     let label_style = Style::new().fg(COLOR_TEXT_DEFAULT);
     let value_style = Style::new().fg(COLOR_SOFT_PURPLE);
 
@@ -194,7 +202,7 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         // Same focus affordance the VIC section carries. Without it this list
         // showed a `▸` selection cursor and a key-hint row with no indication
         // that it was the focused list — the two lists looked equally live.
-        let focused = state.focus == VtaFocus::Dids;
+        let focused = panel_focused && state.focus == VtaFocus::Dids;
         lines.push(Line::from(""));
         lines.push(Line::from(vec![
             Span::styled(
@@ -206,11 +214,7 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
                 },
             ),
             Span::styled(
-                if focused {
-                    "   ◀ focus"
-                } else {
-                    "   [Tab] focus"
-                },
+                focus_hint(focused, panel_focused),
                 Style::new().fg(COLOR_DARK_GRAY),
             ),
         ]));
@@ -314,9 +318,23 @@ pub fn render(state: &VtaState) -> Vec<Line<'static>> {
         );
     }
 
-    render_vics(state, &mut lines);
+    render_vics(state, panel_focused, &mut lines);
 
     lines
+}
+
+/// The focus affordance for one of the two manageable lists.
+///
+/// Three states, not two: the list has the keyboard, the *other* list has it
+/// (Tab switches between them), or the content panel is not focused at all — in
+/// which case Tab does not reach these lists and the operator needs the panel
+/// first. Collapsing the last two into "[Tab] focus" pointed at the wrong key.
+fn focus_hint(focused: bool, panel_focused: bool) -> &'static str {
+    match (focused, panel_focused) {
+        (true, _) => "   ◀ focus",
+        (false, true) => "   [Tab] focus",
+        (false, false) => "   [→] focus the panel",
+    }
 }
 
 /// Push a labelled identity as one row: the verified agent name as the value,
@@ -456,8 +474,8 @@ fn render_transports(state: &VtaState, lines: &mut Vec<Line<'static>>) {
 
 /// Render the "Invitation Credentials" (VIC) manager section: the held VICs with
 /// their lifecycle state, the confirm gates, and the focus-aware key hints.
-fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
-    let focused = state.focus == VtaFocus::Vics;
+fn render_vics(state: &VtaState, panel_focused: bool, lines: &mut Vec<Line<'static>>) {
+    let focused = panel_focused && state.focus == VtaFocus::Vics;
     let header_style = if focused {
         Style::new().fg(COLOR_SUCCESS).bold()
     } else {
@@ -471,10 +489,18 @@ fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
             header_style,
         ),
         Span::styled(
-            if focused {
-                "   ◀ focus"
+            focus_hint(focused, panel_focused),
+            Style::new().fg(COLOR_DARK_GRAY),
+        ),
+        // The vault query runs off the loop now, so the list can be visibly
+        // mid-load. Saying so is the difference between "you hold no VICs" and
+        // "we haven't heard back yet" — the panel used to render both as the
+        // empty state, and the load was only ever noticed as a frozen Tab.
+        Span::styled(
+            if state.vic_loading {
+                "   loading…"
             } else {
-                "   [Tab] focus"
+                ""
             },
             Style::new().fg(COLOR_DARK_GRAY),
         ),
@@ -483,8 +509,12 @@ fn render_vics(state: &VtaState, lines: &mut Vec<Line<'static>>) {
 
     if state.vics.is_empty() {
         lines.push(
-            Line::from("No invitation credentials.   a: import a VIC   ·   i: show inactive")
-                .fg(COLOR_DARK_GRAY),
+            Line::from(if state.vic_loading {
+                "Reading the credential vault…"
+            } else {
+                "No invitation credentials.   a: import a VIC   ·   i: show inactive"
+            })
+            .fg(COLOR_DARK_GRAY),
         );
         return;
     }
@@ -658,7 +688,7 @@ mod tests {
     /// "we talk to the VTA over HTTPS".
     #[test]
     fn transport_row_names_the_transport_in_use() {
-        let out = joined(&render(&vta_managed(None)));
+        let out = joined(&render(&vta_managed(None), true));
         assert!(out.contains("Transport:"), "{out}");
         assert!(out.contains("DIDComm"), "{out}");
         assert!(out.contains("(in use)"), "{out}");
@@ -669,30 +699,36 @@ mod tests {
     /// offers only the transport we happen to be on.
     #[test]
     fn transport_row_says_checking_before_the_probe_lands() {
-        let out = joined(&render(&vta_managed(None)));
+        let out = joined(&render(&vta_managed(None), true));
         assert!(out.contains("checking"), "{out}");
     }
 
     #[test]
     fn transport_row_reports_the_other_advertised_transport() {
-        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
-            tsp_mediator_did: None,
-            mediator_did: Some(MEDIATOR_DID.to_string()),
-            rest_url: Some("https://vta.example".to_string()),
-            error: None,
-        }))));
+        let out = joined(&render(
+            &vta_managed(Some(AdvertisedTransports {
+                tsp_mediator_did: None,
+                mediator_did: Some(MEDIATOR_DID.to_string()),
+                rest_url: Some("https://vta.example".to_string()),
+                error: None,
+            })),
+            true,
+        ));
         assert!(out.contains("REST also available"), "{out}");
     }
 
     /// A VTA that advertises only the transport in use says exactly that.
     #[test]
     fn transport_row_reports_a_single_advertised_transport() {
-        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
-            tsp_mediator_did: None,
-            mediator_did: Some(MEDIATOR_DID.to_string()),
-            rest_url: None,
-            error: None,
-        }))));
+        let out = joined(&render(
+            &vta_managed(Some(AdvertisedTransports {
+                tsp_mediator_did: None,
+                mediator_did: Some(MEDIATOR_DID.to_string()),
+                rest_url: None,
+                error: None,
+            })),
+            true,
+        ));
         assert!(out.contains("only transport offered"), "{out}");
     }
 
@@ -701,12 +737,15 @@ mod tests {
     /// were offered.
     #[test]
     fn a_tsp_advertising_vta_is_not_reported_as_single_transport() {
-        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
-            tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
-            mediator_did: Some(MEDIATOR_DID.to_string()),
-            rest_url: None,
-            error: None,
-        }))));
+        let out = joined(&render(
+            &vta_managed(Some(AdvertisedTransports {
+                tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
+                mediator_did: Some(MEDIATOR_DID.to_string()),
+                rest_url: None,
+                error: None,
+            })),
+            true,
+        ));
         assert!(
             !out.contains("only transport offered"),
             "TSP is offered, so this claim is false: {out}"
@@ -719,12 +758,15 @@ mod tests {
     /// stays on DIDComm. The panel has to express that third thing (VTI R6.4).
     #[test]
     fn tsp_reads_as_carrying_the_trust_task_surface() {
-        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
-            tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
-            mediator_did: Some(MEDIATOR_DID.to_string()),
-            rest_url: None,
-            error: None,
-        }))));
+        let out = joined(&render(
+            &vta_managed(Some(AdvertisedTransports {
+                tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
+                mediator_did: Some(MEDIATOR_DID.to_string()),
+                rest_url: None,
+                error: None,
+            })),
+            true,
+        ));
         assert!(out.contains("TSP for trust tasks"), "{out}");
         assert!(
             !out.contains("TSP also available"),
@@ -740,12 +782,15 @@ mod tests {
     /// the selectable one distinct from the one we cannot speak.
     #[test]
     fn a_triple_transport_vta_reports_both_others() {
-        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
-            tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
-            mediator_did: Some(MEDIATOR_DID.to_string()),
-            rest_url: Some("https://vta.example".to_string()),
-            error: None,
-        }))));
+        let out = joined(&render(
+            &vta_managed(Some(AdvertisedTransports {
+                tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
+                mediator_did: Some(MEDIATOR_DID.to_string()),
+                rest_url: Some("https://vta.example".to_string()),
+                error: None,
+            })),
+            true,
+        ));
         assert!(out.contains("REST also available"), "{out}");
         assert!(out.contains("TSP for trust tasks"), "{out}");
     }
@@ -755,12 +800,15 @@ mod tests {
     /// offered. Both facts are true; unlabelled they read as a contradiction.
     #[test]
     fn a_configured_but_unadvertised_rest_endpoint_is_labelled_as_such() {
-        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
-            tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
-            mediator_did: Some(MEDIATOR_DID.to_string()),
-            rest_url: None,
-            error: None,
-        }))));
+        let out = joined(&render(
+            &vta_managed(Some(AdvertisedTransports {
+                tsp_mediator_did: Some(TSP_MEDIATOR_DID.to_string()),
+                mediator_did: Some(MEDIATOR_DID.to_string()),
+                rest_url: None,
+                error: None,
+            })),
+            true,
+        ));
         assert!(out.contains("REST endpoint"), "{out}");
         assert!(out.contains("(configured; not advertised)"), "{out}");
     }
@@ -778,7 +826,7 @@ mod tests {
                 error: Some("DID did not resolve".to_string()),
             })),
         ] {
-            let out = joined(&render(&state));
+            let out = joined(&render(&state, true));
             assert!(
                 !out.contains("not advertised"),
                 "we have not established that: {out}"
@@ -789,12 +837,15 @@ mod tests {
     /// When the VTA does advertise REST, the endpoint line carries no caveat.
     #[test]
     fn an_advertised_rest_endpoint_is_not_labelled() {
-        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
-            tsp_mediator_did: None,
-            mediator_did: Some(MEDIATOR_DID.to_string()),
-            rest_url: Some("https://vta.example".to_string()),
-            error: None,
-        }))));
+        let out = joined(&render(
+            &vta_managed(Some(AdvertisedTransports {
+                tsp_mediator_did: None,
+                mediator_did: Some(MEDIATOR_DID.to_string()),
+                rest_url: Some("https://vta.example".to_string()),
+                error: None,
+            })),
+            true,
+        ));
         assert!(out.contains("REST endpoint"), "{out}");
         assert!(!out.contains("not advertised"), "{out}");
     }
@@ -803,12 +854,15 @@ mod tests {
     /// an unreachable publication endpoint is not the same fact (VTI R6.4).
     #[test]
     fn a_failed_probe_reads_as_unknown_not_as_unavailable() {
-        let out = joined(&render(&vta_managed(Some(AdvertisedTransports {
-            tsp_mediator_did: None,
-            mediator_did: None,
-            rest_url: None,
-            error: Some("DID did not resolve".to_string()),
-        }))));
+        let out = joined(&render(
+            &vta_managed(Some(AdvertisedTransports {
+                tsp_mediator_did: None,
+                mediator_did: None,
+                rest_url: None,
+                error: Some("DID did not resolve".to_string()),
+            })),
+            true,
+        ));
         assert!(out.contains("other transports unknown"), "{out}");
         assert!(
             out.contains("DID did not resolve"),
@@ -824,7 +878,7 @@ mod tests {
     /// label said nothing about that.
     #[test]
     fn the_credential_row_says_what_the_credential_is_for() {
-        let out = joined(&render(&vta_managed(None)));
+        let out = joined(&render(&vta_managed(None), true));
         assert!(out.contains("Authenticated:"), "{out}");
     }
 
@@ -836,7 +890,7 @@ mod tests {
     fn an_identity_row_leads_with_the_name_and_keeps_the_did_below() {
         let mut state = vta_managed(None);
         state.persona_agent_name = Some("example.com/@alice".to_string());
-        let out = text(&render(&state));
+        let out = text(&render(&state, true));
 
         let name_row = out
             .iter()
@@ -856,7 +910,7 @@ mod tests {
     /// With no verified name the DID is the value and there is no second line.
     #[test]
     fn an_identity_row_without_a_name_shows_only_the_did() {
-        let out = text(&render(&vta_managed(None)));
+        let out = text(&render(&vta_managed(None), true));
         let rows: Vec<_> = out.iter().filter(|l| l.contains(PERSONA_DID)).collect();
         assert_eq!(rows.len(), 1, "DID appears once: {out:?}");
         assert!(rows[0].contains("Persona:"), "{rows:?}");
@@ -875,7 +929,7 @@ mod tests {
             label: "Persona".to_string(),
         }]
         .into();
-        let out = joined(&render(&state));
+        let out = joined(&render(&state, true));
         assert!(!out.contains("Active DIDs"), "{out}");
     }
 
@@ -897,7 +951,7 @@ mod tests {
             },
         ]
         .into();
-        let out = joined(&render(&state));
+        let out = joined(&render(&state, true));
         assert!(out.contains("Active DIDs (2)"), "{out}");
     }
 
@@ -910,7 +964,7 @@ mod tests {
         let mut state = state_with(vec![managed_did(None)], vec![vic(None)]);
 
         state.focus = VtaFocus::Dids;
-        let focused = joined(&render(&state));
+        let focused = joined(&render(&state, true));
         assert!(
             focused.contains("Context Identities (1)   ◀ focus"),
             "{focused}"
@@ -922,7 +976,7 @@ mod tests {
         assert!(focused.contains("n: new persona"), "{focused}");
 
         state.focus = VtaFocus::Vics;
-        let unfocused = joined(&render(&state));
+        let unfocused = joined(&render(&state, true));
         assert!(
             unfocused.contains("Context Identities (1)   [Tab] focus"),
             "{unfocused}"
@@ -933,14 +987,60 @@ mod tests {
         );
     }
 
+    /// With the content panel itself unfocused, neither list may claim the
+    /// keyboard. Both lists used to draw their affordance from `state.focus`
+    /// alone, so a panel whose keys are all discarded still announced "◀ focus"
+    /// and advertised `g` / `n` / `d` — the shortest path to "I pressed the key
+    /// and nothing happened".
+    #[test]
+    fn an_unfocused_panel_points_at_the_panel_not_the_lists() {
+        let mut state = state_with(vec![managed_did(None)], vec![vic(None)]);
+        state.focus = VtaFocus::Dids;
+
+        let out = joined(&render(&state, false));
+        assert!(
+            !out.contains("◀ focus"),
+            "no list has the keyboard when the panel does not: {out}"
+        );
+        assert!(
+            !out.contains("[Tab] focus"),
+            "Tab is not the key that helps here: {out}"
+        );
+        assert!(out.contains("[→] focus the panel"), "{out}");
+        assert!(
+            !out.contains("n: new persona"),
+            "hints belong to a list the keyboard can reach: {out}"
+        );
+    }
+
+    /// An in-flight vault query is visible. "No invitation credentials" is a
+    /// claim about the vault, and it can only be made once the vault answers —
+    /// before this the load was inline, so the panel simply froze instead.
+    #[test]
+    fn a_loading_vic_list_says_so_instead_of_claiming_none() {
+        let mut state = state_with(vec![managed_did(None)], vec![]);
+        state.vic_loading = true;
+
+        let out = joined(&render(&state, true));
+        assert!(out.contains("Reading the credential vault…"), "{out}");
+        assert!(
+            !out.contains("No invitation credentials."),
+            "an unanswered vault is not an empty one: {out}"
+        );
+
+        state.vic_loading = false;
+        let settled = joined(&render(&state, true));
+        assert!(settled.contains("No invitation credentials."), "{settled}");
+    }
+
     // --- VIC issuer ---------------------------------------------------------
 
     #[test]
     fn vic_row_shows_the_issuers_verified_agent_name() {
-        let out = text(&render(&state_with(
-            vec![],
-            vec![vic(Some("example.com/@acme"))],
-        )));
+        let out = text(&render(
+            &state_with(vec![], vec![vic(Some("example.com/@acme"))]),
+            true,
+        ));
         assert!(
             out.iter().any(|l| l.contains("example.com/@acme")),
             "issuer name is shown: {out:?}"
@@ -954,7 +1054,7 @@ mod tests {
     /// A cached negative lookup arrives as `None`, so the row keeps the DID.
     #[test]
     fn vic_row_without_a_name_keeps_the_issuer_did() {
-        let out = text(&render(&state_with(vec![], vec![vic(None)])));
+        let out = text(&render(&state_with(vec![], vec![vic(None)]), true));
         assert!(
             out.iter().any(|l| l.contains(VTC_DID)),
             "issuer DID is shown: {out:?}"
@@ -969,7 +1069,7 @@ mod tests {
     fn delete_confirm_keeps_both_the_name_and_the_did() {
         let mut state = state_with(vec![managed_did(Some("example.com/@alice"))], vec![]);
         state.confirm_delete_did = Some(0);
-        let out = text(&render(&state));
+        let out = text(&render(&state, true));
 
         let prompt = out
             .iter()
@@ -988,7 +1088,7 @@ mod tests {
     fn delete_confirm_without_a_name_shows_the_did() {
         let mut state = state_with(vec![managed_did(None)], vec![]);
         state.confirm_delete_did = Some(0);
-        let out = text(&render(&state));
+        let out = text(&render(&state, true));
 
         let prompt = out
             .iter()

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -408,11 +408,16 @@ impl MainPage {
         // Keys that apply regardless of which list has focus.
         match key.code {
             KeyCode::Tab => {
-                // Switching to the VIC list loads it on demand (no polling).
+                // Focus moves first, then the VIC list is loaded on demand (no
+                // polling). Order matters: the handler services actions in
+                // sequence, so sending the load first put a vault round-trip in
+                // front of a pure in-memory focus change. The load is off the
+                // loop now, but the focus change still goes first — it is what
+                // the operator pressed the key for.
+                let _ = self.action_tx.send(Action::VicFocusToggle);
                 if focus == VtaFocus::Dids {
                     let _ = self.action_tx.send(Action::VicRefresh);
                 }
-                let _ = self.action_tx.send(Action::VicFocusToggle);
                 return true;
             }
             KeyCode::Char('n') => {
@@ -426,6 +431,19 @@ impl MainPage {
             }
             KeyCode::Char('i') => {
                 let _ = self.action_tx.send(Action::VicToggleInactive);
+                return true;
+            }
+            // Manage the selected persona's agent names (claim / park / remove).
+            // Deliberately focus-independent, alongside `n` and `a`: while this
+            // sat in the DID-list arm, pressing it with the VIC list focused was
+            // swallowed with no message and no state change — indistinguishable
+            // from a dead keyboard, and the reported symptom that sent someone
+            // restarting the app. The selection it acts on is the DID list's,
+            // which Tab does not move.
+            KeyCode::Char('g') => {
+                let _ = self
+                    .action_tx
+                    .send(Action::StartAgentNameManager(did_selected));
                 return true;
             }
             KeyCode::Esc => {
@@ -461,13 +479,6 @@ impl MainPage {
                     {
                         let _ = self.action_tx.send(Action::DidConfirmDelete(did_selected));
                     }
-                    true
-                }
-                KeyCode::Char('g') if did_selected < did_count => {
-                    // Manage this persona's agent names (claim / park / remove).
-                    let _ = self
-                        .action_tx
-                        .send(Action::StartAgentNameManager(did_selected));
                     true
                 }
                 _ => false,
@@ -2518,10 +2529,19 @@ impl MainPage {
             }
             AgentNameManagerPhase::Ready | AgentNameManagerPhase::Working => {
                 if overlay.names.is_empty() {
-                    lines.push(Line::from(Span::styled(
-                        "No agent names yet.",
-                        Style::new().fg(COLOR_DARK_GRAY),
-                    )));
+                    // "No agent names yet" is a claim about the registry, and we
+                    // can only make it when the registry actually answered. With
+                    // a failed read it is not just unknown but likely wrong —
+                    // the read that failed is the one *after* a successful claim.
+                    let (text, style) = if overlay.list_stale {
+                        (
+                            "Registry could not be read — any names on this DID are not shown.",
+                            Style::new().fg(COLOR_ORANGE),
+                        )
+                    } else {
+                        ("No agent names yet.", Style::new().fg(COLOR_DARK_GRAY))
+                    };
+                    lines.push(Line::from(Span::styled(text, style)));
                 } else {
                     for (i, row) in overlay.names.iter().enumerate() {
                         let marker = if i == overlay.selected { "▸ " } else { "  " };
@@ -3262,6 +3282,31 @@ mod key_handler_tests {
         }
     }
 
+    /// `g` works with either list focused. It used to live in the DID-list arm,
+    /// so pressing it after a Tab was swallowed silently — no action, no state
+    /// change, no message. The selection it acts on is the DID list's, which Tab
+    /// does not move, so the target is unambiguous either way.
+    #[test]
+    fn vta_g_opens_agent_name_manager_from_the_vic_list_too() {
+        use crate::state_handler::main_page::content::{ManagedDid, VtaFocus};
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
+            s.main_page.content_panel.vta.context_dids = vec![ManagedDid {
+                did: "did:webvh:example.com:alice".into(),
+                agent_name: None,
+                label: "Alice".into(),
+                bound_communities: 1,
+                is_active: true,
+            }]
+            .into();
+            s.main_page.content_panel.vta.focus = VtaFocus::Vics;
+        });
+        page.handle_key_event(press(KeyCode::Char('g')));
+        match rx.try_recv() {
+            Ok(Action::StartAgentNameManager(0)) => {}
+            _ => panic!("expected StartAgentNameManager(0)"),
+        }
+    }
+
     #[test]
     fn agent_name_manager_ready_keys_map_to_actions() {
         use crate::state_handler::main_page::content::{
@@ -3487,18 +3532,35 @@ mod key_handler_tests {
     }
 
     #[test]
-    fn vta_tab_refreshes_then_toggles_focus() {
-        // From the default (Dids) focus, Tab loads the VIC list, then switches.
+    fn vta_tab_toggles_focus_before_refreshing() {
+        // From the default (Dids) focus, Tab switches lists *first*, then asks
+        // for the VIC listing. The reverse order (what this asserted before) put
+        // a credential-vault round-trip in front of the focus change in the
+        // handler's serial queue, so Tab visibly lagged by the length of a
+        // network call.
         let (mut page, mut rx) = page_for(MainMenu::Vta, |_| {});
         page.handle_key_event(press(KeyCode::Tab));
         match rx.try_recv() {
-            Ok(Action::VicRefresh) => {}
-            _ => panic!("expected VicRefresh first"),
+            Ok(Action::VicFocusToggle) => {}
+            _ => panic!("focus must move first, before any VIC listing"),
         }
         match rx.try_recv() {
-            Ok(Action::VicFocusToggle) => {}
-            _ => panic!("expected VicFocusToggle"),
+            Ok(Action::VicRefresh) => {}
+            _ => panic!("expected VicRefresh second"),
         }
+    }
+
+    /// Tab back off the VIC list does not re-list: the listing is loaded on
+    /// demand when the list is entered, not on every focus change.
+    #[test]
+    fn vta_tab_off_the_vic_list_does_not_refresh() {
+        use crate::state_handler::main_page::content::VtaFocus;
+        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
+            s.main_page.content_panel.vta.focus = VtaFocus::Vics;
+        });
+        page.handle_key_event(press(KeyCode::Tab));
+        assert!(matches!(rx.try_recv(), Ok(Action::VicFocusToggle)));
+        assert!(rx.try_recv().is_err(), "no second action expected");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Two ways the VTA Service panel looked broken, both rooted in the state-handler loop servicing actions serially with inline `.await`s.

**Tab lagged by a network round-trip.** The Tab handler sent `VicRefresh` and *then* `VicFocusToggle`. `refresh_vics` awaited `cred_vault_query` inline — a trust task with a 30 s SDK timeout — so the focus change, a two-line in-memory mutation, could not be applied until the vault answered. The delay was invisible and asymmetric: Tab back off the VIC list sends no refresh and was always instant.

**`g` did nothing at all, for three independent reasons** — and a restart "fixed" each one differently, which is what made the report so hard to pin down:

* It lived in the DID-list focus arm, so pressing it with the VIC list focused was swallowed with no action, no state change and no message.
* `did_selected_index` was never clamped when the persona list was rebuilt. Every list-scoped key is guarded on `did_selected < did_count`, so a stale index disabled them all while drawing no cursor to show why. Restarting worked because the index starts at 0.
* Both lists drew their focus affordance from `state.focus` alone, so a panel the keyboard could not reach still announced "◀ focus" and advertised its verbs — while every one of those keys was discarded (content keys are only routed when the content panel is selected).

## Fix

The listing runs as a background dispatch (`DispatchDomain::Vic`), so the loop only starts it: focus moves on the next frame and the list fills in when it lands. **Both** loops get it — the degraded (State-A) loop gains a dispatch channel of its own, because an account with no community lives on this screen and shouldn't be the one that feels slow.

`spawn_vic_refresh` now owns every load, so the mutation paths no longer re-list inline and no stale in-flight result can overwrite a fresh one. Two ordering rules fall out of that:

* A request arriving while the vault is busy is **deferred, not dropped**. The in-flight query predates whatever prompted the new one, so discarding it would leave a just-archived VIC rendered as active until someone refreshed by hand.
* A listing whose `include_inactive` no longer matches the panel is discarded on arrival — `i` was pressed while it was in flight, and the refresh queued behind it carries the right question.

The panel says when a query is in flight. "No invitation credentials" is a claim about the vault and can only be made once the vault answers.

`g` moves up to the focus-independent keys beside `n` and `a` (the selection it acts on is the DID list's, which Tab does not move), the persona selection is clamped on every sync, and the focus affordance now distinguishes three states rather than two — including "the panel itself isn't focused", where it points at the key that actually helps.

Finally, a claim that succeeds and a reload that then fails no longer renders "No agent names yet." above "Applied, but could not reload the list" — the prominent half said the opposite of what happened, for a name the DID document already carried. The overlay marks the registry unknown instead. (The underlying reload failure is a VTA-side contract skew, fixed separately in `verifiable-trust-infrastructure`: OpenVTC needs no dependency change for it.)

## Tests

* Refresh-outcome apply: swaps the listing in and clears the loading flag; clamps a selection past the end; drops a listing for a superseded filter; a failed query keeps the previous list and logs the reason.
* The defer-don't-drop guard across all three outcomes (no session / free / busy).
* The persona-selection clamp on sync.
* `g` from either list; Tab ordering in both directions.
* The panel's unfocused affordance and its loading state.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace` — all green.

## Not covered

The agent-name manager's own list still runs inline on the loop (60 s timeout). It shows a Loading overlay, so it is visible rather than mysterious, but it still parks the loop while it runs.
