### PR TITLE
fix(state-a): service agent names, identity removal and settings before a community exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Removing a persona, and changing settings, work before you join a
+  community.** Two more casualties of the same gap: `y` on the remove-identity
+  confirm was dropped, leaving the prompt on screen with nothing behind it —
+  which reads as a hang — and the entire settings surface was inert, so a
+  State-A account could not change its own protection, logging or mediator.
+  Settings need no messaging and no VTA session at all; they were simply never
+  wired into that loop.
 - **Agent names can be managed on an account's first persona.** With no
   communities yet, OpenVTC runs a second, smaller event loop (State A), and that
   loop had no arm for the agent-name verbs — so `g` on a freshly minted persona
@@ -54,9 +61,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Restarting made it work, because an account that already has a persona starts
   in the full runtime loop instead — which is why this went unnoticed.
 
-  That catch-all now leaves a debug breadcrumb. It is where an action lands when
-  it *should* be serviced and simply has no arm yet, and the only symptom was a
-  key that did nothing.
+  The catch-all that swallowed them now says so on screen, rather than leaving a
+  key that does nothing and no way to tell an unimplemented action from a broken
+  one. What remains behind it genuinely needs a community — the inbox,
+  relationships, credential exchange and the community verbs — and now says
+  that instead of nothing.
 
 - **The main page appears as soon as you press Enter on the loading screen.**
   Startup brought every DIDComm listener up — a mediator authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Agent names can be managed on an account's first persona.** With no
+  communities yet, OpenVTC runs a second, smaller event loop (State A), and that
+  loop had no arm for the agent-name verbs — so `g` on a freshly minted persona
+  was dropped into a catch-all and nothing happened, on the very screen that had
+  just reported "Created persona DID …". State A is where an account's *first*
+  persona is created, so it is also the first place anyone wants to name one.
+  Restarting made it work, because an account that already has a persona starts
+  in the full runtime loop instead — which is why this went unnoticed.
+
+  That catch-all now leaves a debug breadcrumb. It is where an action lands when
+  it *should* be serviced and simply has no arm yet, and the only symptom was a
+  key that did nothing.
+
 - **The main page appears as soon as you press Enter on the loading screen.**
   Startup brought every DIDComm listener up — a mediator authentication
   handshake and a websocket connect each, one after another — on the

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -3045,6 +3045,93 @@ impl StateHandler {
                                 .await;
                         }
                     }
+                    // Settings are config-only: `settings_actions::dispatch`
+                    // takes the config, the state and the save scheduler, and
+                    // touches no messaging and no VTA session. So every one of
+                    // them is serviceable here — and all of them were being
+                    // dropped, which is a State-A account unable to change its
+                    // own protection, logging or mediator.
+                    //
+                    // `ReconnectMediator` is the one outcome this loop cannot
+                    // honour: there is no persona listener to rebuild yet. The
+                    // setting itself is already persisted by the dispatch above,
+                    // so it takes effect when messaging starts.
+                    Action::Settings(sa) => {
+                        if let Some(ctx) = join_ctx.as_mut() {
+                            match settings_actions::dispatch(
+                                sa,
+                                &mut ctx.config,
+                                state,
+                                &self.state_tx,
+                                &mut save,
+                                &self.profile,
+                            )
+                            .await
+                            {
+                                settings_actions::SettingsOutcome::Continue => {}
+                                settings_actions::SettingsOutcome::ExitUserInt => {
+                                    if let Err(e) = terminator.terminate(Interrupted::UserInt) {
+                                        debug!("Failed to send terminate signal: {e}");
+                                    }
+                                    break DegradedOutcome::Exit(Interrupted::UserInt);
+                                }
+                                settings_actions::SettingsOutcome::ReconnectMediator => {
+                                    state.main_page.log(
+                                        "Mediator saved — it takes effect once messaging starts.",
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    // Removing a persona, for the same reason as creating one:
+                    // State A is where an account's first persona is minted, so
+                    // it is where a mistaken one gets thrown away. This was
+                    // listed as "intentionally inert" below, but the pieces it
+                    // needs are all here — the confirm prompt is armed by a nav
+                    // action that already works, and `prepare_delete_context_did`
+                    // is what clears it. Dropping the `y` left the prompt on
+                    // screen with nothing behind it, which reads as a hang.
+                    Action::DeleteDid(i) => {
+                        let domain = background_dispatch::DispatchDomain::Did;
+                        match (join_ctx.as_mut(), messaging) {
+                            (Some(ctx), Some(service)) => {
+                                if !in_flight.try_begin(domain) {
+                                    let msg = background_dispatch::InFlight::busy_message(domain);
+                                    state.main_page.log(msg);
+                                } else {
+                                    let av = ctx.admin_vta.clone();
+                                    if let Some(job) = self.prepare_delete_context_did(
+                                        state,
+                                        &mut ctx.config,
+                                        av.as_ref(),
+                                        service,
+                                        i,
+                                    ) {
+                                        background_dispatch::spawn_dispatch(
+                                            dispatch_tx.clone(),
+                                            domain,
+                                            async move {
+                                                background_dispatch::DispatchOutcome::Did(
+                                                    job.run().await,
+                                                )
+                                            },
+                                        );
+                                    } else {
+                                        // A guard rejected it (logged inline).
+                                        in_flight.finish(domain);
+                                    }
+                                }
+                            }
+                            // No session or no messaging runtime: say so and
+                            // disarm, rather than leaving the prompt hanging.
+                            _ => {
+                                state.main_page.content_panel.vta.confirm_delete_did = None;
+                                state
+                                    .main_page
+                                    .log("Cannot remove an identity right now — no VTA session.");
+                            }
+                        }
+                    }
                     Action::VicRefresh => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
                         spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
@@ -3083,7 +3170,7 @@ impl StateHandler {
                         }
                     }
                     // Messaging-only actions (Inbox / Relationship / Credential /
-                    // Settings / Contact, DeleteDid) are intentionally inert in the
+                    // Settings / Contact) are intentionally inert in the
                     // degraded loop — there's no live messaging/admin context to
                     // service them. The pure nav arms they previously shared this
                     // catch-all with now go through `handle_nav_action` above.
@@ -3096,8 +3183,23 @@ impl StateHandler {
                     // from silence. (The action is not named: `Action` carries
                     // credential and key material in some variants and
                     // deliberately has no `Debug`.)
+                    // Everything left needs a live community or the messaging
+                    // runtime that comes with one: the inbox, relationships,
+                    // credential exchange, and every community verb. They are
+                    // inert here because there is nothing for them to act on.
+                    //
+                    // Inert, but no longer *silent*. This arm is also where an
+                    // action lands that should have been serviced and simply has
+                    // no arm yet — the agent-name verbs, `DeleteDid` and the
+                    // whole settings surface all sat here, and the only symptom
+                    // was a key that did nothing. One line beats guessing.
+                    // (`Action` is not named: some variants carry credential and
+                    // key material, so it deliberately has no `Debug`.)
                     _ => {
                         debug!("action not serviced in State A — no arm in the degraded loop");
+                        state
+                            .main_page
+                            .log("Not available yet — join a community first.");
                     }
                 },
                 Some(outcome) = dispatch_rx.recv() => {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -3009,6 +3009,42 @@ impl StateHandler {
                             ];
                         }
                     }
+                    // Agent-name management, for the persona this loop just
+                    // minted. State A is where an account's FIRST persona is
+                    // created, so it is also the first place anyone wants to
+                    // name one — and `g` reached a loop that had no arm for it
+                    // and dropped it into the catch-all below. Nothing happened
+                    // and nothing said why, on a screen that had just reported
+                    // "Created persona DID …".
+                    //
+                    // The session is cloned rather than borrowed because the
+                    // mutating verbs need `&mut ctx.config` at the same time;
+                    // a `VtaClient` clone is cheap and shares the connection.
+                    Action::StartAgentNameManager(index) => {
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.clone());
+                        self.run_agent_name_open(state, av.as_ref(), index).await;
+                    }
+                    Action::AgentNameManagerClaim => {
+                        if let Some(ctx) = join_ctx.as_mut() {
+                            let av = ctx.admin_vta.clone();
+                            self.run_agent_name_claim(state, &mut ctx.config, &mut save, av.as_ref())
+                                .await;
+                        }
+                    }
+                    Action::AgentNameManagerToggle => {
+                        if let Some(ctx) = join_ctx.as_mut() {
+                            let av = ctx.admin_vta.clone();
+                            self.run_agent_name_toggle(state, &mut ctx.config, &mut save, av.as_ref())
+                                .await;
+                        }
+                    }
+                    Action::AgentNameManagerRemove => {
+                        if let Some(ctx) = join_ctx.as_mut() {
+                            let av = ctx.admin_vta.clone();
+                            self.run_agent_name_remove(state, &mut ctx.config, &mut save, av.as_ref())
+                                .await;
+                        }
+                    }
                     Action::VicRefresh => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
                         spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
@@ -3051,7 +3087,18 @@ impl StateHandler {
                     // degraded loop — there's no live messaging/admin context to
                     // service them. The pure nav arms they previously shared this
                     // catch-all with now go through `handle_nav_action` above.
-                    _ => {}
+                    //
+                    // Leaves a breadcrumb, because this arm is also where an
+                    // action lands that *should* have been serviced and simply
+                    // has no arm yet — the agent-name verbs sat here, and the
+                    // only symptom was a key that did nothing. A dropped action
+                    // is now visible in a debug log instead of being inferred
+                    // from silence. (The action is not named: `Action` carries
+                    // credential and key material in some variants and
+                    // deliberately has no `Debug`.)
+                    _ => {
+                        debug!("action not serviced in State A — no arm in the degraded loop");
+                    }
                 },
                 Some(outcome) = dispatch_rx.recv() => {
                     // Applying needs the config the outcome is annotated against.


### PR DESCRIPTION
## Problem

An account with no community runs a second, smaller event loop (`run_degraded_loop`). It routes pure navigation through the shared `handle_nav_action` and then matches a **hand-written list** of everything else — with a silent `_ => {}` at the end.

Three separate surfaces had never been added to that list, and all three failed the same way: the key did nothing, and nothing said why.

* **`g` on a freshly minted persona.** State A is where an account's *first* persona is created, so it is the first place anyone wants to name one. The four agent-name verbs existed only in the runtime loop. The overlay's pure-state actions (input, select, close, remove-confirm) already went through `handle_nav_action`, so the only half missing was the half that talks to the VTA.
* **`y` on the remove-identity confirm.** `DeleteDid` was commented as "intentionally inert" here, but nothing about it is — and `prepare_delete_context_did`, which is what *clears* the confirm prompt, never ran. The prompt stayed on screen with nothing behind it, which reads as a hang.
* **The entire settings surface.** `settings_actions::dispatch` takes the config, the state and the save scheduler — no messaging, no VTA session — so every settings action is serviceable in State A. All of them were dropped, so a new account could not change its own protection, logging or mediator.

The diagnosis came from an activity log that showed `Created persona DID …` and then, on `g`, **not even** the "No persona selected" line the open path logs when it finds no persona. That absence is what proved the action was dropped before reaching any handler.

Restarting made agent names work, which is why this survived: an account that already holds a persona starts in the full runtime loop instead.

## Fix

The three surfaces are wired to the join context that is already here for `CreatePersonaSubmit` — it holds both the config the mutating verbs persist into and the admin VTA session they dispatch through. The session is cloned rather than borrowed, because those verbs need `&mut ctx.config` at the same time and a `VtaClient` clone is cheap and shares the underlying connection.

`ReconnectMediator` is the one settings outcome this loop cannot honour — there is no persona listener to rebuild yet — so it says the setting takes effect when messaging starts, which is true: the dispatch has already persisted it.

**The catch-all now speaks.** It swallowed all three of these, and in every case the symptom was a dead key: indistinguishable from a broken keyboard, and impossible to tell from an action that is legitimately unavailable.

## The audit

Rather than wait for the next report, every `Action` variant was checked against both loops:

| | |
|---|---|
| 98 | `Action` variants total |
| 39 | pure nav — shared by both loops via `handle_nav_action` |
| 23 | serviced by the join-flow and setup-wizard sub-loops |
| 16 | still runtime-only — **all genuinely need a community** |

The 16 are the inbox, relationships, credential exchange and the community verbs (leave / archive / withdraw / switch / capabilities / VMC). There is nothing for them to act on in State A, and they now say so instead of doing nothing.

## Not covered by a test

Neither loop is factored into a test-callable unit, so the divergence between their action coverage — the actual structural fault — is still only caught by reading both, or by the audit script above. The catch-all's message is the runtime backstop.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace` — all green.
