### PR TITLE
fix(startup): bring listeners up off the loop, so Enter is not ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The main page appears as soon as you press Enter on the loading screen.**
+  Startup brought every DIDComm listener up — a mediator authentication
+  handshake and a websocket connect each, one after another — on the
+  state-handler thread, which is the only thread that services UI actions. The
+  loading screen had already been told to offer "Press Enter to continue", so
+  the keypress sat unread in the action channel until the last socket was up,
+  and the main page then arrived in one late jump. It reads as a freeze, and it
+  got worse with every extra identity on the account. The connects now happen
+  off that thread, which is what the code around them already claimed ("Phase 2
+  … runs ASYNCHRONOUSLY: we do NOT block the UI waiting for the listener").
+
 - **The VTA Service panel stops feeling frozen.** Tab into the Invitation
   Credentials list ran a credential-vault query *before* the focus change, and
   the state handler services actions one at a time — so a two-line in-memory

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -1747,7 +1747,16 @@ pub fn start_empty_service(
 /// panel reports per-listener state, so a missing one is visible rather than
 /// silent, and `reconnect_persona_listener_io` is the recovery path.
 pub async fn install_listeners(service: &Messaging, config: &Config, tdk: &affinidi_tdk::TDK) {
-    for spec in build_listener_configs(config, tdk).await {
+    connect_listeners(service, build_listener_configs(config, tdk).await).await;
+}
+
+/// Bring up each spec's listener, skipping any already installed.
+///
+/// Split from [`install_listeners`] so a caller that cannot hold `Config`
+/// across an await — it is not `Clone` — can still do this part off its own
+/// thread. See [`spawn_install_listeners`].
+pub async fn connect_listeners(service: &Messaging, specs: Vec<ListenerSpec>) {
+    for spec in specs {
         if service.has_listener(&spec.id).await {
             continue;
         }
@@ -1759,6 +1768,41 @@ pub async fn install_listeners(service: &Messaging, config: &Config, tdk: &affin
             );
         }
     }
+}
+
+/// Bring the listeners up in the background, logging what came up.
+///
+/// Each listener costs a mediator authentication handshake and a websocket
+/// connect, and they are installed one after another — so on an account with
+/// several identities this is seconds of network, not microseconds. Startup ran
+/// it inline on the state-handler thread, which is the only thread that services
+/// UI actions: the loading screen offered "Press Enter to continue" and then
+/// ignored the keypress until every socket was up. The Enter was not lost — it
+/// sat in the action channel — so the main page arrived in one late jump, which
+/// reads as a freeze.
+///
+/// Running a service with no listeners yet is already a supported state
+/// (`start_empty_service` exists for it), and the runtime loop flips the
+/// connection status from typed lifecycle events as each one lands, so nothing
+/// downstream needs them to be up before the UI is live.
+pub fn spawn_install_listeners(
+    service: Messaging,
+    specs: Vec<ListenerSpec>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        connect_listeners(&service, specs).await;
+        // Logged here rather than at the call site: the point of the listing is
+        // what actually came up, which is only known once the installs finish.
+        let listeners = service.list_listeners().await;
+        for id in &listeners {
+            tracing::debug!(
+                listener = %crate::display::truncate_did(id, 32),
+                state = ?service.listener_state(id),
+                "registered listener"
+            );
+        }
+        tracing::info!(count = listeners.len(), "DIDComm listeners registered");
+    })
 }
 
 /// Produce a short, collision-resistant identifier from a DID for listener IDs.
@@ -1796,8 +1840,12 @@ pub fn relationship_listener_config_from_secrets(
 
 #[cfg(test)]
 mod supervisor_policy_tests {
-    use super::{REBUILD_BACKOFF_CAP, REBUILD_GRACE, rebuild_backoff, rebuild_due};
+    use super::{
+        ListenerSpec, REBUILD_BACKOFF_CAP, REBUILD_GRACE, rebuild_backoff, rebuild_due,
+        spawn_install_listeners, start_empty_service,
+    };
     use std::time::Duration;
+    use tokio::sync::mpsc;
 
     /// The dangerous direction. A transport that dropped a moment ago is retrying
     /// inside its own ATM; rebuilding now would race a second websocket for the
@@ -1811,6 +1859,45 @@ mod supervisor_policy_tests {
             0,
             None
         ));
+    }
+
+    /// Bringing listeners up must not block the caller.
+    ///
+    /// This is the whole point of the split: each listener costs a mediator
+    /// auth handshake and a websocket connect, in series, and startup used to
+    /// await that on the state-handler thread — the one thread that services UI
+    /// actions. The loading screen offered "Press Enter to continue" and then
+    /// could not read the keypress until the last socket was up.
+    ///
+    /// The spec here names a mediator that cannot resolve, so the install is
+    /// still in flight when the assertion runs: what is being pinned is that
+    /// `spawn_install_listeners` *returns* while that is true.
+    #[tokio::test]
+    async fn installing_listeners_does_not_block_the_caller() {
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+        let service = start_empty_service(event_tx, tokio_util::sync::CancellationToken::new());
+        let spec = ListenerSpec {
+            id: "did:example:unreachable".to_string(),
+            did: "did:example:unreachable".to_string(),
+            mediator_did: "did:example:no-such-mediator".to_string(),
+            label: "test".to_string(),
+            secrets: Vec::new(),
+        };
+
+        let started = std::time::Instant::now();
+        let handle = spawn_install_listeners(service.clone(), vec![spec]);
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "spawning the install must return immediately, took {elapsed:?}"
+        );
+        assert!(
+            !service.has_listener("did:example:unreachable").await,
+            "the unreachable listener must not have been installed synchronously"
+        );
+
+        handle.abort();
     }
 
     /// The other direction: past the grace period nothing else is coming, so a

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -16,7 +16,7 @@ use tokio::sync::{
     broadcast,
     mpsc::{self, UnboundedReceiver},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 /// Tail-truncate a DID for log-message display, fixed at 30 chars.
 pub(crate) fn log_did(did: &str) -> std::borrow::Cow<'_, str> {
@@ -714,7 +714,18 @@ impl StateHandler {
         // Install this account's listeners on the runtime started above. Skips
         // any that already exist, so a State-A join's own persona listener is
         // bound to rather than duplicated (one websocket per DID).
-        didcomm::install_listeners(&didcomm_service, &config, &tdk).await;
+        //
+        // The specs are built here because that needs `Config`, which is not
+        // `Clone` and cannot cross into a task. Bringing the listeners *up* is
+        // the expensive half — a mediator auth handshake and a websocket connect
+        // each, in series — and that half runs off this thread. This is the only
+        // thread that services UI actions, and the loading screen has already
+        // been told to offer "Press Enter to continue": awaiting the connects
+        // here meant the keypress sat unread in the action channel until the last
+        // socket was up, and the main page then arrived in one late jump.
+        let listener_specs = didcomm::build_listener_configs(&config, &tdk).await;
+        let _listener_install =
+            didcomm::spawn_install_listeners(didcomm_service.clone(), listener_specs);
 
         // Process-lifetime LRU of inbound message IDs. Backstop for replay
         // and mediator-pickup duplicates beyond what the TDK already filters.
@@ -724,17 +735,6 @@ impl StateHandler {
         let (lifecycle_log_tx, mut lifecycle_log_rx) =
             mpsc::unbounded_channel::<didcomm::LifecycleLog>();
         let _lifecycle_handle = didcomm::spawn_lifecycle_logger(&didcomm_service, lifecycle_log_tx);
-
-        // Log registered listeners for diagnostics
-        let listeners = didcomm_service.list_listeners().await;
-        for id in &listeners {
-            debug!(
-                listener = %openvtc_core::display::truncate_did(id, 32),
-                state = ?didcomm_service.listener_state(id),
-                "registered listener"
-            );
-        }
-        info!(count = listeners.len(), "DIDComm listeners registered");
 
         // Phase 2 (community/persona DIDComm connection) runs ASYNCHRONOUSLY: we
         // do NOT block the UI waiting for the listener. The main page is already


### PR DESCRIPTION
## Problem

The loading screen offers "Press Enter to continue" once phase 1 finishes, and then ignores the keypress for seconds.

`state.loading_complete = true` is broadcast at `state_handler/mod.rs:712`. The runtime `select!` loop — the only thing that can service `Action::DismissLoading` — did not start until ~130 lines later. In between, that same thread awaited:

```rust
didcomm::install_listeners(&didcomm_service, &config, &tdk).await;
```

which walks the account's identities and, for each one, runs a mediator authentication handshake and a websocket connect — **in series**:

```rust
for spec in build_listener_configs(config, tdk).await {
    if service.has_listener(&spec.id).await { continue }
    add_listener(service, &spec).await          // auth + websocket
}
```

Nothing polls the action channel during that window, so the Enter was not lost — it queued, and the main page arrived in one late jump when the loop finally started. That reads as a freeze, and it grows with every identity on the account.

## Fix

The listener *specs* are still built on this thread, because that needs `Config`, which is not `Clone` and cannot cross into a task. Bringing the listeners **up** — the expensive half — now runs in a spawned task.

That is what the comment twenty lines below it already claimed:

> Phase 2 (community/persona DIDComm connection) runs ASYNCHRONOUSLY: we do NOT block the UI waiting for the listener.

The intent was documented; the implementation just didn't honour it.

## Why nothing downstream needs the sockets first

- A service with no listeners is already a supported state — `start_empty_service` exists for exactly that, and is what starts the runtime here.
- The session manager registers by listener id, not by a live socket.
- The runtime loop flips the connection status from typed lifecycle events as each listener lands, so the UI still reports Connecting → Connected correctly.
- The "registered listener" diagnostics move into the task, since what actually came up is only known once the installs finish.

`install_listeners` keeps its signature for its other caller and delegates to `connect_listeners`, the half that takes owned specs.

## Tests

Spawning the install returns immediately and has not installed the listener synchronously — driven with a spec whose mediator cannot resolve, so the install is demonstrably still in flight when the assertion runs.

The runtime loop itself is not factored into a test-callable unit (same limitation noted on #230), so the call-site ordering is not directly covered; the test pins the property of the function it now calls.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo doc --workspace --no-deps` (no warnings); `cargo test --workspace` — all green.
