### PR TITLE
chore(deps): take the TDK auth fix (tdk-common 0.6.8, did-auth 0.3.11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-authentication"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c566099c0d490d74c836d1008eabb2da3bafc0acd9653d802893893134e91bff"
+checksum = "6baa61c2753f158f246e9b5b5c15d2ec989c8694e7ab550bee817db8d776ade8"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b84deea82515fc558c7c663986060b227b7604612e48fe31ce8cde688fc3ed"
+checksum = "0f0bb62312c455dce9dc7e4899bacecea4b0abb2bb2b11f4b2269d85dcfbd630"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",


### PR DESCRIPTION
Picks up [affinidi-tdk-rs#716](https://github.com/affinidi/affinidi-tdk-rs/pull/716), which stops a proactive token refresh from silently doing nothing.

## What it fixes

The websocket transport refreshes at 80% of the access token's life and rebuilds the socket to carry the new token. The refresh was a no-op — the `force_refresh` intent was dropped before the code that acts on it — so each rebuild re-armed the deadline at 80% of the time *remaining*. On a 900 s token, per profile:

```
T-180s   teardown + reconnect, token unchanged
T-36s    teardown + reconnect, token unchanged
T-7s     teardown + reconnect, token unchanged
expired  teardown + reconnect, token finally refreshed
```

Four teardowns per token per profile instead of one, the last two close enough together to trip our own `cycling rapidly` warning. That is the churn behind the "listeners keep connecting and disconnecting" reports — captured from a live mediator in two separate hour-long debug logs.

## Scope

Lockfile only, and only those two crates. **No manifest change is needed:** `affinidi-messaging-sdk` requires `affinidi-tdk-common = "0.6"`, and that caret already admits 0.6.8, which in turn pins `affinidi-did-authentication` 0.3.11.

The entries are edited in place rather than re-resolved. `cargo update -p affinidi-tdk-common` produces the same two upgrades *plus* 15 unrelated lines — 13 `windows-sys` references, `syn` and `base64` re-selected while the lockfile is rewritten — none of which this bump requires. `cargo metadata` accepts the edited file without rewriting it, so this is what cargo itself would resolve.

## Why the lockfile is the delivery mechanism

We commit `Cargo.lock`, so until this lands, anyone who pulls and rebuilds gets the old auth crates **however recently they ran `cargo update`** — cargo honours the lock. This is exactly what bit a user testing the fix: crates.io had 0.3.11/0.6.8 four hours before their run, they updated and rebuilt, and the flapping was unchanged.

To check any binary directly, without reasoning about lockfiles or which build got launched:

```bash
strings <openvtc-binary> | grep -c "still valid, but a refresh was requested"
```

`1` means the fix is compiled in; `0` means it is not. That string exists only in did-auth 0.3.11.

## Gate

`cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace`; `cargo deny check` — all green.
