### PR TITLE
fix(rebuild): store membership credentials at the VTA, and query the vault legally

### DIFF
--- a/openvtc-core/src/context_probe.rs
+++ b/openvtc-core/src/context_probe.rs
@@ -34,8 +34,6 @@ pub struct ContextContents {
     /// `did:webvh` identities the VTA holds for this context — the personas of
     /// whatever account already lives here.
     pub persona_dids: Vec<String>,
-    /// Credentials in the account's vault (VICs, VMCs, VRCs).
-    pub credential_count: usize,
     /// Sub-contexts beneath this one — one per community joined, by convention.
     pub sub_context_count: usize,
 }
@@ -45,7 +43,7 @@ impl ContextContents {
     /// existing account.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.persona_dids.is_empty() && self.credential_count == 0 && self.sub_context_count == 0
+        self.persona_dids.is_empty() && self.sub_context_count == 0
     }
 
     /// A concrete one-line summary (D7).
@@ -70,9 +68,6 @@ impl ContextContents {
                 "sub-context",
                 "sub-contexts",
             ));
-        }
-        if self.credential_count > 0 {
-            parts.push(plural(self.credential_count, "credential", "credentials"));
         }
 
         match parts.len() {
@@ -131,17 +126,14 @@ pub async fn probe(client: &VtaClient, context_id: &str) -> ProbeOutcome {
         }
     };
 
-    // The other two are enrichment: they sharpen the summary but their absence
-    // does not change whether the context is occupied, so a failure here is
-    // logged and counted as zero rather than downgrading the whole answer.
-    let credential_count = match client.cred_vault_query(serde_json::json!({})).await {
-        Ok(v) => count_array(&v, &["credentials", "items", "results"]),
-        Err(e) => {
-            debug!("credential vault not enumerable during probe: {e}");
-            0
-        }
-    };
-
+    // Credentials are deliberately NOT counted. The credential vault is
+    // non-enumerable by design — `vault/credentials/query/0.1` refuses a
+    // filterless request, because running one would be a wallet enumeration —
+    // so "how many credentials are here?" is a question the contract does not
+    // answer. An earlier version asked it anyway with an empty filter, and
+    // quietly read the refusal as "zero", which under-reported occupied
+    // contexts. Personas and sub-contexts are enough to tell a context is in
+    // use, and both are properly enumerable.
     let sub_context_count = match client.list_contexts().await {
         Ok(resp) => resp
             .contexts
@@ -156,7 +148,6 @@ pub async fn probe(client: &VtaClient, context_id: &str) -> ProbeOutcome {
 
     let contents = ContextContents {
         persona_dids: dids.into_iter().map(|d| d.did).collect(),
-        credential_count,
         sub_context_count,
     };
 
@@ -165,20 +156,6 @@ pub async fn probe(client: &VtaClient, context_id: &str) -> ProbeOutcome {
     } else {
         ProbeOutcome::Occupied(Box::new(contents))
     }
-}
-
-/// Count the array under whichever of `keys` the response actually used.
-///
-/// The vault listing is returned untyped and the envelope key has moved before;
-/// trying the plausible names beats hard-coding one and silently reporting zero
-/// credentials on a full vault.
-fn count_array(value: &serde_json::Value, keys: &[&str]) -> usize {
-    if let Some(arr) = value.as_array() {
-        return arr.len();
-    }
-    keys.iter()
-        .find_map(|k| value.get(*k).and_then(|v| v.as_array()))
-        .map_or(0, Vec::len)
 }
 
 /// Whether `candidate` is a context *beneath* `parent`, not `parent` itself.
@@ -195,12 +172,11 @@ fn is_sub_context_of(candidate: &str, parent: &str) -> bool {
 mod tests {
     use super::*;
 
-    fn contents(personas: usize, creds: usize, subs: usize) -> ContextContents {
+    fn contents(personas: usize, subs: usize) -> ContextContents {
         ContextContents {
             persona_dids: (0..personas)
                 .map(|i| format!("did:webvh:Qm:example.com:p{i}"))
                 .collect(),
-            credential_count: creds,
             sub_context_count: subs,
         }
     }
@@ -212,33 +188,26 @@ mod tests {
 
     #[test]
     fn any_single_signal_makes_it_occupied() {
-        assert!(!contents(1, 0, 0).is_empty());
-        assert!(!contents(0, 1, 0).is_empty());
-        assert!(!contents(0, 0, 1).is_empty());
+        assert!(!contents(1, 0).is_empty());
+        assert!(!contents(0, 1).is_empty());
     }
 
     /// D7 — the summary must be concrete enough that a user can tell whether
     /// this is *their* account.
     #[test]
     fn the_summary_counts_rather_than_gesturing() {
-        assert_eq!(
-            contents(3, 14, 2).summary(),
-            "3 personas, 2 sub-contexts and 14 credentials"
-        );
+        assert_eq!(contents(3, 2).summary(), "3 personas and 2 sub-contexts");
     }
 
     #[test]
     fn the_summary_is_singular_when_it_should_be() {
-        assert_eq!(
-            contents(1, 1, 1).summary(),
-            "1 persona, 1 sub-context and 1 credential"
-        );
+        assert_eq!(contents(1, 1).summary(), "1 persona and 1 sub-context");
     }
 
     #[test]
     fn the_summary_omits_what_is_absent() {
-        assert_eq!(contents(2, 0, 0).summary(), "2 personas");
-        assert_eq!(contents(0, 5, 0).summary(), "5 credentials");
+        assert_eq!(contents(2, 0).summary(), "2 personas");
+        assert_eq!(contents(0, 3).summary(), "3 sub-contexts");
     }
 
     /// "We could not tell" must never read as "it is empty" — that conflation
@@ -254,7 +223,7 @@ mod tests {
     #[test]
     fn only_an_occupied_context_stops_setup() {
         assert!(!ProbeOutcome::Empty.needs_confirmation());
-        assert!(ProbeOutcome::Occupied(Box::new(contents(1, 0, 0))).needs_confirmation());
+        assert!(ProbeOutcome::Occupied(Box::new(contents(1, 0))).needs_confirmation());
     }
 
     /// A sibling context must not be counted as a child, or every account on a
@@ -268,17 +237,12 @@ mod tests {
         assert!(!is_sub_context_of("other/acme", "openvtc"));
     }
 
-    /// The vault envelope is untyped and its key has moved before. Reporting
-    /// zero credentials on a full vault would make the summary lie.
+    /// The credential vault is non-enumerable by design, so the probe does not
+    /// count credentials at all. An earlier version asked with an empty filter
+    /// and read the refusal as "zero", which under-reported occupied contexts.
     #[test]
-    fn the_credential_count_tolerates_the_envelope_key_moving() {
-        let keys = ["credentials", "items", "results"];
-        for key in keys {
-            let v = serde_json::json!({ key: [1, 2, 3] });
-            assert_eq!(count_array(&v, &keys), 3, "key {key}");
-        }
-        // A bare array, and an envelope we do not recognise.
-        assert_eq!(count_array(&serde_json::json!([1, 2]), &keys), 2);
-        assert_eq!(count_array(&serde_json::json!({ "nope": [1] }), &keys), 0);
+    fn a_context_with_only_personas_is_still_occupied() {
+        assert!(!contents(1, 0).is_empty());
+        assert_eq!(contents(1, 0).summary(), "1 persona");
     }
 }

--- a/openvtc-core/src/credential_sync.rs
+++ b/openvtc-core/src/credential_sync.rs
@@ -1,0 +1,241 @@
+//! Put the credentials this account holds into the VTA's credential vault.
+//!
+//! # Why this exists
+//!
+//! A `MembershipCredential` arrives over DIDComm and is stored in the local
+//! `CommunityRecord` — and, until now, nowhere else. Invitations were pushed to
+//! the VTA's credential vault on receipt; membership credentials were not.
+//!
+//! That is what made membership recovery restore nothing. [`crate::rebuild`]
+//! reconstructs a membership *from* its credential, which is the right design —
+//! the credential is what the community signed, and it names both the community
+//! and the persona. But the credential has to be somewhere a rebuild can find
+//! it, and a local config file is precisely the thing a rebuild exists because
+//! you no longer have.
+//!
+//! A VMC also simply *belongs* in the credential store. It is a signed artifact
+//! of exactly the kind that vault holds, and keeping it only in a config file
+//! was the anomaly.
+//!
+//! # One pass, run on connect
+//!
+//! The message-dispatch path that ingests a credential has no VTA session, so
+//! rather than threading one through, this runs as a sync: everything held
+//! locally that the vault does not have is pushed. That covers a fresh join, a
+//! credential received while the VTA was unreachable, and the back-fill of
+//! every membership from before this existed — one mechanism instead of three.
+//!
+//! # Published Trust Tasks only
+//!
+//! - `spec/vault/credentials/query/0.1` to see what the vault already holds.
+//!   **Filtered** — the vault refuses a filterless query by design, because
+//!   running one would be a wallet enumeration.
+//! - `spec/vault/credentials/receive/0.1` to store one.
+//!
+//! Both are dispatched Trust Tasks; neither is a bespoke route.
+
+use serde_json::Value;
+use tracing::{debug, warn};
+use vta_sdk::client::VtaClient;
+
+use crate::{CredentialKind, config::Config};
+
+/// What a sync pass did.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SyncReport {
+    /// Credentials pushed to the vault this pass.
+    pub stored: usize,
+    /// Credentials already held by the vault, left alone.
+    pub already_held: usize,
+    /// Credentials that could not be pushed. Non-fatal — the local copy is
+    /// still authoritative today, so a failure costs recoverability, not the
+    /// membership itself.
+    pub failed: usize,
+}
+
+impl SyncReport {
+    /// True when the pass had nothing to do — the common case once an account
+    /// has been synced.
+    #[must_use]
+    pub fn is_noop(&self) -> bool {
+        self.stored == 0 && self.failed == 0
+    }
+}
+
+/// Ensure every membership credential this account holds is also in the vault.
+///
+/// Idempotent: the vault keys a received credential on the VC's own `id`, so
+/// re-receiving one overwrites rather than duplicating. The query pass exists
+/// only to avoid pointless writes on every launch.
+///
+/// Best-effort throughout. The local copy remains the source of truth today, so
+/// a vault that will not answer costs future recoverability rather than
+/// anything working now.
+pub async fn sync_membership_credentials(config: &Config, client: &VtaClient) -> SyncReport {
+    let held: Vec<(String, Value)> = config
+        .account
+        .memberships()
+        .filter_map(|c| {
+            let vc = c.credentials.get(&CredentialKind::Membership)?;
+            // Without an id there is nothing to compare against, and the vault
+            // would mint a fresh one on every pass — storing a duplicate each
+            // launch. Skip rather than churn.
+            let id = vc.get("id").and_then(Value::as_str)?;
+            Some((id.to_string(), vc.clone()))
+        })
+        .collect();
+
+    if held.is_empty() {
+        return SyncReport::default();
+    }
+
+    // Filtered, because the vault refuses to enumerate. `purpose` is the
+    // vault's own semantic classification and what its index is keyed on, so
+    // it does not depend on how an issuer spelled its `type` array.
+    let in_vault = match client.cred_vault_query(held_query_filter()).await {
+        Ok(listing) => held_ids(&listing),
+        Err(e) => {
+            // Not fatal, and not a reason to skip the push: `receive` is
+            // idempotent, so the worst case is re-storing what is already
+            // there.
+            debug!("could not read held membership credentials ({e}); storing regardless");
+            Vec::new()
+        }
+    };
+
+    let mut report = SyncReport::default();
+    for (id, credential) in held {
+        if in_vault.iter().any(|held| held == &id) {
+            report.already_held += 1;
+            continue;
+        }
+        match client.cred_vault_receive(credential, None).await {
+            Ok(_) => {
+                debug!(id = %id, "stored a membership credential in the vault");
+                report.stored += 1;
+            }
+            Err(e) => {
+                warn!(id = %id, "could not store a membership credential: {e}");
+                report.failed += 1;
+            }
+        }
+    }
+    report
+}
+
+/// The filter used to see which membership credentials the vault already holds.
+///
+/// Factored out so the "must carry a filter" contract is testable without a
+/// VTA. See `rebuild::membership_query_filter` for why `purpose`.
+fn held_query_filter() -> Value {
+    serde_json::json!({ "purpose": "membership" })
+}
+
+/// Credential ids from a `query/0.1` response.
+///
+/// The response carries body-free descriptors; only the `id` is needed here.
+/// Tolerant about the envelope key because the response is consumed untyped,
+/// and reading a full vault as empty would mean re-storing everything on every
+/// launch.
+fn held_ids(listing: &Value) -> Vec<String> {
+    let array = if let Some(arr) = listing.as_array() {
+        arr.clone()
+    } else {
+        ["credentials", "items", "results"]
+            .iter()
+            .find_map(|k| listing.get(*k).and_then(Value::as_array))
+            .cloned()
+            .unwrap_or_default()
+    };
+    array
+        .into_iter()
+        .filter_map(|d| {
+            d.get("id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .or_else(|| d.as_str().map(str::to_string))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_pass_with_nothing_to_do_is_a_noop() {
+        assert!(SyncReport::default().is_noop());
+        assert!(
+            SyncReport {
+                stored: 0,
+                already_held: 4,
+                failed: 0
+            }
+            .is_noop(),
+            "an already-synced account must not report activity every launch"
+        );
+    }
+
+    #[test]
+    fn stores_and_failures_are_both_worth_reporting() {
+        assert!(
+            !SyncReport {
+                stored: 1,
+                already_held: 0,
+                failed: 0
+            }
+            .is_noop()
+        );
+        assert!(
+            !SyncReport {
+                stored: 0,
+                already_held: 0,
+                failed: 1
+            }
+            .is_noop(),
+            "a failure costs future recoverability and must be visible"
+        );
+    }
+
+    /// **Contract regression guard**, mirroring the one in `rebuild`: the vault
+    /// refuses a filterless query as a wallet enumeration, so the sync's own
+    /// query must carry a filter too.
+    #[test]
+    fn the_sync_query_carries_a_filter() {
+        let filter = held_query_filter();
+        let obj = filter.as_object().expect("an object");
+        assert!(
+            !obj.is_empty(),
+            "a filterless vault query is refused by contract"
+        );
+        assert_eq!(
+            obj.get("purpose").and_then(Value::as_str),
+            Some("membership")
+        );
+    }
+
+    #[test]
+    fn ids_are_read_from_whichever_envelope_the_vault_used() {
+        for key in ["credentials", "items", "results"] {
+            let listing = serde_json::json!({ key: [{ "id": "vmc-1" }] });
+            assert_eq!(held_ids(&listing), vec!["vmc-1".to_string()], "key {key}");
+        }
+        assert_eq!(
+            held_ids(&serde_json::json!([{ "id": "vmc-1" }])),
+            vec!["vmc-1".to_string()]
+        );
+    }
+
+    /// Reading a full vault as empty would re-store everything every launch,
+    /// so an unrecognised envelope must be visibly empty rather than guessed at.
+    #[test]
+    fn an_unrecognised_envelope_yields_nothing() {
+        assert!(held_ids(&serde_json::json!({ "unexpected": [{ "id": "x" }] })).is_empty());
+    }
+
+    #[test]
+    fn a_descriptor_without_an_id_is_skipped() {
+        let listing = serde_json::json!({ "credentials": [{ "types": ["X"] }, { "id": "ok" }] });
+        assert_eq!(held_ids(&listing), vec!["ok".to_string()]);
+    }
+}

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod config;
 // module writes about its own items breaks — which is what failed CI on #192
 // and again here.
 pub mod context_probe;
+pub mod credential_sync;
 pub mod devices;
 pub mod diagnostics;
 pub mod didcomm;

--- a/openvtc-core/src/rebuild.rs
+++ b/openvtc-core/src/rebuild.rs
@@ -36,7 +36,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{debug, warn};
+use tracing::warn;
 use vta_sdk::client::VtaClient;
 
 use crate::errors::OpenVTCError;
@@ -130,8 +130,12 @@ pub struct RebuildPlan {
     pub memberships: Vec<RebuiltMembership>,
     /// Credentials that looked like memberships but did not verify.
     pub rejected: Vec<RejectedCredential>,
-    /// Credentials of other kinds (VICs, role credentials), carried across
-    /// as-is — they are signed artifacts and need no reconstruction.
+    /// Credentials of other kinds (VICs, role credentials) are **not counted**.
+    ///
+    /// Counting them would mean enumerating the vault, which `query/0.1`
+    /// refuses by design. They are restored as they stand — they are signed
+    /// artifacts needing no reconstruction — but the plan cannot say how many
+    /// there are without asking a question the contract forbids.
     pub other_credential_count: usize,
 }
 
@@ -281,41 +285,49 @@ pub async fn plan(
 
     let mut memberships = Vec::new();
     let mut rejected = Vec::new();
-    let mut other_credential_count = 0usize;
 
-    match client.cred_vault_query(serde_json::json!({})).await {
-        Ok(listing) => {
-            for credential in credentials_in(&listing) {
-                match crate::CredentialKind::from_credential(&credential) {
-                    Some(crate::CredentialKind::Membership) => {
-                        match membership_from_credential(&credential, &known, now) {
-                            Ok(m) => memberships.push(m),
-                            Err(reason) => {
-                                warn!(
-                                    reason = %reason.summary(),
-                                    "membership credential did not verify during rebuild"
-                                );
-                                rejected.push(RejectedCredential {
-                                    id: credential
-                                        .get("id")
-                                        .and_then(Value::as_str)
-                                        .map(str::to_string),
-                                    reason,
-                                });
-                            }
-                        }
-                    }
-                    // Signed artifacts of other kinds need no reconstruction —
-                    // they are restored as they stand.
-                    Some(_) => other_credential_count += 1,
-                    None => debug!("skipping credential of unknown kind during rebuild"),
-                }
-            }
-        }
+    // The credential vault is deliberately **non-enumerable**: `query/0.1`
+    // refuses a filterless request, because running one would be a wallet
+    // enumeration. So this asks the only question it needs — "which membership
+    // credentials are held?" — as an indexed filter.
+    //
+    // `purpose` rather than `type`: the purpose is the vault's own semantic
+    // classification and is what the index is keyed on, so it does not depend
+    // on how a particular issuer spelled its `type` array.
+    let descriptors = match client.cred_vault_query(membership_query_filter()).await {
+        Ok(listing) => descriptors_in(&listing),
         Err(e) => {
             // Degrade rather than fail: personas and their keys are the larger
             // half of an account, and are worth restoring without memberships.
-            warn!("credential vault not readable during rebuild: {e}");
+            warn!("credential vault not queryable during rebuild: {e}");
+            Vec::new()
+        }
+    };
+
+    // `query` returns **body-free descriptors** — id, types, issuer, purpose,
+    // status — and a membership is defined by its *subject*, which only the
+    // body carries. So each descriptor is fetched with `get/0.1` before it can
+    // be verified.
+    for id in descriptors {
+        let credential = match client.cred_vault_get(&id).await {
+            Ok(v) => v.get("credential").cloned().unwrap_or(v),
+            Err(e) => {
+                warn!(id = %id, "could not fetch a held credential during rebuild: {e}");
+                continue;
+            }
+        };
+        match membership_from_credential(&credential, &known, now) {
+            Ok(m) => memberships.push(m),
+            Err(reason) => {
+                warn!(
+                    reason = %reason.summary(),
+                    "membership credential did not verify during rebuild"
+                );
+                rejected.push(RejectedCredential {
+                    id: Some(id),
+                    reason,
+                });
+            }
         }
     }
 
@@ -324,16 +336,32 @@ pub async fn plan(
         personas,
         memberships,
         rejected,
-        other_credential_count,
+        // Always zero from a live plan: see the field's docs.
+        other_credential_count: 0,
     })
 }
 
-/// Pull credential objects out of a vault listing, whichever envelope it used.
+/// The filter used to find held membership credentials.
 ///
-/// The listing is untyped and its envelope key has moved before; a bare array
-/// and the common wrappers are all accepted so a full vault is never read as an
-/// empty one.
-fn credentials_in(listing: &Value) -> Vec<Value> {
+/// Factored out so the "this query must carry a filter" contract is testable
+/// without a VTA — see `the_membership_query_carries_a_filter`.
+///
+/// `purpose` rather than `type`: the purpose is the vault's own semantic
+/// classification and what its secondary index is keyed on, so it does not
+/// depend on how a particular issuer spelled its `type` array.
+fn membership_query_filter() -> Value {
+    serde_json::json!({ "purpose": "membership" })
+}
+
+/// Descriptor ids from a `query/0.1` response.
+///
+/// The response is `{ credentials: [CredentialDescriptor, …] }`, and a
+/// descriptor carries only `id`, `types`, `issuerDid`, `purpose` and `status` —
+/// deliberately **no body**. The id is the handle `get/0.1` takes.
+///
+/// Tolerant about the envelope key because the response is consumed untyped and
+/// a wrong guess would silently read a full vault as an empty one.
+fn descriptors_in(listing: &Value) -> Vec<String> {
     let array = if let Some(arr) = listing.as_array() {
         arr.clone()
     } else {
@@ -344,15 +372,14 @@ fn credentials_in(listing: &Value) -> Vec<Value> {
             .unwrap_or_default()
     };
 
-    // Entries may be the credential itself or a wrapper carrying it.
     array
         .into_iter()
-        .map(|entry| {
-            entry
-                .get("credential")
-                .or_else(|| entry.get("vc"))
-                .cloned()
-                .unwrap_or(entry)
+        .filter_map(|d| {
+            d.get("id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                // A bare string id, should the envelope ever carry one.
+                .or_else(|| d.as_str().map(str::to_string))
         })
         .collect()
 }
@@ -533,26 +560,55 @@ mod tests {
         assert!(all.contains("contact"), "{all}");
     }
 
-    /// Reporting zero credentials on a full vault would make the plan lie.
+    /// **Contract regression guard.** The credential vault is non-enumerable:
+    /// `vault/credentials/query/0.1` refuses a filterless request, because
+    /// running one would be a wallet enumeration. An earlier version of this
+    /// module sent `{}` and read the refusal as "no credentials", which
+    /// silently restored zero memberships from a healthy account.
+    ///
+    /// Pins that the query this module sends carries a filter. A future edit
+    /// that drops it fails here rather than in production.
     #[test]
-    fn credentials_are_found_whatever_the_envelope() {
-        let one = serde_json::json!({ "id": "a" });
-        for key in ["credentials", "items", "results"] {
-            let listing = serde_json::json!({ key: [one.clone()] });
-            assert_eq!(credentials_in(&listing).len(), 1, "key {key}");
-        }
-        assert_eq!(credentials_in(&serde_json::json!([one.clone()])).len(), 1);
-        assert!(credentials_in(&serde_json::json!({ "nope": [one] })).is_empty());
+    fn the_membership_query_carries_a_filter() {
+        let filter = membership_query_filter();
+        let obj = filter.as_object().expect("an object");
+        assert!(
+            !obj.is_empty(),
+            "a filterless vault query is refused by contract as an enumeration"
+        );
+        assert_eq!(
+            obj.get("purpose").and_then(serde_json::Value::as_str),
+            Some("membership"),
+            "the vault indexes on its own semantic purpose, not the issuer's type spelling"
+        );
     }
 
-    /// Vault rows wrap the credential; the rebuild needs the credential.
+    /// The vault returns body-free descriptors; only the id is usable, and it
+    /// is the handle `get/0.1` takes. Misreading the envelope would make a full
+    /// vault look empty and silently restore no memberships.
     #[test]
-    fn a_wrapped_credential_is_unwrapped() {
-        let listing = serde_json::json!({
-            "credentials": [{ "vaultId": "v1", "credential": { "id": "inner" } }]
-        });
-        let found = credentials_in(&listing);
-        assert_eq!(found.len(), 1);
-        assert_eq!(found[0]["id"], "inner");
+    fn descriptor_ids_are_found_whatever_the_envelope() {
+        let one = serde_json::json!({ "id": "vmc-1", "types": ["MembershipCredential"] });
+        for key in ["credentials", "items", "results"] {
+            let listing = serde_json::json!({ key: [one.clone()] });
+            assert_eq!(
+                descriptors_in(&listing),
+                vec!["vmc-1".to_string()],
+                "key {key}"
+            );
+        }
+        assert_eq!(
+            descriptors_in(&serde_json::json!([one.clone()])),
+            vec!["vmc-1".to_string()]
+        );
+        assert!(descriptors_in(&serde_json::json!({ "nope": [one] })).is_empty());
+    }
+
+    /// A descriptor with no id cannot be fetched, so it is skipped rather than
+    /// turned into a rejection the user cannot act on.
+    #[test]
+    fn a_descriptor_without_an_id_is_skipped() {
+        let listing = serde_json::json!({ "credentials": [{ "types": ["X"] }, { "id": "keep" }] });
+        assert_eq!(descriptors_in(&listing), vec!["keep".to_string()]);
     }
 }

--- a/openvtc/src/cli.rs
+++ b/openvtc/src/cli.rs
@@ -71,6 +71,13 @@ pub fn cli() -> Command {
                         .long("json")
                         .action(clap::ArgAction::SetTrue)
                         .help("Emit the report as JSON instead of a rendered map"),
+                    Arg::new("recoverable")
+                        .long("recoverable")
+                        .action(clap::ArgAction::SetTrue)
+                        .help(
+                            "Also report whether this account could be rebuilt from its \
+                             Trust Context if this machine were lost. Read-only.",
+                        ),
                 ]),
         )
 }

--- a/openvtc/src/health_cmd.rs
+++ b/openvtc/src/health_cmd.rs
@@ -31,6 +31,7 @@ pub async fn run(
     config: Option<&Config>,
     vtc_args: &[String],
     as_json: bool,
+    recoverable: bool,
 ) -> Result<()> {
     let local = local_report(profile);
 
@@ -68,6 +69,20 @@ pub async fn run(
             format!("VTC {} (--vtc)", short_tail(did)),
             did.clone(),
         ));
+    }
+
+    // `--recoverable` answers a question the local section cannot: if this
+    // machine were lost, could the account be rebuilt from its Trust Context?
+    // Strictly read-only — the same plan the setup wizard would build, printed
+    // rather than applied.
+    if recoverable {
+        match config {
+            Some(config) => report_recoverability(config).await,
+            None => eprintln!(
+                "{}",
+                style("--recoverable needs a loadable account; skipping.").color256(CLI_ORANGE)
+            ),
+        }
     }
 
     // No subjects means no *network* checks — but the local section above is
@@ -552,6 +567,181 @@ fn protocols(list: &[vta_sdk::protocol::matching::Protocol]) -> String {
         .map(|p| p.as_str())
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Report whether this account could be rebuilt from its Trust Context.
+///
+/// The question this answers is not "is my config intact" — that is the local
+/// section — but "if this machine vanished, is what the VTA holds enough?"
+///
+/// It runs exactly the plan the setup wizard's Recover option would, and prints
+/// it instead of applying it. Nothing is written.
+///
+/// The part worth watching is the **key mapping**. A rebuilt persona is only
+/// usable if each verification method in its DID document can be matched back
+/// to a VTA key, and that match only fires when the store's `key_id` *is* a
+/// verification-method id of the DID, or when its label is. A deployment that
+/// labels keys some other way cannot be rebuilt, and this is where that shows
+/// up — before it matters.
+async fn report_recoverability(config: &Config) {
+    use openvtc_core::config::KeyBackend;
+
+    println!("{}", style("Recoverability").color256(CLI_BLUE).bold());
+
+    let KeyBackend::Vta { .. } = &config.key_backend else {
+        println!("  This profile does not use a VTA, so there is nothing to rebuild from.\n");
+        return;
+    };
+
+    let client = match openvtc_core::config::build_runtime_vta_client(&config.key_backend).await {
+        Ok(c) => c,
+        Err(e) => {
+            println!("  Could not open a VTA session: {e}\n");
+            return;
+        }
+    };
+
+    let context_id = config.account.top_context_id.clone();
+    let now = chrono::Utc::now();
+
+    let plan = match openvtc_core::rebuild::plan(&client, &context_id, now).await {
+        Ok(p) => p,
+        Err(e) => {
+            println!("  Could not read the context: {e}\n");
+            client.shutdown().await;
+            return;
+        }
+    };
+
+    let keys = match client
+        .list_keys(0, 500, Some("active"), Some(&context_id))
+        .await
+    {
+        Ok(resp) => resp
+            .keys
+            .into_iter()
+            .filter_map(|k| {
+                let key_type = match k.key_type {
+                    vta_sdk::keys::KeyType::Ed25519 => {
+                        openvtc_core::rebuild_apply::KeyPurposeHint::Signing
+                    }
+                    vta_sdk::keys::KeyType::X25519 => {
+                        openvtc_core::rebuild_apply::KeyPurposeHint::Encryption
+                    }
+                    _ => return None,
+                };
+                Some(openvtc_core::rebuild_apply::KeyCandidate {
+                    key_id: k.key_id,
+                    label: k.label,
+                    key_type,
+                    created_at: k.created_at,
+                })
+            })
+            .collect::<Vec<_>>(),
+        Err(e) => {
+            println!("  Could not list the context's keys: {e}\n");
+            client.shutdown().await;
+            return;
+        }
+    };
+
+    let rebuilt = openvtc_core::rebuild_apply::apply(&plan, &keys, now);
+    client.shutdown().await;
+
+    // Held locally vs held at the VTA. Without this line a reader cannot tell
+    // "this account has no memberships" from "its memberships have not been
+    // stored at the VTA yet", and those need different actions.
+    let held_locally = config
+        .account
+        .memberships()
+        .filter(|c| {
+            c.credentials
+                .contains_key(&openvtc_core::CredentialKind::Membership)
+        })
+        .count();
+
+    println!("  context          {context_id}");
+    println!("  at the VTA       {}", plan.summary());
+    println!("  usable keys      {}", keys.len());
+    println!("  held locally     {held_locally} membership credential(s)");
+    println!("  would restore    {}", rebuilt.summary());
+
+    // The diagnosis, stated rather than left to be inferred from the counts.
+    if rebuilt.account.personas.is_empty() && !plan.personas.is_empty() {
+        println!(
+            "\n  {}",
+            style(
+                "NOT RECOVERABLE: the VTA holds identities, but none of their keys could \
+                 be matched to them, so a rebuilt account could not sign or receive."
+            )
+            .color256(CLI_RED)
+        );
+        println!(
+            "  {}",
+            style(
+                "A key matches only when its store id — or its label — is a verification \
+                 method of the persona's DID. This deployment appears to label them some \
+                 other way, so recovery would need a different mapping."
+            )
+            .color256(CLI_ORANGE)
+        );
+    } else if rebuilt.account.personas.is_empty() {
+        println!(
+            "\n  {}",
+            style("Nothing to recover: this context holds no identities.").color256(CLI_ORANGE)
+        );
+    } else if rebuilt.skipped.is_empty() {
+        println!(
+            "\n  {}",
+            style("RECOVERABLE: every identity in this context maps to its keys.")
+                .color256(CLI_PURPLE)
+        );
+    } else {
+        println!(
+            "\n  {}",
+            style(format!(
+                "PARTIALLY RECOVERABLE: {} of {} identities map to their keys.",
+                rebuilt.account.personas.len(),
+                plan.personas.len()
+            ))
+            .color256(CLI_ORANGE)
+        );
+    }
+
+    // The specific gap this check exists to surface: the credential is held,
+    // but not where a rebuild would look for it.
+    if held_locally > rebuilt.account.memberships().count() {
+        println!(
+            "\n  {}",
+            style(format!(
+                "{} membership credential(s) are held locally but not at the VTA, so they \
+                 would NOT be recovered. Launch OpenVTC once while online — it stores them \
+                 on connect — then re-run this.",
+                held_locally - rebuilt.account.memberships().count()
+            ))
+            .color256(CLI_ORANGE)
+        );
+    }
+
+    for s in &rebuilt.skipped {
+        println!("    - {} — {}", truncate_did(&s.did), s.reason.summary());
+    }
+    for r in &plan.rejected {
+        println!(
+            "    - credential {} — {}",
+            r.id.as_deref().unwrap_or("(unnamed)"),
+            r.reason.summary()
+        );
+    }
+
+    println!(
+        "\n  {}",
+        style("Not restored by a rebuild, whatever the outcome above:").color256(CLI_BLUE)
+    );
+    for gap in openvtc_core::rebuild::RebuildPlan::known_gaps() {
+        println!("    - {gap}");
+    }
+    println!();
 }
 
 #[cfg(test)]

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -438,7 +438,8 @@ async fn main() -> Result<()> {
             .unwrap_or_default();
         let as_json = health_args.get_flag("json");
         let config = load_config_for_health(&profile, unlock_code_arg.as_deref()).await;
-        return health_cmd::run(&profile, config.as_ref(), &vtc_dids, as_json).await;
+        let recoverable = health_args.get_flag("recoverable");
+        return health_cmd::run(&profile, config.as_ref(), &vtc_dids, as_json, recoverable).await;
     }
 
     // Check if profile is currently active elsewhere?

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -726,6 +726,41 @@ impl StateHandler {
             ));
         }
 
+        // Put any membership credential this account holds into the VTA's
+        // credential vault, if it is not there already. Idempotent, and covers
+        // three cases with one mechanism: a join that just completed, one
+        // received while the VTA was unreachable, and the back-fill of every
+        // membership from before credentials were stored there at all.
+        //
+        // This is what makes membership recovery work: `rebuild` reconstructs a
+        // membership from the credential the community signed, and that
+        // credential has to be somewhere other than the config file a rebuild
+        // exists because you no longer have.
+        if let Some(client) = admin_vta.as_ref() {
+            let report =
+                openvtc_core::credential_sync::sync_membership_credentials(&config, client).await;
+            if report.stored > 0 {
+                // Worth an activity-log line rather than only a debug one:
+                // this is the moment the account becomes recoverable, and a
+                // user who has just joined a community should be able to see
+                // that it happened.
+                state.main_page.log(format!(
+                    "Stored {} membership credential(s) at the VTA — this account can now \
+                     be recovered from its Trust Context",
+                    report.stored
+                ));
+            }
+            if report.failed > 0 {
+                // Costs recoverability rather than anything working now, so it
+                // is worth saying but not worth alarming about.
+                state.main_page.log(format!(
+                    "{} membership credential(s) could not be stored at the VTA — \
+                     this account may not be fully recoverable until they are",
+                    report.failed
+                ));
+            }
+        }
+
         // Fetch VTA context name, reusing the always-on admin session.
         if let Some(client) = admin_vta.as_ref()
             && let Ok(resp) = client.list_contexts().await

--- a/openvtc/src/ui/pages/setup_flow/context_occupied.rs
+++ b/openvtc/src/ui/pages/setup_flow/context_occupied.rs
@@ -218,7 +218,6 @@ mod tests {
             persona_dids: (0..personas)
                 .map(|i| format!("did:webvh:QmAAAAAAAAAAAA:example.com:persona{i}"))
                 .collect(),
-            credential_count: 14,
             sub_context_count: 2,
         })));
         state
@@ -258,10 +257,7 @@ mod tests {
         let text = flat(&occupied_state(3));
         assert!(text.contains("already in use"), "{text}");
         assert!(text.contains("openvtc"), "{text}");
-        assert!(
-            text.contains("3 personas, 2 sub-contexts and 14 credentials"),
-            "{text}"
-        );
+        assert!(text.contains("3 personas and 2 sub-contexts"), "{text}");
     }
 
     /// The misreading that would make this page actively harmful.

--- a/openvtc/src/ui/pages/setup_flow/navigation.rs
+++ b/openvtc/src/ui/pages/setup_flow/navigation.rs
@@ -230,7 +230,6 @@ mod tests {
         let mut state = empty_state();
         state.vta.context_probe = Some(ProbeOutcome::Occupied(Box::new(ContextContents {
             persona_dids: vec!["did:webvh:Qm:example.com:alice".to_string()],
-            credential_count: 3,
             sub_context_count: 1,
         })));
 


### PR DESCRIPTION
## Why

**Membership recovery restored nothing.** Running #250 against a live VTA found three defects — all in assumptions about the credential vault's *contract* rather than in the code, which is why the unit tests could not catch them: they feed the plan a listing of full credential bodies, a fair model of the design and wrong about the service.

Two of these shipped in #248 and #250. This is a fix against `main`.

## The three defects

**1. A `MembershipCredential` was never stored at the VTA at all.** Invitations were pushed to the credential vault on receipt; VMCs went into the local `CommunityRecord` and nowhere else. `rebuild` reconstructs a membership *from* its credential — the right design, since the credential is what the community signed and it names both parties — but the credential has to be somewhere other than the config file a rebuild exists *because you no longer have*.

**2. `cred_vault_query({})` is refused by design.** The vault is deliberately non-enumerable — `CredentialQuery::is_empty()` exists precisely to reject a filterless request, because *"running it would be a wallet enumeration"*. Both `rebuild` and `context_probe` sent `{}`, and **both read the refusal as "zero credentials" and carried on**. So the occupied-context probe was under-reporting too.

**3. `query/0.1` returns body-free descriptors** — `id`, `types`, `issuerDid`, `purpose`, `status`. A membership is defined by its **subject**, which only the body carries, so every descriptor would have been rejected as `NoSubject`. Each is now fetched with `get/0.1` before verification.

## Published Trust Tasks only

Every call dispatches through `dispatch_trust_task`:

- `spec/vault/credentials/receive/0.1` — store
- `spec/vault/credentials/query/0.1` — find, **filtered**
- `spec/vault/credentials/get/0.1` — fetch a body

No bespoke routes.

## Design notes

**The sync runs on connect**, not at message ingest, because the dispatch path has no VTA session. One mechanism then covers three cases: a join that just completed, a credential received while the VTA was unreachable, and the back-fill of every membership from before this existed. It's idempotent — the vault keys a received credential on the VC's own `id` — so the query pass exists only to avoid pointless writes on every launch.

**The probe no longer counts credentials.** Non-enumeration is the point, so "how many credentials are here?" is a question the contract doesn't answer. Personas and sub-contexts are enough to tell a context is in use, and both are properly enumerable.

**Both query filters are factored into named functions** so a test can assert they carry a filter. A future edit that drops one fails in CI rather than in production, silently restoring nothing.

## `openvtc health --recoverable`

The read-only diagnostic that found all of this, kept because *"if this machine were lost, could this account be rebuilt?"* is worth being able to ask at any time. It runs the same plan the wizard's Recover option would and prints it instead of applying it.

It reports credentials held **locally** alongside those held **at the VTA** — without that a reader cannot tell "no memberships" from "not stored at the VTA yet", and those need different actions.

## Verified end to end against a live VTA

Before:
```
  held locally     1 membership credential(s)
  would restore    1 persona, 0 memberships
  ⚠ 1 membership credential(s) are held locally but not at the VTA…
```

After:
```
  at the VTA       1 persona, 1 membership
  held locally     1 membership credential(s)
  would restore    1 persona, 1 membership
  RECOVERABLE: every identity in this context maps to its keys.
```

Stored via `receive`, found via filtered `query`, body fetched via `get`, verified against the persona. The key mapping (`select_secret_kid`) was also confirmed working — 24 keys present, correctly attributed, none mis-assigned.

Full gate green: fmt, clippy `-D warnings`, both test configurations, and `cargo doc -D warnings`.
