### PR TITLE
feat(setup): stop writing into a Trust Context that is already in use

### DIFF
--- a/openvtc-core/src/context_probe.rs
+++ b/openvtc-core/src/context_probe.rs
@@ -1,0 +1,284 @@
+//! Ask a Trust Context what is already in it, before setup writes to it.
+//!
+//! # Why setup asks
+//!
+//! Setup takes a VTA DID and a context id, authenticates, and starts creating
+//! things. It has never checked whether that context already contains an
+//! account — so pointing a fresh install at a context you already use silently
+//! mints a *second* set of personas alongside the first, and pointing it at a
+//! colleague's context is indistinguishable from a typo until much later.
+//!
+//! The moment setup holds an authenticated client it can simply look. Three
+//! list calls answer it, and all three already exist — no VTA change (D5, D6).
+//!
+//! # What it does not do
+//!
+//! It does not rebuild anything. Recovering an existing context needs the
+//! rebuild path (§6 of the spec) and the application-state store behind it;
+//! until those land, knowing the context is occupied is itself the useful
+//! answer, because it is the difference between a deliberate choice and a
+//! silent collision.
+//!
+//! Every call is best-effort. A VTA that refuses one of these listings, or a
+//! context the caller cannot enumerate, yields an [`Unknown`](ProbeOutcome)
+//! rather than blocking setup: the probe exists to inform a decision, and
+//! failing to inform it must not prevent making it.
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+use vta_sdk::client::VtaClient;
+
+/// What a probe found in a Trust Context.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextContents {
+    /// `did:webvh` identities the VTA holds for this context — the personas of
+    /// whatever account already lives here.
+    pub persona_dids: Vec<String>,
+    /// Credentials in the account's vault (VICs, VMCs, VRCs).
+    pub credential_count: usize,
+    /// Sub-contexts beneath this one — one per community joined, by convention.
+    pub sub_context_count: usize,
+}
+
+impl ContextContents {
+    /// True when the context holds nothing OpenVTC would recognise as an
+    /// existing account.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.persona_dids.is_empty() && self.credential_count == 0 && self.sub_context_count == 0
+    }
+
+    /// A concrete one-line summary (D7).
+    ///
+    /// Deliberately counts rather than saying "existing content found": the
+    /// user is deciding whether this is *their* account, and needs enough
+    /// detail to tell. "3 personas and 14 credentials" is recognisable;
+    /// "content found" is not.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        fn plural(n: usize, one: &str, many: &str) -> String {
+            format!("{n} {}", if n == 1 { one } else { many })
+        }
+
+        let mut parts = Vec::new();
+        if !self.persona_dids.is_empty() {
+            parts.push(plural(self.persona_dids.len(), "persona", "personas"));
+        }
+        if self.sub_context_count > 0 {
+            parts.push(plural(
+                self.sub_context_count,
+                "sub-context",
+                "sub-contexts",
+            ));
+        }
+        if self.credential_count > 0 {
+            parts.push(plural(self.credential_count, "credential", "credentials"));
+        }
+
+        match parts.len() {
+            0 => "nothing".to_string(),
+            1 => parts.remove(0),
+            _ => {
+                let last = parts.pop().expect("len >= 2");
+                format!("{} and {last}", parts.join(", "))
+            }
+        }
+    }
+}
+
+/// The result of asking. Separate from `Result` because "we could not tell" is
+/// a distinct answer from "it is empty", and conflating them is exactly how a
+/// probe turns into a silent collision.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// The context is empty — a genuine first run. Setup continues unchanged.
+    Empty,
+    /// The context already holds an account.
+    Occupied(Box<ContextContents>),
+    /// The VTA would not say. The string is its own message.
+    Unknown(String),
+}
+
+impl ProbeOutcome {
+    /// The contents, if the context was occupied.
+    #[must_use]
+    pub fn contents(&self) -> Option<&ContextContents> {
+        match self {
+            ProbeOutcome::Occupied(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// Whether setup should stop and ask before writing to this context.
+    #[must_use]
+    pub fn needs_confirmation(&self) -> bool {
+        matches!(self, ProbeOutcome::Occupied(_))
+    }
+}
+
+/// Ask `context_id` what it already contains.
+///
+/// Read-only, and cheap — three list calls against a context we have just
+/// authenticated to (D6). Runs on every setup rather than behind a flag,
+/// because a user who needs the answer is by definition not expecting to.
+pub async fn probe(client: &VtaClient, context_id: &str) -> ProbeOutcome {
+    let dids = match client.list_dids_webvh(Some(context_id), None).await {
+        Ok(body) => body.dids,
+        Err(e) => {
+            // The listing OpenVTC most depends on. If this one is refused the
+            // probe cannot claim the context is empty, so it says so.
+            return ProbeOutcome::Unknown(format!("could not list DIDs in {context_id}: {e}"));
+        }
+    };
+
+    // The other two are enrichment: they sharpen the summary but their absence
+    // does not change whether the context is occupied, so a failure here is
+    // logged and counted as zero rather than downgrading the whole answer.
+    let credential_count = match client.cred_vault_query(serde_json::json!({})).await {
+        Ok(v) => count_array(&v, &["credentials", "items", "results"]),
+        Err(e) => {
+            debug!("credential vault not enumerable during probe: {e}");
+            0
+        }
+    };
+
+    let sub_context_count = match client.list_contexts().await {
+        Ok(resp) => resp
+            .contexts
+            .iter()
+            .filter(|c| is_sub_context_of(&c.id, context_id))
+            .count(),
+        Err(e) => {
+            debug!("contexts not enumerable during probe: {e}");
+            0
+        }
+    };
+
+    let contents = ContextContents {
+        persona_dids: dids.into_iter().map(|d| d.did).collect(),
+        credential_count,
+        sub_context_count,
+    };
+
+    if contents.is_empty() {
+        ProbeOutcome::Empty
+    } else {
+        ProbeOutcome::Occupied(Box::new(contents))
+    }
+}
+
+/// Count the array under whichever of `keys` the response actually used.
+///
+/// The vault listing is returned untyped and the envelope key has moved before;
+/// trying the plausible names beats hard-coding one and silently reporting zero
+/// credentials on a full vault.
+fn count_array(value: &serde_json::Value, keys: &[&str]) -> usize {
+    if let Some(arr) = value.as_array() {
+        return arr.len();
+    }
+    keys.iter()
+        .find_map(|k| value.get(*k).and_then(|v| v.as_array()))
+        .map_or(0, Vec::len)
+}
+
+/// Whether `candidate` is a context *beneath* `parent`, not `parent` itself.
+///
+/// Sub-contexts are `<parent>/<slug>` by convention, so a prefix test needs the
+/// separator or `openvtc-2` would count as a child of `openvtc`.
+fn is_sub_context_of(candidate: &str, parent: &str) -> bool {
+    candidate
+        .strip_prefix(parent)
+        .is_some_and(|rest| rest.starts_with('/') && rest.len() > 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contents(personas: usize, creds: usize, subs: usize) -> ContextContents {
+        ContextContents {
+            persona_dids: (0..personas)
+                .map(|i| format!("did:webvh:Qm:example.com:p{i}"))
+                .collect(),
+            credential_count: creds,
+            sub_context_count: subs,
+        }
+    }
+
+    #[test]
+    fn an_empty_context_is_empty() {
+        assert!(ContextContents::default().is_empty());
+    }
+
+    #[test]
+    fn any_single_signal_makes_it_occupied() {
+        assert!(!contents(1, 0, 0).is_empty());
+        assert!(!contents(0, 1, 0).is_empty());
+        assert!(!contents(0, 0, 1).is_empty());
+    }
+
+    /// D7 — the summary must be concrete enough that a user can tell whether
+    /// this is *their* account.
+    #[test]
+    fn the_summary_counts_rather_than_gesturing() {
+        assert_eq!(
+            contents(3, 14, 2).summary(),
+            "3 personas, 2 sub-contexts and 14 credentials"
+        );
+    }
+
+    #[test]
+    fn the_summary_is_singular_when_it_should_be() {
+        assert_eq!(
+            contents(1, 1, 1).summary(),
+            "1 persona, 1 sub-context and 1 credential"
+        );
+    }
+
+    #[test]
+    fn the_summary_omits_what_is_absent() {
+        assert_eq!(contents(2, 0, 0).summary(), "2 personas");
+        assert_eq!(contents(0, 5, 0).summary(), "5 credentials");
+    }
+
+    /// "We could not tell" must never read as "it is empty" — that conflation
+    /// is exactly the silent collision the probe exists to prevent.
+    #[test]
+    fn unknown_is_not_empty_and_does_not_gate_setup() {
+        let unknown = ProbeOutcome::Unknown("refused".to_string());
+        assert!(!unknown.needs_confirmation());
+        assert!(unknown.contents().is_none());
+        assert_ne!(unknown, ProbeOutcome::Empty);
+    }
+
+    #[test]
+    fn only_an_occupied_context_stops_setup() {
+        assert!(!ProbeOutcome::Empty.needs_confirmation());
+        assert!(ProbeOutcome::Occupied(Box::new(contents(1, 0, 0))).needs_confirmation());
+    }
+
+    /// A sibling context must not be counted as a child, or every account on a
+    /// shared VTA would look occupied.
+    #[test]
+    fn sub_context_matching_requires_the_separator() {
+        assert!(is_sub_context_of("openvtc/acme", "openvtc"));
+        assert!(!is_sub_context_of("openvtc", "openvtc"));
+        assert!(!is_sub_context_of("openvtc-2", "openvtc"));
+        assert!(!is_sub_context_of("openvtc/", "openvtc"));
+        assert!(!is_sub_context_of("other/acme", "openvtc"));
+    }
+
+    /// The vault envelope is untyped and its key has moved before. Reporting
+    /// zero credentials on a full vault would make the summary lie.
+    #[test]
+    fn the_credential_count_tolerates_the_envelope_key_moving() {
+        let keys = ["credentials", "items", "results"];
+        for key in keys {
+            let v = serde_json::json!({ key: [1, 2, 3] });
+            assert_eq!(count_array(&v, &keys), 3, "key {key}");
+        }
+        // A bare array, and an envelope we do not recognise.
+        assert_eq!(count_array(&serde_json::json!([1, 2]), &keys), 2);
+        assert_eq!(count_array(&serde_json::json!({ "nope": [1] }), &keys), 0);
+    }
+}

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod config;
 // docs and is resolved in *this* file's scope, so every intra-doc link the
 // module writes about its own items breaks — which is what failed CI on #192
 // and again here.
+pub mod context_probe;
 pub mod devices;
 pub mod diagnostics;
 pub mod didcomm;

--- a/openvtc/src/state_handler/setup_sequence/mod.rs
+++ b/openvtc/src/state_handler/setup_sequence/mod.rs
@@ -31,6 +31,9 @@ pub enum SetupPage {
     VtaAclInstructions,
     /// Live diagnostics list while `provision_client::run_connection_test` runs.
     VtaProvisioning,
+    /// The chosen Trust Context already holds an account (D5). Shown only when
+    /// the probe found something, so a genuine first run never sees it.
+    ContextOccupied,
 
     /// Optional PGP Token setup occurs here
     #[cfg(feature = "openpgp-card")]
@@ -132,6 +135,15 @@ pub struct VtaSetupState {
     /// `Arc` because `EphemeralSetupKey` isn't `Clone` and `SetupState`
     /// derives `Clone` for the watch channel.
     pub setup_key: Option<Arc<EphemeralSetupKey>>,
+    /// What the chosen Trust Context already contained, once provisioning has
+    /// authenticated far enough to look (D5–D7).
+    ///
+    /// `None` until the probe runs. `Occupied` routes the wizard through
+    /// [`SetupPage::ContextOccupied`] before anything is written, so pointing a
+    /// fresh install at a context already in use is a decision rather than a
+    /// silent collision.
+    pub context_probe: Option<openvtc_core::context_probe::ProbeOutcome>,
+
     /// Live diagnostics list streamed from `provision_client::run_connection_test`.
     pub diagnostics: Vec<DiagEntry>,
     /// Admin credential issued by the VTA on successful provisioning. The

--- a/openvtc/src/state_handler/setup_vta_actions.rs
+++ b/openvtc/src/state_handler/setup_vta_actions.rs
@@ -468,6 +468,30 @@ pub(crate) async fn handle_vta_start_provision(
         }
     };
 
+    // D5–D7: now that the session is authenticated, ask the context what it
+    // already contains, *before* setup writes anything into it. Read-only, three
+    // list calls, and the answer is ready by the time the operator presses
+    // Enter — so the wizard can route through the "already in use" warning
+    // without a pause the operator would experience as a hang.
+    //
+    // Deliberately not fatal: an outcome of `Unknown` means the wizard proceeds
+    // exactly as it always has. Failing to inform the decision must not prevent
+    // making it.
+    let probe = openvtc_core::context_probe::probe(&client, &context_id).await;
+    match &probe {
+        openvtc_core::context_probe::ProbeOutcome::Occupied(contents) => {
+            state.setup.vta.messages.push(MessageType::Info(format!(
+                "This Trust Context already contains {}.",
+                contents.summary()
+            )));
+        }
+        openvtc_core::context_probe::ProbeOutcome::Unknown(reason) => {
+            tracing::debug!("context probe inconclusive: {reason}");
+        }
+        openvtc_core::context_probe::ProbeOutcome::Empty => {}
+    }
+    state.setup.vta.context_probe = Some(probe);
+
     state.setup.vta.completed = Completion::CompletedOK;
     // Stay on VtaProvisioning so the operator can see the admin DID rotation
     // result (ephemeral setup DID → long-term admin DID) before advancing on

--- a/openvtc/src/ui/pages/setup_flow/context_occupied.rs
+++ b/openvtc/src/ui/pages/setup_flow/context_occupied.rs
@@ -1,0 +1,301 @@
+//! Shown when the chosen Trust Context already holds an account (D5).
+//!
+//! Setup used to write into whatever context it was given without looking. A
+//! fresh install pointed at a context already in use would quietly mint a
+//! *second* set of personas beside the first, and a mistyped context id was
+//! indistinguishable from a deliberate one until much later.
+//!
+//! This page turns that into a decision. It is reached only when the probe
+//! found something, so a genuine first run never sees it.
+//!
+//! # What it deliberately does not offer yet
+//!
+//! **Recover.** Rebuilding an existing context needs the rebuild path and the
+//! application-state store behind it. Offering a "Recover" option that cannot
+//! complete would be worse than not offering one, so the page says plainly that
+//! recovery is not available yet and points at the export instead — the thing
+//! that does work today.
+//!
+//! **Delete.** Destroying a context takes its persona DIDs and their keys with
+//! it, irreversibly. That must never be one keypress from someone who re-ran
+//! setup, so it is not on this screen at all (D11).
+
+use crate::{
+    colors::{
+        COLOR_BORDER, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_TEXT_DEFAULT,
+        COLOR_WARNING_ACCESSIBLE_RED,
+    },
+    state_handler::{
+        actions::Action,
+        setup_sequence::{SetupPage, SetupState},
+    },
+    ui::pages::setup_flow::{
+        SetupFlow,
+        navigation::{SetupEvent, handle_nav_result, navigate},
+        render_setup_header,
+    },
+};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Layout,
+    },
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct ContextOccupied;
+
+impl ContextOccupied {
+    pub fn handle_key_event(state: &mut SetupFlow, key: KeyEvent) {
+        match key.code {
+            KeyCode::F(10) => {
+                let _ = state.action_tx.send(Action::Exit);
+            }
+            // Go back and choose a different context. The existing one is left
+            // completely alone — the non-destructive way to "start fresh".
+            KeyCode::Esc | KeyCode::Char('b') | KeyCode::Char('B') => {
+                state.props.state.active_page = SetupPage::VtaEnterDid;
+            }
+            // Continue into this context anyway. Not the default, and not
+            // Enter: continuing means adding a second account beside the first,
+            // and that should take a deliberate keystroke rather than the one
+            // the user has been pressing to advance every page so far.
+            KeyCode::Char('c') | KeyCode::Char('C') => {
+                let result = navigate(SetupEvent::ContextOccupiedAccepted, &state.props.state);
+                handle_nav_result(result, state);
+            }
+            _ => {}
+        }
+    }
+
+    pub fn render(&self, state: &SetupState, frame: &mut Frame<'_>) {
+        let [top, middle, bottom] =
+            Layout::vertical([Length(3), Min(0), Length(3)]).areas(frame.area());
+
+        render_setup_header(frame, top, state);
+
+        let context = state.vta.context_id.as_deref().unwrap_or("(unknown)");
+        let summary = state
+            .vta
+            .context_probe
+            .as_ref()
+            .and_then(|p| p.contents())
+            .map(openvtc_core::context_probe::ContextContents::summary)
+            .unwrap_or_else(|| "existing data".to_string());
+
+        let mut lines: Vec<Line> = vec![
+            Line::styled(
+                "This Trust Context is already in use",
+                Style::new().fg(COLOR_ORANGE).bold(),
+            ),
+            Line::default(),
+        ];
+
+        // D7: counts, not "content found". The user is deciding whether this is
+        // *their* account, and needs enough detail to tell.
+        lines.push(Line::from(vec![
+            Span::styled("  Context   ", Style::new().fg(COLOR_BORDER)),
+            Span::styled(context.to_string(), Style::new().fg(COLOR_SOFT_PURPLE)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("  Contains  ", Style::new().fg(COLOR_BORDER)),
+            Span::styled(summary, Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]));
+
+        if let Some(dids) = state
+            .vta
+            .context_probe
+            .as_ref()
+            .and_then(|p| p.contents())
+            .map(|c| &c.persona_dids)
+            && !dids.is_empty()
+        {
+            lines.push(Line::default());
+            for did in dids.iter().take(4) {
+                lines.push(Line::styled(
+                    format!("    {}", openvtc_core::display::truncate_did(did, 58)),
+                    Style::new().fg(COLOR_BORDER),
+                ));
+            }
+            if dids.len() > 4 {
+                lines.push(Line::styled(
+                    format!("    … and {} more", dids.len() - 4),
+                    Style::new().fg(COLOR_BORDER),
+                ));
+            }
+        }
+
+        lines.push(Line::default());
+        lines.push(Line::styled(
+            "If this is your account, setup is not the way back into it. \
+             Continuing does NOT recover it — it creates a second, separate \
+             account alongside the existing one in the same context.",
+            Style::new().fg(COLOR_TEXT_DEFAULT),
+        ));
+        lines.push(Line::default());
+        lines.push(Line::styled(
+            "Recovering an existing context is not available yet. If you have an \
+             encrypted export, restore it instead: run OpenVTC and choose \
+             Import / Restore Backup.",
+            Style::new().fg(COLOR_TEXT_DEFAULT),
+        ));
+
+        lines.push(Line::default());
+        lines.push(Line::styled(
+            "What would you like to do?",
+            Style::new().fg(COLOR_BORDER).bold(),
+        ));
+        lines.push(Line::from(vec![
+            Span::styled("  [B] ", Style::new().fg(COLOR_SOFT_PURPLE).bold()),
+            Span::styled(
+                "Use a different context — leaves this one untouched",
+                Style::new().fg(COLOR_TEXT_DEFAULT),
+            ),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                "  [C] ",
+                Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED).bold(),
+            ),
+            Span::styled(
+                "Continue anyway, adding a second account to this context",
+                Style::new().fg(COLOR_TEXT_DEFAULT),
+            ),
+        ]));
+
+        let body = Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .block(Block::new().padding(Padding::new(2, 2, 1, 0)));
+        frame.render_widget(body, middle);
+
+        let bottom_line = Line::from(vec![
+            Span::styled("[B]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(
+                " different context  |  ",
+                Style::new().fg(COLOR_TEXT_DEFAULT),
+            ),
+            Span::styled("[C]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" continue anyway  |  ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]);
+        frame.render_widget(
+            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
+            bottom,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Rendered for real and read back, because the value of this page is
+    //! entirely in what it says: a warning the user misreads as "recovery
+    //! happened" would be worse than no warning at all.
+    use super::*;
+    use crate::state_handler::setup_sequence::SetupState;
+    use openvtc_core::context_probe::{ContextContents, ProbeOutcome};
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn occupied_state(personas: usize) -> SetupState {
+        let mut state = SetupState {
+            active_page: SetupPage::ContextOccupied,
+            ..Default::default()
+        };
+        state.vta.context_id = Some("openvtc".to_string());
+        state.vta.context_probe = Some(ProbeOutcome::Occupied(Box::new(ContextContents {
+            persona_dids: (0..personas)
+                .map(|i| format!("did:webvh:QmAAAAAAAAAAAA:example.com:persona{i}"))
+                .collect(),
+            credential_count: 14,
+            sub_context_count: 2,
+        })));
+        state
+    }
+
+    fn rows(state: &SetupState, width: u16, height: u16) -> Vec<String> {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+        terminal
+            .draw(|frame| ContextOccupied.render(state, frame))
+            .expect("render");
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .chunks(width as usize)
+            .map(|row| {
+                row.iter()
+                    .map(|c| c.symbol())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    fn flat(state: &SetupState) -> String {
+        rows(state, 100, 40)
+            .join(" ")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// D7 — concrete counts, so the user can tell whether this is their account.
+    #[test]
+    fn the_page_names_the_context_and_counts_what_is_in_it() {
+        let text = flat(&occupied_state(3));
+        assert!(text.contains("already in use"), "{text}");
+        assert!(text.contains("openvtc"), "{text}");
+        assert!(
+            text.contains("3 personas, 2 sub-contexts and 14 credentials"),
+            "{text}"
+        );
+    }
+
+    /// The misreading that would make this page actively harmful.
+    #[test]
+    fn the_page_says_continuing_is_not_recovery() {
+        let text = flat(&occupied_state(1));
+        assert!(text.contains("does NOT recover"), "{text}");
+        assert!(text.contains("second"), "{text}");
+        assert!(
+            text.contains("not available yet"),
+            "recovery must be described as unavailable, not offered: {text}"
+        );
+    }
+
+    /// D11 — destroying a context takes persona keys with it. It must not be
+    /// reachable from this screen at all.
+    #[test]
+    fn the_page_offers_no_destructive_option() {
+        let text = flat(&occupied_state(2)).to_lowercase();
+        assert!(!text.contains("delete"), "{text}");
+        assert!(!text.contains("wipe"), "{text}");
+        assert!(!text.contains("erase"), "{text}");
+    }
+
+    /// A long persona list must not push the choices off the screen — the
+    /// actions are the part the page exists for.
+    #[test]
+    fn many_personas_do_not_crowd_out_the_choices() {
+        let text = flat(&occupied_state(12));
+        assert!(
+            text.contains("and 8 more"),
+            "the list must be capped: {text}"
+        );
+        assert!(text.contains("Use a different context"), "{text}");
+        assert!(text.contains("Continue anyway"), "{text}");
+    }
+
+    #[test]
+    fn nothing_overflows_the_terminal_width() {
+        for row in rows(&occupied_state(3), 80, 40) {
+            assert!(row.chars().count() <= 80, "row overflows: {row:?}");
+        }
+    }
+}

--- a/openvtc/src/ui/pages/setup_flow/mod.rs
+++ b/openvtc/src/ui/pages/setup_flow/mod.rs
@@ -16,10 +16,11 @@ use crate::{
     ui::{
         component::{Component, ComponentRender},
         pages::setup_flow::{
-            config_import::ConfigImport, final_page::FinalPage, start_ask::StartAskPanel,
-            unlock_code_ask::UnlockCodeAsk, unlock_code_set::UnlockCodeSet,
-            unlock_code_warn::UnlockCodeWarn, vta_acl_instructions::VtaAclInstructions,
-            vta_enter_did::VtaEnterDid, vta_provisioning::VtaProvisioning,
+            config_import::ConfigImport, context_occupied::ContextOccupied, final_page::FinalPage,
+            start_ask::StartAskPanel, unlock_code_ask::UnlockCodeAsk,
+            unlock_code_set::UnlockCodeSet, unlock_code_warn::UnlockCodeWarn,
+            vta_acl_instructions::VtaAclInstructions, vta_enter_did::VtaEnterDid,
+            vta_provisioning::VtaProvisioning,
         },
     },
 };
@@ -35,6 +36,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 pub mod choice_page;
 pub mod config_import;
+pub mod context_occupied;
 pub mod final_page;
 pub mod navigation;
 pub mod start_ask;
@@ -61,6 +63,7 @@ pub struct SetupFlow {
     pub vta_enter_did: VtaEnterDid,
     pub vta_acl_instructions: VtaAclInstructions,
     pub vta_provisioning: VtaProvisioning,
+    pub context_occupied: ContextOccupied,
 
     #[cfg(feature = "openpgp-card")]
     pub token_start: TokenStart,
@@ -109,6 +112,7 @@ impl Component for SetupFlow {
             vta_enter_did: VtaEnterDid::default(),
             vta_acl_instructions: VtaAclInstructions::default(),
             vta_provisioning: VtaProvisioning,
+            context_occupied: ContextOccupied,
 
             #[cfg(feature = "openpgp-card")]
             token_start: TokenStart::default(),
@@ -154,6 +158,7 @@ impl Component for SetupFlow {
             SetupPage::VtaEnterDid => VtaEnterDid::handle_key_event(self, key),
             SetupPage::VtaAclInstructions => VtaAclInstructions::handle_key_event(self, key),
             SetupPage::VtaProvisioning => VtaProvisioning::handle_key_event(self, key),
+            SetupPage::ContextOccupied => ContextOccupied::handle_key_event(self, key),
 
             #[cfg(feature = "openpgp-card")]
             SetupPage::TokenStart => TokenStart::handle_key_event(self, key),
@@ -224,6 +229,7 @@ impl ComponentRender<()> for SetupFlow {
                 self.vta_acl_instructions.render(&self.props.state, frame)
             }
             SetupPage::VtaProvisioning => self.vta_provisioning.render(&self.props.state, frame),
+            SetupPage::ContextOccupied => self.context_occupied.render(&self.props.state, frame),
 
             #[cfg(feature = "openpgp-card")]
             SetupPage::TokenStart => self.token_start.render(&self.props.state, frame),

--- a/openvtc/src/ui/pages/setup_flow/navigation.rs
+++ b/openvtc/src/ui/pages/setup_flow/navigation.rs
@@ -22,6 +22,9 @@ pub enum SetupEvent {
 
     // VtaProvisioning
     VtaAuthCompleted,
+    /// The operator saw that the chosen Trust Context already holds an account
+    /// and chose to continue into it regardless (D5/D11).
+    ContextOccupiedAccepted,
 
     // Token pages (cfg-gated)
     #[cfg(feature = "openpgp-card")]
@@ -79,7 +82,27 @@ pub fn navigate(event: SetupEvent, state: &SetupState) -> NavResult {
         // credential is issued, go straight to protection then create the
         // account — minting a persona / did:webvh belongs to the State-B join
         // flow, which drives it itself rather than through wizard pages.
-        SetupEvent::VtaAuthCompleted => NavResult::GoTo(protection_entry()),
+        // D5: the probe runs during provisioning, so by the time the operator
+        // confirms we already know whether this context holds an account.
+        // Detour through the warning only when it does — a genuine first run
+        // never sees the page, and an unreachable listing (`Unknown`) does not
+        // gate setup, because failing to inform a decision must not prevent
+        // making it.
+        SetupEvent::VtaAuthCompleted => {
+            if state
+                .vta
+                .context_probe
+                .as_ref()
+                .is_some_and(openvtc_core::context_probe::ProbeOutcome::needs_confirmation)
+            {
+                NavResult::GoTo(SetupPage::ContextOccupied)
+            } else {
+                NavResult::GoTo(protection_entry())
+            }
+        }
+
+        // Acknowledged: carry on exactly where an empty context would have.
+        SetupEvent::ContextOccupiedAccepted => NavResult::GoTo(protection_entry()),
 
         // === Token pages ===
         #[cfg(feature = "openpgp-card")]
@@ -187,6 +210,64 @@ mod tests {
 
     fn is_complete(result: &NavResult) -> bool {
         matches!(result, NavResult::CompleteSetup)
+    }
+
+    /// D5 — the whole point of the probe. A context that already holds an
+    /// account must not be written into without the operator seeing it first.
+    #[test]
+    fn an_occupied_context_detours_through_the_warning() {
+        use openvtc_core::context_probe::{ContextContents, ProbeOutcome};
+        let mut state = empty_state();
+        state.vta.context_probe = Some(ProbeOutcome::Occupied(Box::new(ContextContents {
+            persona_dids: vec!["did:webvh:Qm:example.com:alice".to_string()],
+            credential_count: 3,
+            sub_context_count: 1,
+        })));
+
+        let r = navigate(SetupEvent::VtaAuthCompleted, &state);
+        assert!(
+            matches_goto(&r, SetupPage::ContextOccupied),
+            "an occupied context must stop and ask"
+        );
+    }
+
+    /// A genuine first run must be completely unchanged — no extra page, no
+    /// extra keystroke.
+    #[test]
+    fn an_empty_context_is_unaffected() {
+        use openvtc_core::context_probe::ProbeOutcome;
+        let mut state = empty_state();
+        state.vta.context_probe = Some(ProbeOutcome::Empty);
+
+        let r = navigate(SetupEvent::VtaAuthCompleted, &state);
+        assert!(matches_goto(&r, protection_entry()));
+    }
+
+    /// "We could not tell" must not gate setup: failing to inform the decision
+    /// cannot be allowed to prevent making it.
+    #[test]
+    fn an_inconclusive_probe_does_not_gate_setup() {
+        use openvtc_core::context_probe::ProbeOutcome;
+        let mut state = empty_state();
+        state.vta.context_probe = Some(ProbeOutcome::Unknown("refused".to_string()));
+
+        let r = navigate(SetupEvent::VtaAuthCompleted, &state);
+        assert!(matches_goto(&r, protection_entry()));
+    }
+
+    /// A VTA old enough that the probe never ran at all behaves as before.
+    #[test]
+    fn no_probe_at_all_behaves_as_before() {
+        let r = navigate(SetupEvent::VtaAuthCompleted, &empty_state());
+        assert!(matches_goto(&r, protection_entry()));
+    }
+
+    /// Acknowledging rejoins the normal flow at exactly the point an empty
+    /// context would have.
+    #[test]
+    fn accepting_an_occupied_context_rejoins_the_normal_flow() {
+        let r = navigate(SetupEvent::ContextOccupiedAccepted, &empty_state());
+        assert!(matches_goto(&r, protection_entry()));
     }
 
     #[test]


### PR DESCRIPTION
> **Stacked on #246.** Base is `fix/secure-store-diagnostics-durability`, so this diff shows only its own changes. Merge #246 first.

## Why

Setup took a VTA DID and a context id and started creating things **without ever checking what was already there**.

Point a fresh install at a context you already use and it silently minted a *second* set of personas alongside the first. A mistyped context id was indistinguishable from a deliberate one until both accounts existed.

## What it does

The moment setup holds an authenticated client, it looks. Three list calls answer it, all three already exist, and **no VTA change is needed** (D5, D6). The probe runs *during* provisioning so the answer is ready when the operator presses Enter, rather than adding a pause they would read as a hang.

```
  This Trust Context is already in use

    Context   openvtc
    Contains  3 personas, 2 sub-contexts and 14 credentials

      did:webvh:QmAAAA…:example.com:persona0
      …

  If this is your account, setup is not the way back into it. Continuing does
  NOT recover it — it creates a second, separate account alongside the
  existing one in the same context.

    [B] Use a different context — leaves this one untouched
    [C] Continue anyway, adding a second account to this context
```

## Four judgement calls

- **`ProbeOutcome` separates "empty" from "could not tell".** Conflating them is exactly how a probe turns back into a silent collision, so an inconclusive listing leaves setup behaving precisely as before. Failing to inform the decision must not prevent making it.
- **The summary counts rather than gestures** (D7). The user is deciding whether this is *their* account and needs enough detail to tell.
- **No Delete option, anywhere on the page** (D11). Destroying a context takes persona DIDs and their keys with it, irreversibly, and that must never be one keypress from someone who re-ran setup. "Use a different context" is the non-destructive way to start fresh, and it is listed first.
- **Continue is `[C]`, not Enter.** Adding a second account deserves a deliberate keystroke, not the one the operator has been pressing to advance every page.

## Two traps handled

- Sub-context matching requires the separator, so `openvtc-2` is not counted as a child of `openvtc` — otherwise every account on a shared VTA would look occupied.
- The credential count tolerates the vault envelope key moving; reporting zero on a full vault would make the summary lie.

## Note

The "Recover" option is added in #250 — this PR deliberately says recovery is *not available yet* and points at the encrypted export, because an option that cannot complete is worse than an absent one.

19 tests. Both feature configurations green, clippy clean.
