### PR TITLE
chore(deps): affinidi-messaging-sdk 0.19.10, so a refused socket says why

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.19.9"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd4c9f5aaf47ef876e858a80e1a4c396a04f19a2301f2b0eb4ec4af45ea7180"
+checksum = "ec00c929a9abc492c502d35eeaed2b661e332ad90b8a224ef41bb66f0506aa39"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,12 +66,24 @@ affinidi-messaging-delivery = "0.1.14"
 # 0.1.5 the enum is exhaustively matched already and that arm is an
 # unreachable pattern, which `-D warnings` rejects.
 affinidi-messaging-core = "0.1.6"
-# Floor is 0.19.9 (affinidi-tdk-rs #717): the release that moves the messaging
-# crates from `trust-tasks-rs` 0.9 to 0.11. That is not a courtesy bump — this
-# workspace is on 0.11, `affinidi-messaging-sdk` carries `trust-tasks-rs` types
-# in its own API (`MediatorAcl` reaches `atm.trust_tasks().account_update`), and
-# a copy left on 0.9 is a *second* semver-incompatible `trust-tasks-rs` whose
-# types do not unify. Same class of failure as the `vta-sdk` note below.
+# Floor is 0.19.10 (affinidi-tdk-rs #718): the release where a closed websocket
+# says why it closed. The transport matched the close frame as `Message::Close(_)`
+# and discarded it — `debug!("WebSocket connection closed by server")` — so a
+# refused duplicate arrived here as a socket that simply vanished, and the loop
+# reconnected into a duel. The mediator's `Close` now carries a reason, each with
+# its own problem-report code, and the sdk surfaces the close code and reason at
+# WARN. `duplicate-channel` is preserved verbatim for the genuinely-replaced
+# case, so the matches on it below are unaffected. Filed from this side as
+# `OpenVTC/verifiable-trust-infrastructure#1028`; the eviction *policy* is
+# deliberately unchanged, because displacement is what triggers the mediator's
+# stored-mail redelivery for clients that do not pull explicitly.
+#
+# 0.19.9 (#717) is the release that moves the messaging crates from
+# `trust-tasks-rs` 0.9 to 0.11. That is not a courtesy bump — this workspace is
+# on 0.11, `affinidi-messaging-sdk` carries `trust-tasks-rs` types in its own
+# API (`MediatorAcl` reaches `atm.trust_tasks().account_update`), and a copy
+# left on 0.9 is a *second* semver-incompatible `trust-tasks-rs` whose types do
+# not unify. Same class of failure as the `vta-sdk` note below.
 #
 # 0.19.8 (#716) is the fix underneath it, and the one this repo chased for weeks:
 # `_refresh_authentication` discarded `force_refresh`, so the websocket
@@ -83,7 +95,7 @@ affinidi-messaging-core = "0.1.6"
 # Earlier floors are below this one by construction: 0.19.4 (#694) was the
 # `live_stream_next*` read guard that blocked `stop_websocket` for the remainder
 # of a 10s poll window, so quitting the TUI mid-window paid it.
-affinidi-messaging-sdk = "0.19.9"
+affinidi-messaging-sdk = "0.19.10"
 # `StreamExt::next` on the `BoxStream` returned by `MessagingService::subscribe`.
 futures-util = "0.3"
 # Agent names (DID shortcuts). `agent-names` carries the parse /


### PR DESCRIPTION
Floor `affinidi-messaging-sdk` 0.19.9 → 0.19.10 (affinidi/affinidi-tdk-rs#718). Manifest note and lockfile only; no code changes.

## Why

Two instances of this app on the same persona reconnect-loop against each other and it presents as a **network fault** rather than as "you have this open twice". The cause is not the mediator's one-socket-per-DID rule — it is that nothing on either side ever said what happened.

- **Server half.** `WebSocketCommands::Close` carried no reason, so the handler answered all three of its senders identically — the `duplicate-channel` problem report and `"replaced by a newer connection"`. That includes a newcomer **refused** by the duel damper, whose own connection was never displaced: the exact inverse of true.
- **Client half.** The sdk's websocket transport matched the close frame as `Message::Close(_)` and discarded it, logging `WebSocket connection closed by server` at debug. So even a correct reason on the wire changed nothing here.

#718 gives `Close` a `CloseReason`, maps each to its own problem-report code and close text, and surfaces the close code and reason at WARN in the sdk.

## Compatibility

`duplicate-channel` is preserved verbatim for the genuinely-replaced case. This repo matches on it only in doc comments and `openvtc-core/tests/didcomm_transport_e2e.rs`, and those are unaffected — hence a floor bump with no code change.

The eviction **policy** is deliberately untouched upstream. Displacement is what triggers the mediator's `spawn_inbox_redelivery`, and this repo is not representative in pulling stored mail explicitly via `message_pickup` — refusing outright would silently drop the stored-mail re-cover for clients that don't.

## Known gap

The mediator half of #718 is `affinidi-messaging-mediator` 0.18.21, and the newest `affinidi-messaging-test-mediator` (0.2.52) still embeds 0.18.20. The `#[ignore]`d transport e2e therefore still exercises the old close behaviour until a fixture carrying 0.18.21 publishes; the new reasons reach a live client only against a deployed mediator ≥ 0.18.21.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass locally.

Closes the client-side half of OpenVTC/verifiable-trust-infrastructure#1028.