### PR TITLE
docs(messaging): correct the stale bounded-channel comment on the DIDComm event channel

### DIFF
--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -636,9 +636,11 @@ impl StateHandler {
         // connect the applicant before it submits, exactly as the runtime-loop
         // join already does.
         //
-        // Bounded so a misbehaving mediator can't grow our memory without limit;
-        // overflows surface as `try_send` warnings and the message is left in the
-        // mailbox for `Messaging::pickup_stored` to collect on the next connect.
+        // Unbounded, deliberately: by the time an event reaches this channel the
+        // delivery layer has already acked the message, so a bounded channel's
+        // overflow drop destroys a membership credential or join verdict rather
+        // than deferring it (#221, fixed in #224). Full rationale on
+        // `didcomm::DIDCOMM_EVENT_CHANNEL_CAPACITY`.
         let (didcomm_event_tx, mut didcomm_event_rx) = mpsc::unbounded_channel();
         let shutdown_token = tokio_util::sync::CancellationToken::new();
         let didcomm_service =


### PR DESCRIPTION
The comment above the DIDComm event channel in `state_handler/mod.rs` still
described the pre-#224 behaviour — bounded, with overflow surfacing as
`try_send` warnings and the message left in the mailbox for `pickup_stored` to
collect on the next connect. It sat directly above `mpsc::unbounded_channel()`.

#224 removed that bound precisely because the drop was not deferral. The
delivery layer acks before the event reaches this channel, and an ack is a
delete at the mediator, so an overflow destroyed membership credentials and
join verdicts outright — #221 is what that looked like from the outside.

This points the comment at the ADR on `DIDCOMM_EVENT_CHANNEL_CAPACITY`, which
carries the full reasoning (including why backpressure was never on offer).

Comment-only; no behaviour change.

Found by an external RAHP/DRARM assessment of the Cypress release
(sankarshanmukhopadhyay/rahp-toolkit#18). The stale comment was the strongest
evidence behind that assessment's "unbounded queue growth" finding, which the
ADR already answers — so the comment was actively costing us review time.
