### PR TITLE
perf(r14): send community leave and VMC issuance off the loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Leaving a community, or issuing it your membership credential, no longer
+  freezes the application.** Both send to the community and were awaited on the
+  state-handler thread — and an unreachable community is a *likely* reason to
+  leave one, which is exactly when the send retries longest. Both now run off
+  the loop. A successful leave still marks the membership Left and tears down
+  its messaging session; the record moves on the send rather than on a receipt,
+  because the community's acknowledgement is advisory and a member who has
+  announced a departure should not still be shown as a member if it never
+  answers.
+
 - **Opening the capabilities view, refreshing it, or committing a toggle no
   longer freezes the application.** Each of those sends a governance document to
   the community and waits for the *send* — which retries against an unreachable

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -83,6 +83,10 @@ pub(crate) enum DispatchDomain {
     /// sweep: sharing a domain would let a background refresh delay an operator
     /// who is claiming a name, and the two touch different state.
     AgentNameManage,
+    /// A send addressed to a community: leaving it, or issuing it the
+    /// reciprocal membership credential. Serialised together because both
+    /// address the same peer and both are user-initiated one at a time.
+    Community,
     /// Capability query / toggle: one governance document sent to a community.
     /// The community's *answer* is not part of this — it arrives later on the
     /// inbound channel and is matched by thread id — so what this domain
@@ -107,6 +111,7 @@ impl DispatchDomain {
             DispatchDomain::AgentName => "Agent name refresh",
             DispatchDomain::VtaTransports => "VTA transport probe",
             DispatchDomain::AgentNameManage => "Agent name change",
+            DispatchDomain::Community => "Community request",
             DispatchDomain::Capabilities => "Capability request",
             DispatchDomain::Vic => "Invitation credential refresh",
         }
@@ -185,6 +190,8 @@ pub(crate) enum DispatchOutcome {
     /// [`AgentNameOutcome::apply`](crate::state_handler::agent_name_actions::AgentNameOutcome::apply)
     /// applies the registry, the overlay status and the persisted display name.
     AgentNameManage(crate::state_handler::agent_name_actions::AgentNameOutcome),
+    /// A community send finished (leave / issue membership credential).
+    Community(crate::state_handler::community_actions::CommunityOutcome),
     /// A capability query or toggle was sent (or failed to send).
     Capabilities(crate::state_handler::capability_actions::CapabilityOutcome),
     /// A VIC vault mutation finished (import / archive / unarchive / restore /
@@ -217,6 +224,7 @@ impl DispatchOutcome {
             DispatchOutcome::AgentName(_) => DispatchDomain::AgentName,
             DispatchOutcome::VtaTransports(_) => DispatchDomain::VtaTransports,
             DispatchOutcome::AgentNameManage(_) => DispatchDomain::AgentNameManage,
+            DispatchOutcome::Community(_) => DispatchDomain::Community,
             DispatchOutcome::Capabilities(_) => DispatchDomain::Capabilities,
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::VicMutation(_) => DispatchDomain::Vic,
@@ -277,13 +285,21 @@ pub(crate) fn spawn_dispatch<F>(
 /// persists it), and removes the provisional `RequestSent` record it pre-inserted
 /// (see [`RelationshipOutcome::apply`]) so a failed send leaves no relationship
 /// record — exactly the pre-R14 net state.
+/// A community whose messaging session the caller still owes a teardown, and
+/// the persona that held it.
+///
+/// Returned rather than acted on because the session manager and the messaging
+/// service belong to the runtime loop, while this function is shared with the
+/// degraded loop — which has no sessions and ignores it.
+pub(crate) type PendingDeregistration = Option<(String, openvtc_core::config::account::PersonaId)>;
+
 pub(crate) fn apply_outcome(
     state: &mut State,
     config: &mut Config,
     save: &mut SaveScheduler,
     in_flight: &mut InFlight,
     outcome: DispatchOutcome,
-) {
+) -> PendingDeregistration {
     let domain = outcome.domain();
     match outcome {
         DispatchOutcome::MediatorReconnect(result) => match result {
@@ -338,6 +354,11 @@ pub(crate) fn apply_outcome(
             state.main_page.content_panel.vta.transports.advertised = Some(advertised);
         }
         DispatchOutcome::AgentNameManage(outcome) => outcome.apply(state, config, save),
+        DispatchOutcome::Community(outcome) => {
+            let pending = outcome.apply(state, config, save);
+            in_flight.finish(domain);
+            return pending;
+        }
         DispatchOutcome::Capabilities(outcome) => outcome.apply(state),
         DispatchOutcome::Vic(outcome) => outcome.apply(state, config),
         DispatchOutcome::VicMutation(outcome) => outcome.apply(state),
@@ -350,6 +371,7 @@ pub(crate) fn apply_outcome(
         }
     }
     in_flight.finish(domain);
+    None
 }
 
 #[cfg(test)]

--- a/openvtc/src/state_handler/community_actions.rs
+++ b/openvtc/src/state_handler/community_actions.rs
@@ -1,0 +1,244 @@
+//! Community sends, off the loop thread (R14).
+//!
+//! Two verbs address a community directly: leaving it (`members/self-remove`)
+//! and issuing it the reciprocal membership credential (`members/vmc`). Both
+//! were awaited inline, and both send to a peer that may be exactly the thing
+//! that has gone wrong — leaving a community whose VTC is unreachable is a
+//! *likely* reason to leave it, and that is precisely when the send retries
+//! longest.
+//!
+//! The post-send work differs in kind, which is why leaving needs more than the
+//! shared apply path: a successful leave also tears down that community's
+//! messaging session, and the session manager lives in the runtime loop. The
+//! outcome therefore *reports* the teardown it needs — `apply` returns the
+//! community to deregister — and the runtime loop performs it. The degraded
+//! loop has no sessions to tear down and ignores the answer.
+
+use std::sync::Arc;
+
+use affinidi_tdk::messaging::ATM;
+use affinidi_tdk::messaging::profiles::ATMProfile;
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+
+use crate::state_handler::save_coalesce::SaveScheduler;
+use crate::state_handler::state::State;
+use openvtc_core::config::Config;
+use openvtc_core::config::account::PersonaId;
+
+/// Which document a job sends to the community.
+pub(crate) enum Verb {
+    /// `members/self-remove` — leave. On success the membership is marked Left
+    /// and its session torn down; the community's receipt is advisory.
+    Leave,
+    /// `members/vmc` — issue the reciprocal membership credential, signed by the
+    /// member.
+    IssueVmc { signing_secret: Box<Secret> },
+}
+
+/// Everything the send needs, resolved on the loop thread.
+pub(crate) struct CommunityJob {
+    pub(crate) atm: ATM,
+    pub(crate) profile: Arc<ATMProfile>,
+    pub(crate) member_did: String,
+    pub(crate) mediator: String,
+    pub(crate) vtc_did: String,
+    pub(crate) persona: PersonaId,
+    pub(crate) verb: Verb,
+}
+
+impl CommunityJob {
+    /// Do the send. I/O only.
+    pub(crate) async fn run(self) -> CommunityOutcome {
+        let leaving = matches!(self.verb, Verb::Leave);
+        let result = match &self.verb {
+            Verb::Leave => openvtc_core::join::submit_self_remove(
+                &self.atm,
+                &self.profile,
+                &self.member_did,
+                &self.vtc_did,
+                &self.mediator,
+                None,
+            )
+            .await
+            .map(|_| ()),
+            Verb::IssueVmc { signing_secret } => openvtc_core::members::issue_and_send_member_vmc(
+                &self.atm,
+                &self.profile,
+                signing_secret,
+                &self.member_did,
+                &self.vtc_did,
+                &self.mediator,
+            )
+            .await
+            .map(|_| ()),
+        };
+        CommunityOutcome {
+            vtc_did: self.vtc_did,
+            persona: self.persona,
+            leaving,
+            error: result.err().map(|e| format!("{e}")),
+        }
+    }
+}
+
+/// What the send did. Data only; applied on the loop thread.
+pub(crate) struct CommunityOutcome {
+    vtc_did: String,
+    persona: PersonaId,
+    /// `true` for a leave, whose success also changes the membership record.
+    leaving: bool,
+    error: Option<String>,
+}
+
+impl CommunityOutcome {
+    /// Apply the record change and the status line, and say whether the loop
+    /// still owes this community a session teardown.
+    ///
+    /// The teardown is reported rather than done because the session manager and
+    /// the messaging service belong to the runtime loop, and this runs from the
+    /// shared apply path that both loops call.
+    pub(crate) fn apply(
+        self,
+        state: &mut State,
+        config: &mut Config,
+        save: &mut SaveScheduler,
+    ) -> Option<(String, PersonaId)> {
+        // Set through a local rather than a long-lived `&mut` into `state`:
+        // two of the arms also want to log, which needs `main_page` again.
+        fn status(state: &mut State, msg: String) {
+            state.main_page.content_panel.communities.status_message = Some(msg);
+        }
+        match (self.error, self.leaving) {
+            (None, true) => {
+                // The record moves on the send, not on a receipt: the community's
+                // acknowledgement is advisory, and a member who has announced a
+                // departure should not still be shown as a member if it never
+                // answers.
+                if let Some(c) = config.account.membership_mut(&self.vtc_did, self.persona) {
+                    c.leave();
+                }
+                save.mark_dirty();
+                status(state, "Left the community.".to_string());
+                state.main_page.sync_from_config(config);
+                return Some((self.vtc_did, self.persona));
+            }
+            (None, false) => {
+                status(
+                    state,
+                    "Membership credential issued and sent to the community.".to_string(),
+                );
+            }
+            (Some(e), true) => {
+                state.main_page.log_error("Leave failed", e.as_str());
+                status(state, format!("Couldn't leave: {e}"));
+            }
+            (Some(e), false) => {
+                state
+                    .main_page
+                    .log_error("Issue membership credential failed", e.as_str());
+                status(
+                    state,
+                    format!("Couldn't issue the membership credential: {e}"),
+                );
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+
+    const VTC: &str = "did:webvh:QmScidCommunity:example.com:acme";
+
+    fn outcome(leaving: bool, error: Option<&str>) -> CommunityOutcome {
+        CommunityOutcome {
+            vtc_did: VTC.to_string(),
+            persona: PersonaId(uuid::Uuid::nil()),
+            leaving,
+            error: error.map(ToString::to_string),
+        }
+    }
+
+    /// A successful leave asks the loop to tear the session down. Nothing else
+    /// can: the session manager is not reachable from the shared apply path.
+    #[test]
+    fn a_successful_leave_asks_for_a_session_teardown() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+
+        let deregister = outcome(true, None).apply(&mut state, &mut config, &mut save);
+
+        assert_eq!(deregister.map(|(v, _)| v).as_deref(), Some(VTC));
+        assert!(save.is_pending(), "the record change must be persisted");
+    }
+
+    /// A *failed* leave must not tear anything down — the membership is still
+    /// live, and the session is what would carry a retry.
+    #[test]
+    fn a_failed_leave_keeps_the_session() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+
+        let deregister =
+            outcome(true, Some("peer unreachable")).apply(&mut state, &mut config, &mut save);
+
+        assert!(deregister.is_none());
+        assert!(
+            state
+                .main_page
+                .content_panel
+                .communities
+                .status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("Couldn't leave")),
+        );
+    }
+
+    /// Issuing a credential never touches the session or the record — it is a
+    /// send with a status line.
+    #[test]
+    fn issuing_a_credential_touches_neither_session_nor_record() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+
+        let deregister = outcome(false, None).apply(&mut state, &mut config, &mut save);
+
+        assert!(deregister.is_none());
+        assert!(!save.is_pending(), "nothing to persist");
+        assert!(
+            state
+                .main_page
+                .content_panel
+                .communities
+                .status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("issued")),
+        );
+    }
+
+    /// A failed issue reports why, and still changes nothing.
+    #[test]
+    fn a_failed_issue_reports_the_reason() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+
+        let deregister =
+            outcome(false, Some("vault refused")).apply(&mut state, &mut config, &mut save);
+
+        assert!(deregister.is_none());
+        assert!(
+            state
+                .main_page
+                .activity_log
+                .iter()
+                .any(|e| e.summary.contains("vault refused")),
+        );
+    }
+}

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -202,6 +202,7 @@ mod agent_name_manage;
 mod agent_name_refresh;
 mod background_dispatch;
 mod capability_actions;
+mod community_actions;
 mod create_persona;
 mod credential_actions;
 /// The DIDComm transport module, which now lives in `openvtc-core`.
@@ -972,8 +973,11 @@ impl StateHandler {
                         }
                     },
                     Action::LeaveCommunity(i) => {
-                        // R-L-1: send MEMBER_SELF_REMOVE, then set Left + deregister
-                        // the session on send success (the receipt is advisory).
+                        // R-L-1: send MEMBER_SELF_REMOVE, then set Left +
+                        // deregister the session once it lands (the community's
+                        // receipt is advisory). Both halves are in
+                        // `community_actions`; the session teardown is reported
+                        // back to this loop, which owns the session manager.
                         state.main_page.content_panel.communities.confirm_leave = None;
                         let target = config
                             .account
@@ -982,57 +986,21 @@ impl StateHandler {
                             .filter(|c| c.status.is_active())
                             .map(|c| (c.vtc_did.clone(), c.persona_ref));
                         if let Some((vtc, persona_id)) = target {
-                            // Owned send inputs from the persona's runtime identity,
-                            // so no config borrow is held across the network await.
-                            let sender = config.identities.get(&persona_id).map(|id| {
-                                (
-                                    id.persona_did().to_string(),
-                                    id.profile().clone(),
-                                    id.mediator_did.clone().unwrap_or_default(),
-                                )
-                            });
-                            let send = match (sender, tdk.atm.as_ref()) {
-                                (Some((member_did, profile, mediator)), Some(atm)) => {
-                                    openvtc_core::join::submit_self_remove(
-                                        atm, &profile, &member_did, &vtc, &mediator, None,
-                                    )
-                                    .await
+                            match capability_sender(&config, &tdk, persona_id) {
+                                Some((atm, profile, member_did, mediator)) => {
+                                    spawn_community_job(
+                                        &dispatch_tx, &mut in_flight, &mut state,
+                                        community_actions::CommunityJob {
+                                            atm, profile, member_did, mediator,
+                                            vtc_did: vtc, persona: persona_id,
+                                            verb: community_actions::Verb::Leave,
+                                        },
+                                    );
                                 }
-                                _ => Err(openvtc_core::errors::OpenVTCError::Config(
-                                    "Messaging unavailable — cannot leave right now.".into(),
-                                )),
-                            };
-                            match send {
-                                Ok(_) => {
-                                    if let Some(c) =
-                                        config.account.membership_mut(&vtc, persona_id)
-                                    {
-                                        c.leave();
-                                    }
-                                    save.mark_dirty();
-                                    deregister_inactive_community(
-                                        &mut session_manager,
-                                        &didcomm_service,
-                                        &config,
-                                        &mut state,
-                                        &vtc,
-                                        persona_id,
-                                    )
-                                    .await;
-                                    state.main_page.sync_from_config(&config);
-                                    state
-                                        .main_page
-                                        .content_panel
-                                        .communities
-                                        .status_message = Some("Left the community.".to_string());
-                                }
-                                Err(e) => {
-                                    state.main_page.log_error("Leave failed", &e);
-                                    state
-                                        .main_page
-                                        .content_panel
-                                        .communities
-                                        .status_message = Some(format!("Couldn't leave: {e}"));
+                                None => {
+                                    state.main_page.content_panel.communities.status_message = Some(
+                                        "Messaging unavailable — cannot leave right now.".to_string(),
+                                    );
                                 }
                             }
                         }
@@ -1167,22 +1135,39 @@ impl StateHandler {
                             .filter(|c| c.status.is_active())
                             .map(|c| (c.vtc_did.clone(), c.persona_ref));
                         if let Some((vtc, persona_id)) = target {
-                            match message_dispatch::issue_member_vmc_for(&config, &tdk, &vtc, persona_id)
-                                .await
-                            {
-                                Ok(_) => {
-                                    state.main_page.content_panel.communities.status_message = Some(
-                                        "Membership credential issued and sent to the community."
-                                            .to_string(),
-                                    );
-                                }
-                                Err(e) => {
-                                    state
-                                        .main_page
-                                        .log_error("Issue membership credential failed", &e);
+                            // The signing key is read here for the same reason as
+                            // the capability toggle: it comes from the in-memory
+                            // secrets resolver, not the network, and reading it
+                            // here lets the job own a `Secret` rather than borrow
+                            // `Config`.
+                            let ready = match (
+                                capability_sender(&config, &tdk, persona_id),
+                                config.get_persona_keys_for(persona_id, &tdk).await,
+                            ) {
+                                (Some(sender), Ok(keys)) => Some((sender, keys)),
+                                (_, Err(e)) => {
                                     state.main_page.content_panel.communities.status_message =
-                                        Some(format!("Couldn't issue the membership credential: {e}"));
+                                        Some(format!("Couldn't sign the membership credential: {e}"));
+                                    None
                                 }
+                                (None, _) => {
+                                    state.main_page.content_panel.communities.status_message = Some(
+                                        "Messaging unavailable — cannot issue right now.".to_string(),
+                                    );
+                                    None
+                                }
+                            };
+                            if let Some(((atm, profile, member_did, mediator), keys)) = ready {
+                                spawn_community_job(
+                                    &dispatch_tx, &mut in_flight, &mut state,
+                                    community_actions::CommunityJob {
+                                        atm, profile, member_did, mediator,
+                                        vtc_did: vtc, persona: persona_id,
+                                        verb: community_actions::Verb::IssueVmc {
+                                            signing_secret: Box::new(keys.signing.secret.clone()),
+                                        },
+                                    },
+                                );
                             }
                         }
                     },
@@ -1944,13 +1929,30 @@ impl StateHandler {
                 // and inbound DIDComm events are all serviced *while* the spawned
                 // I/O is still pending.
                 Some(outcome) = dispatch_rx.recv() => {
-                    background_dispatch::apply_outcome(
+                    let pending_deregistration = background_dispatch::apply_outcome(
                         &mut state,
                         &mut config,
                         &mut save,
                         &mut in_flight,
                         outcome,
                     );
+                    // A community we have just left still holds a messaging
+                    // session. The session manager lives here, not in the shared
+                    // apply path, so the outcome reports the teardown and this
+                    // arm performs it. Local work — removing a listener — not a
+                    // network call.
+                    if let Some((vtc, persona)) = pending_deregistration {
+                        deregister_inactive_community(
+                            &mut session_manager,
+                            &didcomm_service,
+                            &config,
+                            &mut state,
+                            &vtc,
+                            persona,
+                        )
+                        .await;
+                        state.main_page.sync_from_config(&config);
+                    }
                     // A refresh asked for while the vault was busy is re-issued
                     // here, now that the domain is free — see `vic_refresh_queued`.
                     if state.main_page.content_panel.vta.vic_refresh_queued {
@@ -2977,13 +2979,18 @@ impl StateHandler {
                     // nowhere to go, but its domain must still be freed or the
                     // guard stays set for the life of the loop.
                     match join_ctx.as_mut() {
-                        Some(ctx) => background_dispatch::apply_outcome(
-                            state,
-                            &mut ctx.config,
-                            &mut save,
-                            &mut in_flight,
-                            outcome,
-                        ),
+                        // State A holds no messaging sessions, so a pending
+                        // deregistration cannot arise here — and could not be
+                        // honoured if it did.
+                        Some(ctx) => {
+                            let _ = background_dispatch::apply_outcome(
+                                state,
+                                &mut ctx.config,
+                                &mut save,
+                                &mut in_flight,
+                                outcome,
+                            );
+                        }
                         None => in_flight.finish(outcome.domain()),
                     }
                     if state.main_page.content_panel.vta.vic_refresh_queued {
@@ -3125,6 +3132,28 @@ fn apply_capability_replies(
             }
         }
     }
+}
+
+/// Send a document addressed to a community, off the loop.
+///
+/// The busy-guard serialises leave and issue-credential together: both address
+/// the same peer, both are user-initiated one at a time, and a second send while
+/// one is retrying would tell the community two things at once.
+fn spawn_community_job(
+    dispatch_tx: &tokio::sync::mpsc::UnboundedSender<background_dispatch::DispatchOutcome>,
+    in_flight: &mut background_dispatch::InFlight,
+    state: &mut State,
+    job: community_actions::CommunityJob,
+) {
+    let domain = background_dispatch::DispatchDomain::Community;
+    if !in_flight.try_begin(domain) {
+        state.main_page.content_panel.communities.status_message =
+            Some(background_dispatch::InFlight::busy_message(domain));
+        return;
+    }
+    background_dispatch::spawn_dispatch(dispatch_tx.clone(), domain, async move {
+        background_dispatch::DispatchOutcome::Community(job.run().await)
+    });
 }
 
 /// Resolve the messaging identity a capability document is sent as.


### PR DESCRIPTION
Fourth R14 batch: the two verbs addressed at a community — leaving it (`members/self-remove`) and issuing it the reciprocal membership credential (`members/vmc`).

## Why these matter more than their size suggests

Both send to a peer that may be exactly the thing that has gone wrong. **An unreachable community is a likely reason to leave one**, and that is precisely when `send_message_with_retry` retries longest — so the arm most likely to hang was the one for getting out.

## The design question this batch forced

Leaving needs more than the shared apply path: a successful leave also tears down that community's messaging session, and the session manager belongs to the runtime loop — while `apply_outcome` is shared with the degraded loop, which has no sessions at all.

Threading the session manager into a shared signature that one of its two callers cannot satisfy would have been the wrong shape. Instead `apply_outcome` now **returns** the community still owed a teardown:

```rust
pub(crate) type PendingDeregistration = Option<(String, PersonaId)>;
```

The runtime loop performs it; the degraded loop ignores it, and says why. The teardown itself is local — removing a listener — not a network call.

## Preserved behaviour worth stating

The record moves **on the send, not on a receipt**. The community's acknowledgement is advisory, and a member who has announced a departure should not still be shown as a member if the community never answers. That was the inline behaviour and it is unchanged.

`issue_member_vmc_for` stays in `message_dispatch`: a second caller answers a VTC's `request-vmc` from the inbound path, which does not run on this loop. I deleted it first and the compiler caught the other caller — only the loop arm stopped using it.

## Tests

A successful leave asks for a session teardown and marks the config dirty; a failed leave keeps the session (the membership is still live, and the session is what would carry a retry); issuing a credential touches neither session nor record; a failed issue reports why.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo doc --workspace --no-deps` (no warnings); `cargo test --workspace` **and** `--no-default-features`.

## R14 status after this

Done: agent names (#237), VIC vault (#239), capabilities (#242), community sends (this).

What is left is no longer a queue of similar ports:

* **`Action::Credential`** delegates to `credential_actions::dispatch`, a sub-dispatcher that mutates config and state and uses the messaging service — it needs restructuring into prepare/job/apply the way `inbox_actions` already is, not a lift.
* **create-persona** still needs its own design: `mint_persona_into` interleaves config mutation with network work, is shared with the join flow, and streams progress into the overlay.
* **`WithdrawJoin`, `DeleteCommunity`** have no network send at all — their only awaits are local listener teardown.
* **`StartJoin`** is deliberately modal; the join flow owns its own loop.
* The `Settings` and openpgp-card awaits are local.
