### PR TITLE
harden(loops): make both action matches exhaustive, so divergence cannot recur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   R-A-5 regardless. The main page still *detects* an existing did-git-sign
   config; re-offering the install needs a new entry point.
 
+### Changed
+
+- **Neither event loop can silently drop an action again.** OpenVTC runs two
+  action loops — the runtime one, and a smaller one for an account with no
+  community — and each matched a hand-written list of actions ending in a silent
+  catch-all. That is how three surfaces came to be missing from the second one,
+  each presenting as a key that did nothing. Both matches are now exhaustive with
+  no catch-all, so adding an `Action` variant fails to compile until someone
+  decides what *each* loop does with it. Verified by adding a probe variant: two
+  `E0004` errors, one per loop. Actions that are genuinely unavailable before you
+  join a community stay inert, but say so on screen rather than doing nothing.
+
 ### Fixed
 
 - **Removing a persona, and changing settings, work before you join a

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1684,7 +1684,45 @@ impl StateHandler {
                             }
                         }
                     },
-                    _ => {}
+                    // ---- Listed so this match stays EXHAUSTIVE; no `_` arm ----
+                    //
+                    // The mirror of the degraded loop's listing. A silent
+                    // catch-all here would hide the same class of defect in the
+                    // other direction: an action wired into State A, or sent by
+                    // a screen, that this loop never services.
+
+                    // Serviced by `handle_nav_action` in the guard arm above.
+                    Action::MainMenuSelected(..) | Action::MainPanelSwitch(..) |
+                    Action::DismissLoading | Action::CapabilitiesClose | Action::CapabilitiesUp |
+                    Action::CapabilitiesDown | Action::CapabilitiesDetail |
+                    Action::CapabilitiesToggleArm | Action::CapabilitiesToggleCancel |
+                    Action::CommunitySelect(..) | Action::CommunityConfirmDelete(..) |
+                    Action::CommunityCancelDelete | Action::CommunityConfirmLeave(..) |
+                    Action::CommunityCancelLeave | Action::CommunityConfirmWithdraw(..) |
+                    Action::CommunityCancelWithdraw | Action::CommunitySwitcherMove(..) |
+                    Action::CloseCommunitySwitcher | Action::DidSelect(..) |
+                    Action::DidConfirmDelete(..) | Action::DidCancelDelete |
+                    Action::StartCreatePersona | Action::CreatePersonaInput(..) |
+                    Action::CreatePersonaClose | Action::AgentNameManagerInput(..) |
+                    Action::AgentNameManagerSelect(..) | Action::AgentNameManagerConfirmRemove |
+                    Action::AgentNameManagerCancelRemove | Action::AgentNameManagerClose |
+                    Action::VicSelect(..) | Action::VicFocusToggle | Action::VicConfirmDelete(..) |
+                    Action::VicCancelDelete | Action::VicConfirmPurge(..) | Action::VicCancelPurge |
+                    Action::StartAddVic | Action::AddVicInput(..) | Action::AddVicPaste(..) |
+                    Action::AddVicClose => {}
+
+                    // Owned by the join-flow and setup-wizard sub-loops.
+                    Action::ActivateMainMenu | Action::JoinSubmitVtc(..) |
+                    Action::JoinIdentitySelect(..) | Action::JoinIdentityChoose |
+                    Action::JoinReuseConfirm | Action::JoinReuseCancel |
+                    Action::JoinInvitationSelect(..) | Action::JoinInvitationChoose |
+                    Action::JoinCancel | Action::JoinPasteVic(..) | Action::JoinPasteFromClipboard |
+                    Action::JoinClearVic | Action::ImportConfig(..) | Action::SetProtection(..) |
+                    Action::VtaSubmitDid(..) | Action::VtaStartProvision(..) |
+                    Action::SetupCompleted(..) => {}
+                    #[cfg(feature = "openpgp-card")]
+                    Action::GetTokens | Action::SetAdminPin(..) | Action::SetTouchPolicy(..) |
+                    Action::SetTokenName(..) | Action::FactoryReset(..) | Action::TokenWriteKeys(..) => {}
                 },
                 // DIDComm inbound message events
                 Some(event) = didcomm_event_rx.recv() => {
@@ -3183,20 +3221,69 @@ impl StateHandler {
                     // from silence. (The action is not named: `Action` carries
                     // credential and key material in some variants and
                     // deliberately has no `Debug`.)
-                    // Everything left needs a live community or the messaging
-                    // runtime that comes with one: the inbox, relationships,
-                    // credential exchange, and every community verb. They are
-                    // inert here because there is nothing for them to act on.
+                    // ---- Everything below is listed so this match stays EXHAUSTIVE ----
                     //
-                    // Inert, but no longer *silent*. This arm is also where an
-                    // action lands that should have been serviced and simply has
-                    // no arm yet — the agent-name verbs, `DeleteDid` and the
-                    // whole settings surface all sat here, and the only symptom
-                    // was a key that did nothing. One line beats guessing.
-                    // (`Action` is not named: some variants carry credential and
-                    // key material, so it deliberately has no `Debug`.)
-                    _ => {
-                        debug!("action not serviced in State A — no arm in the degraded loop");
+                    // There is deliberately no `_` arm. This loop's coverage was
+                    // a hand-written list next to a silent catch-all, and three
+                    // surfaces were quietly missing from it (#235): the
+                    // agent-name verbs, `DeleteDid`, and every setting. Each one
+                    // presented as a key that did nothing. Without a catch-all a
+                    // new `Action` variant cannot be added without deciding,
+                    // here, what an account with no community does with it — the
+                    // compiler asks, instead of a user reporting a dead key.
+                    //
+                    // The `openpgp-card` arms are split out because those
+                    // variants do not exist in a default build: one flat list
+                    // compiles under a single feature set and breaks the other,
+                    // which is what CI caught the first time round.
+
+                    // Serviced by `handle_nav_action` in the guard arm above.
+                    // Unreachable here; listed for exhaustiveness only.
+                    Action::MainMenuSelected(..) | Action::MainPanelSwitch(..) |
+                    Action::DismissLoading | Action::CapabilitiesClose | Action::CapabilitiesUp |
+                    Action::CapabilitiesDown | Action::CapabilitiesDetail |
+                    Action::CapabilitiesToggleArm | Action::CapabilitiesToggleCancel |
+                    Action::CommunitySelect(..) | Action::CommunityConfirmDelete(..) |
+                    Action::CommunityCancelDelete | Action::CommunityConfirmLeave(..) |
+                    Action::CommunityCancelLeave | Action::CommunityConfirmWithdraw(..) |
+                    Action::CommunityCancelWithdraw | Action::CommunitySwitcherMove(..) |
+                    Action::CloseCommunitySwitcher | Action::DidSelect(..) |
+                    Action::DidConfirmDelete(..) | Action::DidCancelDelete |
+                    Action::StartCreatePersona | Action::CreatePersonaInput(..) |
+                    Action::CreatePersonaClose | Action::AgentNameManagerInput(..) |
+                    Action::AgentNameManagerSelect(..) | Action::AgentNameManagerConfirmRemove |
+                    Action::AgentNameManagerCancelRemove | Action::AgentNameManagerClose |
+                    Action::VicSelect(..) | Action::VicFocusToggle | Action::VicConfirmDelete(..) |
+                    Action::VicCancelDelete | Action::VicConfirmPurge(..) | Action::VicCancelPurge |
+                    Action::StartAddVic | Action::AddVicInput(..) | Action::AddVicPaste(..) |
+                    Action::AddVicClose => {}
+
+                    // Owned by the join-flow and setup-wizard sub-loops, which
+                    // run their own action loops and never delegate to this one.
+                    Action::ActivateMainMenu | Action::JoinSubmitVtc(..) |
+                    Action::JoinIdentitySelect(..) | Action::JoinIdentityChoose |
+                    Action::JoinReuseConfirm | Action::JoinReuseCancel |
+                    Action::JoinInvitationSelect(..) | Action::JoinInvitationChoose |
+                    Action::JoinCancel | Action::JoinPasteVic(..) | Action::JoinPasteFromClipboard |
+                    Action::JoinClearVic | Action::ImportConfig(..) | Action::SetProtection(..) |
+                    Action::VtaSubmitDid(..) | Action::VtaStartProvision(..) |
+                    Action::SetupCompleted(..) => {}
+                    #[cfg(feature = "openpgp-card")]
+                    Action::GetTokens | Action::SetAdminPin(..) | Action::SetTouchPolicy(..) |
+                    Action::SetTokenName(..) | Action::FactoryReset(..) | Action::TokenWriteKeys(..) => {}
+
+                    // Genuinely unavailable: these need a live community and the
+                    // messaging runtime that comes with it. Inert, but not
+                    // silent — a dead key is indistinguishable from a broken one.
+                    Action::Inbox(..) | Action::Relationship(..) | Action::Credential(..) |
+                    Action::IssueMemberVmc(..) | Action::CapabilitiesOpen(..) |
+                    Action::CapabilitiesRefresh | Action::CapabilitiesToggleCommit |
+                    Action::SetActiveCommunity(..) | Action::ToggleFavourite(..) |
+                    Action::AcknowledgeCommunity(..) | Action::LeaveCommunity(..) |
+                    Action::WithdrawJoin(..) | Action::ArchiveCommunity(..) |
+                    Action::ToggleShowArchived | Action::OpenCommunitySwitcher |
+                    Action::CommunitySwitcherSelect => {
+                        debug!("action needs a community — not serviced in State A");
                         state
                             .main_page
                             .log("Not available yet — join a community first.");


### PR DESCRIPTION
## The risk this closes

OpenVTC services actions in **two** loops — `main_loop`, and `run_degraded_loop` for an account with no community — and each matched a hand-written list of `Action` variants ending in a silent `_ => {}`.

The lists could drift apart, and did. The agent-name verbs, `DeleteDid` and the entire settings surface were all missing from the second one (#235). Every one presented identically — a key that did nothing — and each was found only when a user reported it. #235 audited them back into agreement, but nothing stopped the next omission.

## The fix

Both matches now cover every variant, with **no catch-all**. Adding an `Action` fails to compile until someone decides what *each* loop does with it, and rustc names the loop and suggests the arm.

Verified by adding a probe variant to the enum:

```
error[E0004]: non-exhaustive patterns: `Action::ProbeVariantForHardeningCheck` not covered
```

Exactly **two** such errors — one per loop — then reverted.

## Why the arms are grouped the way they are

The grouping is the documentation. Each listed-for-exhaustiveness arm says why it is there:

* **Serviced by `handle_nav_action` in the guard arm above.** Needed because Rust's exhaustiveness checker cannot see through a guarded arm — `_ if handle_nav_action(…)` does not count toward coverage — so every nav action must still be named.
* **Owned by the join-flow and setup-wizard sub-loops**, which run their own action loops and never delegate.
* **Genuinely needs a community** and the messaging runtime that comes with it. This is the only reachable-and-inert group, and it now says so on screen instead of doing nothing.

The groups were derived by partitioning all 98 variants against what each loop, `handle_nav_action`, and the sub-loops actually match — not by hand.

## Scope

No behaviour change beyond that one message. Every arm that did work still does.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace` — all green.
