### PR TITLE
perf(r14): run the VIC vault mutations off the state-handler loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Importing or archiving an invitation credential no longer freezes the
+  application.** Every vault verb — import, archive, unarchive, restore,
+  soft-delete, purge — ran its round-trip on the state-handler thread, and each
+  was followed by a re-read of the listing, so a single keypress could park
+  every other part of the app for two round-trips. The work now runs off the
+  loop. Validation of a pasted credential deliberately stays on it: rejecting a
+  bad paste is local and instant, and it is what keeps you on the input field
+  with the reason rather than dropping you into a failed state.
+
 - **Managing agent names no longer freezes the application.** The overlay's five
   verbs are Trust Tasks with a 60-second timeout each, and a mutation is *two* of
   them — the change, then the authoritative re-read of the registry. They ran on

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -179,6 +179,10 @@ pub(crate) enum DispatchOutcome {
     /// [`AgentNameOutcome::apply`](crate::state_handler::agent_name_actions::AgentNameOutcome::apply)
     /// applies the registry, the overlay status and the persisted display name.
     AgentNameManage(crate::state_handler::agent_name_actions::AgentNameOutcome),
+    /// A VIC vault mutation finished (import / archive / unarchive / restore /
+    /// delete / purge). Shares the `Vic` domain with the listing, so the
+    /// re-read it asks for cannot start until this outcome frees it.
+    VicMutation(crate::state_handler::vic::VicMutationOutcome),
     /// A VIC list refresh finished. [`VicRefreshOutcome::apply`](crate::state_handler::vic::VicRefreshOutcome::apply)
     /// swaps in the
     /// listing (or logs why it could not be read); display-only, so it touches
@@ -206,6 +210,7 @@ impl DispatchOutcome {
             DispatchOutcome::VtaTransports(_) => DispatchDomain::VtaTransports,
             DispatchOutcome::AgentNameManage(_) => DispatchDomain::AgentNameManage,
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
+            DispatchOutcome::VicMutation(_) => DispatchDomain::Vic,
             DispatchOutcome::Panicked(domain) => *domain,
         }
     }
@@ -325,6 +330,7 @@ pub(crate) fn apply_outcome(
         }
         DispatchOutcome::AgentNameManage(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Vic(outcome) => outcome.apply(state, config),
+        DispatchOutcome::VicMutation(outcome) => outcome.apply(state),
         DispatchOutcome::Panicked(domain) => {
             // The job panicked and produced no real outcome. Surface a generic
             // failure so the user isn't left staring at a stuck "in progress"; the

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1462,22 +1462,23 @@ impl StateHandler {
                         spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
                     },
                     Action::AddVicSubmit => {
-                        self.run_add_vic(&mut state, admin_vta.as_ref()).await;
-                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
+                        if let Some(vic) = vic_to_import(&mut state) {
+                            spawn_vic_mutation(
+                                &dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref(),
+                                vic::VicVerb::Add(vic),
+                            );
+                        }
                     },
                     Action::VicArchive(i)
                     | Action::VicUnarchive(i)
                     | Action::VicRestore(i)
                     | Action::DeleteVic(i)
                     | Action::PurgeVic(i) => {
-                        self.run_vic_lifecycle(
-                            &mut state,
-                            admin_vta.as_ref(),
-                            &action,
-                            i,
-                        )
-                        .await;
-                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
+                        if let Some(verb) = vic_lifecycle_verb(&mut state, &action, i) {
+                            spawn_vic_mutation(
+                                &dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref(), verb,
+                            );
+                        }
                     },
                     Action::CreatePersonaCopy => {
                         if let Some(did) = state
@@ -2374,107 +2375,6 @@ impl StateHandler {
         Some((o.persona_did.clone(), row.name.clone(), row.enabled))
     }
 
-    /// Validate + store the pasted VIC from the add-VIC overlay. Mirrors
-    /// `run_create_persona`'s phase handling. The caller re-lists the vault
-    /// afterwards — see [`spawn_vic_refresh`], which owns every load so a stale
-    /// in-flight query can never overwrite a fresh one.
-    async fn run_add_vic(&self, state: &mut State, admin_vta: Option<&vta_sdk::client::VtaClient>) {
-        use crate::state_handler::main_page::content::AddVicPhase;
-
-        let json = match state.main_page.add_vic.as_ref() {
-            Some(o) if o.phase == AddVicPhase::Input => o.input.value().to_string(),
-            _ => return,
-        };
-        if json.trim().is_empty() {
-            if let Some(o) = state.main_page.add_vic.as_mut() {
-                o.messages = vec!["Paste an invitation credential (VIC) first.".to_string()];
-            }
-            let _ = self.state_tx.send(state.clone());
-            return;
-        }
-        let Some(admin_vta) = admin_vta else {
-            if let Some(o) = state.main_page.add_vic.as_mut() {
-                o.phase = AddVicPhase::Failed;
-                o.messages = vec!["VTA session unavailable — cannot store the VIC.".to_string()];
-            }
-            let _ = self.state_tx.send(state.clone());
-            return;
-        };
-
-        if let Some(o) = state.main_page.add_vic.as_mut() {
-            o.phase = AddVicPhase::Working;
-            o.messages = vec!["Storing invitation credential…".to_string()];
-        }
-        let _ = self.state_tx.send(state.clone());
-
-        match vic::add_vic(admin_vta, &json).await {
-            Ok(()) => {
-                if let Some(o) = state.main_page.add_vic.as_mut() {
-                    o.phase = AddVicPhase::Done;
-                    o.messages.push("Invitation credential stored.".to_string());
-                }
-                state.main_page.log("Stored an invitation credential.");
-            }
-            Err(e) => {
-                // A validation error keeps the operator on the input phase so they
-                // can fix the paste; a storage error is terminal for this attempt.
-                if let Some(o) = state.main_page.add_vic.as_mut() {
-                    o.phase = AddVicPhase::Failed;
-                    o.messages.push(format!("Failed: {e}"));
-                }
-                state
-                    .main_page
-                    .log_error("Storing the invitation credential failed", &e);
-            }
-        }
-        let _ = self.state_tx.send(state.clone());
-    }
-
-    /// Run a VIC lifecycle verb (archive / unarchive / restore / soft-delete /
-    /// purge) against the selected VIC, clearing any confirmation arm. `index`
-    /// is into the displayed VIC list. The caller re-lists the vault afterwards
-    /// (see [`spawn_vic_refresh`]).
-    async fn run_vic_lifecycle(
-        &self,
-        state: &mut State,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-        action: &Action,
-        index: usize,
-    ) {
-        // Clear the confirmation arms regardless of outcome.
-        state.main_page.content_panel.vta.confirm_delete_vic = None;
-        state.main_page.content_panel.vta.confirm_purge_vic = None;
-
-        let Some(admin_vta) = admin_vta else { return };
-        let Some(id) = state
-            .main_page
-            .content_panel
-            .vta
-            .vics
-            .get(index)
-            .map(|v| v.id.clone())
-        else {
-            return;
-        };
-
-        let (result, verb) = match action {
-            Action::VicArchive(_) => (vic::archive_vic(admin_vta, &id).await, "Archived"),
-            Action::VicUnarchive(_) => (vic::unarchive_vic(admin_vta, &id).await, "Unarchived"),
-            Action::VicRestore(_) => (vic::restore_vic(admin_vta, &id).await, "Restored"),
-            Action::DeleteVic(_) => (vic::delete_vic(admin_vta, &id).await, "Deleted"),
-            Action::PurgeVic(_) => (vic::purge_vic(admin_vta, &id).await, "Purged"),
-            _ => return,
-        };
-        match result {
-            Ok(()) => state
-                .main_page
-                .log(format!("{verb} invitation credential.")),
-            Err(e) => state
-                .main_page
-                .log_error(format!("VIC {} failed", verb.to_lowercase()), &e),
-        }
-    }
-
     /// Remove the community at `index` in the Communities display list: withdraw
     /// a live (Pending/Active) membership first (R-C-8 — for a pending join this
     /// is the withdrawal), then delete the record, persist, and refresh the
@@ -2937,18 +2837,25 @@ impl StateHandler {
                         spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
                     }
                     Action::AddVicSubmit => {
-                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        self.run_add_vic(state, av).await;
-                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.clone());
+                        if let Some(vic) = vic_to_import(state) {
+                            spawn_vic_mutation(
+                                &dispatch_tx, &mut in_flight, state, av.as_ref(),
+                                vic::VicVerb::Add(vic),
+                            );
+                        }
                     }
                     Action::VicArchive(i)
                     | Action::VicUnarchive(i)
                     | Action::VicRestore(i)
                     | Action::DeleteVic(i)
                     | Action::PurgeVic(i) => {
-                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
-                        self.run_vic_lifecycle(state, av, &action, i).await;
-                        spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.clone());
+                        if let Some(verb) = vic_lifecycle_verb(state, &action, i) {
+                            spawn_vic_mutation(
+                                &dispatch_tx, &mut in_flight, state, av.as_ref(), verb,
+                            );
+                        }
                     }
                     Action::CreatePersonaCopy => {
                         if let Some(did) = state
@@ -3200,6 +3107,100 @@ fn apply_capability_replies(
             }
         }
     }
+}
+
+/// Start a VIC vault mutation off the loop, shared by both loops.
+///
+/// The import's *validation* stays on the loop deliberately: parsing the paste
+/// and checking it is an invitation credential is local and instant, and it is
+/// what decides whether the operator stays on the input field to fix it. Only
+/// the vault round-trip is backgrounded.
+///
+/// Mutations share the `Vic` domain with the listing, so a mutation and a
+/// refresh cannot overlap and produce a list that reflects neither. The refresh
+/// that follows is *requested* by the outcome rather than started here — see
+/// [`vic::VicMutationOutcome::apply`].
+fn spawn_vic_mutation(
+    dispatch_tx: &tokio::sync::mpsc::UnboundedSender<background_dispatch::DispatchOutcome>,
+    in_flight: &mut background_dispatch::InFlight,
+    state: &mut State,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
+    verb: vic::VicVerb,
+) {
+    let domain = background_dispatch::DispatchDomain::Vic;
+    let Some(admin_vta) = admin_vta else { return };
+    if !in_flight.try_begin(domain) {
+        state
+            .main_page
+            .log(background_dispatch::InFlight::busy_message(domain));
+        return;
+    }
+    let job = vic::VicJob {
+        admin_vta: admin_vta.clone(),
+        verb,
+    };
+    background_dispatch::spawn_dispatch(dispatch_tx.clone(), domain, async move {
+        background_dispatch::DispatchOutcome::VicMutation(job.run().await)
+    });
+}
+
+/// Validate the pasted invitation credential on the loop, returning the parsed
+/// body to store. A bad paste keeps the operator on the input field with the
+/// reason, exactly as it did when the whole import ran inline.
+fn vic_to_import(state: &mut State) -> Option<serde_json::Value> {
+    use main_page::content::AddVicPhase;
+
+    let json = match state.main_page.add_vic.as_ref() {
+        Some(o) if o.phase == AddVicPhase::Input => o.input.value().to_string(),
+        _ => return None,
+    };
+    fn fail(state: &mut State, msg: String) -> Option<serde_json::Value> {
+        if let Some(o) = state.main_page.add_vic.as_mut() {
+            o.messages = vec![msg];
+        }
+        None
+    }
+    if json.trim().is_empty() {
+        return fail(
+            state,
+            "Paste an invitation credential (VIC) first.".to_string(),
+        );
+    }
+    let vic: serde_json::Value = match serde_json::from_str(json.trim()) {
+        Ok(v) => v,
+        Err(e) => return fail(state, format!("Failed: not valid JSON: {e}")),
+    };
+    if let Err(e) = openvtc_core::join::validate_invitation_credential(&vic) {
+        return fail(state, format!("Failed: {e}"));
+    }
+    if let Some(o) = state.main_page.add_vic.as_mut() {
+        o.phase = AddVicPhase::Working;
+        o.messages = vec!["Storing invitation credential…".to_string()];
+    }
+    Some(vic)
+}
+
+/// The vault verb an armed lifecycle key acts on, with its target id.
+fn vic_lifecycle_verb(state: &mut State, action: &Action, index: usize) -> Option<vic::VicVerb> {
+    // The confirmation arms are resolved either way.
+    state.main_page.content_panel.vta.confirm_delete_vic = None;
+    state.main_page.content_panel.vta.confirm_purge_vic = None;
+
+    let id = state
+        .main_page
+        .content_panel
+        .vta
+        .vics
+        .get(index)
+        .map(|v| v.id.clone())?;
+    Some(match action {
+        Action::VicArchive(_) => vic::VicVerb::Archive(id),
+        Action::VicUnarchive(_) => vic::VicVerb::Unarchive(id),
+        Action::VicRestore(_) => vic::VicVerb::Restore(id),
+        Action::DeleteVic(_) => vic::VicVerb::Delete(id),
+        Action::PurgeVic(_) => vic::VicVerb::Purge(id),
+        _ => return None,
+    })
 }
 
 /// Start an agent-name verb off the loop, shared by both loops.

--- a/openvtc/src/state_handler/vic.rs
+++ b/openvtc/src/state_handler/vic.rs
@@ -39,50 +39,6 @@ pub(crate) async fn list_vics(
     Ok(creds.iter().map(VicSummary::from_descriptor).collect())
 }
 
-/// Import a pasted VIC into the vault: validate it is a *complete* Invitation
-/// Credential, then store it via `cred_vault_receive`. The vault keys it under
-/// the VC's own `id` — so a stripped copy with no top-level `id` could never be
-/// retrieved for presentation anyway; rejecting it here gives a clear reason.
-pub(crate) async fn add_vic(admin_vta: &VtaClient, json: &str) -> Result<()> {
-    let vic: serde_json::Value =
-        serde_json::from_str(json.trim()).map_err(|e| anyhow::anyhow!("not valid JSON: {e}"))?;
-    openvtc_core::join::validate_invitation_credential(&vic).map_err(|e| anyhow::anyhow!(e))?;
-    admin_vta.cred_vault_receive(vic, None).await?;
-    Ok(())
-}
-
-/// Archive a VIC (hidden from query/presentation, restorable via unarchive).
-pub(crate) async fn archive_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
-    admin_vta.cred_vault_archive(id, Some(REASON)).await?;
-    Ok(())
-}
-
-/// Return an archived VIC to active.
-pub(crate) async fn unarchive_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
-    admin_vta.cred_vault_unarchive(id, Some(REASON)).await?;
-    Ok(())
-}
-
-/// Soft-delete a VIC (recoverable tombstone within the grace window).
-pub(crate) async fn delete_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
-    admin_vta
-        .cred_vault_delete(id, /* force */ false, Some(REASON))
-        .await?;
-    Ok(())
-}
-
-/// Restore a soft-deleted VIC (only within the grace window).
-pub(crate) async fn restore_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
-    admin_vta.cred_vault_restore(id, Some(REASON)).await?;
-    Ok(())
-}
-
-/// Irreversibly purge a VIC and its index rows.
-pub(crate) async fn purge_vic(admin_vta: &VtaClient, id: &str) -> Result<()> {
-    admin_vta.cred_vault_purge(id, Some(REASON)).await?;
-    Ok(())
-}
-
 // ****************************************************************************
 // Background refresh
 // ****************************************************************************
@@ -252,5 +208,214 @@ mod tests {
                 .any(|e| e.summary.contains("connection refused")),
             "the failure reason must reach the log"
         );
+    }
+}
+
+// ****************************************************************************
+// Background mutations
+// ****************************************************************************
+
+/// A vault mutation, already resolved to the id (or body) it acts on.
+///
+/// Import is split at the validation boundary: the paste is parsed and checked
+/// on the loop thread, because that is local, instant, and decides whether the
+/// operator stays on the input field to fix it. Only the store round-trip is
+/// carried here.
+pub(crate) enum VicVerb {
+    /// Store a validated invitation credential.
+    Add(serde_json::Value),
+    /// Hide from query/presentation, restorable.
+    Archive(String),
+    /// Return an archived VIC to active.
+    Unarchive(String),
+    /// Restore a soft-deleted VIC.
+    Restore(String),
+    /// Soft-delete.
+    Delete(String),
+    /// Irreversible purge.
+    Purge(String),
+}
+
+impl VicVerb {
+    /// Past-tense word for the activity-log line, and the noun the error uses.
+    fn verb(&self) -> &'static str {
+        match self {
+            VicVerb::Add(_) => "Stored",
+            VicVerb::Archive(_) => "Archived",
+            VicVerb::Unarchive(_) => "Unarchived",
+            VicVerb::Restore(_) => "Restored",
+            VicVerb::Delete(_) => "Deleted",
+            VicVerb::Purge(_) => "Purged",
+        }
+    }
+}
+
+/// One backgrounded vault mutation.
+pub(crate) struct VicJob {
+    pub(crate) admin_vta: VtaClient,
+    pub(crate) verb: VicVerb,
+}
+
+impl VicJob {
+    /// Do the round-trip. I/O only.
+    pub(crate) async fn run(self) -> VicMutationOutcome {
+        let verb = self.verb.verb();
+        let is_add = matches!(self.verb, VicVerb::Add(_));
+        let result = match self.verb {
+            VicVerb::Add(vic) => self
+                .admin_vta
+                .cred_vault_receive(vic, None)
+                .await
+                .map(|_| ()),
+            VicVerb::Archive(id) => self
+                .admin_vta
+                .cred_vault_archive(&id, Some(REASON))
+                .await
+                .map(|_| ()),
+            VicVerb::Unarchive(id) => self
+                .admin_vta
+                .cred_vault_unarchive(&id, Some(REASON))
+                .await
+                .map(|_| ()),
+            VicVerb::Restore(id) => self
+                .admin_vta
+                .cred_vault_restore(&id, Some(REASON))
+                .await
+                .map(|_| ()),
+            VicVerb::Delete(id) => self
+                .admin_vta
+                .cred_vault_delete(&id, /* force */ false, Some(REASON))
+                .await
+                .map(|_| ()),
+            VicVerb::Purge(id) => self
+                .admin_vta
+                .cred_vault_purge(&id, Some(REASON))
+                .await
+                .map(|_| ()),
+        };
+        VicMutationOutcome {
+            verb,
+            is_add,
+            error: result.err().map(|e| format!("{e}")),
+        }
+    }
+}
+
+/// What a vault mutation did. Data only; applied on the loop thread.
+pub(crate) struct VicMutationOutcome {
+    verb: &'static str,
+    /// The import overlay only exists for `Add`, and only it has phases to move.
+    is_add: bool,
+    error: Option<String>,
+}
+
+impl VicMutationOutcome {
+    /// Apply on the loop thread, and ask for the listing to be re-read.
+    ///
+    /// The re-read is requested rather than started: mutations and refreshes
+    /// share the `Vic` domain, so the refresh cannot begin until this outcome
+    /// has freed it. Setting the queued flag hands that to the dispatch arm,
+    /// which re-issues it the moment the domain is free — the same path a
+    /// refresh rejected by the busy-guard already takes.
+    pub(crate) fn apply(self, state: &mut State) {
+        use crate::state_handler::main_page::content::AddVicPhase;
+
+        state.main_page.content_panel.vta.vic_refresh_queued = true;
+
+        match self.error {
+            None => {
+                if self.is_add
+                    && let Some(o) = state.main_page.add_vic.as_mut()
+                {
+                    o.phase = AddVicPhase::Done;
+                    o.messages.push("Invitation credential stored.".to_string());
+                }
+                state
+                    .main_page
+                    .log(format!("{} invitation credential.", self.verb));
+            }
+            Some(e) => {
+                if self.is_add
+                    && let Some(o) = state.main_page.add_vic.as_mut()
+                {
+                    // A storage failure is terminal for this attempt; a bad
+                    // paste never reaches here, because it is rejected on the
+                    // loop before the job is spawned.
+                    o.phase = AddVicPhase::Failed;
+                    o.messages.push(format!("Failed: {e}"));
+                }
+                state.main_page.log_error(
+                    format!("VIC {} failed", self.verb.to_lowercase()),
+                    e.as_str(),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod mutation_tests {
+    use super::*;
+    use crate::state_handler::main_page::content::AddVicPhase;
+
+    fn outcome(verb: &'static str, is_add: bool, error: Option<&str>) -> VicMutationOutcome {
+        VicMutationOutcome {
+            verb,
+            is_add,
+            error: error.map(ToString::to_string),
+        }
+    }
+
+    /// Every mutation asks for the listing to be re-read, because the vault is
+    /// authoritative and the panel has just been invalidated. It *asks* rather
+    /// than starting one: mutation and refresh share a domain, so the refresh
+    /// cannot begin until this outcome frees it.
+    #[test]
+    fn a_mutation_requests_a_refresh() {
+        let mut state = State::default();
+        outcome("Archived", false, None).apply(&mut state);
+        assert!(state.main_page.content_panel.vta.vic_refresh_queued);
+    }
+
+    /// A failed mutation still asks: the vault's state is now unknown, which is
+    /// exactly when a stale list is most misleading.
+    #[test]
+    fn a_failed_mutation_still_requests_a_refresh() {
+        let mut state = State::default();
+        outcome("Purged", false, Some("vault refused")).apply(&mut state);
+        assert!(state.main_page.content_panel.vta.vic_refresh_queued);
+        assert!(
+            state
+                .main_page
+                .activity_log
+                .iter()
+                .any(|e| e.summary.contains("vault refused")),
+            "the reason must reach the log"
+        );
+    }
+
+    /// A successful import completes the overlay; a failed store is terminal
+    /// for that attempt. A *bad paste* never reaches here — it is rejected on
+    /// the loop before a job is spawned, so the operator keeps the input field.
+    #[test]
+    fn an_import_moves_the_overlay_to_a_terminal_phase() {
+        use crate::state_handler::main_page::content::AddVicState;
+        for (error, want) in [(None, AddVicPhase::Done), (Some("no"), AddVicPhase::Failed)] {
+            let mut state = State::default();
+            state.main_page.add_vic = Some(AddVicState {
+                phase: AddVicPhase::Working,
+                ..Default::default()
+            });
+            outcome("Stored", true, error).apply(&mut state);
+            assert_eq!(state.main_page.add_vic.as_ref().unwrap().phase, want);
+        }
+    }
+
+    /// A lifecycle verb has no overlay to move, and must not invent one.
+    #[test]
+    fn a_lifecycle_verb_leaves_the_import_overlay_alone() {
+        let mut state = State::default();
+        outcome("Deleted", false, None).apply(&mut state);
+        assert!(state.main_page.add_vic.is_none());
     }
 }


### PR DESCRIPTION
Second R14 batch. Stacks alongside #237 (agent names) — independent files apart from `background_dispatch.rs` and the two loops' arms, so whichever lands second may want a trivial rebase.

## Problem

Import, archive, unarchive, restore, soft-delete and purge each ran their vault round-trip inline on the state-handler thread, and each was followed by a listing re-read. One keypress parked inbound DIDComm, listener lifecycle, the save scheduler and the keyboard for **two** round-trips.

## The split is at the validation boundary, not the action boundary

Parsing a pasted credential and checking it really is an invitation is local and instant — and it is what decides whether the operator stays on the input field to fix it. That stays on the loop. Only the store is carried into the job.

A bad paste therefore cannot reach a `Failed` phase at all: the distinction the inline code drew between *"fix your paste"* and *"the vault refused it"* is now preserved by construction rather than by matching on an error string.

## Ordering

Mutations share the `Vic` domain with the listing, which is what makes this safe: a mutation and a refresh cannot overlap and leave a list reflecting neither.

The follow-up refresh is **requested** by the outcome rather than started by it, through the `vic_refresh_queued` flag that the dispatch arm already re-issues when the domain frees — the same path a refresh rejected by the busy-guard takes. A *failed* mutation asks for one too: that is precisely when the panel is most misleading.

## Also

The six per-verb wrappers are gone. `VicJob` calls the vault directly and the verb is data, which is what let the six near-identical `run_vic_lifecycle` arms collapse. `list_vics` stays — the refresh still needs it.

## Tests

A mutation requests a refresh; a failed one requests it too and puts the reason in the log; an import moves the overlay to a terminal phase either way; a lifecycle verb leaves the import overlay alone.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo doc --workspace --no-deps` (no warnings); `cargo test --workspace` **and** `--no-default-features`.

## On create-persona, which I did not do

It was next by user-visible pain, and it needs its own design rather than this shape. `mint_standalone_persona` takes `&mut Config` and its tail — `Config::mint_persona_into` — interleaves config mutation with network work, including `atm.profile_add`. Splitting it means changing a path the join flow shares, and it also streams progress into the overlay, which needs a channel this mechanism does not have yet. Worth doing, worth scoping separately.

Remaining after this: capabilities, credential exchange, VMC issuance, community self-removal, and create-persona.
