### PR TITLE
perf(r14): run the agent-name verbs off the state-handler loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Managing agent names no longer freezes the application.** The overlay's five
+  verbs are Trust Tasks with a 60-second timeout each, and a mutation is *two* of
+  them — the change, then the authoritative re-read of the registry. They ran on
+  the state-handler thread, which is the only thread that services anything: for
+  up to two minutes no inbound DIDComm was processed, no listener lifecycle
+  applied, and no key read, including `q`. The overlay locks its own input while
+  it works, so the freeze looked local to the overlay; it was not. The work now
+  runs off the loop, and a result that arrives after the overlay has been closed
+  or switched to another persona is dropped rather than written over it — though
+  a name it verified is still cached, because that is a fact about the DID
+  regardless of what is on screen.
+
 - **Neither event loop can silently drop an action again.** OpenVTC runs two
   action loops — the runtime one, and a smaller one for an account with no
   community — and each matched a hand-written list of actions ending in a silent

--- a/openvtc/src/state_handler/agent_name_actions.rs
+++ b/openvtc/src/state_handler/agent_name_actions.rs
@@ -1,0 +1,384 @@
+//! Agent-name management, off the loop thread (R14).
+//!
+//! The four verbs behind the agent-name overlay — open, claim, park/resume,
+//! remove — are Trust Tasks against the VTA, each with a 60-second timeout
+//! ([`agent_name_manage`]), and a mutation is *two* round trips: the change,
+//! then a re-read of the registry, which is authoritative. Run inline on the
+//! state-handler thread that was up to two minutes with no inbound DIDComm
+//! serviced, no listener lifecycle applied, and no key read — including `q`.
+//!
+//! The overlay's `Working` phase locks its own input, so the freeze was easy to
+//! miss from inside the overlay. It was not local to the overlay: it stopped the
+//! whole application.
+//!
+//! Shape follows [`inbox_actions`](super::inbox_actions) and
+//! [`relationship_actions`](super::relationship_actions): the loop resolves what
+//! the job needs and hands over owned values, the job does I/O only, and every
+//! mutation happens back on the loop in [`AgentNameOutcome::apply`].
+
+use vta_sdk::client::VtaClient;
+use vta_sdk::protocols::did_management::agent_name::AgentNameEntry;
+
+use crate::state_handler::agent_name_manage;
+use crate::state_handler::main_page::content::{AgentNameManagerPhase, AgentNameRow};
+use crate::state_handler::save_coalesce::SaveScheduler;
+use crate::state_handler::state::State;
+use openvtc_core::config::Config;
+
+/// Which verb a job runs. `Open` is a read; the rest mutate and then re-read.
+pub(crate) enum Verb {
+    /// Load the registry for a persona whose overlay has just opened.
+    Open,
+    /// Bind `name`, after a fast availability check.
+    Claim(String),
+    /// Stop `name` resolving while keeping it reserved to this DID.
+    Park(String),
+    /// Resume a parked `name`.
+    Resume(String),
+    /// Release `name` — anyone may then reclaim it. Destructive.
+    Remove(String),
+}
+
+impl Verb {
+    /// Present-tense status shown while the job runs.
+    pub(crate) fn status(&self) -> String {
+        match self {
+            Verb::Open => "Loading agent names…".to_string(),
+            Verb::Claim(n) => format!("Claiming @{n}…"),
+            Verb::Park(n) => format!("Parking @{n}…"),
+            Verb::Resume(n) => format!("Resuming @{n}…"),
+            Verb::Remove(n) => format!("Removing @{n}…"),
+        }
+    }
+}
+
+/// Everything the spawned job needs, already resolved on the loop thread.
+pub(crate) struct AgentNameJob {
+    pub(crate) vta: VtaClient,
+    pub(crate) persona_did: String,
+    /// Host the persona's DID is served from, for the display-cache entry.
+    pub(crate) host: String,
+    pub(crate) verb: Verb,
+}
+
+impl AgentNameJob {
+    /// Run the verb, then re-read the registry. I/O only — no `State`, no
+    /// `Config`, nothing that has to be mutated on the loop.
+    pub(crate) async fn run(self) -> AgentNameOutcome {
+        let mut out = AgentNameOutcome {
+            persona_did: self.persona_did.clone(),
+            host: self.host,
+            message: None,
+            log: None,
+            names: None,
+            clear_input: false,
+        };
+        let did = &self.persona_did;
+
+        match &self.verb {
+            Verb::Open => {}
+            Verb::Claim(name) => {
+                // Fast-path rejection: a reserved or already-taken name fails
+                // the check before any publish, with a clearer reason than the
+                // set error. A check *failure* is non-fatal — fall through to
+                // `set`, which is authoritative (and closes the check→set race
+                // if someone claims it in between).
+                if let Ok(avail) = agent_name_manage::check_name(&self.vta, did, name).await
+                    && !avail.available
+                {
+                    let why = if avail.reserved {
+                        "a reserved name"
+                    } else {
+                        "already taken on this domain"
+                    };
+                    out.message = Some(format!("@{name} is {why} ({}).", avail.domain));
+                    // The registry did not change; leave the list alone.
+                    return out;
+                }
+                match agent_name_manage::set_name(&self.vta, did, name).await {
+                    Ok(_) => {
+                        out.log = Some(format!("Claimed agent name @{name}"));
+                        out.clear_input = true;
+                    }
+                    Err(e) => {
+                        out.message = Some(format!("Could not claim @{name}: {e:#}"));
+                        return out;
+                    }
+                }
+            }
+            Verb::Park(name) | Verb::Resume(name) => {
+                let parking = matches!(self.verb, Verb::Park(_));
+                let result = if parking {
+                    agent_name_manage::disable_name(&self.vta, did, name).await
+                } else {
+                    agent_name_manage::enable_name(&self.vta, did, name).await
+                };
+                match result {
+                    Ok(_) => {
+                        out.log = Some(format!(
+                            "{} agent name @{name}",
+                            if parking { "Parked" } else { "Resumed" }
+                        ));
+                    }
+                    Err(e) => {
+                        out.message = Some(format!(
+                            "Could not {} @{name}: {e:#}",
+                            if parking { "park" } else { "resume" }
+                        ));
+                        return out;
+                    }
+                }
+            }
+            Verb::Remove(name) => {
+                match agent_name_manage::remove_name(&self.vta, did, name).await {
+                    Ok(_) => out.log = Some(format!("Removed agent name @{name}")),
+                    Err(e) => {
+                        out.message = Some(format!("Could not remove @{name}: {e:#}"));
+                        return out;
+                    }
+                }
+            }
+        }
+
+        // The registry is authoritative, so every path that changed it re-reads
+        // it rather than patching the list locally.
+        out.names = Some(
+            agent_name_manage::list_names(&self.vta, did)
+                .await
+                .map_err(|e| format!("{e:#}")),
+        );
+        if out.names.as_ref().is_some_and(Result::is_err) && out.log.is_some() {
+            // The mutation landed and only the read-back failed. Say both, in
+            // that order: the claim is done, the list is unknown.
+            out.message = Some(format!(
+                "Applied, but could not reload the list: {}",
+                out.names
+                    .as_ref()
+                    .and_then(|r| r.as_ref().err())
+                    .cloned()
+                    .unwrap_or_default()
+            ));
+        }
+        out
+    }
+}
+
+/// What the job learned. Data only; applied on the loop thread.
+pub(crate) struct AgentNameOutcome {
+    persona_did: String,
+    host: String,
+    /// Status line for the overlay.
+    message: Option<String>,
+    /// Activity-log line, for a mutation that actually landed.
+    log: Option<String>,
+    /// The registry as re-read afterwards. `None` means it was deliberately
+    /// left alone (a rejected claim changed nothing).
+    names: Option<Result<Vec<AgentNameEntry>, String>>,
+    /// A successful claim empties the input.
+    clear_input: bool,
+}
+
+impl AgentNameOutcome {
+    /// Apply on the loop thread: overlay rows and status, the persisted display
+    /// name, and the activity log.
+    ///
+    /// The config half runs even when the overlay has since been closed or
+    /// switched to another persona — a verified name that was just claimed is
+    /// worth caching either way — while the overlay half is dropped, because it
+    /// would otherwise write one persona's registry over another's.
+    pub(crate) fn apply(self, state: &mut State, config: &mut Config, save: &mut SaveScheduler) {
+        let overlay_matches = state
+            .main_page
+            .agent_names
+            .as_ref()
+            .is_some_and(|o| o.persona_did == self.persona_did);
+
+        if let Some(line) = self.log {
+            state.main_page.log(line);
+        }
+
+        // Persisted display name: the first *served* name, host-qualified.
+        if let Some(Ok(names)) = self.names.as_ref() {
+            let cached = names
+                .iter()
+                .find(|n| n.enabled)
+                .filter(|_| !self.host.is_empty())
+                .map(|n| format!("{}/@{}", self.host, n.name));
+            config.set_cached_agent_name(&self.persona_did, cached, chrono::Utc::now());
+            save.mark_dirty();
+            state.main_page.sync_from_config(config);
+        }
+
+        if !overlay_matches {
+            return;
+        }
+        let Some(o) = state.main_page.agent_names.as_mut() else {
+            return;
+        };
+        o.phase = AgentNameManagerPhase::Ready;
+        if self.clear_input {
+            o.input.reset();
+        }
+        match self.names {
+            Some(Ok(names)) => {
+                o.names = names
+                    .into_iter()
+                    .map(|e| AgentNameRow {
+                        name: e.name,
+                        enabled: e.enabled,
+                    })
+                    .collect();
+                o.selected = o.selected.min(o.names.len().saturating_sub(1));
+                o.list_stale = false;
+                o.message = self.message;
+            }
+            Some(Err(_)) => {
+                // The read failed, so what is on screen is not the registry.
+                o.list_stale = true;
+                o.message = self.message;
+            }
+            None => o.message = self.message,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+    use crate::state_handler::main_page::content::AgentNameManagerState;
+
+    const DID: &str = "did:webvh:QmScidPersona:example.com:alice";
+
+    fn entry(name: &str, enabled: bool) -> AgentNameEntry {
+        AgentNameEntry {
+            name: name.to_string(),
+            enabled,
+            created_at: 0,
+        }
+    }
+
+    fn open_overlay(state: &mut State, did: &str) {
+        state.main_page.agent_names = Some(AgentNameManagerState {
+            persona_did: did.to_string(),
+            host: "example.com".to_string(),
+            phase: AgentNameManagerPhase::Working,
+            ..Default::default()
+        });
+    }
+
+    fn outcome(names: Option<Result<Vec<AgentNameEntry>, String>>) -> AgentNameOutcome {
+        AgentNameOutcome {
+            persona_did: DID.to_string(),
+            host: "example.com".to_string(),
+            message: None,
+            log: None,
+            names,
+            clear_input: false,
+        }
+    }
+
+    /// The happy path: rows land, the phase unlocks, and the first *served*
+    /// name becomes the persona's persisted display name.
+    #[test]
+    fn a_listing_populates_the_overlay_and_caches_the_served_name() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        open_overlay(&mut state, DID);
+
+        outcome(Some(Ok(vec![entry("parked", false), entry("alice", true)]))).apply(
+            &mut state,
+            &mut config,
+            &mut save,
+        );
+
+        let o = state.main_page.agent_names.as_ref().unwrap();
+        assert_eq!(o.phase, AgentNameManagerPhase::Ready);
+        assert_eq!(o.names.len(), 2);
+        assert!(!o.list_stale);
+        assert_eq!(config.agent_name_for(DID), Some("example.com/@alice"));
+        assert!(save.is_pending());
+    }
+
+    /// A failed read-back marks the registry unknown rather than rendering an
+    /// empty list as "no names" — the claim may well have succeeded.
+    #[test]
+    fn a_failed_read_back_marks_the_list_stale() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        open_overlay(&mut state, DID);
+
+        outcome(Some(Err("vault unreachable".to_string()))).apply(
+            &mut state,
+            &mut config,
+            &mut save,
+        );
+
+        let o = state.main_page.agent_names.as_ref().unwrap();
+        assert!(o.list_stale);
+        assert_eq!(o.phase, AgentNameManagerPhase::Ready);
+    }
+
+    /// The UI is responsive while the job runs, so the operator can close the
+    /// overlay or open another persona's before it lands. The overlay half is
+    /// then dropped — writing one persona's registry into another's overlay is
+    /// exactly the confusion the whole listener-identity work was about.
+    #[test]
+    fn an_outcome_for_another_persona_does_not_touch_the_overlay() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        open_overlay(&mut state, "did:webvh:QmScidOther:example.com:bob");
+
+        outcome(Some(Ok(vec![entry("alice", true)]))).apply(&mut state, &mut config, &mut save);
+
+        let o = state.main_page.agent_names.as_ref().unwrap();
+        assert!(
+            o.names.is_empty(),
+            "another persona's rows must not land here"
+        );
+        assert_eq!(o.phase, AgentNameManagerPhase::Working);
+    }
+
+    /// …but the persisted name still applies, because it is a fact about the
+    /// DID and not about what happens to be on screen.
+    #[test]
+    fn the_cached_name_applies_even_with_the_overlay_closed() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+
+        outcome(Some(Ok(vec![entry("alice", true)]))).apply(&mut state, &mut config, &mut save);
+
+        assert!(state.main_page.agent_names.is_none());
+        assert_eq!(config.agent_name_for(DID), Some("example.com/@alice"));
+    }
+
+    /// A rejected claim changed nothing, so the list is left exactly as it was
+    /// rather than being re-read or blanked.
+    #[test]
+    fn a_rejected_claim_leaves_the_list_untouched() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        open_overlay(&mut state, DID);
+        if let Some(o) = state.main_page.agent_names.as_mut() {
+            o.names = vec![AgentNameRow {
+                name: "existing".to_string(),
+                enabled: true,
+            }];
+        }
+
+        let mut out = outcome(None);
+        out.message = Some("@taken is already taken on this domain (example.com).".to_string());
+        out.apply(&mut state, &mut config, &mut save);
+
+        let o = state.main_page.agent_names.as_ref().unwrap();
+        assert_eq!(o.names.len(), 1, "the existing row must survive");
+        assert_eq!(o.names[0].name, "existing");
+        assert!(o.message.as_deref().is_some_and(|m| m.contains("taken")));
+        assert_eq!(o.phase, AgentNameManagerPhase::Ready);
+    }
+}

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -73,6 +73,16 @@ pub(crate) enum DispatchDomain {
     /// VTA transport probe: resolve the VTA's DID document to learn which
     /// transports it advertises. Read-only, one resolve, off the loop.
     VtaTransports,
+    /// Agent-name management: the overlay's open / claim / park / resume /
+    /// remove verbs. Each is a Trust Task with a 60 s timeout, and a mutation
+    /// is two of them (the change, then the authoritative re-read) — so this
+    /// domain is the longest-running of the lot, and the one whose inline
+    /// await could park the loop for two minutes.
+    ///
+    /// Separate from [`Self::AgentName`], which is the periodic *display-name*
+    /// sweep: sharing a domain would let a background refresh delay an operator
+    /// who is claiming a name, and the two touch different state.
+    AgentNameManage,
     /// Invitation-credential (VIC) list refresh: one credential-vault query
     /// against the always-on admin VTA session (30 s timeout in the SDK).
     /// Read-only. Backgrounded because it is bound to *navigation* — Tab into
@@ -91,6 +101,7 @@ impl DispatchDomain {
             DispatchDomain::Did => "Identity deletion",
             DispatchDomain::AgentName => "Agent name refresh",
             DispatchDomain::VtaTransports => "VTA transport probe",
+            DispatchDomain::AgentNameManage => "Agent name change",
             DispatchDomain::Vic => "Invitation credential refresh",
         }
     }
@@ -164,6 +175,10 @@ pub(crate) enum DispatchOutcome {
     /// advertises, or the reason the probe could not tell. Display-only — it
     /// touches no `Config`, so it never marks the config dirty.
     VtaTransports(crate::state_handler::main_page::content::AdvertisedTransports),
+    /// An agent-name verb finished (open / claim / park / resume / remove).
+    /// [`AgentNameOutcome::apply`](crate::state_handler::agent_name_actions::AgentNameOutcome::apply)
+    /// applies the registry, the overlay status and the persisted display name.
+    AgentNameManage(crate::state_handler::agent_name_actions::AgentNameOutcome),
     /// A VIC list refresh finished. [`VicRefreshOutcome::apply`](crate::state_handler::vic::VicRefreshOutcome::apply)
     /// swaps in the
     /// listing (or logs why it could not be read); display-only, so it touches
@@ -189,6 +204,7 @@ impl DispatchOutcome {
             DispatchOutcome::Did(_) => DispatchDomain::Did,
             DispatchOutcome::AgentName(_) => DispatchDomain::AgentName,
             DispatchOutcome::VtaTransports(_) => DispatchDomain::VtaTransports,
+            DispatchOutcome::AgentNameManage(_) => DispatchDomain::AgentNameManage,
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::Panicked(domain) => *domain,
         }
@@ -307,6 +323,7 @@ pub(crate) fn apply_outcome(
             // from `Config` and would drop a field the config does not hold.
             state.main_page.content_panel.vta.transports.advertised = Some(advertised);
         }
+        DispatchOutcome::AgentNameManage(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Vic(outcome) => outcome.apply(state, config),
         DispatchOutcome::Panicked(domain) => {
             // The job panicked and produced no real outcome. Surface a generic

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -197,6 +197,7 @@ pub(crate) fn resolve_did_to_display(config: &openvtc_core::config::Config, did:
 }
 
 pub mod actions;
+mod agent_name_actions;
 mod agent_name_manage;
 mod agent_name_refresh;
 mod background_dispatch;
@@ -1413,35 +1414,41 @@ impl StateHandler {
                         .await;
                     },
                     Action::StartAgentNameManager(index) => {
-                        self.run_agent_name_open(&mut state, admin_vta.as_ref(), index)
-                            .await;
+                        if let Some(did) = self.open_agent_name_overlay(&mut state, index) {
+                            spawn_agent_name_job(
+                                &dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref(),
+                                did, agent_name_actions::Verb::Open,
+                            );
+                        }
                     },
                     Action::AgentNameManagerClaim => {
-                        self.run_agent_name_claim(
-                            &mut state,
-                            &mut config,
-                            &mut save,
-                            admin_vta.as_ref(),
-                        )
-                        .await;
+                        if let Some((did, name)) = self.agent_name_to_claim(&mut state) {
+                            spawn_agent_name_job(
+                                &dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref(),
+                                did, agent_name_actions::Verb::Claim(name),
+                            );
+                        }
                     },
                     Action::AgentNameManagerToggle => {
-                        self.run_agent_name_toggle(
-                            &mut state,
-                            &mut config,
-                            &mut save,
-                            admin_vta.as_ref(),
-                        )
-                        .await;
+                        if let Some((did, name, enabled)) = self.selected_agent_name(&state) {
+                            let verb = if enabled {
+                                agent_name_actions::Verb::Park(name)
+                            } else {
+                                agent_name_actions::Verb::Resume(name)
+                            };
+                            spawn_agent_name_job(
+                                &dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref(),
+                                did, verb,
+                            );
+                        }
                     },
                     Action::AgentNameManagerRemove => {
-                        self.run_agent_name_remove(
-                            &mut state,
-                            &mut config,
-                            &mut save,
-                            admin_vta.as_ref(),
-                        )
-                        .await;
+                        if let Some((did, name, _)) = self.selected_agent_name(&state) {
+                            spawn_agent_name_job(
+                                &dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref(),
+                                did, agent_name_actions::Verb::Remove(name),
+                            );
+                        }
                     },
                     Action::VicRefresh => {
                         // Off the loop: this is Tab into the VIC list, and the
@@ -2308,18 +2315,13 @@ impl StateHandler {
         let _ = self.state_tx.send(state.clone());
     }
 
-    /// Open the agent-name manager for the persona at `index` in the VTA panel's
-    /// context-identity list, and load its registry. Runs inline (modal): the
-    /// overlay shows "Loading…" while the list task round-trips.
-    async fn run_agent_name_open(
-        &self,
-        state: &mut State,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-        index: usize,
-    ) {
-        use crate::state_handler::main_page::content::{
-            AgentNameManagerPhase, AgentNameManagerState,
-        };
+    /// The `(persona_did, name, enabled)` of the overlay's selected row, if the
+    /// overlay is open, `Ready`, and has a selection.
+    /// The persona an agent-name overlay would open for, and the label/host to
+    /// show while it loads. `None` (with a reason logged) when the selection
+    /// points at no row.
+    fn open_agent_name_overlay(&self, state: &mut State, index: usize) -> Option<String> {
+        use main_page::content::{AgentNameManagerPhase, AgentNameManagerState};
 
         let Some(persona) = state
             .main_page
@@ -2335,8 +2337,7 @@ impl StateHandler {
             state
                 .main_page
                 .log("No persona selected — create or select a persona DID first.");
-            let _ = self.state_tx.send(state.clone());
-            return;
+            return None;
         };
         state.main_page.agent_names = Some(AgentNameManagerState {
             persona_did: persona.did.clone(),
@@ -2345,245 +2346,24 @@ impl StateHandler {
             phase: AgentNameManagerPhase::Loading,
             ..Default::default()
         });
-        let _ = self.state_tx.send(state.clone());
-
-        let Some(admin_vta) = admin_vta else {
-            self.set_agent_name_message(
-                state,
-                AgentNameManagerPhase::Ready,
-                "VTA session unavailable — cannot manage agent names right now.",
-            );
-            return;
-        };
-        match agent_name_manage::list_names(admin_vta, &persona.did).await {
-            Ok(names) => self.apply_agent_name_list(state, names, AgentNameManagerPhase::Ready),
-            Err(e) => {
-                if let Some(o) = state.main_page.agent_names.as_mut() {
-                    o.list_stale = true;
-                }
-                self.set_agent_name_message(
-                    state,
-                    AgentNameManagerPhase::Ready,
-                    format!("Could not load agent names: {e:#}"),
-                )
-            }
-        }
+        Some(persona.did)
     }
 
-    /// Claim the name in the overlay's input (`set`), then refresh the registry.
-    async fn run_agent_name_claim(
-        &self,
-        state: &mut State,
-        config: &mut Config,
-        save: &mut save_coalesce::SaveScheduler,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-    ) {
-        use crate::state_handler::main_page::content::AgentNameManagerPhase;
-
-        let (persona_did, name) = match state.main_page.agent_names.as_ref() {
-            Some(o) if o.phase == AgentNameManagerPhase::Ready => {
-                (o.persona_did.clone(), o.input.value().trim().to_string())
-            }
-            _ => return,
-        };
-        if name.is_empty() {
-            self.set_agent_name_message(state, AgentNameManagerPhase::Ready, "Enter a name first.");
-            return;
-        }
-        let Some(admin_vta) =
-            self.begin_agent_name_work(state, admin_vta, &format!("Claiming @{name}…"))
-        else {
-            return;
-        };
-        // Fast-path rejection: a reserved or already-taken name fails the check
-        // before any publish, with a clearer reason than the set error. A check
-        // failure is non-fatal — fall through to `set`, which is authoritative
-        // (and closes the check→set race if someone claims it in between).
-        if let Ok(avail) = agent_name_manage::check_name(admin_vta, &persona_did, &name).await
-            && !avail.available
-        {
-            let why = if avail.reserved {
-                "a reserved name"
-            } else {
-                "already taken on this domain"
-            };
-            self.set_agent_name_message(
-                state,
-                AgentNameManagerPhase::Ready,
-                format!("@{name} is {why} ({}).", avail.domain),
-            );
-            return;
-        }
-        match agent_name_manage::set_name(admin_vta, &persona_did, &name).await {
-            Ok(_) => {
-                if let Some(o) = state.main_page.agent_names.as_mut() {
-                    o.input.reset();
-                }
-                state.main_page.log(format!("Claimed agent name @{name}"));
-                self.refresh_agent_names(state, config, save, admin_vta, &persona_did)
-                    .await;
-            }
-            Err(e) => self.set_agent_name_message(
-                state,
-                AgentNameManagerPhase::Ready,
-                format!("Could not claim @{name}: {e:#}"),
-            ),
-        }
-    }
-
-    /// Park (`disable`) or resume (`enable`) the selected name, then refresh.
-    async fn run_agent_name_toggle(
-        &self,
-        state: &mut State,
-        config: &mut Config,
-        save: &mut save_coalesce::SaveScheduler,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-    ) {
-        use crate::state_handler::main_page::content::AgentNameManagerPhase;
-
-        let (persona_did, name, enabled) = match self.selected_agent_name(state) {
-            Some(v) => v,
-            None => return,
-        };
-        let verb = if enabled { "Parking" } else { "Resuming" };
-        let Some(admin_vta) =
-            self.begin_agent_name_work(state, admin_vta, &format!("{verb} @{name}…"))
-        else {
-            return;
-        };
-        let result = if enabled {
-            agent_name_manage::disable_name(admin_vta, &persona_did, &name).await
-        } else {
-            agent_name_manage::enable_name(admin_vta, &persona_did, &name).await
-        };
-        match result {
-            Ok(_) => {
-                state.main_page.log(format!(
-                    "{} agent name @{name}",
-                    if enabled { "Parked" } else { "Resumed" }
-                ));
-                self.refresh_agent_names(state, config, save, admin_vta, &persona_did)
-                    .await;
-            }
-            Err(e) => self.set_agent_name_message(
-                state,
-                AgentNameManagerPhase::Ready,
-                format!("Could not {} @{name}: {e:#}", verb.to_lowercase()),
-            ),
-        }
-    }
-
-    /// Remove (release) the selected name, then refresh.
-    async fn run_agent_name_remove(
-        &self,
-        state: &mut State,
-        config: &mut Config,
-        save: &mut save_coalesce::SaveScheduler,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-    ) {
-        use crate::state_handler::main_page::content::AgentNameManagerPhase;
-
-        let (persona_did, name, _enabled) = match self.selected_agent_name(state) {
-            Some(v) => v,
-            None => return,
-        };
-        let Some(admin_vta) =
-            self.begin_agent_name_work(state, admin_vta, &format!("Removing @{name}…"))
-        else {
-            return;
-        };
-        match agent_name_manage::remove_name(admin_vta, &persona_did, &name).await {
-            Ok(_) => {
-                state.main_page.log(format!("Removed agent name @{name}"));
-                self.refresh_agent_names(state, config, save, admin_vta, &persona_did)
-                    .await;
-            }
-            Err(e) => self.set_agent_name_message(
-                state,
-                AgentNameManagerPhase::Ready,
-                format!("Could not remove @{name}: {e:#}"),
-            ),
-        }
-    }
-
-    /// Re-list the registry after a mutation and reconcile the persisted
-    /// name cache: the persona's displayed name becomes its first *enabled*
-    /// entry (or `None` when it has none), so the header/panels reflect the
-    /// change without waiting for the background sweep.
-    async fn refresh_agent_names(
-        &self,
-        state: &mut State,
-        config: &mut Config,
-        save: &mut save_coalesce::SaveScheduler,
-        admin_vta: &vta_sdk::client::VtaClient,
-        persona_did: &str,
-    ) {
-        use crate::state_handler::main_page::content::AgentNameManagerPhase;
-
-        let host = state
-            .main_page
-            .agent_names
-            .as_ref()
-            .map(|o| o.host.clone())
-            .unwrap_or_default();
-        match agent_name_manage::list_names(admin_vta, persona_did).await {
-            Ok(names) => {
-                // First served name → the persona's displayed name.
-                let cached = names
-                    .iter()
-                    .find(|n| n.enabled)
-                    .filter(|_| !host.is_empty())
-                    .map(|n| format!("{host}/@{}", n.name));
-                config.set_cached_agent_name(persona_did, cached, chrono::Utc::now());
-                save.mark_dirty();
-                state.main_page.sync_from_config(config);
-                self.apply_agent_name_list(state, names, AgentNameManagerPhase::Ready);
-            }
-            Err(e) => {
-                // The mutation landed — only the read-back failed. Mark the list
-                // unknown so the overlay stops presenting it as the registry.
-                if let Some(o) = state.main_page.agent_names.as_mut() {
-                    o.list_stale = true;
-                }
-                self.set_agent_name_message(
-                    state,
-                    AgentNameManagerPhase::Ready,
-                    format!("Applied, but could not reload the list: {e:#}"),
-                )
-            }
-        }
-    }
-
-    /// Enter the `Working` phase with a status line, returning the VTA client, or
-    /// surface "VTA unavailable" and return `None`.
-    fn begin_agent_name_work<'a>(
-        &self,
-        state: &mut State,
-        admin_vta: Option<&'a vta_sdk::client::VtaClient>,
-        status: &str,
-    ) -> Option<&'a vta_sdk::client::VtaClient> {
-        use crate::state_handler::main_page::content::AgentNameManagerPhase;
-        let Some(admin_vta) = admin_vta else {
-            self.set_agent_name_message(
-                state,
-                AgentNameManagerPhase::Ready,
-                "VTA session unavailable — cannot manage agent names right now.",
-            );
+    /// The typed name to claim, once it is non-empty and the overlay is idle.
+    fn agent_name_to_claim(&self, state: &mut State) -> Option<(String, String)> {
+        use main_page::content::AgentNameManagerPhase;
+        let o = state.main_page.agent_names.as_mut()?;
+        if o.phase != AgentNameManagerPhase::Ready {
             return None;
-        };
-        if let Some(o) = state.main_page.agent_names.as_mut() {
-            o.phase = AgentNameManagerPhase::Working;
-            o.message = Some(status.to_string());
-            // The confirm (if any) has served its purpose — the mutation is now
-            // running; don't leave it armed over the refreshed list.
-            o.confirm_remove = None;
         }
-        let _ = self.state_tx.send(state.clone());
-        Some(admin_vta)
+        let name = o.input.value().trim().to_string();
+        if name.is_empty() {
+            o.message = Some("Enter a name first.".to_string());
+            return None;
+        }
+        Some((o.persona_did.clone(), name))
     }
 
-    /// The `(persona_did, name, enabled)` of the overlay's selected row, if the
-    /// overlay is open, `Ready`, and has a selection.
     fn selected_agent_name(&self, state: &State) -> Option<(String, String, bool)> {
         use crate::state_handler::main_page::content::AgentNameManagerPhase;
         let o = state.main_page.agent_names.as_ref()?;
@@ -2592,45 +2372,6 @@ impl StateHandler {
         }
         let row = o.names.get(o.selected)?;
         Some((o.persona_did.clone(), row.name.clone(), row.enabled))
-    }
-
-    /// Replace the overlay's rows and phase from a fresh registry listing,
-    /// clamping the selection into range.
-    fn apply_agent_name_list(
-        &self,
-        state: &mut State,
-        names: Vec<vta_sdk::protocols::did_management::agent_name::AgentNameEntry>,
-        phase: crate::state_handler::main_page::content::AgentNameManagerPhase,
-    ) {
-        use crate::state_handler::main_page::content::AgentNameRow;
-        if let Some(o) = state.main_page.agent_names.as_mut() {
-            o.names = names
-                .into_iter()
-                .map(|e| AgentNameRow {
-                    name: e.name,
-                    enabled: e.enabled,
-                })
-                .collect();
-            o.selected = o.selected.min(o.names.len().saturating_sub(1));
-            o.phase = phase;
-            o.message = None;
-            o.list_stale = false;
-        }
-        let _ = self.state_tx.send(state.clone());
-    }
-
-    /// Set the overlay's status line and phase (no-op if the overlay is closed).
-    fn set_agent_name_message(
-        &self,
-        state: &mut State,
-        phase: crate::state_handler::main_page::content::AgentNameManagerPhase,
-        message: impl Into<String>,
-    ) {
-        if let Some(o) = state.main_page.agent_names.as_mut() {
-            o.phase = phase;
-            o.message = Some(message.into());
-        }
-        let _ = self.state_tx.send(state.clone());
     }
 
     /// Validate + store the pasted VIC from the add-VIC overlay. Mirrors
@@ -3060,27 +2801,42 @@ impl StateHandler {
                     // a `VtaClient` clone is cheap and shares the connection.
                     Action::StartAgentNameManager(index) => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.clone());
-                        self.run_agent_name_open(state, av.as_ref(), index).await;
+                        if let Some(did) = self.open_agent_name_overlay(state, index) {
+                            spawn_agent_name_job(
+                                &dispatch_tx, &mut in_flight, state, av.as_ref(),
+                                did, agent_name_actions::Verb::Open,
+                            );
+                        }
                     }
                     Action::AgentNameManagerClaim => {
-                        if let Some(ctx) = join_ctx.as_mut() {
-                            let av = ctx.admin_vta.clone();
-                            self.run_agent_name_claim(state, &mut ctx.config, &mut save, av.as_ref())
-                                .await;
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.clone());
+                        if let Some((did, name)) = self.agent_name_to_claim(state) {
+                            spawn_agent_name_job(
+                                &dispatch_tx, &mut in_flight, state, av.as_ref(),
+                                did, agent_name_actions::Verb::Claim(name),
+                            );
                         }
                     }
                     Action::AgentNameManagerToggle => {
-                        if let Some(ctx) = join_ctx.as_mut() {
-                            let av = ctx.admin_vta.clone();
-                            self.run_agent_name_toggle(state, &mut ctx.config, &mut save, av.as_ref())
-                                .await;
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.clone());
+                        if let Some((did, name, enabled)) = self.selected_agent_name(state) {
+                            let verb = if enabled {
+                                agent_name_actions::Verb::Park(name)
+                            } else {
+                                agent_name_actions::Verb::Resume(name)
+                            };
+                            spawn_agent_name_job(
+                                &dispatch_tx, &mut in_flight, state, av.as_ref(), did, verb,
+                            );
                         }
                     }
                     Action::AgentNameManagerRemove => {
-                        if let Some(ctx) = join_ctx.as_mut() {
-                            let av = ctx.admin_vta.clone();
-                            self.run_agent_name_remove(state, &mut ctx.config, &mut save, av.as_ref())
-                                .await;
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.clone());
+                        if let Some((did, name, _)) = self.selected_agent_name(state) {
+                            spawn_agent_name_job(
+                                &dispatch_tx, &mut in_flight, state, av.as_ref(),
+                                did, agent_name_actions::Verb::Remove(name),
+                            );
                         }
                     }
                     // Settings are config-only: `settings_actions::dispatch`
@@ -3444,6 +3200,69 @@ fn apply_capability_replies(
             }
         }
     }
+}
+
+/// Start an agent-name verb off the loop, shared by both loops.
+///
+/// The loop resolves what the job needs — which persona, which name, the host
+/// for the display-cache entry — and hands over owned values; the job does the
+/// Trust Tasks and nothing else. Every verb is up to two 60 s round trips, and
+/// awaiting them here parked the whole application: no inbound DIDComm, no
+/// listener lifecycle, no keys, including `q`.
+///
+/// The overlay is put into `Working` (or `Loading`, on open) *before* the spawn,
+/// so its own input stays locked for the duration exactly as it did when this
+/// ran inline. What changes is that everything else keeps running.
+fn spawn_agent_name_job(
+    dispatch_tx: &tokio::sync::mpsc::UnboundedSender<background_dispatch::DispatchOutcome>,
+    in_flight: &mut background_dispatch::InFlight,
+    state: &mut State,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
+    persona_did: String,
+    verb: agent_name_actions::Verb,
+) {
+    use main_page::content::AgentNameManagerPhase;
+
+    let domain = background_dispatch::DispatchDomain::AgentNameManage;
+    let opening = matches!(verb, agent_name_actions::Verb::Open);
+    let status = verb.status();
+
+    let Some(admin_vta) = admin_vta else {
+        if let Some(o) = state.main_page.agent_names.as_mut() {
+            o.phase = AgentNameManagerPhase::Ready;
+            o.message =
+                Some("VTA session unavailable — cannot manage agent names right now.".to_string());
+        }
+        return;
+    };
+    if !in_flight.try_begin(domain) {
+        if let Some(o) = state.main_page.agent_names.as_mut() {
+            o.message = Some(background_dispatch::InFlight::busy_message(domain));
+        }
+        return;
+    }
+
+    if let Some(o) = state.main_page.agent_names.as_mut() {
+        o.phase = if opening {
+            AgentNameManagerPhase::Loading
+        } else {
+            AgentNameManagerPhase::Working
+        };
+        o.message = Some(status);
+        // The confirm (if any) has served its purpose — the mutation is now
+        // running; don't leave it armed over the refreshed list.
+        o.confirm_remove = None;
+    }
+
+    let job = agent_name_actions::AgentNameJob {
+        vta: admin_vta.clone(),
+        host: agent_name_manage::derive_host(&persona_did).unwrap_or_default(),
+        persona_did,
+        verb,
+    };
+    background_dispatch::spawn_dispatch(dispatch_tx.clone(), domain, async move {
+        background_dispatch::DispatchOutcome::AgentNameManage(job.run().await)
+    });
 }
 
 /// Record what a refresh request does to the panel, and answer whether the


### PR DESCRIPTION
First R14 batch, and the worst offender of the 32 inline `.await` calls left in the runtime loop's action arms.

## Problem

Each agent-name Trust Task carries a **60-second timeout**, and every mutation is *two* of them — the change, then the authoritative re-read of the registry. Awaiting that inline parked the one thread that services everything: inbound DIDComm, listener lifecycle, the save scheduler, and every keystroke including `q`. Up to two minutes, for one keypress.

It was easy to under-read. The overlay's `Working` phase locks its own input, so from inside the overlay the pause looks like the overlay waiting on a network call. It was the whole application stopping — the same defect as the Tab lag (#230) and the startup freeze (#233), which were the two instances that happened to get reported.

## Fix

`agent_name_actions` follows the shape `inbox_actions` and `relationship_actions` already use: the loop resolves what the job needs and hands over owned values, the job does I/O only, and every mutation lands back on the loop in `AgentNameOutcome::apply`.

The four runners and the four helpers they shared are gone. What remains on the loop is resolving *which* persona and *which* name — pure state.

## Two things the outcome has to get right

Now that the UI stays live while a job runs, results can arrive into a changed world:

* **An outcome for a persona the overlay is no longer showing must not write its registry into the overlay.** The operator can close it, or open another persona's, mid-flight. One persona's names appearing under another's heading is exactly the class of confusion #231 and #234 were about.
* **The cached display name applies anyway.** It is a fact about the DID, established by a round-trip that completed, and it does not stop being true because a panel closed.

A rejected claim carries `names: None` — the registry did not change, so the list is left exactly as it was rather than re-read or blanked.

## Unchanged on purpose

Input locking: `Loading`/`Working` still swallow keys, so a mutation cannot be double-fired. Whether Esc should now back out of an overlay whose job is still running is a UX question this PR does not answer — the application being responsive is what makes it askable at all. Worth deciding separately.

## Tests

A listing populates the overlay and caches the served name; a failed read-back marks the list stale rather than rendering empty as "no names"; an outcome for another persona leaves the overlay alone; the cached name still applies with the overlay closed; a rejected claim leaves the existing rows untouched.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace` **and** `--no-default-features` (the configuration that caught #236) — all green.

## Remaining R14 batches

Roughly 24 inline awaits left, in rough order of user-visible pain: create-persona (mint), the VIC lifecycle and import, capabilities, credential exchange, VMC issuance and community self-removal. Each is a separate PR of this shape.
