### PR TITLE
chore(deps): vta-sdk 0.27, trust-tasks 0.11, and one sdk in the binary again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.18.19"
+version = "0.18.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a513e48e9a4874be509e9b9dde954a03b59272a96934f045151d0414ae3de17"
+checksum = "ab9d65f2641d3df7aef6687abd2bd0788d7f9e725755baed7460449303b42dee"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -416,7 +416,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "url",
  "uuid",
 ]
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954fe9bbc880aa008e9f01eeac117ab45419df00fddc40541c975fc70b3de506"
+checksum = "6cd4c9f5aaf47ef876e858a80e1a4c396a04f19a2301f2b0eb4ec4af45ea7180"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -505,15 +505,15 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "uuid",
 ]
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.2.51"
+version = "0.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004ee041b061e9b91f440fee6db14ca003f0881933faab17ba05d2442eb8910"
+checksum = "5727932e3b6db173056fd0faa74b21c3000db7b7e718aedf237611107e0f699f"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -1627,9 +1627,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2308,12 +2308,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.24.0",
- "darling_macro 0.24.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
@@ -2380,11 +2380,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.24.0",
+ "darling_core 0.24.1",
  "quote",
  "syn 3.0.3",
 ]
@@ -2709,7 +2709,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vgi-core",
- "vta-sdk",
+ "vta-sdk 0.25.1",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -2988,9 +2988,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -3640,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4083,9 +4083,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4203,7 +4203,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.24.0",
+ "darling 0.24.1",
  "indoc",
  "proc-macro2",
  "quote",
@@ -5459,7 +5459,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "windows-native-keyring-store",
  "x25519-dalek 2.0.1",
  "zeroize",
@@ -5515,10 +5515,10 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-capability-client",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vta-service",
  "wiremock",
  "x25519-dalek 2.0.1",
@@ -6288,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -6637,18 +6637,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8324,37 +8324,37 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb9544464e98ff02398134df574ae40caf193146c8db44cc3a774255931b3a8b"
+checksum = "8c744c8389d63e3e4d6bf89a44df0fa6429cc449cf24c70e33bb3f6ef0a10f37"
 dependencies = [
  "chrono",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001ffbb2589cc5626f2eb2bcf006cd0da4bd37ce0f45143a9ceb7821f1758393"
+checksum = "4dcb2a620b363ca38771125868e36a0e4204a13ea0ca1a756fcd441f5a341330"
 dependencies = [
  "affinidi-messaging-didcomm",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283761acdbaeec3c82db38c7ecf750847d89098a1a7e2a83becb26b1eddc20d4"
+checksum = "5b05af8774339d7c1fb29bde5ab5c37893221b9b5e95429bdd3db8f4404ae650"
 dependencies = [
  "axum",
  "chrono",
@@ -8365,15 +8365,15 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "uuid",
 ]
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e14b624ab8fb95442a6183d756f9416ff4b931790bff45ebc59f4a9a8fb576a"
+checksum = "69ac669b4bcaa91fd640e2630a4791fc1fb5fe4b38d1d22ab1e4e34d3e8cad9e"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8383,7 +8383,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
 ]
 
 [[package]]
@@ -8391,6 +8391,22 @@ name = "trust-tasks-rs"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fafd737292481f82d012e197981c7955d2f3f00a7c45708aa46916c4bdd0a9d"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "jsonschema",
+ "regress",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "trust-tasks-rs"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8480433b7122652533d7c76f5378196f3be02ed295d124174ef36c6968af54cc"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8708,21 +8724,21 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vta-audit"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf21460b1f83cca236ddc6d6fee37cba96c868bf7626cc6c788a02ff85d1da3"
+checksum = "fb035957b9233d977562b9f921e0568607b78cac7f4e861697d13330a0550ff3"
 dependencies = [
  "tracing",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-backup"
-version = "0.1.10"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a29da2d6f68589b56f64f1632acc98aefa67d223fc9363a7dd58060e3f538b"
+checksum = "bcc4ed29ecd6f012625ee9a7a4abccac99032f231447487ba52bc61dfe4505f0"
 dependencies = [
  "aes-gcm 0.10.3",
  "argon2",
@@ -8739,7 +8755,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vta-support",
  "vti-common",
  "zeroize",
@@ -8747,9 +8763,9 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.11.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09c51e2c838152c5409c92a4dc524c89e5cb3f7648d5e5eab9032598a8604ea"
+checksum = "3fbde7acfdf6876547f09cc0e9b2ff098c07cc99848ebdaf7285fe65538f33b1"
 dependencies = [
  "aes-gcm 0.10.3",
  "affinidi-crypto",
@@ -8767,16 +8783,16 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vti-common",
  "x25519-dalek 3.0.0",
 ]
 
 [[package]]
 name = "vta-config"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8cff6ff7fd2af3a2d3de643d746aaa7eda820876f0e429e7daf2cea851fad7"
+checksum = "0de44d78ab545cdf5c284958cfd4c7137121fe97520bb785d13752a11f4de36a"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -8784,16 +8800,16 @@ dependencies = [
  "sha2 0.11.0",
  "toml",
  "tracing",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vti-common",
  "vti-secrets",
 ]
 
 [[package]]
 name = "vta-keys"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d481d50d600f63a7efc899fd2a27b6f27058404bfc6f379c4c836ad3f6e26db"
+checksum = "f0bfa80f554e1cb6c292c627374cbae1a730e4e88e99d4a98ebc7f927b7330a3"
 dependencies = [
  "aes-gcm 0.10.3",
  "affinidi-crypto",
@@ -8816,7 +8832,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vti-common",
  "vti-secrets",
  "x25519-dalek 3.0.0",
@@ -8825,18 +8841,18 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b193d77bfde10d20fe5d8505c0227ed82e10381367a2e7c920daafe661ce47"
+checksum = "cb05d678089790cb375f4eaa4fb5f7f7fbe6f56b60a3db67d8cd0e71fa4cd85f"
 dependencies = [
  "vti-common",
 ]
 
 [[package]]
 name = "vta-policy"
-version = "0.2.7"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63de2aa3be212e2932e7bbe8e9ea88c5b1b61bd7b1072abb33c28988421c4667"
+checksum = "5b79f0364e006ed8985b3898bf7cc333880cf1b88da2bad72112afb26f48654a"
 dependencies = [
  "hex",
  "multibase",
@@ -8848,19 +8864,61 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-sdk"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5defc0ceb38b15e3b9e9aca86c5bf6cf9f2a6a80310340c1f42a106bd8772898"
+checksum = "732ada630aaad06a9516e4e38baf77410c872a6dab044ce37b13b94beec1a1ce"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
  "affinidi-did-common",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-secrets-resolver",
+ "affinidi-tdk",
+ "affinidi-vc",
+ "agent-names",
+ "base64 0.22.1",
+ "chrono",
+ "ciborium",
+ "curve25519-dalek 5.0.0",
+ "didwebvh-rs",
+ "ed25519-dalek 3.0.0",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hpke",
+ "multibase",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "trust-tasks-rs 0.9.0",
+ "url",
+ "uuid",
+ "x25519-dalek 3.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9118a296fa721073c4902c0cc3f7d446c7a92627f52b5e97d4d6ccc7a2782a"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
@@ -8871,7 +8929,6 @@ dependencies = [
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
- "agent-names",
  "apple-native-keyring-store",
  "base64 0.22.1",
  "chrono",
@@ -8893,7 +8950,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "url",
  "utoipa",
  "uuid",
@@ -8904,9 +8961,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f7e60361c0265f1510cfe166ebf9a69f77006d24a2d53ceec42ee248d737cc"
+checksum = "5aa63f0908ccafcf5f557bea087cf3fdb45b02825f6dfbb8d7d327e79e0869a4"
 dependencies = [
  "aes-gcm 0.10.3",
  "affinidi-crypto",
@@ -8969,7 +9026,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "url",
  "urlencoding",
  "utoipa",
@@ -8982,7 +9039,7 @@ dependencies = [
  "vta-keys",
  "vta-keyspaces",
  "vta-policy",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vta-support",
  "vta-sweepers",
  "vta-vault",
@@ -8998,9 +9055,9 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.2.7"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b7ace51f1c03a3f315fa6dc9783e0a704f66b403ba1942b4900a07de700f8e"
+checksum = "5ed376b10ff13f3c9b72d2b587f9dc2c55e4033a096de086cf5732b02c8ab705"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9013,15 +9070,15 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-sweepers"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca887b8df5a12634b3bae103aecea56189f9ee73e2d058570ea2b0edf57a8202"
+checksum = "122f5e88fcb41abb85f36bbcf6afcdc0d62520cb2f1ed57735c3a00b58fde633"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9034,9 +9091,9 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24630ec664315555c13b722c2eedbd4caa7b67e153ab594f18732526c492e876"
+checksum = "a483d16d57bea2182e9dbd6c69012dd1b9dfdf17551089e071e6632d19230acf"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9059,34 +9116,35 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vti-common",
  "x509-parser 0.18.1",
 ]
 
 [[package]]
 name = "vta-webvh"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa7c0bbad5f76144c1a2b8b92af91f30917c42c257be09587fda3fad51fcf5e"
+checksum = "698b48cdd46a789c99d8b163baef68644156ea1a3275bf4bd6a206562233ffda"
 dependencies = [
  "affinidi-tdk",
+ "chrono",
  "reqwest",
  "serde",
  "serde_json",
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "vti-common",
  "zeroize",
 ]
 
 [[package]]
 name = "vti-common"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "837506c0e67d4cb45e424dd07335d794d7a2da0adec55b9b3a79cc0507981922"
+checksum = "b1fae4aa06eadcdee9c3663c987405aec92ce28634fe8bd1aafc5ce6141e7cbe"
 dependencies = [
  "aes-gcm 0.10.3",
  "affinidi-data-integrity",
@@ -9115,21 +9173,21 @@ dependencies = [
  "tokio",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs",
+ "trust-tasks-rs 0.11.1",
  "url",
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.27.0",
  "webauthn-rs",
  "zeroize",
 ]
 
 [[package]]
 name = "vti-secrets"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1937d80c2c27c2435216411e89335ae3157943795fbc4d71b0ec8d77affa04c"
+checksum = "026deeed018a32e8b33d5ecb9a233c1eec881eeaa94f010bb8bc6c8b62586067"
 dependencies = [
  "hex",
  "serde",
@@ -10102,9 +10160,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -10113,9 +10171,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "url",
  "uuid",
 ]
@@ -505,7 +505,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "uuid",
 ]
 
@@ -2685,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "did-git-sign"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3af0736305b0e190928fb1d8795a6f5d35762f26d3fc45d52d1ef9379021d2"
+checksum = "3c286e9d2e2257a8b08c318da6c92171fbec55fc864163ba58ee6555c9d5c3a3"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -2709,7 +2709,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vgi-core",
- "vta-sdk 0.25.1",
+ "vta-sdk",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -5459,7 +5459,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "windows-native-keyring-store",
  "x25519-dalek 2.0.1",
  "zeroize",
@@ -5515,10 +5515,10 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vta-service",
  "wiremock",
  "x25519-dalek 2.0.1",
@@ -8332,7 +8332,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "uuid",
 ]
 
@@ -8346,7 +8346,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "uuid",
 ]
 
@@ -8365,7 +8365,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tower",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "uuid",
 ]
 
@@ -8383,23 +8383,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "trust-tasks-rs 0.11.1",
-]
-
-[[package]]
-name = "trust-tasks-rs"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fafd737292481f82d012e197981c7955d2f3f00a7c45708aa46916c4bdd0a9d"
-dependencies = [
- "async-trait",
- "chrono",
- "jsonschema",
- "regress",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.20",
+ "trust-tasks-rs",
 ]
 
 [[package]]
@@ -8704,9 +8688,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vgi-core"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b7f19034decc19684bb2092ab3eb5a525d58a89699946ef6a1219e990da349"
+checksum = "f6610cc81d2a1e816cd0c820a38de1bf22d60155bc5aa957751662f9e72224ed"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -8730,7 +8714,7 @@ checksum = "fb035957b9233d977562b9f921e0568607b78cac7f4e861697d13330a0550ff3"
 dependencies = [
  "tracing",
  "uuid",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vti-common",
 ]
 
@@ -8755,7 +8739,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vta-support",
  "vti-common",
  "zeroize",
@@ -8783,7 +8767,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vti-common",
  "x25519-dalek 3.0.0",
 ]
@@ -8800,7 +8784,7 @@ dependencies = [
  "sha2 0.11.0",
  "toml",
  "tracing",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vti-common",
  "vti-secrets",
 ]
@@ -8832,7 +8816,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vti-common",
  "vti-secrets",
  "x25519-dalek 3.0.0",
@@ -8864,51 +8848,8 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vti-common",
-]
-
-[[package]]
-name = "vta-sdk"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732ada630aaad06a9516e4e38baf77410c872a6dab044ce37b13b94beec1a1ce"
-dependencies = [
- "affinidi-crypto",
- "affinidi-data-integrity",
- "affinidi-did-common",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-messaging-core",
- "affinidi-messaging-delivery",
- "affinidi-messaging-didcomm",
- "affinidi-openid4vci",
- "affinidi-openid4vp",
- "affinidi-secrets-resolver",
- "affinidi-tdk",
- "affinidi-vc",
- "agent-names",
- "base64 0.22.1",
- "chrono",
- "ciborium",
- "curve25519-dalek 5.0.0",
- "didwebvh-rs",
- "ed25519-dalek 3.0.0",
- "futures-util",
- "getrandom 0.4.3",
- "hpke",
- "multibase",
- "reqwest",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
- "trust-tasks-rs 0.9.0",
- "url",
- "uuid",
- "x25519-dalek 3.0.0",
- "zeroize",
 ]
 
 [[package]]
@@ -8919,6 +8860,7 @@ checksum = "8c9118a296fa721073c4902c0cc3f7d446c7a92627f52b5e97d4d6ccc7a2782a"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
+ "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
@@ -8929,6 +8871,7 @@ dependencies = [
  "affinidi-secrets-resolver",
  "affinidi-tdk",
  "affinidi-vc",
+ "agent-names",
  "apple-native-keyring-store",
  "base64 0.22.1",
  "chrono",
@@ -8950,7 +8893,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "uuid",
@@ -9026,7 +8969,7 @@ dependencies = [
  "trust-tasks-didcomm",
  "trust-tasks-https",
  "trust-tasks-proof",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "url",
  "urlencoding",
  "utoipa",
@@ -9039,7 +8982,7 @@ dependencies = [
  "vta-keys",
  "vta-keyspaces",
  "vta-policy",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vta-support",
  "vta-sweepers",
  "vta-vault",
@@ -9070,7 +9013,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vti-common",
 ]
 
@@ -9116,7 +9059,7 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vti-common",
  "x509-parser 0.18.1",
 ]
@@ -9135,7 +9078,7 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "vti-common",
  "zeroize",
 ]
@@ -9173,12 +9116,12 @@ dependencies = [
  "tokio",
  "tracing",
  "trust-tasks-capability-client",
- "trust-tasks-rs 0.11.1",
+ "trust-tasks-rs",
  "url",
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.27.0",
+ "vta-sdk",
  "webauthn-rs",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,9 @@ dtg-credentials = "0.2"
 
 aes-gcm = "0.11"
 argon2 = "0.5"
-affinidi-tdk = "0.8"
+# 0.8.5 is `vta-sdk` 0.27's and `vta-service` 0.19's own requirement — the floor
+# is set by the graph, and this line only records it.
+affinidi-tdk = "0.8.5"
 affinidi-data-integrity = "0.7"
 # The delivery layer (D1). Replaced `affinidi-messaging-didcomm-service`, the
 # type-routed framework both VTI services had already cut over from (#189).
@@ -49,20 +51,39 @@ affinidi-data-integrity = "0.7"
 # `MessageTransport` contract it builds on; `-sdk` supplies `DidCommTransport`, the
 # DIDComm implementation of that contract (and the one that also surfaces inbound
 # TSP off the same multiplexed pickup socket).
-affinidi-messaging-delivery = "0.1.12"
+#
+# Floor is 0.1.14 (affinidi-tdk-rs #710): the dispatcher acked every inbound
+# message unconditionally, and an ack is a *delete* at the mediator — including
+# when `subscribers.send` had just reported nobody listening. No subscriber is
+# installed for a moment at startup and again on the way down, so whatever
+# arrived in those windows was destroyed rather than redelivered. For this repo
+# that window's contents are a membership credential or a join reply, which is
+# the class of loss `#218`'s pickup-on-connect exists to prevent — and this layer
+# was undoing it one level down.
+affinidi-messaging-delivery = "0.1.14"
 # Floor is 0.1.6: it marks `Protocol` `#[non_exhaustive]` and adds the
 # `DIDCommV1` variant. The inbound dispatcher's wildcard arm needs both — on
 # 0.1.5 the enum is exhaustively matched already and that arm is an
 # unreachable pattern, which `-D warnings` rejects.
 affinidi-messaging-core = "0.1.6"
-# Floor is 0.19.4 (affinidi-tdk-rs #694, shipped alongside VTI #917):
-# `live_stream_next*` held a read guard on `ws_channel_tx` across its wait while
-# `stop_websocket` needs the write guard, so an in-flight poll blocked shutdown
-# until the poll window elapsed. The delivery layer's window is 10s and its
-# inbound pump reads ahead after every frame, so quitting the TUI mid-window
-# paid the remainder. Left at `0.19.2` a clean checkout could resolve back onto
-# the stall.
-affinidi-messaging-sdk = "0.19.4"
+# Floor is 0.19.9 (affinidi-tdk-rs #717): the release that moves the messaging
+# crates from `trust-tasks-rs` 0.9 to 0.11. That is not a courtesy bump — this
+# workspace is on 0.11, `affinidi-messaging-sdk` carries `trust-tasks-rs` types
+# in its own API (`MediatorAcl` reaches `atm.trust_tasks().account_update`), and
+# a copy left on 0.9 is a *second* semver-incompatible `trust-tasks-rs` whose
+# types do not unify. Same class of failure as the `vta-sdk` note below.
+#
+# 0.19.8 (#716) is the fix underneath it, and the one this repo chased for weeks:
+# `_refresh_authentication` discarded `force_refresh`, so the websocket
+# transport's proactive refresh at 80% of token life rebuilt the socket *without*
+# refreshing and re-armed at 80% of the time remaining — a geometric cascade of
+# reconnects per token rather than one clean cycle. See `#231`–`#234`, where the
+# symptom was two listeners flapping about every 15 minutes.
+#
+# Earlier floors are below this one by construction: 0.19.4 (#694) was the
+# `live_stream_next*` read guard that blocked `stop_websocket` for the remainder
+# of a 10s poll window, so quitting the TUI mid-window paid it.
+affinidi-messaging-sdk = "0.19.9"
 # `StreamExt::next` on the `BoxStream` returned by `MessagingService::subscribe`.
 futures-util = "0.3"
 # Agent names (DID shortcuts). `agent-names` carries the parse /
@@ -70,7 +91,11 @@ futures-util = "0.3"
 # `agent-names` feature is NOT default, and a direct dependency here is what
 # turns it on — via feature unification — for the shared `DIDCacheClient` the
 # TDK hands out. Without it `DIDCacheClient::resolve_any` does not exist.
-agent-names = "0.1.2"
+#
+# 0.1.3 is `vta-sdk` 0.27's own requirement, so it is the floor whether or not
+# this line states it. Stating it keeps the manifest honest about what the graph
+# actually resolves rather than implying 0.1.2 is still viable.
+agent-names = "0.1.3"
 affinidi-did-resolver-cache-sdk = { version = "0.8.19", features = [
   "agent-names",
 ] }
@@ -140,56 +165,81 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # our copy has to be the same crate version vta-sdk resolves, or the two are
 # distinct types that do not unify.
 #
-# Moved 0.6 → 0.9 when vta-sdk went to 0.25, as it moved 0.4 → 0.6 when vta-sdk
-# went to 0.23.3. This is a *follow*, not a lead: holding an older line here
+# Moved 0.9 → 0.11 when vta-sdk went to 0.27, as it moved 0.6 → 0.9 when vta-sdk
+# went to 0.25 and 0.4 → 0.6 when vta-sdk went to 0.23.3. This is a *follow*, not
+# a lead: holding an older line here
 # stops matching the stack and starts splitting the type — on the 0.4 → 0.6 move
 # a `cargo update` alone put 0.4.1 and 0.6.5 in the same binary, which is the
 # exact failure the paragraph above exists to prevent. `cargo tree -d` is the
 # check: two `trust-tasks-rs` rows means this pin has drifted from vta-sdk's
 # again, whichever direction it drifted.
 #
-# `trust-tasks-capability-client` moves with it (0.5 → 0.8) for the same reason
-# — it re-exports the same `TrustTask`.
+# `trust-tasks-capability-client` moves with it (0.8 → 0.9) for the same reason
+# — it re-exports the same `TrustTask`. Its own leading component moves one step
+# per two of this crate's because it tracks its API, not the framework's;
+# upstream releases the six siblings as one event for exactly this reason
+# (trust-tasks-tf #250, where a sibling left behind produced
+# `expected TrustTask<Value>, found a different TrustTask<Value>`).
 #
 # Note the check has to include the **dev** graph. On the 0.6 → 0.9 move the
 # shipped graph was clean while `cargo tree -d -e normal,build,dev` still showed
 # two, because `openvtc-core` dev-depends on `vta-service` for `MockVta` and
-# that pin was a line behind. See its note in `openvtc-core/Cargo.toml`.
-trust-tasks-rs = "0.9"
-trust-tasks-capability-client = "0.8"
+# that pin was a line behind. See its note in `openvtc-core/Cargo.toml`. The
+# 0.9 → 0.11 move needed a third crate to follow as well: the messaging stack
+# carries `trust-tasks-rs` types in its own API, so `affinidi-messaging-sdk` has
+# a floor of 0.19.9 above for the same reason (affinidi-tdk-rs #717).
+trust-tasks-rs = "0.11"
+trust-tasks-capability-client = "0.9"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-# The 0.23 line. Moved off 0.21.12 for `CreateDidWebvhRequest.add_tsp_service`
-# (VTI #959), which is what lets a minted persona advertise `#tsp` at all — see
-# the call site in `setup_sequence/vta.rs`. Without it a persona's document
-# carries one `DIDCommMessaging` entry, so a peer's both-ends transport match
-# can never resolve to TSP however much TSP the rest of the stack speaks.
+# The 0.27 line — the one `vta-service` 0.19 is built on, and the one that
+# declares `trust-tasks-rs ^0.11`. As always this pin *follows* the VTA rather
+# than leading it; see the `trust-tasks-rs` note above for why the two versions
+# cannot be chosen independently.
 #
-# Two minors were crossed (0.22 and 0.23, each breaking under 0.x semver) and the only
-# thing that broke here was the new field itself: verified by building this
-# workspace against the unreleased sdk before the bump, where `add_tsp_service`
-# was the sole compile error and every test still passed.
+# 0.25 → 0.27 crossed two minors and broke nothing here — the workspace compiled
+# and tested clean with no source change. What it buys is a live defect fix that
+# reaches this repo silently:
 #
-# Now the 0.25 line, which declares `trust-tasks-rs ^0.9`. The 0.24 line is
-# below the floor by construction: it declares `^0.6`, so a checkout resolving
-# back to it while this workspace is on 0.9 would put two `trust-tasks-rs` in
-# the binary again — the same trap 0.23.0 (`^0.4`) posed against 0.6.
+# 0.27.0 (VTI #1033) repairs the Trust-Task response decode. VTI #1000 folded
+# Trust-Task payloads to lowerCamelCase per SPEC §4.10 but excluded
+# `client/types.rs` on a stale path assumption, so the agent moved to `basePath`
+# while the client went on demanding `base_path` — eleven required fields with no
+# `default`, across `contexts` create/get/update/list and `keys`
+# sign/rename/revoke/export-secret, failing hard on every transport. Our two
+# `list_contexts()` call sites (`state_handler/mod.rs`, `context_probe.rs`) both
+# sit behind `let Ok(..)`/`match`, so against a post-#1000 agent this degraded
+# quietly rather than erroring: the sub-context probe simply saw nothing. The fix
+# is intake aliases, not a rename, so 0.27 also still decodes an older agent's
+# snake_case — safe against a VTA on either side of the fold.
 #
-# 0.24 → 0.25 crossed one minor and broke exactly one thing here:
-# `CreateKeyRequest` gained `internal` (VTI #995, non-extractable keys), so the
-# seven struct literals in `state_handler/` name it. `None` is deliberate —
-# absent is today's behaviour, and `Some(true)` mints a key that cannot be
-# recovered from the mnemonic or any backup.
+# 0.26.0 (VTI #1012) adds `VtaClient::idempotent`, which holds one
+# `idempotencyKey` across every attempt of an operation so a retried
+# `create_key` is deduplicated at the VTA instead of taking effect twice. Not
+# adopted here yet — our retry owner is `vta_retry()` — but it is the seam that
+# eventually replaces it, and the SDK is now the layer that retries.
 #
-# The old 0.21.x floor notes are gone with the line. Each recorded a defect this
-# repo had no lever over — 0.21.10's `trust-tasks-rs` `^0.4` requirement (type
-# unification across the sdk boundary), 0.21.11's `provision/integration/0.2`
-# camelCase ask tags (VTI #917), 0.21.12's `CreateKeyBody` serialising unset
-# members as `null` and killing key creation over DIDComm and TSP (VTI #919).
-# All are below this floor by construction; they are kept in git history rather
-# than as a wall of satisfied constraints.
-vta-sdk = { version = "0.25", features = [
+# 0.26 is not itself a viable floor: it declares `trust-tasks-rs ^0.9`, so a
+# checkout resolving back to it while this workspace is on 0.11 would put two
+# `trust-tasks-rs` in the binary — the same trap 0.24 (`^0.6`) posed against 0.9
+# and 0.23.0 (`^0.4`) posed against 0.6.
+#
+# Older floor notes are gone with their lines and kept in git history rather than
+# as a wall of satisfied constraints. Each recorded a defect this repo had no
+# lever over: 0.23's `CreateDidWebvhRequest.add_tsp_service` (VTI #959, the field
+# that lets a minted persona advertise `#tsp` at all — see
+# `setup_sequence/vta.rs`), 0.25's `CreateKeyRequest.internal` (VTI #995), and
+# the 0.21.x line's `provision/integration/0.2` casing (VTI #917) and `null`
+# `CreateKeyBody` members (VTI #919).
+#
+# One consumer still holds this graph back: `did-git-sign` 0.4.5 requires
+# `vta-sdk ^0.25`, so `cargo tree -d` reports 0.25.1 alongside 0.27.0 and a
+# `trust-tasks-rs` 0.9 beneath it. No type crosses that boundary — we use only
+# `did_git_sign::{config, init}` — so it builds and tests clean, but it is the
+# duplicate this file exists to prevent and it clears when VGI cuts a release on
+# 0.27, exactly as #216 did for the 0.23 move.
+vta-sdk = { version = "0.27", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,12 +233,12 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # the 0.21.x line's `provision/integration/0.2` casing (VTI #917) and `null`
 # `CreateKeyBody` members (VTI #919).
 #
-# One consumer still holds this graph back: `did-git-sign` 0.4.5 requires
-# `vta-sdk ^0.25`, so `cargo tree -d` reports 0.25.1 alongside 0.27.0 and a
-# `trust-tasks-rs` 0.9 beneath it. No type crosses that boundary — we use only
-# `did_git_sign::{config, init}` — so it builds and tests clean, but it is the
-# duplicate this file exists to prevent and it clears when VGI cuts a release on
-# 0.27, exactly as #216 did for the 0.23 move.
+# The graph holds exactly one `vta-sdk` and one `trust-tasks-rs`, and keeping it
+# that way took a release in another repo: `did-git-sign` 0.4.5 required
+# `vta-sdk ^0.25`, so until VGI published 0.4.6 on 0.27 this workspace carried
+# 0.25.1 beside 0.27.0. That is the third consecutive cycle it has done so — see
+# the floor note on `did-git-sign` in `openvtc/Cargo.toml`, which is where the
+# obligation is written down.
 vta-sdk = { version = "0.27", features = [
   "session",
   "client",

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -102,12 +102,15 @@ affinidi-messaging-test-mediator = "0.2"
 # `vta-service` is the VTA server crate; it carries the credential-vault
 # lifecycle tasks (receive/query/archive/delete/restore/purge) + the
 # `MockVta::start_provisionable` seams used by the e2e tests. Track this with
-# the vta-sdk major: 0.17 is the line built against vta-sdk 0.25, as 0.15 was
-# against 0.23, 0.14 against 0.21 and 0.13 against 0.20. An older line pulls an
-# older sdk into the test build and the two disagree about the wire types the
-# e2e tests assert on.
+# the vta-sdk major: 0.19 is the line built against vta-sdk 0.27, as 0.17 was
+# against 0.25, 0.15 against 0.23, 0.14 against 0.21 and 0.13 against 0.20. An
+# older line pulls an older sdk into the test build and the two disagree about
+# the wire types the e2e tests assert on.
 #
-# Moving to 0.15 is what collapses the *second* vta-sdk this workspace grew when
+# 0.19 also carries `trust-tasks-rs ^0.11`, which is what keeps the **dev** graph
+# from growing the second `trust-tasks-rs` the root manifest's note warns about.
+#
+# Moving to 0.15 is what collapsed the *second* vta-sdk this workspace grew when
 # the runtime dependency went to 0.23 (#213): 0.14.37 asks for `vta-sdk ^0.21`,
 # so `cargo tree -i vta-sdk` reported both 0.21.12 and 0.23.0 and the dev-only
 # copy sat one major behind everything it is meant to test against. It is not
@@ -115,7 +118,7 @@ affinidi-messaging-test-mediator = "0.2"
 # ApproveScope, ContextDirection}` as its own public API, so a graph holding two
 # sdks has two distinct `ApproveScope` types that do not unify. VTI republished
 # this crate for exactly this reason (see its Cargo.toml note on `publish`).
-vta-service = { version = "0.17", default-features = false, features = ["test-support", "rest", "didcomm"] }
+vta-service = { version = "0.19", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -33,21 +33,32 @@ anyhow.workspace = true
 # own repo (OpenVTC/verifiable-git-infrastructure); openvtc is a downstream
 # consumer of the published crate.
 #
-# Floor is 0.4.3: the first release built on vta-sdk 0.23, so it is what
-# finally leaves ONE vta-sdk in this binary. 0.4.2 requires `vta-sdk ^0.21`,
-# which is where the 0.21 copy came from once #213 took the workspace to 0.23 —
-# `cargo tree -i vta-sdk` reported 0.21.21 and 0.23.0 side by side, the former
-# reachable only through this crate. (#214 cleared the matching duplicate on the
-# `vta-service` dev-dependency; this clears the other half.) Two sdks are not
-# merely untidy: `vti-common` re-exports `vta_sdk::acl::{ActScope, ApproveScope,
-# ContextDirection}` as its own public API, so the copies carry types that
-# cannot unify.
+# Floor is 0.4.6: the first release built on vta-sdk 0.27, so it is what leaves
+# ONE vta-sdk in this binary. This is the third consecutive cycle where that
+# sentence had to be rewritten — 0.4.3 was the first on 0.23, 0.4.5 the first on
+# 0.25 — so read it as a standing obligation rather than a historical note: when
+# the workspace's vta-sdk minor moves, VGI has to publish before this line can
+# follow, and until it does the graph carries two sdks.
+#
+# The floor must name the exact release, never a lower caret. `"0.4.3"` admitted
+# 0.4.5, which requires `vta-sdk ^0.25` — so while this workspace was already on
+# 0.27, `cargo tree -d -e normal,build,dev` reported 0.25.1 beside 0.27.0 (and
+# `trust-tasks-rs` 0.9.0 beside 0.11.1 beneath it), reachable only through this
+# one edge. A caret that permits any release below the current sdk line lets a
+# clean checkout resolve straight back onto that duplicate.
+#
+# Two sdks are not merely untidy: `vti-common` re-exports
+# `vta_sdk::acl::{ActScope, ApproveScope, ContextDirection}` as its own public
+# API, so the copies carry types that cannot unify. The reason this particular
+# duplicate never broke a build is narrow and not worth relying on — we use only
+# `did_git_sign::{config, init}`, so no type crosses the boundary. One new import
+# is all it would take.
 #
 # Earlier floors are below this one by construction and kept in git history
-# rather than as a wall of satisfied constraints — 0.4.2 was the release on
-# vta-sdk 0.21.10 (and so on trust-tasks-rs 0.4), where 0.4.0/0.4.1 were on
-# `^0.19` and put a second vta-sdk *and* a second trust-tasks in the binary.
-did-git-sign = "0.4.3"
+# rather than as a wall of satisfied constraints — 0.4.5 was the first release on
+# vta-sdk 0.25, 0.4.3 the first on 0.23, and 0.4.0/0.4.1 were on `^0.19` and put
+# a second vta-sdk *and* a second trust-tasks in the binary.
+did-git-sign = "0.4.6"
 base64.workspace = true
 byteorder.workspace = true
 chrono.workspace = true


### PR DESCRIPTION
**Zero source changes.** Two `vta-sdk` minors were crossed and nothing here broke — which is worth stating, because the 0.22→0.23 and 0.24→0.25 moves each broke exactly one struct literal. Manifests and the lockfile, and that is all.

Two commits: the sdk line, then the `did-git-sign` floor that VGI had to publish before this repo could take it.

## What moves

| requirement | from | to |
|---|---|---|
| `vta-sdk` | 0.25 | **0.27** |
| `trust-tasks-rs` | 0.9 | **0.11** |
| `trust-tasks-capability-client` | 0.8 | **0.9** |
| `vta-service` (**dev**-dependency) | 0.17 | **0.19** |
| `affinidi-messaging-sdk` | 0.19.4 | **0.19.9** |
| `affinidi-messaging-delivery` | 0.1.12 | **0.1.14** |
| `affinidi-tdk` | 0.8 | 0.8.5 |
| `agent-names` | 0.1.2 | 0.1.3 |

The first four cannot move independently: `vta-sdk` 0.27 declares `trust-tasks-rs ^0.11`, `trust-tasks-capability-client` re-exports the same `TrustTask`, and `vta-service` 0.19 is the line built on `vta-sdk` 0.27. Any one held back is a second semver-incompatible copy of a type that crosses the sdk boundary.

`affinidi-tdk` 0.8.5 and `agent-names` 0.1.3 are floors **by construction** — both are `vta-sdk` 0.27's own requirements. The manifest now says so rather than implying the older versions are still viable.

## A third crate has to follow trust-tasks, not just `vta-service`

`affinidi-messaging-sdk` carries `trust-tasks-rs` types in its own public API — `acl_setup.rs` hands a `MediatorAcl` built from its own copy into `atm.trust_tasks().account_update`. A copy left on 0.9 is not untidy, it is `expected MediatorAcl, found a different MediatorAcl`.

So its floor goes to **0.19.9**, the release where affinidi-tdk-rs #717 moves the messaging crates to 0.11. This is easy to miss because it reads as an unrelated transport dependency — same shape as the `vta-service` trap #229 documented, where the crate that reintroduces the duplicate is never the one you set out to bump.

## Three floors that are live defect fixes

**`affinidi-messaging-sdk` 0.19.8 — the listener flapping we chased for weeks.** tdk #716: `_refresh_authentication` discarded `force_refresh`, so the websocket transport's proactive refresh at 80% of token life rebuilt the socket *without* refreshing and re-armed at 80% of the time **remaining**. A geometric cascade of reconnects per token instead of one clean cycle — the symptom #231–#234 saw as two listeners flapping every ~15 minutes. The lockfile has carried it since #232; the **floor** did not, so a clean checkout could resolve straight back onto the storm.

**`affinidi-messaging-delivery` 0.1.14 — messages destroyed, not delayed.** tdk #710: the dispatcher acked every inbound message unconditionally, and an ack is a **delete at the mediator** — including when `subscribers.send` had just reported nobody listening. No subscriber is installed for a moment at startup and again on the way down. For this repo the contents of those windows are a membership credential or a join reply: exactly the class of loss #218's pickup-on-connect exists to prevent, being undone one layer below it.

**`vta-sdk` 0.27.0 — a silent degradation on our own call sites.** VTI #1033: #1000 folded Trust-Task payloads to lowerCamelCase per SPEC §4.10 but excluded `client/types.rs` on a stale path assumption, so the agent moved to `basePath` while the client went on demanding `base_path` — eleven required fields with no `default`, across `contexts` create/get/update/list and `keys` sign/rename/revoke/export-secret.

Both our `list_contexts()` call sites sit behind `let Ok(..)`/`match` (`state_handler/mod.rs:766`, `openvtc-core/src/context_probe.rs:137`), so against a post-#1000 agent this never surfaced as an error — the sub-context probe simply saw nothing. The fix is intake **aliases** rather than a rename, so 0.27 still decodes an older agent's snake_case: safe against a VTA on either side of the fold.

## Also in 0.26, not adopted

VTI #1012 adds `VtaClient::idempotent`, which holds one `idempotencyKey` across every attempt of an operation so a retried `create_key` is deduplicated at the VTA rather than taking effect twice. Our retry owner is still `vta_retry()`. Left alone here — but it is the seam that should replace it, and the manifest note records that so it is not rediscovered from scratch.

0.26 is also **not a viable floor**: it declares `trust-tasks-rs ^0.9`, so a checkout resolving back to it while this workspace is on 0.11 puts two `trust-tasks-rs` in the binary — the same trap 0.24 (`^0.6`) posed against 0.9 and 0.23.0 (`^0.4`) posed against 0.6.

## The other half: `did-git-sign` had to be released first

`did-git-sign` 0.4.5 requires `vta-sdk ^0.25`, so moving this workspace to 0.27 left the published signer dragging the old line back in through a single edge:

```
vta-sdk v0.25.1
└── did-git-sign v0.4.5
    └── openvtc v0.3.1
```

**Third cycle running** — the same position #229 described before VGI 0.4.5, and #216 before that. OpenVTC/verifiable-git-infrastructure#32 published **0.4.6** on `vta-sdk` 0.27, and the second commit here takes it. `cargo update -p did-git-sign` states the result plainly:

```
Updating did-git-sign v0.4.5 -> v0.4.6
Removing trust-tasks-rs v0.9.0
Updating vgi-core v0.4.5 -> v0.4.6
Removing vta-sdk v0.25.1
```

### Why the requirement names 0.4.6 rather than staying on a caret

`"0.4.3"` already admitted 0.4.5 — that is exactly how the duplicate arrived while this line looked untouched. A caret permitting any release built on an older sdk lets a clean checkout resolve straight back onto the second copy, with nothing in the manifest to say it happened. The floor has to name the release that is actually on the current sdk line.

The comment also records why this particular duplicate never broke a build, because the reason is narrow and should not be read as safety: we use only `did_git_sign::{config, init}`, so no type crosses the boundary. One new import is all it would take — `vti-common` re-exports `vta_sdk::acl::{ActScope, ApproveScope, ContextDirection}` as its own public API, so the copies do carry types that cannot unify.

Note VGI still holds `trust-tasks-rs` 0.9 via `trql-client` → `verify-trust` (the trust registry has published nothing on 0.11 yet). That does **not** reach here: `did-git-sign` has no trql-client edge. Documented on both sides.

## Comments updated

Every block that moved now records **this** move rather than the last one, and older satisfied floors are dropped to git history rather than kept as a wall of constraints. New notes: why `affinidi-messaging-sdk` is a trust-tasks follower, why 0.26 is not a floor, and the standing cross-repo obligation on `did-git-sign` — written once, in that crate's floor note, with the root `vta-sdk` block pointing at it rather than describing it twice.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace` — pass
- `cargo test --workspace --no-default-features` — pass
- `cargo test -p openvtc-core --features arbitrary --lib` — 430 pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean (a separate lint set from clippy, and its own CI gate)
- `cargo test --workspace -- --ignored` — pass, including `mockvta_bootstrap_e2e`, `join_lifecycle_e2e` and `relationship_e2e`. These are the only thing here that actually exercises **`vta-service` 0.19**; plain `cargo test --workspace` skips every one of them.
- `cargo outdated --root-deps-only` — *"All dependencies are up to date"*
- `cargo tree -d -e normal,build,dev` — lists **none** of `vta-sdk`, `vta-service`, `trust-tasks-rs`, `trust-tasks-capability-client`, `vti-common`, `affinidi-tdk`, `dtg-credentials`, `didwebvh-rs`, `agent-names`, `did-git-sign` or `vgi-core`
- `cargo tree -i vta-sdk` — a single **0.27.0** node, with all four consumers (`openvtc`, `openvtc-core`, `did-git-sign`, `vta-service`) on it

The full gate was re-run after the second commit, not just the first.
