### PR TITLE
fix(logs): identify the listener behind a lifecycle line, not just its name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   — the prominent half saying the opposite of what had happened, for a name the
   DID document already carried. A registry that could not be read is now shown
   as unknown rather than empty.
+- **Listener log lines identify the listener, not just its name.** A name is not
+  an identity: aliases and verified agent names are many-to-one, and a
+  relationship R-DID resolves through to its peer's name — so two different
+  listeners could produce byte-identical activity-log lines. Once names resolved
+  a few minutes after launch, a log that had been readable as distinct listeners
+  collapsed into one repeated name, and "one listener reconnecting in a loop"
+  became indistinguishable from "several reconnecting on their own schedules".
+  Every line that names a listener now carries the listener id it resolved from
+  — abbreviated beside the name, in full behind `Enter` — because the id is what
+  correlates with the mediator's own logs.
+- **A disconnect with no transport error says so.** It rendered as a bare
+  "disconnected", identical to a drop whose cause was simply not captured, so a
+  socket that closed cleanly and one that was lost for unknown reasons read the
+  same.
 
 - **A pasted invitation now fills in the community it is for, and Enter says
   something either way.** On the join entry page a pasted VIC was routed to the

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -65,42 +65,106 @@ pub(crate) fn community_label(
 /// used as an identity — it is a map key for cycling detection and reconnect
 /// matching, and DIDs sharing a trailing path segment across hosts would
 /// collide if it were shortened.
+/// A lifecycle line for the activity log: what the operator reads, plus the
+/// diagnostic detail behind `Enter`.
+pub(crate) struct LifecycleLine {
+    /// The one-line summary.
+    pub summary: String,
+    /// Identifying detail, when there is a listener to identify.
+    pub detail: Option<String>,
+}
+
+/// Render a listener lifecycle event for the activity log.
+///
+/// The summary names the listener the way the rest of the UI names identities —
+/// alias, else verified agent name, else truncated DID — but a name **alone is
+/// not an identity**. `resolve_did_to_display` is many-to-one: an alias or an
+/// agent name can stand for more than one listener, and a relationship R-DID
+/// resolves through to its peer's name. Two different listeners could therefore
+/// produce byte-identical lines, and did: a report of one listener "cycling"
+/// turned out to be indistinguishable, on screen, from several listeners
+/// reconnecting on their own schedules.
+///
+/// So every line that names a listener also carries the listener id it resolved
+/// from — abbreviated in the summary when a name was substituted, in full in the
+/// detail. The id is what correlates with the mediator's logs; the name is only
+/// what makes the line readable.
 pub(crate) fn format_lifecycle_log(
     config: &openvtc_core::config::Config,
     event: &didcomm::LifecycleLog,
-) -> String {
+) -> LifecycleLine {
     use didcomm::LifecycleLog;
-    match event {
-        LifecycleLog::Connected { listener_id } => {
-            format!(
-                "Listener '{}' connected",
-                resolve_did_to_display(config, listener_id)
-            )
+
+    /// `'name' (did:webvh:Qm…)` — the parenthetical only when a name was
+    /// actually substituted, so an unnamed listener is not printed twice.
+    fn who(config: &openvtc_core::config::Config, listener_id: &str) -> String {
+        let display = resolve_did_to_display(config, listener_id);
+        let truncated = log_did(listener_id);
+        if display == truncated {
+            format!("'{display}'")
+        } else {
+            format!("'{display}' ({truncated})")
         }
+    }
+
+    fn detail_for(config: &openvtc_core::config::Config, listener_id: &str) -> String {
+        format!(
+            "listener id: {listener_id}\ndisplayed as: {}",
+            resolve_did_to_display(config, listener_id)
+        )
+    }
+
+    match event {
+        LifecycleLog::Connected { listener_id } => LifecycleLine {
+            summary: format!("Listener {} connected", who(config, listener_id)),
+            detail: Some(detail_for(config, listener_id)),
+        },
         LifecycleLog::Disconnected { listener_id, error } => {
-            let who = resolve_did_to_display(config, listener_id);
-            match error {
-                Some(e) => format!("Listener '{who}' disconnected: {e}"),
-                None => format!("Listener '{who}' disconnected"),
+            // An absent error is not the same as an unexplained drop, and the
+            // line used to render both as a bare "disconnected". Saying which
+            // one it was is the difference between "the peer closed the socket"
+            // and "we lost it and do not know why" (VTI R6.4).
+            let reason = match error {
+                Some(e) => format!(": {e}"),
+                None => " (no transport error reported)".to_string(),
+            };
+            LifecycleLine {
+                summary: format!("Listener {} disconnected{reason}", who(config, listener_id)),
+                detail: Some(match error {
+                    Some(e) => format!("{}\nerror: {e}", detail_for(config, listener_id)),
+                    None => format!(
+                        "{}\nerror: none reported — the connection closed without a transport \
+                         error",
+                        detail_for(config, listener_id)
+                    ),
+                }),
             }
         }
-        LifecycleLog::CyclingRapidly { listener_id } => {
-            format!(
-                "WARNING: Listener '{}' cycling rapidly — possible duplicate connection",
-                resolve_did_to_display(config, listener_id)
-            )
-        }
+        LifecycleLog::CyclingRapidly { listener_id } => LifecycleLine {
+            summary: format!(
+                "WARNING: Listener {} cycling rapidly — possible duplicate connection",
+                who(config, listener_id)
+            ),
+            detail: Some(format!(
+                "{}\nthis listener dropped twice within the cycling window",
+                detail_for(config, listener_id)
+            )),
+        },
         LifecycleLog::Restarting {
             listener_id,
             attempt,
             delay,
-        } => {
-            format!(
-                "Listener '{}' restarting (attempt {attempt}, backoff {delay:?})",
-                resolve_did_to_display(config, listener_id)
-            )
-        }
-        LifecycleLog::Missed { count } => format!("Missed {count} lifecycle event(s)"),
+        } => LifecycleLine {
+            summary: format!(
+                "Listener {} restarting (attempt {attempt}, backoff {delay:?})",
+                who(config, listener_id)
+            ),
+            detail: Some(detail_for(config, listener_id)),
+        },
+        LifecycleLog::Missed { count } => LifecycleLine {
+            summary: format!("Missed {count} lifecycle event(s)"),
+            detail: None,
+        },
     }
 }
 
@@ -1834,7 +1898,11 @@ impl StateHandler {
                 Some(event) = lifecycle_log_rx.recv() => {
                     // Formatted here, not in the logger task: naming a listener
                     // needs `config`, which only this thread holds.
-                    state.main_page.log(format_lifecycle_log(&config, &event));
+                    let line = format_lifecycle_log(&config, &event);
+                    match line.detail {
+                        Some(detail) => state.main_page.log_detailed(line.summary, detail),
+                        None => state.main_page.log(line.summary),
+                    }
                 },
                 // Typed listener lifecycle events → drive the connection status
                 // asynchronously (phase 2). The persona listener connecting flips
@@ -3666,11 +3734,12 @@ mod tests {
         assert!(!must_hand_off(true, true, false));
     }
 
-    /// Lifecycle log lines name the listener by its verified agent name. These
-    /// showed raw `did:webvh:` strings because the logger task is detached and
-    /// has no `Config` to resolve with.
+    /// Lifecycle log lines name the listener by its verified agent name — and
+    /// carry the listener id it resolved from, because a name is not an
+    /// identity: `resolve_did_to_display` is many-to-one, so without the id two
+    /// different listeners can produce byte-identical lines.
     #[test]
-    fn lifecycle_log_shows_the_verified_agent_name() {
+    fn lifecycle_log_shows_the_agent_name_and_the_listener_id() {
         const DID: &str = "did:webvh:QmScidAAAAAAAAAAAAAAAAAAAAAAAA:webvh.storm.ws:magic-depart";
 
         let mut config = crate::state_handler::dispatch_util::test_config();
@@ -3686,7 +3755,22 @@ mod tests {
                 listener_id: DID.to_string(),
             },
         );
-        assert_eq!(line, "Listener 'webvh.storm.ws/@magic-depart' connected");
+        assert!(
+            line.summary.contains("'webvh.storm.ws/@magic-depart'"),
+            "{}",
+            line.summary
+        );
+        assert!(
+            line.summary.contains("did:webvh:QmScid"),
+            "the name must not be the only identifier: {}",
+            line.summary
+        );
+        assert!(line.summary.ends_with(" connected"), "{}", line.summary);
+        assert!(
+            line.detail.as_deref().is_some_and(|d| d.contains(DID)),
+            "the full id belongs in the detail: {:?}",
+            line.detail
+        );
 
         // The error detail survives, alongside the resolved name.
         let line = format_lifecycle_log(
@@ -3696,9 +3780,78 @@ mod tests {
                 error: Some("connection reset".into()),
             },
         );
-        assert_eq!(
-            line,
-            "Listener 'webvh.storm.ws/@magic-depart' disconnected: connection reset"
+        assert!(
+            line.summary.ends_with("disconnected: connection reset"),
+            "{}",
+            line.summary
+        );
+    }
+
+    /// Two listeners that render under the same name still produce
+    /// distinguishable lines. This is the reported failure: a relationship
+    /// R-DID resolves through to its peer's agent name, so a persona and an
+    /// R-DID pointed at that same peer both read as `host/@name` — and a log
+    /// full of one name gives no way to tell one listener reconnecting in a
+    /// loop from several reconnecting on their own schedules.
+    #[test]
+    fn two_listeners_sharing_a_name_are_still_told_apart() {
+        const PERSONA: &str = "did:webvh:QmScidAAAAAAAAAAAAAAAAAAAAAAAA:example.com:alice";
+        const OTHER: &str = "did:webvh:QmScidZZZZZZZZZZZZZZZZZZZZZZZZ:example.com:alice-two";
+
+        let mut config = crate::state_handler::dispatch_util::test_config();
+        let now = chrono::Utc::now();
+        config.set_cached_agent_name(PERSONA, Some("example.com/@alice".into()), now);
+        config.set_cached_agent_name(OTHER, Some("example.com/@alice".into()), now);
+
+        let one = format_lifecycle_log(
+            &config,
+            &didcomm::LifecycleLog::Disconnected {
+                listener_id: PERSONA.to_string(),
+                error: None,
+            },
+        );
+        let two = format_lifecycle_log(
+            &config,
+            &didcomm::LifecycleLog::Disconnected {
+                listener_id: OTHER.to_string(),
+                error: None,
+            },
+        );
+
+        assert_ne!(
+            one.summary, two.summary,
+            "distinct listeners must not render identically"
+        );
+        assert_ne!(one.detail, two.detail);
+    }
+
+    /// A drop with no transport error is reported as such. It used to render as
+    /// a bare "disconnected", identical to a drop whose error was simply not
+    /// captured — so "the socket closed cleanly" and "we lost it and cannot say
+    /// why" were the same line.
+    #[test]
+    fn a_drop_without_an_error_says_so() {
+        const DID: &str = "did:webvh:QmScidCCCCCCCCCCCCCCCCCCCCCCCC:example.com:quiet";
+        let config = crate::state_handler::dispatch_util::test_config();
+
+        let line = format_lifecycle_log(
+            &config,
+            &didcomm::LifecycleLog::Disconnected {
+                listener_id: DID.to_string(),
+                error: None,
+            },
+        );
+        assert!(
+            line.summary.contains("no transport error reported"),
+            "{}",
+            line.summary
+        );
+        assert!(
+            line.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("none reported")),
+            "{:?}",
+            line.detail
         );
     }
 
@@ -3714,17 +3867,23 @@ mod tests {
             &didcomm::LifecycleLog::Connected {
                 listener_id: DID.to_string(),
             },
-        );
+        )
+        .summary;
         assert!(line.starts_with("Listener '"), "{line}");
         assert!(line.ends_with("' connected"), "{line}");
         assert!(
             !line.contains("@"),
             "no name exists, so none may appear: {line}"
         );
+        // With no name substituted there is nothing to disambiguate, so the id
+        // is not repeated in parentheses.
+        assert!(!line.contains(") connected"), "id printed twice: {line}");
 
-        assert_eq!(
-            format_lifecycle_log(&config, &didcomm::LifecycleLog::Missed { count: 3 }),
-            "Missed 3 lifecycle event(s)"
+        let missed = format_lifecycle_log(&config, &didcomm::LifecycleLog::Missed { count: 3 });
+        assert_eq!(missed.summary, "Missed 3 lifecycle event(s)");
+        assert!(
+            missed.detail.is_none(),
+            "a lagged-stream notice identifies no listener"
         );
     }
 


### PR DESCRIPTION
## Problem

A report of a listener connecting and disconnecting repeatedly, with an activity log in which every line reads:

```
[11:49:28] Listener 'dids.firstperson.dev/@geoffturk' connected
[11:49:28] WARNING: Listener 'dids.firstperson.dev/@geoffturk' cycling rapidl…
[11:49:28] Listener 'dids.firstperson.dev/@geoffturk' disconnected
[11:49:22] Listener 'dids.firstperson.dev/@geoffturk' connected
…
[11:04:33] Listener 'did:webvh:Qmaye5WLSxpCXraiu...' connected
```

Nothing in that log can say whether it is one listener cycling or several reconnecting independently, because the lines carry no identity — only a name.

**A name is not an identity.** `resolve_did_to_display` is many-to-one by construction: a contact alias or a verified agent name can stand for more than one DID, and a relationship R-DID deliberately resolves *through* to its peer's persona name. Two distinct listeners can render byte-identically.

It also changes under the reader. A listener that comes up before the background agent-name sweep lands is logged as a truncated DID, and minutes later as a name — visible in the log above, where the same listener appears as a DID at 11:04:33 and as a name from 11:16 on. The log appears to switch subject exactly when the sweep completes, which reads as *"this started when we began using an agent name"*.

## Fix

Every line that names a listener now carries the id it resolved from — abbreviated beside the name in the summary, in full in the detail behind `Enter`, alongside what it displayed as. The parenthetical is added only when a name was actually substituted, so an unnamed listener is not printed twice. `format_lifecycle_log` returns a summary/detail pair rather than a `String`.

A disconnect carrying no transport error now says "no transport error reported" rather than rendering as a bare "disconnected" — which was identical to a drop whose cause simply was not captured. Telling a clean close from an unexplained loss is the distinction R6.4 asks for.

**This changes what the log can tell you. It changes no connection behaviour.**

## On the underlying churn

Worth stating plainly, because this PR does not address it and should not be read as if it does:

* **Agent names are not in the connection path.** Every use of `Config::agent_name_for` is display-only — panels, log lines, join summaries. Nothing keys a transport, listener, session or identity by name, so resolving one cannot cause a reconnect.
* **The cadence does not match the agent-name sweep.** The sweep ticks every 300 s and only re-resolves entries past `AGENT_NAME_TTL` (24 h), so after the first successful lookup a DID is not touched again for a day. In the reported log, drops cluster on a **~14 min 58 s** period (11:16:33 → 11:31:31 → 11:46:29, and the same spacing for the other two phases), each cluster being a short burst of 2–3 drop/reconnect pairs that then settles. A ~15-minute period is the mediator access-token lifetime, not anything in this repo.
* The two `cycling rapidly` warnings correspond to same-id drops 7 s apart, inside the 10 s `CYCLING_WINDOW`.

So the likely subject is reconnect-on-token-refresh in the messaging layer, and the next step is a debug log (`OPENVTC_DEBUG_LOG`) covering one full cluster — the `checking auth expiry` lines will confirm or kill it. This PR is what makes that log interpretable: with ids on every line, "one listener burst-reconnecting every 15 minutes" and "three listeners on staggered schedules" stop looking the same.

## Tests

The name and the id both appear in the summary and the full id in the detail; two listeners sharing a name render differently in both; an unnamed listener does not repeat its id; a no-error drop says so; a lagged-stream notice still identifies no listener.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo doc --workspace --no-deps` (no warnings); `cargo test --workspace` — all green.

Note: **Cargo Deny** will fail here as it does on main and on #230 — RUSTSEC-2026-0258 (h2 < 0.4.16), published after these branches were cut and unrelated to any of them.
