### PR TITLE
feat(relationships): default to a pairwise R-DID, and say what the choice costs

### DIFF
--- a/docs/relationships-vrcs.md
+++ b/docs/relationships-vrcs.md
@@ -1,6 +1,14 @@
 # Relationships and VRCs
 
-The OpenVTC tool enables you to establish relationships with other DIDs (e.g., peers, coworkers, or community members) and communicate privately through the DIDComm protocol using your **Persona DID (P-DID)** or **Relationship DID (R-DID)**.
+> **Note:** The command examples in this guide predate the TUI and are being
+> rewritten. The `openvtc relationships` and `openvtc vrcs` subcommands no
+> longer exist — relationships are managed from the Relationships panel and the
+> Inbox in the TUI. The flow and the concepts below are still accurate; only the
+> invocations are stale.
+
+The OpenVTC tool enables you to establish relationships with other DIDs (e.g., peers, coworkers, or community members) and communicate privately through the DIDComm protocol.
+
+Each relationship gets its own **Relationship DID (R-DID)** by default — a pairwise identifier used only with that one contact. You can choose to use your **Persona DID (P-DID)** instead; see [Choosing your identifier](#choosing-your-identifier) for what that costs.
 
 Once a relationship is established, you can request a **Verifiable Relationship Credential (VRC)**, a peer-to-peer credential that attests to verifiable trust relationships between personhood credential holders.
 
@@ -32,6 +40,7 @@ sequenceDiagram
 
 ## Table of Contents
 
+- [Choosing your identifier](#choosing-your-identifier)
 - [Establish Relationship](#establish-relationship)
   - [1. Send Relationship Request (Requestor)](#1-send-relationship-request-requestor)
   - [2. Accept Relationship Request (Respondent)](#2-accept-relationship-request-respondent)
@@ -43,27 +52,53 @@ sequenceDiagram
   - [3. Claim and Store VRC (Requestor)](#3-claim-and-store-vrc-requestor)
 - [List and View VRCs](#list-and-view-vrcs)
 
+## Choosing your identifier
+
+Every relationship is established under one of two identifiers, chosen when you
+send the request or accept an incoming one. The default is the pairwise R-DID.
+
+| | **Pairwise R-DID** (default) | **Your persona DID** |
+| --- | --- | --- |
+| What the contact sees | A fresh `did:peer` used only with them | Your published `did:webvh` |
+| Linkable to your other relationships | No — each contact sees a different identifier | Yes — every contact sees the same string |
+| Resolvable by anyone | No | Yes, and it often carries your verified agent name |
+| Recognisable as you | No, unless you tell them | Yes, immediately |
+
+The cost of reusing the persona DID is that correlation stops being an inference
+and becomes a lookup: two contacts who compare notes see the same identifier and
+can resolve it to a named identity. That is why pairwise is the default.
+
+The reason to choose the persona DID anyway is recognition — a contact who
+already knows your published DID or agent name can verify it is really you
+without a separate introduction.
+
+Once a relationship holds an R-DID, subsequent messages always use it. There is
+no fallback to the persona DID mid-relationship.
+
+**Note:** The three handshake messages (request, accept, finalise) are routed
+between persona DIDs regardless of this choice, because the mediator has to
+route them before a pairwise channel exists. The R-DID takes over once the
+relationship is established. Full pairwise operation, including the VRC issuer
+field, depends on protocol work tracked in
+[verifiable-trust-infrastructure#1054](https://github.com/OpenVTC/verifiable-trust-infrastructure/issues/1054).
+
 ## Establish Relationship
 
 Follow these steps to establish a relationship with another Persona DID.
 
 ### 1. Send Relationship Request (Requestor)
 
-Send a relationship request to another DID:
+In the Relationships panel, start a new request and fill in:
 
-```bash
-openvtc relationships request --respondent <Persona_DID> --alias <Respondent_Alias>
-```
+| Field | Description |
+| --- | --- |
+| DID | The respondent's persona DID, or an agent name such as `example.com/@bob` |
+| Alias | A local name for this relationship |
+| Reason | Why you are asking |
+| Contact you as | `Pairwise R-DID` (default) or `Your persona DID` — press Space to change |
 
-This command sends a relationship request and sets an alias for the relationship.
-
-**Optional:** Generate a local Relationship DID (R-DID) for private communication:
-
-```bash
-openvtc relationships request --respondent <Persona_DID> --alias <Respondent_Alias> --generate-did
-```
-
-When an R-DID is present, subsequent communication uses the R-DID for privacy; otherwise, it uses your P-DID.
+The last field is the choice described in [Choosing your identifier](#choosing-your-identifier).
+It defaults to minting a fresh R-DID for this contact.
 
 **Note:** Initiating a relationship request automatically adds the respondent to your Contacts list.
 
@@ -87,9 +122,15 @@ For more details, see the [CLI documentation](./openvtc-tool-commands.md#openvtc
 
    The tool fetches messages from the mediator. If you have a relationship request, you'll see a task with type **`Relationship Request`**.
 
-   Select the task ID and click **Accept this relationship request**.
+   Open the task to see the request detail.
 
-2. Choose whether to generate an R-DID for private communication.
+2. Accept it with either identifier:
+
+   - `a` — accept with a pairwise R-DID (the default, private path)
+   - `p` — accept as your persona DID
+
+   See [Choosing your identifier](#choosing-your-identifier) for the trade-off.
+   The detail view states both outcomes at the point of choice.
 
 3. Enter an alias for the requestor to easily identify this relationship.
 

--- a/openvtc/src/state_handler/relationship_actions.rs
+++ b/openvtc/src/state_handler/relationship_actions.rs
@@ -1053,7 +1053,12 @@ fn handle_start_new_request(state: &mut State) {
         did_input: String::new(),
         alias_input: String::new(),
         reason_input: String::new(),
-        generate_r_did: false,
+        // Pairwise by default (#241). The persona DID is a published,
+        // resolvable `did:webvh` that often carries a verified agent name, so
+        // reusing it across contacts makes correlation a lookup rather than an
+        // inference. Opting out stays available on field 3, labelled with what
+        // it costs.
+        generate_r_did: true,
         active_field: 0,
     };
 }
@@ -1603,6 +1608,75 @@ mod tests {
         config.private.relationships.relationships.insert(key, rel);
     }
 
+    /// Register an *established* relationship whose `our_did` is a pairwise
+    /// R-DID (distinct from the persona DID), i.e. the post-handshake steady
+    /// state that #241's "no silent revert" rule is about.
+    fn register_pairwise_relationship(config: &mut Config, remote_p_did: &str, our_r_did: &str) {
+        let key = Arc::new(remote_p_did.to_string());
+        let rel = RelRecord {
+            task_id: Arc::new("task-1".to_string()),
+            our_did: Arc::new(our_r_did.to_string()),
+            remote_p_did: Arc::clone(&key),
+            // Their pairwise DID, not their persona DID.
+            remote_did: Arc::new(format!("{remote_p_did}-rdid")),
+            created: Utc::now(),
+            state: RelationshipState::Established,
+            our_persona: config.active_persona,
+            needs_reestablishment: false,
+        };
+        config.private.relationships.relationships.insert(key, rel);
+    }
+
+    /// #241 criterion 3 — once a relationship holds an R-DID, a subsequent
+    /// message must not revert to the persona DID. Guards the property on the
+    /// ping path: the message `from`, the recipient, and the listener the send
+    /// is routed through all come from the relationship record, never from the
+    /// persona. A fallback here would re-expose the persona DID mid-relationship
+    /// and defeat the pairwise default.
+    #[tokio::test]
+    async fn established_pairwise_relationship_never_pings_from_the_persona_did() {
+        let mut config = Box::new(test_config());
+        let mut state = State::default();
+        let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let service = openvtc_core::didcomm::Messaging::start(event_tx);
+
+        let remote = "did:peer:remote";
+        let our_r_did = "did:peer:our-rdid";
+        register_pairwise_relationship(&mut config, remote, our_r_did);
+
+        let job = prepare_ping(&mut config, &service, &mut state, remote).expect("ping prepares");
+
+        let RelationshipJob::Send(send) = job else {
+            panic!("ping must produce a Send job");
+        };
+
+        assert_eq!(
+            send.message.from.as_deref(),
+            Some(our_r_did),
+            "an established relationship must speak as its R-DID, not the persona DID"
+        );
+        assert_eq!(
+            send.to_did.as_str(),
+            format!("{remote}-rdid"),
+            "the ping must address the remote's R-DID, not their persona DID"
+        );
+        assert_eq!(
+            send.listener_id,
+            openvtc_core::didcomm::listener_id_for_did(our_r_did, &config),
+            "the send must route through the relationship listener"
+        );
+        assert!(
+            matches!(
+                send.effect,
+                RelationshipEffect::Ping {
+                    using_rdid: true,
+                    ..
+                }
+            ),
+            "the effect must record that the pairwise DID was used"
+        );
+    }
+
     /// A successful Ping outcome creates the TrustPing task + activity log and
     /// sets the panel status to "Ping sent" — the same final state the old inline
     /// `handle_ping` success arm produced.
@@ -1992,10 +2066,12 @@ mod tests {
     fn start_new_request_and_cancel_back() {
         let mut state = State::default();
         handle_start_new_request(&mut state);
+        // Pairwise is the default (#241) — a new request mints an R-DID unless
+        // the operator deliberately turns it off.
         assert!(matches!(
             rel_mode(&state),
             RelationshipsMode::NewRequest {
-                generate_r_did: false,
+                generate_r_did: true,
                 active_field: 0,
                 ..
             }
@@ -2099,11 +2175,12 @@ mod tests {
     fn toggle_r_did_flips_flag() {
         let mut state = State::default();
         handle_start_new_request(&mut state);
+        // Starts pairwise (#241), so the first toggle is the opt-out.
         handle_toggle_r_did(&mut state);
         assert!(matches!(
             rel_mode(&state),
             RelationshipsMode::NewRequest {
-                generate_r_did: true,
+                generate_r_did: false,
                 ..
             }
         ));
@@ -2111,7 +2188,7 @@ mod tests {
         assert!(matches!(
             rel_mode(&state),
             RelationshipsMode::NewRequest {
-                generate_r_did: false,
+                generate_r_did: true,
                 ..
             }
         ));

--- a/openvtc/src/ui/pages/main/components/inbox_panel.rs
+++ b/openvtc/src/ui/pages/main/components/inbox_panel.rs
@@ -204,12 +204,8 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
             if uses_r_did {
                 lines.push(Line::from(""));
                 lines.push(
-                    Line::from("  ⚠ Sender is using a relationship DID for privacy.")
-                        .fg(COLOR_ORANGE),
-                );
-                lines.push(
-                    Line::from("    Use A (Shift+A) to accept with your own R-DID.")
-                        .fg(COLOR_ORANGE),
+                    Line::from("  Sender is using a pairwise relationship DID for privacy.")
+                        .fg(COLOR_DARK_GRAY),
                 );
             }
             if let Some(reason) = reason {
@@ -222,10 +218,31 @@ pub fn render_task_detail(task: &ActiveTaskView) -> Vec<Line<'static>> {
                 Span::styled("Task:  ", Style::new().fg(COLOR_DARK_GRAY)),
                 Span::styled(task_id.clone(), Style::new().fg(COLOR_DARK_GRAY)),
             ]));
+            // Spell out both outcomes: the accept key that costs nothing extra
+            // is the private one, and the opt-out states its cost (#241).
             lines.push(Line::from(""));
             lines.push(
-                Line::from("a: accept  A: accept (R-DID)  r: reject  d: dismiss  Esc: back")
+                Line::from("  a: accept with a pairwise R-DID — used only with this")
                     .fg(COLOR_DARK_GRAY),
+            );
+            lines.push(
+                Line::from("     contact, so your relationships cannot be linked by")
+                    .fg(COLOR_DARK_GRAY),
+            );
+            lines.push(Line::from("     identifier.").fg(COLOR_DARK_GRAY));
+            lines.push(
+                Line::from("  p: accept as your persona DID — a published address they")
+                    .fg(COLOR_ORANGE),
+            );
+            lines.push(
+                Line::from("     can resolve and compare with other contacts.").fg(COLOR_ORANGE),
+            );
+            lines.push(Line::from(""));
+            lines.push(
+                Line::from(
+                    "a: accept (R-DID)  p: accept (persona DID)  r: reject  d: dismiss  Esc: back",
+                )
+                .fg(COLOR_DARK_GRAY),
             );
         }
         ActiveTaskView::VRCRequestInbound {

--- a/openvtc/src/ui/pages/main/components/relationships_panel.rs
+++ b/openvtc/src/ui/pages/main/components/relationships_panel.rs
@@ -469,19 +469,48 @@ fn render_form(
     } else {
         Style::new().fg(COLOR_DARK_GRAY)
     };
-    let toggle_value = if generate_r_did { "Yes" } else { "No" };
+    let toggle_value = if generate_r_did {
+        "Pairwise R-DID (recommended)"
+    } else {
+        "Your persona DID"
+    };
     lines.push(Line::from(vec![
         Span::styled(if is_active { "▸ " } else { "  " }, field_style),
-        Span::styled("[Space] Generate random R-DID: ".to_string(), field_style),
+        Span::styled("[Space] Contact you as: ".to_string(), field_style),
         Span::styled(toggle_value.to_string(), value_style),
     ]));
+
+    // Spell out the trade-off at the point of choice — the cost of reusing the
+    // persona DID is invisible at the moment the decision is made (#241).
+    lines.push(Line::from(""));
+    if generate_r_did {
+        lines.push(
+            Line::from("  A fresh DID used only with this contact. Your persona DID is")
+                .fg(COLOR_DARK_GRAY),
+        );
+        lines.push(
+            Line::from("  not reused, so this relationship cannot be matched against")
+                .fg(COLOR_DARK_GRAY),
+        );
+        lines.push(Line::from("  your other ones by identifier.").fg(COLOR_DARK_GRAY));
+    } else {
+        lines.push(
+            Line::from("  ⚠ This contact sees your persona DID — a published address")
+                .fg(COLOR_ORANGE),
+        );
+        lines.push(
+            Line::from("    anyone can resolve, and compare with other contacts to")
+                .fg(COLOR_ORANGE),
+        );
+        lines.push(Line::from("    link your relationships together.").fg(COLOR_ORANGE));
+    }
 
     lines.push(Line::from(""));
     lines.push(
         Line::from("DID accepts an agent name too, e.g. example.com/@bob").fg(COLOR_DARK_GRAY),
     );
     lines.push(
-        Line::from("Tab: next field  Space: toggle R-DID  Enter (on R-DID): submit  Esc: cancel")
+        Line::from("Tab: next field  Space: change  Enter (on last field): submit  Esc: cancel")
             .fg(COLOR_DARK_GRAY),
     );
 

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -911,7 +911,19 @@ impl MainPage {
                     let _ = self.action_tx.send(Action::Inbox(InboxAction::Back));
                     true
                 }
-                KeyCode::Char('A') if is_rel_inbound => {
+                // Accepting with a pairwise R-DID is the default path (#241);
+                // `A` stays wired to it so existing muscle memory keeps giving
+                // the private outcome it always gave.
+                KeyCode::Char('p') if is_rel_inbound => {
+                    let _ = self
+                        .action_tx
+                        .send(Action::Inbox(InboxAction::AcceptRelationship {
+                            task_id,
+                            generate_r_did: false,
+                        }));
+                    true
+                }
+                KeyCode::Char('a') | KeyCode::Char('A') if is_rel_inbound => {
                     let _ = self
                         .action_tx
                         .send(Action::Inbox(InboxAction::AcceptRelationship {
@@ -921,14 +933,7 @@ impl MainPage {
                     true
                 }
                 KeyCode::Char('a') => {
-                    if is_rel_inbound {
-                        let _ =
-                            self.action_tx
-                                .send(Action::Inbox(InboxAction::AcceptRelationship {
-                                    task_id,
-                                    generate_r_did: false,
-                                }));
-                    } else if is_vrc_issued {
+                    if is_vrc_issued {
                         let _ = self
                             .action_tx
                             .send(Action::Inbox(InboxAction::AcceptVrc { task_id }));


### PR DESCRIPTION
Client-side half of #241 (RAHP finding `OVTC-RAHP-04`). Makes pairwise the
default and puts the trade-off in front of the operator at the moment they
choose.

## What changed

**Request form** — `generate_r_did` now defaults to `true`. The toggle reads
`Contact you as: Pairwise R-DID (recommended) / Your persona DID` and renders
the consequence of whichever is selected, rather than a bare Yes/No.

**Inbox accept** — the convenient key is now the private one:

| Key | Before | After |
| --- | --- | --- |
| `a` | accept with persona DID | accept with pairwise R-DID |
| `A` | accept with R-DID | accept with R-DID (unchanged) |
| `p` | — | accept with persona DID |

`A` deliberately keeps its old meaning, so anyone with existing muscle memory
gets the private outcome they always got. No keystroke that used to produce an
R-DID now produces a persona DID.

**Docs** — `docs/relationships-vrcs.md` gains a *Choosing your identifier*
comparison table and drops the `--generate-did` example. That flag, and the
whole `openvtc relationships` subcommand, have not existed since the v0.2.0 TUI
rewrite (`1f31455`); the file also contradicted itself, with a diagram showing
pairwise as the normal flow and prose calling it optional. Added a note that
the remaining command examples are stale — rewriting the guide for the TUI is a
separate job.

**Regression guard** — `established_pairwise_relationship_never_pings_from_the_persona_did`
pins criterion 3: an established relationship's ping takes its `from`, its
recipient and its listener from the relationship record. The property held
already; nothing tested it. Verified the test fails when `prepare_ping` is made
to read `persona_did_arc()` instead.

## What this does *not* do

It does not satisfy acceptance criterion 4. Two counterparties can still
correlate you, for two reasons that are not client-side:

- The three handshake messages (request/accept/finalise) are routed
  persona-to-persona by design — the mediator has to route them before a
  pairwise channel exists.
- The VRC `issuer` must be the persona DID, because the VTC's
  `relationships.rego` requires issuer *and* subject to be current ACL-listed
  members. A VRC issued under a pairwise R-DID is rejected today.

Raised upstream as OpenVTC/verifiable-trust-infrastructure#1054. The commit
message and the docs both say so, so a flipped boolean does not later read as
"correlation solved".

Also corrected on the issue: proposal 2 (CLI opt-out flag) has nothing to
change, since the CLI it refers to is gone.

## Checks

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`,
`cargo test --workspace` (all green), and
`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`.

Refs #241