### PR TITLE
perf(r14): move the last two network actions off the loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Requesting a credential from a peer, and creating a persona, no longer
+  freeze the application.** These were the last two network actions still
+  awaited on the state-handler thread. Creating a persona is half a dozen VTA
+  round-trips, so it was the longest freeze left in the app — and the one an
+  operator is most likely to hit, since it is how an account gets its first
+  identity. Both now run off the loop, and the persona overlay still shows each
+  step as it happens: long jobs can report progress without blocking anything.
+  A persona is only shown as created once it has actually been written to the
+  config, rather than when the VTA finished minting it.
+
 - **Leaving a community, or issuing it your membership credential, no longer
   freezes the application.** Both send to the community and were awaited on the
   state-handler thread — and an unreachable community is a *likely* reason to

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -83,6 +83,11 @@ pub(crate) enum DispatchDomain {
     /// sweep: sharing a domain would let a background refresh delay an operator
     /// who is claiming a name, and the two touch different state.
     AgentNameManage,
+    /// Minting a standalone persona: several VTA trust tasks (find a hosting
+    /// server, mint the DID, create three keys), reported step by step.
+    Persona,
+    /// Requesting a verifiable relationship credential from a peer.
+    Credential,
     /// A send addressed to a community: leaving it, or issuing it the
     /// reciprocal membership credential. Serialised together because both
     /// address the same peer and both are user-initiated one at a time.
@@ -111,6 +116,8 @@ impl DispatchDomain {
             DispatchDomain::AgentName => "Agent name refresh",
             DispatchDomain::VtaTransports => "VTA transport probe",
             DispatchDomain::AgentNameManage => "Agent name change",
+            DispatchDomain::Persona => "Persona creation",
+            DispatchDomain::Credential => "Credential request",
             DispatchDomain::Community => "Community request",
             DispatchDomain::Capabilities => "Capability request",
             DispatchDomain::Vic => "Invitation credential refresh",
@@ -190,6 +197,23 @@ pub(crate) enum DispatchOutcome {
     /// [`AgentNameOutcome::apply`](crate::state_handler::agent_name_actions::AgentNameOutcome::apply)
     /// applies the registry, the overlay status and the persisted display name.
     AgentNameManage(crate::state_handler::agent_name_actions::AgentNameOutcome),
+    /// A job reporting a step it has reached, while still running.
+    ///
+    /// The only outcome that does **not** finish its domain: the job that sent
+    /// it is still going, and finishing here would let a second job start
+    /// alongside it. It exists because a long job's steps are worth showing —
+    /// minting a persona is half a dozen VTA round-trips, and a spinner that
+    /// says nothing for that long is indistinguishable from a hang.
+    Progress(ProgressUpdate),
+    /// A standalone persona mint finished. On success the persist is still
+    /// owed — see [`AfterApply::PersistPersona`].
+    ///
+    /// Boxed because a `MintedPersona` carries a whole `SetupState` (~2 KB),
+    /// and every other outcome is two orders of magnitude smaller: unboxed, the
+    /// enum would cost that on every dispatch of every domain.
+    Persona(Box<crate::state_handler::create_persona::MintOutcome>),
+    /// A VRC request was sent to a peer (or failed to send).
+    Credential(crate::state_handler::credential_actions::VrcRequestOutcome),
     /// A community send finished (leave / issue membership credential).
     Community(crate::state_handler::community_actions::CommunityOutcome),
     /// A capability query or toggle was sent (or failed to send).
@@ -224,11 +248,32 @@ impl DispatchOutcome {
             DispatchOutcome::AgentName(_) => DispatchDomain::AgentName,
             DispatchOutcome::VtaTransports(_) => DispatchDomain::VtaTransports,
             DispatchOutcome::AgentNameManage(_) => DispatchDomain::AgentNameManage,
+            DispatchOutcome::Progress(update) => update.domain(),
+            DispatchOutcome::Persona(_) => DispatchDomain::Persona,
+            DispatchOutcome::Credential(_) => DispatchDomain::Credential,
             DispatchOutcome::Community(_) => DispatchDomain::Community,
             DispatchOutcome::Capabilities(_) => DispatchDomain::Capabilities,
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::VicMutation(_) => DispatchDomain::Vic,
             DispatchOutcome::Panicked(domain) => *domain,
+        }
+    }
+}
+
+/// A step a running job has reached. Typed per consumer rather than a bare
+/// string, so the applier knows where the text belongs without a domain lookup
+/// and a new consumer cannot silently borrow another's display surface.
+pub(crate) enum ProgressUpdate {
+    /// A step of a standalone persona mint, for the create-persona overlay.
+    PersonaMint(String),
+}
+
+impl ProgressUpdate {
+    /// The domain whose job is reporting. Not finished — see
+    /// [`DispatchOutcome::Progress`].
+    fn domain(&self) -> DispatchDomain {
+        match self {
+            ProgressUpdate::PersonaMint(_) => DispatchDomain::Persona,
         }
     }
 }
@@ -285,13 +330,25 @@ pub(crate) fn spawn_dispatch<F>(
 /// persists it), and removes the provisional `RequestSent` record it pre-inserted
 /// (see [`RelationshipOutcome::apply`]) so a failed send leaves no relationship
 /// record — exactly the pre-R14 net state.
-/// A community whose messaging session the caller still owes a teardown, and
-/// the persona that held it.
+/// Work an outcome needs that [`apply_outcome`] itself cannot do, handed back
+/// to whichever loop called it.
 ///
-/// Returned rather than acted on because the session manager and the messaging
-/// service belong to the runtime loop, while this function is shared with the
-/// degraded loop — which has no sessions and ignores it.
-pub(crate) type PendingDeregistration = Option<(String, openvtc_core::config::account::PersonaId)>;
+/// This exists because `apply_outcome` is shared by the runtime loop and the
+/// degraded loop, and they hold different things. Rather than widen the
+/// signature with parameters one caller cannot supply — a session manager the
+/// degraded loop has no equivalent of, or an `async` persist the pure applier
+/// has no business awaiting — the outcome says what is still owed and the loop
+/// that can do it, does it.
+pub(crate) enum AfterApply {
+    /// Everything was applied here.
+    Nothing,
+    /// A community was left; its messaging session is still registered. Only
+    /// the runtime loop owns a session manager, so only it can honour this.
+    Deregister(String, openvtc_core::config::account::PersonaId),
+    /// A persona was minted at the VTA and must now be written into the config.
+    /// The persist is `async` and mutates `Config`, so it runs in the loop.
+    PersistPersona(Box<crate::state_handler::create_persona::MintedPersona>),
+}
 
 pub(crate) fn apply_outcome(
     state: &mut State,
@@ -299,8 +356,23 @@ pub(crate) fn apply_outcome(
     save: &mut SaveScheduler,
     in_flight: &mut InFlight,
     outcome: DispatchOutcome,
-) -> PendingDeregistration {
+) -> AfterApply {
     let domain = outcome.domain();
+
+    // Progress is the one outcome that leaves its domain busy: the job is still
+    // running. Handled before the match so the `finish` at the end cannot be
+    // reached for it.
+    if let DispatchOutcome::Progress(update) = outcome {
+        match update {
+            ProgressUpdate::PersonaMint(step) => {
+                if let Some(o) = state.main_page.create_persona.as_mut() {
+                    o.messages.push(step);
+                }
+            }
+        }
+        return AfterApply::Nothing;
+    }
+
     match outcome {
         DispatchOutcome::MediatorReconnect(result) => match result {
             ReconnectOutcome::Connected => {
@@ -357,11 +429,26 @@ pub(crate) fn apply_outcome(
         DispatchOutcome::Community(outcome) => {
             let pending = outcome.apply(state, config, save);
             in_flight.finish(domain);
-            return pending;
+            return match pending {
+                Some((vtc, persona)) => AfterApply::Deregister(vtc, persona),
+                None => AfterApply::Nothing,
+            };
         }
+        DispatchOutcome::Persona(outcome) => {
+            let pending = outcome.apply(state);
+            in_flight.finish(domain);
+            return match pending {
+                Some(minted) => AfterApply::PersistPersona(Box::new(minted)),
+                None => AfterApply::Nothing,
+            };
+        }
+        DispatchOutcome::Credential(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Capabilities(outcome) => outcome.apply(state),
         DispatchOutcome::Vic(outcome) => outcome.apply(state, config),
         DispatchOutcome::VicMutation(outcome) => outcome.apply(state),
+        // Handled above, before the domain is finished. Listed because the
+        // match must stay exhaustive.
+        DispatchOutcome::Progress(_) => unreachable!("progress returns before this match"),
         DispatchOutcome::Panicked(domain) => {
             // The job panicked and produced no real outcome. Surface a generic
             // failure so the user isn't left staring at a stuck "in progress"; the
@@ -371,7 +458,7 @@ pub(crate) fn apply_outcome(
         }
     }
     in_flight.finish(domain);
-    None
+    AfterApply::Nothing
 }
 
 #[cfg(test)]
@@ -694,5 +781,71 @@ mod tests {
             !save2.is_pending(),
             "an unchanged sweep must not re-dirty the config"
         );
+    }
+}
+
+#[cfg(test)]
+mod progress_tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+    use crate::state_handler::main_page::content::{CreatePersonaPhase, CreatePersonaState};
+
+    /// Progress is the one outcome that must NOT free its domain: the job that
+    /// sent it is still running, and freeing it would let a second mint start
+    /// alongside the first.
+    #[tokio::test]
+    async fn progress_renders_a_step_without_freeing_the_domain() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        let mut in_flight = InFlight::default();
+        state.main_page.create_persona = Some(CreatePersonaState {
+            phase: CreatePersonaPhase::Working,
+            ..Default::default()
+        });
+        assert!(in_flight.try_begin(DispatchDomain::Persona));
+
+        apply_outcome(
+            &mut state,
+            &mut config,
+            &mut save,
+            &mut in_flight,
+            DispatchOutcome::Progress(ProgressUpdate::PersonaMint("Minting the DID…".into())),
+        );
+
+        assert!(
+            in_flight.is_busy(DispatchDomain::Persona),
+            "the job is still running, so its domain must stay claimed"
+        );
+        let messages = &state.main_page.create_persona.as_ref().unwrap().messages;
+        assert_eq!(
+            messages.last().map(String::as_str),
+            Some("Minting the DID…")
+        );
+        assert_eq!(
+            state.main_page.create_persona.as_ref().unwrap().phase,
+            CreatePersonaPhase::Working,
+            "progress never moves the phase — only the final outcome does"
+        );
+    }
+
+    /// A progress update for an overlay that has since closed is dropped, not
+    /// resurrected into one.
+    #[tokio::test]
+    async fn progress_for_a_closed_overlay_is_dropped() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        let mut in_flight = InFlight::default();
+
+        apply_outcome(
+            &mut state,
+            &mut config,
+            &mut save,
+            &mut in_flight,
+            DispatchOutcome::Progress(ProgressUpdate::PersonaMint("Minting…".into())),
+        );
+
+        assert!(state.main_page.create_persona.is_none());
     }
 }

--- a/openvtc/src/state_handler/create_persona.rs
+++ b/openvtc/src/state_handler/create_persona.rs
@@ -32,12 +32,14 @@ use crate::state_handler::setup_sequence::{SetupState, config::ConfigExtension, 
 pub(crate) async fn mint_standalone_persona(
     admin_vta: &VtaClient,
     tdk: &TDK,
-    config: &mut Config,
-    profile: &str,
+    inputs: MintInputs,
     label: String,
     mut progress: impl FnMut(&str),
-) -> Result<(PersonaId, String)> {
-    let top_context_id = config.account.top_context_id.clone();
+) -> Result<MintedPersona> {
+    let MintInputs {
+        top_context_id,
+        custom_mediator,
+    } = inputs;
     if top_context_id.is_empty() {
         anyhow::bail!("No account context yet — finish setup before creating a persona.");
     }
@@ -75,14 +77,6 @@ pub(crate) async fn mint_standalone_persona(
         progress(&warning);
     }
 
-    // The persona's mediator is the account's VTA mediator: the DID minted via
-    // the VTA's webvh server advertises that mediator, so the persona listener
-    // must use the same one (mirrors the join flow).
-    let custom_mediator = match &config.key_backend {
-        KeyBackend::Vta { mediator_did, .. } => mediator_did.clone(),
-        _ => None,
-    };
-
     // Persist via the shared mint path. `mint_persona_into` reads the persona
     // keys, DID, document, mediator, and username from a `SetupState`, so build a
     // scratch one carrying just those — no community/sub-context is involved.
@@ -97,7 +91,207 @@ pub(crate) async fn mint_standalone_persona(
         ..Default::default()
     };
 
-    progress("Saving persona…");
-    let persona_id = Config::mint_persona_into(config, &setup, tdk, profile).await?;
-    Ok((persona_id, did))
+    Ok(MintedPersona { setup, did })
+}
+
+/// The `Config` reads a mint needs, taken on the loop thread so the mint itself
+/// can run without one.
+pub(crate) struct MintInputs {
+    pub(crate) top_context_id: String,
+    /// The persona's mediator is the account's VTA mediator: the DID minted via
+    /// the VTA's webvh server advertises that mediator, so the persona listener
+    /// must use the same one (mirrors the join flow).
+    pub(crate) custom_mediator: Option<String>,
+}
+
+impl MintInputs {
+    /// Read them. Pure — no I/O, so it stays on the loop.
+    pub(crate) fn from_config(config: &Config) -> Self {
+        Self {
+            top_context_id: config.account.top_context_id.clone(),
+            custom_mediator: match &config.key_backend {
+                KeyBackend::Vta { mediator_did, .. } => mediator_did.clone(),
+                _ => None,
+            },
+        }
+    }
+}
+
+/// A persona minted at the VTA but not yet written into the config.
+///
+/// The write is deliberately *not* part of the job:
+/// [`ConfigExtension::mint_persona_into`] takes `&mut Config`, and it is shared
+/// with the join flow — so rather than restructure a path the riskiest flow in
+/// the app depends on, the mint stops at the point where the network work is
+/// done and hands this back for the loop to persist. Everything
+/// `mint_persona_into` does from here is local: building key info, an
+/// `ATMProfile`, `profile_add(.., false)` — registration explicitly without a
+/// socket — and secrets-resolver inserts.
+pub(crate) struct MintedPersona {
+    pub(crate) setup: SetupState,
+    pub(crate) did: String,
+}
+
+impl MintedPersona {
+    /// Write the persona into the config. Runs on the loop thread, from
+    /// whichever loop is live — a first persona is minted in State A.
+    pub(crate) async fn persist(
+        &self,
+        config: &mut Config,
+        tdk: &TDK,
+        profile: &str,
+    ) -> Result<PersonaId> {
+        Config::mint_persona_into(config, &self.setup, tdk, profile).await
+    }
+}
+
+// ****************************************************************************
+// Off-loop mint (R14)
+// ****************************************************************************
+
+/// One standalone mint, resolved on the loop thread.
+///
+/// Half a dozen VTA trust tasks — find a hosting server, mint the DID, create
+/// three keys — awaited inline. The overlay showed each step, so the wait was
+/// explained; what was not explained is that the *rest of the application*
+/// stopped with it, including the inbound DIDComm channel.
+pub(crate) struct MintJob {
+    pub(crate) admin_vta: VtaClient,
+    pub(crate) tdk: TDK,
+    pub(crate) inputs: MintInputs,
+    pub(crate) label: String,
+    /// Where each step is reported while the job runs.
+    pub(crate) progress_tx: tokio::sync::mpsc::UnboundedSender<
+        crate::state_handler::background_dispatch::DispatchOutcome,
+    >,
+}
+
+impl MintJob {
+    /// Run the mint, streaming each step. I/O only — the persist is the loop's.
+    pub(crate) async fn run(self) -> MintOutcome {
+        use crate::state_handler::background_dispatch::{DispatchOutcome, ProgressUpdate};
+
+        let progress_tx = self.progress_tx;
+        let result = mint_standalone_persona(
+            &self.admin_vta,
+            &self.tdk,
+            self.inputs,
+            self.label,
+            |step| {
+                // A dropped receiver means the loop has gone; the mint carries
+                // on either way, because abandoning a half-minted DID is worse
+                // than finishing one nobody is watching.
+                let _ = progress_tx.send(DispatchOutcome::Progress(ProgressUpdate::PersonaMint(
+                    step.to_string(),
+                )));
+            },
+        )
+        .await;
+
+        match result {
+            Ok(minted) => MintOutcome {
+                minted: Some(minted),
+                error: None,
+            },
+            Err(e) => MintOutcome {
+                minted: None,
+                error: Some(format!("{e}")),
+            },
+        }
+    }
+}
+
+/// What the mint produced. Data only; applied on the loop thread.
+pub(crate) struct MintOutcome {
+    minted: Option<MintedPersona>,
+    error: Option<String>,
+}
+
+impl MintOutcome {
+    /// Report a failure, or hand the minted persona back for the loop to
+    /// persist. The overlay is only moved to `Done` once the persist has
+    /// happened — a persona the operator can see but the config does not hold
+    /// would be a lie the next launch corrects.
+    pub(crate) fn apply(
+        self,
+        state: &mut crate::state_handler::state::State,
+    ) -> Option<MintedPersona> {
+        use crate::state_handler::main_page::content::CreatePersonaPhase;
+
+        match (self.minted, self.error) {
+            (Some(minted), _) => {
+                if let Some(o) = state.main_page.create_persona.as_mut() {
+                    o.messages.push("Saving persona…".to_string());
+                }
+                Some(minted)
+            }
+            (None, Some(e)) => {
+                if let Some(o) = state.main_page.create_persona.as_mut() {
+                    o.phase = CreatePersonaPhase::Failed;
+                    o.messages.push(format!("Failed: {e}"));
+                }
+                state
+                    .main_page
+                    .log_error("Create persona failed", e.as_str());
+                None
+            }
+            (None, None) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod mint_outcome_tests {
+    use super::*;
+    use crate::state_handler::main_page::content::{CreatePersonaPhase, CreatePersonaState};
+    use crate::state_handler::state::State;
+
+    fn working(state: &mut State) {
+        state.main_page.create_persona = Some(CreatePersonaState {
+            phase: CreatePersonaPhase::Working,
+            ..Default::default()
+        });
+    }
+
+    /// A successful mint does NOT complete the overlay: the persona exists at
+    /// the VTA but not yet in the config, and showing "created" before the
+    /// persist would be a claim the next launch contradicts. It hands the
+    /// persona back for the loop to write.
+    #[test]
+    fn a_successful_mint_defers_completion_to_the_persist() {
+        let mut state = State::default();
+        working(&mut state);
+
+        let minted = MintOutcome {
+            minted: Some(MintedPersona {
+                setup: SetupState::default(),
+                did: "did:webvh:QmScid:example.com:new".to_string(),
+            }),
+            error: None,
+        }
+        .apply(&mut state);
+
+        assert!(minted.is_some(), "the persist is still owed");
+        let o = state.main_page.create_persona.as_ref().unwrap();
+        assert_eq!(o.phase, CreatePersonaPhase::Working, "not done until saved");
+        assert!(o.did.is_none(), "no DID shown before it is persisted");
+    }
+
+    /// A failed mint is terminal and says why.
+    #[test]
+    fn a_failed_mint_fails_the_overlay() {
+        let mut state = State::default();
+        working(&mut state);
+
+        let minted = MintOutcome {
+            minted: None,
+            error: Some("no hosting server".to_string()),
+        }
+        .apply(&mut state);
+
+        assert!(minted.is_none());
+        let o = state.main_page.create_persona.as_ref().unwrap();
+        assert_eq!(o.phase, CreatePersonaPhase::Failed);
+        assert!(o.messages.iter().any(|m| m.contains("no hosting server")));
+    }
 }

--- a/openvtc/src/state_handler/credential_actions.rs
+++ b/openvtc/src/state_handler/credential_actions.rs
@@ -2,62 +2,135 @@
 
 use std::sync::Arc;
 
-use affinidi_tdk::TDK;
 use anyhow::Result;
 use openvtc_core::didcomm::Messaging;
 use openvtc_core::{config::Config, logs::LogFamily, tasks::TaskType, vrc::VrcRequest};
 use tracing::{debug, info};
 
-/// Send a VRC request to a remote party via an established relationship.
-pub async fn send_vrc_request(
-    config: &mut Config,
-    _tdk: &TDK,
+/// One VRC request, resolved on the loop thread.
+///
+/// The only credential action that touches the network. It used to be awaited
+/// inline, which meant asking a peer for a credential froze the application for
+/// as long as the send retried — and an unresponsive peer is a common reason for
+/// the request to be slow, not a rare one.
+pub(crate) struct VrcRequestJob {
+    pub(crate) service: Messaging,
+    /// The DIDComm message, built on the loop where `Config` is available.
+    pub(crate) message: Box<affinidi_tdk::didcomm::Message>,
+    /// Listener the send goes out through, resolved from our side's DID.
+    pub(crate) listener_id: String,
+    pub(crate) remote_did: Arc<String>,
+    pub(crate) remote_p_did: Arc<String>,
+    /// Message id, which becomes the tracking task's id on success.
+    pub(crate) msg_id: Arc<String>,
+}
+
+impl VrcRequestJob {
+    /// Send it. I/O only.
+    pub(crate) async fn run(self) -> VrcRequestOutcome {
+        let result = crate::state_handler::didcomm::send_message_via(
+            &self.service,
+            &self.message,
+            &self.listener_id,
+            &self.remote_did,
+        )
+        .await;
+        VrcRequestOutcome {
+            remote_p_did: self.remote_p_did,
+            msg_id: self.msg_id,
+            error: result.err().map(|e| format!("{e}")),
+        }
+    }
+}
+
+/// What the send did. Data only; applied on the loop thread.
+pub(crate) struct VrcRequestOutcome {
+    remote_p_did: Arc<String>,
+    msg_id: Arc<String>,
+    error: Option<String>,
+}
+
+impl VrcRequestOutcome {
+    /// Record the tracking task and report, or say why the request never left.
+    ///
+    /// The task is created *after* the send, as it was inline: a task tracking
+    /// a request that was never sent would sit in the inbox waiting for a reply
+    /// that cannot come.
+    pub(crate) fn apply(self, state: &mut State, config: &mut Config, save: &mut SaveScheduler) {
+        match self.error {
+            None => {
+                let our_persona = config.active_persona;
+                config.private.tasks.new_task_for(
+                    &self.msg_id,
+                    TaskType::VRCRequestOutbound {
+                        remote_p_did: Arc::clone(&self.remote_p_did),
+                    },
+                    our_persona,
+                );
+                config.public.logs.insert(
+                    LogFamily::Relationship,
+                    format!(
+                        "Requested VRC from ({}) Task ID ({})",
+                        self.remote_p_did, self.msg_id
+                    ),
+                );
+                info!(to = %self.remote_p_did, "VRC request sent");
+
+                state.main_page.content_panel.credentials.mode = CredentialsMode::List;
+                let display_name =
+                    crate::state_handler::resolve_did_to_display(config, &self.remote_p_did);
+                dispatch_util::save_and_sync(
+                    &mut state.main_page,
+                    config,
+                    save,
+                    dispatch_util::Persist::SaveAndSync,
+                    |mp| &mut mp.content_panel.credentials.status_message,
+                    format!("VRC request sent to {display_name}"),
+                    dispatch_util::SyncLog::Plain(format!("VRC request sent to {display_name}")),
+                );
+            }
+            Some(e) => {
+                // `record_error` takes an `anyhow::Error`; the job hands back a
+                // formatted string, because an error cannot cross the channel.
+                dispatch_util::record_error(
+                    &mut state.main_page,
+                    |mp| &mut mp.content_panel.credentials.status_message,
+                    "Failed to send VRC request",
+                    &anyhow::anyhow!(e),
+                );
+            }
+        }
+    }
+}
+
+/// Resolve a VRC request on the loop: the relationship's two DIDs, the message,
+/// and the listener it goes out through. `None` when the relationship is gone.
+pub(crate) fn prepare_vrc_request(
+    config: &Config,
     service: &Messaging,
     remote_p_did: &str,
     reason: Option<&str>,
-) -> Result<()> {
+) -> Option<VrcRequestJob> {
     let remote_key = Arc::new(remote_p_did.to_string());
+    let relationship = config.private.relationships.get(&remote_key)?;
+    let our_did = Arc::clone(&relationship.our_did);
+    let remote_did = Arc::clone(&relationship.remote_did);
 
-    let (our_did, remote_did) = {
-        let relationship = config
-            .private
-            .relationships
-            .get(&remote_key)
-            .ok_or_else(|| anyhow::anyhow!("No relationship found for {}", remote_p_did))?;
-        (
-            Arc::clone(&relationship.our_did),
-            Arc::clone(&relationship.remote_did),
-        )
-    };
-
-    let request_body = VrcRequest {
-        reason: reason.map(|s| s.to_string()),
-    };
-
-    let message = request_body.create_message(&remote_did, &our_did)?;
+    let message = VrcRequest {
+        reason: reason.map(ToString::to_string),
+    }
+    .create_message(&remote_did, &our_did)
+    .ok()?;
     let msg_id = Arc::new(message.id.clone());
 
-    super::didcomm::send_message(service, config, &message, &our_did, &remote_did)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to send VRC request: {e}"))?;
-
-    // Create tracking task, tagged with the working community's persona (D10).
-    let our_persona = config.active_persona;
-    config.private.tasks.new_task_for(
-        &msg_id,
-        TaskType::VRCRequestOutbound {
-            remote_p_did: remote_key,
-        },
-        our_persona,
-    );
-
-    config.public.logs.insert(
-        LogFamily::Relationship,
-        format!("Requested VRC from ({}) Task ID ({})", remote_p_did, msg_id),
-    );
-
-    info!(to = %remote_p_did, "VRC request sent");
-    Ok(())
+    Some(VrcRequestJob {
+        service: service.clone(),
+        listener_id: crate::state_handler::didcomm::listener_id_for_did(&our_did, config),
+        message: Box::new(message),
+        remote_did,
+        remote_p_did: remote_key,
+        msg_id,
+    })
 }
 
 /// Remove a VRC by its ID from both received and issued collections.
@@ -144,42 +217,6 @@ fn handle_reason_update(state: &mut State, value: String) {
     }
 }
 
-async fn handle_submit_request(
-    config: &mut Box<Config>,
-    tdk: &TDK,
-    service: &Messaging,
-    state: &mut State,
-    save: &mut SaveScheduler,
-    relationship_p_did: &str,
-    reason: Option<&str>,
-) {
-    match send_vrc_request(config, tdk, service, relationship_p_did, reason).await {
-        Ok(()) => {
-            state.main_page.content_panel.credentials.mode = CredentialsMode::List;
-            // Names the party, like every other user-facing status line.
-            let display_name =
-                crate::state_handler::resolve_did_to_display(config, relationship_p_did);
-            dispatch_util::save_and_sync(
-                &mut state.main_page,
-                config,
-                save,
-                dispatch_util::Persist::SaveAndSync,
-                |mp| &mut mp.content_panel.credentials.status_message,
-                format!("VRC request sent to {display_name}"),
-                dispatch_util::SyncLog::Plain(format!("VRC request sent to {display_name}")),
-            );
-        }
-        Err(e) => {
-            dispatch_util::record_error(
-                &mut state.main_page,
-                |mp| &mut mp.content_panel.credentials.status_message,
-                "Failed to send VRC request",
-                &e,
-            );
-        }
-    }
-}
-
 fn handle_remove(
     config: &mut Box<Config>,
     state: &mut State,
@@ -205,12 +242,15 @@ fn handle_remove(
     );
 }
 
-/// Dispatch a single `CredentialAction` to its handler.
-pub(crate) async fn dispatch(
+/// Dispatch a single `CredentialAction`.
+///
+/// Takes neither the TDK nor the messaging service any more: the one action that
+/// used them — requesting a VRC from a peer — is dispatched off the loop, so
+/// everything reaching here is state or config. Not `async` either, for the same
+/// reason.
+pub(crate) fn dispatch(
     action: CredentialAction,
     config: &mut Box<Config>,
-    tdk: &TDK,
-    service: &Messaging,
     state: &mut State,
     save: &mut SaveScheduler,
 ) {
@@ -224,20 +264,12 @@ pub(crate) async fn dispatch(
         CredentialAction::StartNewRequest => handle_start_new_request(state),
         CredentialAction::SelectRelationship(index) => handle_select_relationship(state, index),
         CredentialAction::ReasonUpdate(value) => handle_reason_update(state, value),
-        CredentialAction::SubmitRequest {
-            relationship_p_did,
-            reason,
-        } => {
-            handle_submit_request(
-                config,
-                tdk,
-                service,
-                state,
-                save,
-                &relationship_p_did,
-                reason.as_deref(),
-            )
-            .await
+        // `SubmitRequest` is not handled here: it is the one credential action
+        // that goes to the network, so the loop resolves it into a
+        // `VrcRequestJob` and dispatches it. Everything else in this module is
+        // state or config, which is why the dispatcher stayed on the loop.
+        CredentialAction::SubmitRequest { .. } => {
+            debug_assert!(false, "SubmitRequest is dispatched by the loop");
         }
         CredentialAction::Remove { vrc_id } => handle_remove(config, state, save, &vrc_id),
         // R25 confirmation arming/cancel — pure state mutations.
@@ -357,5 +389,59 @@ mod tests {
                 "reason_update is a no-op outside NewRequest"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod vrc_request_tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+
+    fn outcome(error: Option<&str>) -> VrcRequestOutcome {
+        VrcRequestOutcome {
+            remote_p_did: Arc::new("did:webvh:QmScidPeer:example.com:bob".to_string()),
+            msg_id: Arc::new("msg-1".to_string()),
+            error: error.map(ToString::to_string),
+        }
+    }
+
+    /// A sent request creates the task that will match the reply. It is created
+    /// on the outcome, not before the send, so a request that never left cannot
+    /// leave a task waiting for a reply that cannot come.
+    #[test]
+    fn a_sent_request_creates_the_tracking_task() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+
+        outcome(None).apply(&mut state, &mut config, &mut save);
+
+        assert_eq!(config.private.tasks.tasks.len(), 1, "one tracking task");
+        assert!(save.is_pending());
+    }
+
+    /// A failed send creates none, and says why.
+    #[test]
+    fn a_failed_request_creates_no_task() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+
+        outcome(Some("peer unreachable")).apply(&mut state, &mut config, &mut save);
+
+        assert_eq!(
+            config.private.tasks.tasks.len(),
+            0,
+            "no task for a failed send"
+        );
+        assert!(
+            state
+                .main_page
+                .content_panel
+                .credentials
+                .status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("unreachable")),
+        );
     }
 }

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1407,14 +1407,12 @@ impl StateHandler {
                     Action::CreatePersonaSubmit => {
                         // Mint a standalone persona DID using the always-on admin
                         // VTA session; the overlay shows progress and, on success,
-                        // the new DID (copied to the clipboard).
-                        self.run_create_persona(
-                            &mut state,
-                            &tdk,
-                            &mut config,
+                        // the new DID (copied to the clipboard). The mint runs off
+                        // this loop and streams its steps back as progress.
+                        spawn_persona_mint(
+                            &dispatch_tx, &mut in_flight, &mut state, &config, &tdk,
                             admin_vta.as_ref(),
-                        )
-                        .await;
+                        );
                     },
                     Action::StartAgentNameManager(index) => {
                         if let Some(did) = self.open_agent_name_overlay(&mut state, index) {
@@ -1618,15 +1616,44 @@ impl StateHandler {
                         }
                     },
                     Action::Credential(ca) => {
-                        credential_actions::dispatch(
-                            ca,
-                            &mut config,
-                            &tdk,
-                            &didcomm_service,
-                            &mut state,
-                            &mut save,
-                        )
-                        .await;
+                        // One of the twelve credential actions goes to the
+                        // network — requesting a VRC from a peer — so it is
+                        // resolved here and dispatched. The other eleven are
+                        // state or config, and the dispatcher handles them
+                        // inline as before.
+                        if let actions::CredentialAction::SubmitRequest {
+                            relationship_p_did,
+                            reason,
+                        } = &ca
+                        {
+                            let domain = background_dispatch::DispatchDomain::Credential;
+                            if !in_flight.try_begin(domain) {
+                                state.main_page.content_panel.credentials.status_message =
+                                    Some(background_dispatch::InFlight::busy_message(domain));
+                            } else if let Some(job) = credential_actions::prepare_vrc_request(
+                                &config,
+                                &didcomm_service,
+                                relationship_p_did,
+                                reason.as_deref(),
+                            ) {
+                                background_dispatch::spawn_dispatch(
+                                    dispatch_tx.clone(),
+                                    domain,
+                                    async move {
+                                        background_dispatch::DispatchOutcome::Credential(
+                                            job.run().await,
+                                        )
+                                    },
+                                );
+                            } else {
+                                in_flight.finish(domain);
+                                state.main_page.content_panel.credentials.status_message = Some(
+                                    "That relationship is no longer available.".to_string(),
+                                );
+                            }
+                        } else {
+                            credential_actions::dispatch(ca, &mut config, &mut state, &mut save);
+                        }
                     },
                     Action::Settings(sa) => {
                         match settings_actions::dispatch(
@@ -1929,13 +1956,17 @@ impl StateHandler {
                 // and inbound DIDComm events are all serviced *while* the spawned
                 // I/O is still pending.
                 Some(outcome) = dispatch_rx.recv() => {
-                    let pending_deregistration = background_dispatch::apply_outcome(
+                    let after = background_dispatch::apply_outcome(
                         &mut state,
                         &mut config,
                         &mut save,
                         &mut in_flight,
                         outcome,
                     );
+                    let pending_deregistration = settle_after_apply(
+                        after, &mut state, &mut config, &tdk, self.profile.as_str(),
+                    )
+                    .await;
                     // A community we have just left still holds a messaging
                     // session. The session manager lives here, not in the shared
                     // apply path, so the outcome reports the teardown and this
@@ -2250,90 +2281,6 @@ impl StateHandler {
         }
 
         Ok(result)
-    }
-
-    /// Mint a standalone persona DID for the open create-persona overlay, driving
-    /// it through Working → Done/Failed. Reads the entered label, runs the VTA
-    /// mint (streaming progress into the overlay), and on success stores + copies
-    /// the new DID and refreshes the VTA panel so the orphan persona appears.
-    async fn run_create_persona(
-        &self,
-        state: &mut State,
-        tdk: &TDK,
-        config: &mut Config,
-        admin_vta: Option<&vta_sdk::client::VtaClient>,
-    ) {
-        use crate::state_handler::main_page::content::CreatePersonaPhase;
-
-        // Only act from the label phase; read + validate the label.
-        let label = match state.main_page.create_persona.as_ref() {
-            Some(o) if o.phase == CreatePersonaPhase::Label => o.label.value().trim().to_string(),
-            _ => return,
-        };
-        if label.is_empty() {
-            if let Some(o) = state.main_page.create_persona.as_mut() {
-                o.messages = vec!["Enter a label first.".to_string()];
-            }
-            let _ = self.state_tx.send(state.clone());
-            return;
-        }
-        let Some(admin_vta) = admin_vta else {
-            if let Some(o) = state.main_page.create_persona.as_mut() {
-                o.phase = CreatePersonaPhase::Failed;
-                o.messages = vec![
-                    "VTA session unavailable — cannot create a persona right now.".to_string(),
-                ];
-            }
-            let _ = self.state_tx.send(state.clone());
-            return;
-        };
-
-        // Lock input and enter the Working phase.
-        if let Some(o) = state.main_page.create_persona.as_mut() {
-            o.phase = CreatePersonaPhase::Working;
-            o.messages = vec![format!("Creating persona “{label}”…")];
-        }
-        let _ = self.state_tx.send(state.clone());
-
-        // Run the mint, streaming each network step into the overlay.
-        let state_tx = &self.state_tx;
-        let result = create_persona::mint_standalone_persona(
-            admin_vta,
-            tdk,
-            config,
-            self.profile.as_str(),
-            label,
-            |msg| {
-                if let Some(o) = state.main_page.create_persona.as_mut() {
-                    o.messages.push(msg.to_string());
-                }
-                let _ = state_tx.send(state.clone());
-            },
-        )
-        .await;
-
-        match result {
-            Ok((_persona_id, did)) => {
-                let copied = crate::clipboard::copy_to_clipboard(&did).is_ok();
-                if let Some(o) = state.main_page.create_persona.as_mut() {
-                    o.phase = CreatePersonaPhase::Done;
-                    o.did = Some(did.clone());
-                    o.copied = copied;
-                    o.messages.push("Persona created.".to_string());
-                }
-                // Refresh the VTA panel so the new orphan persona is listed.
-                state.main_page.sync_from_config(config);
-                state.main_page.log(format!("Created persona DID {did}"));
-            }
-            Err(e) => {
-                if let Some(o) = state.main_page.create_persona.as_mut() {
-                    o.phase = CreatePersonaPhase::Failed;
-                    o.messages.push(format!("Failed: {e}"));
-                }
-                state.main_page.log_error("Create persona failed", &e);
-            }
-        }
-        let _ = self.state_tx.send(state.clone());
     }
 
     /// The `(persona_did, name, enabled)` of the overlay's selected row, if the
@@ -2692,14 +2639,11 @@ impl StateHandler {
                         // Minting needs only the admin VTA session + account
                         // context, both present in State-A — so a brand-new account
                         // (which runs here) can create its first persona DID.
-                        if let Some(ctx) = join_ctx.as_mut() {
-                            self.run_create_persona(
-                                state,
-                                &ctx.tdk,
-                                &mut ctx.config,
+                        if let Some(ctx) = join_ctx.as_ref() {
+                            spawn_persona_mint(
+                                &dispatch_tx, &mut in_flight, state, &ctx.config, &ctx.tdk,
                                 ctx.admin_vta.as_ref(),
-                            )
-                            .await;
+                            );
                         } else if let Some(o) = state.main_page.create_persona.as_mut() {
                             o.phase = main_page::content::CreatePersonaPhase::Failed;
                             o.messages = vec![
@@ -2983,13 +2927,25 @@ impl StateHandler {
                         // deregistration cannot arise here — and could not be
                         // honoured if it did.
                         Some(ctx) => {
-                            let _ = background_dispatch::apply_outcome(
+                            let after = background_dispatch::apply_outcome(
                                 state,
                                 &mut ctx.config,
                                 &mut save,
                                 &mut in_flight,
                                 outcome,
                             );
+                            // State A holds no messaging sessions, so a pending
+                            // deregistration cannot arise here; a persona
+                            // persist very much can — this is where an account's
+                            // first one is minted.
+                            let _ = settle_after_apply(
+                                after,
+                                state,
+                                &mut ctx.config,
+                                &ctx.tdk,
+                                self.profile.as_str(),
+                            )
+                            .await;
                         }
                         None => in_flight.finish(outcome.domain()),
                     }
@@ -3132,6 +3088,124 @@ fn apply_capability_replies(
             }
         }
     }
+}
+
+/// Do the work an outcome handed back because [`background_dispatch::apply_outcome`]
+/// could not: it is shared by both loops, and they hold different things.
+///
+/// Split out so both loops honour it identically — a persona minted in State A
+/// must be persisted exactly as one minted at runtime.
+async fn settle_after_apply(
+    after: background_dispatch::AfterApply,
+    state: &mut State,
+    config: &mut Config,
+    tdk: &TDK,
+    profile: &str,
+) -> Option<(String, openvtc_core::config::account::PersonaId)> {
+    use main_page::content::CreatePersonaPhase;
+
+    match after {
+        background_dispatch::AfterApply::Nothing => None,
+        // Only the runtime loop owns a session manager, so it is handed back up.
+        background_dispatch::AfterApply::Deregister(vtc, persona) => Some((vtc, persona)),
+        background_dispatch::AfterApply::PersistPersona(minted) => {
+            match minted.persist(config, tdk, profile).await {
+                Ok(_) => {
+                    let did = minted.did.clone();
+                    let copied = crate::clipboard::copy_to_clipboard(&did).is_ok();
+                    if let Some(o) = state.main_page.create_persona.as_mut() {
+                        o.phase = CreatePersonaPhase::Done;
+                        o.did = Some(did.clone());
+                        o.copied = copied;
+                        o.messages.push("Persona created.".to_string());
+                    }
+                    // Refresh the VTA panel so the new orphan persona is listed.
+                    state.main_page.sync_from_config(config);
+                    state.main_page.log(format!("Created persona DID {did}"));
+                }
+                Err(e) => {
+                    // The DID exists at the VTA but is not in the config. Say so
+                    // plainly: it is not lost, and a retry would mint a second.
+                    if let Some(o) = state.main_page.create_persona.as_mut() {
+                        o.phase = CreatePersonaPhase::Failed;
+                        o.messages
+                            .push(format!("Minted, but could not be saved: {e}"));
+                    }
+                    state
+                        .main_page
+                        .log_error("Persona minted but not saved", &e);
+                }
+            }
+            None
+        }
+    }
+}
+
+/// Start a standalone persona mint off the loop, shared by both loops.
+///
+/// The label is validated here — empty is an instant, local rejection that
+/// should keep the operator in the field — and the `Config` reads the mint needs
+/// are taken here too, so the job carries no borrow.
+///
+/// `progress_tx` is the dispatch channel itself: the job reports each step as a
+/// non-terminal [`background_dispatch::DispatchOutcome::Progress`], which the
+/// applier renders into the overlay without freeing the domain.
+fn spawn_persona_mint(
+    dispatch_tx: &tokio::sync::mpsc::UnboundedSender<background_dispatch::DispatchOutcome>,
+    in_flight: &mut background_dispatch::InFlight,
+    state: &mut State,
+    config: &Config,
+    tdk: &TDK,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
+) {
+    use main_page::content::CreatePersonaPhase;
+
+    let label = match state.main_page.create_persona.as_ref() {
+        Some(o) if o.phase == CreatePersonaPhase::Label => o.label.value().trim().to_string(),
+        _ => return,
+    };
+    fn fail(state: &mut State, msg: &str, terminal: bool) {
+        if let Some(o) = state.main_page.create_persona.as_mut() {
+            if terminal {
+                o.phase = CreatePersonaPhase::Failed;
+            }
+            o.messages = vec![msg.to_string()];
+        }
+    }
+    if label.is_empty() {
+        return fail(state, "Enter a label first.", false);
+    }
+    let Some(admin_vta) = admin_vta else {
+        return fail(
+            state,
+            "VTA session unavailable — cannot create a persona right now.",
+            true,
+        );
+    };
+    let domain = background_dispatch::DispatchDomain::Persona;
+    if !in_flight.try_begin(domain) {
+        return fail(
+            state,
+            &background_dispatch::InFlight::busy_message(domain),
+            false,
+        );
+    }
+
+    if let Some(o) = state.main_page.create_persona.as_mut() {
+        o.phase = CreatePersonaPhase::Working;
+        o.messages = vec![format!("Creating persona \u{201c}{label}\u{201d}\u{2026}")];
+    }
+
+    let job = create_persona::MintJob {
+        admin_vta: admin_vta.clone(),
+        tdk: tdk.clone(),
+        inputs: create_persona::MintInputs::from_config(config),
+        label,
+        progress_tx: dispatch_tx.clone(),
+    };
+    background_dispatch::spawn_dispatch(dispatch_tx.clone(), domain, async move {
+        background_dispatch::DispatchOutcome::Persona(Box::new(job.run().await))
+    });
 }
 
 /// Send a document addressed to a community, off the loop.


### PR DESCRIPTION
Closes the R14 sweep. Contains the progress mechanism, then the credential request, then the persona mint — in that order, because each needed the one before.

## 1. A way for a running job to report progress

`DispatchOutcome::Progress` is the **only** outcome that does not finish its domain: the job that sent it is still running, and finishing would let a second start alongside it. It carries a typed `ProgressUpdate`, not a bare string, so a new consumer cannot silently borrow another's display surface.

Both loops already have a dispatch arm, so both get this for free — no second channel, no new `select!` arm.

Without it, the persona overlay would have gone from a step-by-step account of a slow operation to a spinner that says nothing for half a dozen round-trips. That is how a working mint comes to look like a hang, which is the exact confusion this whole R14 sweep started from.

## 2. The credential request

**I was wrong when I called this a restructure.** Only one of twelve `CredentialAction` variants touches the network; the other eleven are state or config. It is one arm: the loop resolves the relationship's two DIDs, builds the message and picks the listener; the job sends.

The satisfying consequence is that `credential_actions::dispatch` loses its TDK and messaging parameters and stops being `async` — which is the clearest possible statement of what that module now is.

## 3. The persona mint

`mint_standalone_persona` no longer takes `Config`: its two reads become `MintInputs`, and it returns a `MintedPersona` (the `SetupState` and DID) instead of persisting.

**The persist deliberately stays on the loop.** `mint_persona_into` is shared with the join flow and is not worth restructuring for this, because everything it does is local — key info, an `ATMProfile`, `profile_add(.., false)` (registration explicitly *without* a socket), and secrets-resolver inserts. My earlier claim that this batch would have to touch the join path was wrong, and reading it properly is what made this tractable.

That persist is `async` and mutates `Config`, which the shared applier cannot do — so `AfterApply` generalises the return added in #243 to `Nothing | Deregister | PersistPersona`. Both loops settle it through one helper, because **a first persona is minted in State A** and must be persisted exactly as one minted at runtime.

### The ordering that matters

The overlay is marked Done *after* the persist, not when the VTA finishes minting. A persona shown as created but absent from the config would be a claim the next launch contradicts. When the persist fails, the message says the DID was **minted but not saved** — it exists at the VTA, and a retry would mint a second.

`DispatchOutcome::Persona` is boxed: a `MintedPersona` carries a whole `SetupState` (~2 KB) against ~136 bytes for the next largest variant, and unboxed, every dispatch of every domain would pay for it. Clippy caught that.

## Tests

Progress renders a step without freeing its domain, and is dropped for a closed overlay; a sent VRC request creates the tracking task while a failed one creates none; a successful mint defers completion to the persist and shows no DID before it; a failed mint is terminal.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo doc --workspace --no-deps` (no warnings); `cargo test --workspace` **and** `--no-default-features`.

## R14 after this

Five batches: agent names (#237), VIC vault (#239), capabilities (#242), community sends (#243), and this. Every network action a keypress can start now runs off the state-handler loop.

What still awaits on it is local by nature: settings, openpgp-card token operations, listener teardown for withdraw/delete-community, the in-memory secrets reads before a signature, and the already-migrated prepare steps. `StartJoin` remains deliberately modal, with the join flow owning its own loop.
