### PR TITLE
feat(relationships)!: issue the VRC under the relationship DID, not the persona

### DIFF
--- a/docs/relationships-vrcs.md
+++ b/docs/relationships-vrcs.md
@@ -78,9 +78,13 @@ no fallback to the persona DID mid-relationship.
 **Note:** The three handshake messages (request, accept, finalise) are routed
 between persona DIDs regardless of this choice, because the mediator has to
 route them before a pairwise channel exists. The R-DID takes over once the
-relationship is established. Full pairwise operation, including the VRC issuer
-field, depends on protocol work tracked in
-[verifiable-trust-infrastructure#1054](https://github.com/OpenVTC/verifiable-trust-infrastructure/issues/1054).
+relationship is established, and the VRC is issued under it — so the durable
+credential, which is the artifact that would otherwise correlate you across
+every relationship you hold, names only the pairwise identifier.
+
+The handshake DIDs are observed once, by the mediator, at establishment. The
+credential lasts as long as either party keeps it. That asymmetry is why the
+issuer field mattered more than the routing does.
 
 ## Establish Relationship
 
@@ -174,7 +178,11 @@ Task Id: 020bb98e-5460-4d42-b369-bf4a65b4909c Type: Relationship request finaliz
 
 ## Request Verifiable Relationship Credential (VRC)
 
-A VRC is a peer-to-peer credential that attests to verifiable trust relationships between P-DIDs (e.g., coworkers, peers, or community members).
+A VRC is a peer-to-peer credential attesting to a verifiable trust relationship
+between two parties (coworkers, peers, community members). It names each side by
+the identifier that side uses in *this* relationship — the pairwise R-DID by
+default, or the persona DID if that was chosen when the relationship was
+established.
 
 ### Prerequisite
 
@@ -237,7 +245,7 @@ Issued VRC
     "DTGCredential",
     "RelationshipCredential"
   ],
-  "issuer": "did:webvh:QmQzm...",
+  "issuer": "did:peer:2.Vz6Mkgt...",
   "validFrom": "2025-12-02T08:58:43Z",
   "validUntil": "2026-12-02T00:00:00Z",
   "credentialSubject": {

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -699,12 +699,22 @@ pub fn vet_vrc_issued(
     }
     let remote_p_did = Arc::clone(&relationship.remote_p_did);
 
-    // Gate 2: issuer must be the authenticated sender's persona DID.
-    if vrc.issuer() != remote_p_did.as_str() {
+    // Gate 2: the issuer must be the identity the sender uses *in this
+    // relationship* — their R-DID, or their persona DID for a relationship
+    // established without one (`remote_did` equals `remote_p_did` there).
+    //
+    // This used to demand the persona DID, which forced the durable credential
+    // to name an identity shared across every one of the sender's
+    // relationships. Binding it to `remote_did` is also strictly tighter:
+    // Gate 1 matched `from_did` — the authenticated DIDComm sender — against
+    // this same field, so the credential is now pinned to the channel it
+    // arrived on rather than to a persona that could have issued it anywhere.
+    if vrc.issuer() != relationship.remote_did.as_str() {
         return Err(format!(
-            "credential issuer ({}) is not the sender's persona DID ({})",
+            "credential issuer ({}) is not the DID the sender uses in this \
+             relationship ({})",
             vrc.issuer(),
-            remote_p_did
+            relationship.remote_did
         ));
     }
 
@@ -1975,10 +1985,51 @@ mod tests {
             },
         );
 
-        let vrc = unsigned_vrc(sender_p);
+        // Issued under the sender's relationship DID — the pairwise form.
+        let vrc = unsigned_vrc(sender_r);
         let resolved = vet_vrc_issued(&rels, &tasks, &vrc, &from, Some(request.as_str()))
             .expect("legitimate VRC must pass vetting");
         assert_eq!(resolved, Some(request));
+    }
+
+    /// A VRC issued under the sender's *persona* DID, on a relationship that
+    /// uses a relationship DID, is refused.
+    ///
+    /// This is the behaviour change: the persona-issued credential is exactly
+    /// what correlated every relationship a persona had, because the VRC is the
+    /// durable artifact both parties keep and may publish to the trust graph.
+    /// Accepting it would leave the pairwise channel leading straight back to
+    /// the persona.
+    #[test]
+    fn vrc_issued_under_the_senders_persona_did_is_refused() {
+        let sender_p = "did:webvh:example:sender-persona";
+        let sender_r = "did:peer:2.SENDER_RELATIONSHIP";
+        let from = Arc::new(sender_r.to_string());
+        let rel = relationship(sender_p, sender_r, RelationshipState::Established);
+        let rels = relationships_with(&rel);
+
+        let vrc = unsigned_vrc(sender_p);
+        let err = vet_vrc_issued(&rels, &Tasks::default(), &vrc, &from, None)
+            .expect_err("a persona-issued VRC must not pass vetting");
+        assert!(
+            err.contains("is not the DID the sender uses in this relationship"),
+            "unexpected rejection reason: {err}"
+        );
+    }
+
+    /// A relationship established without a dedicated relationship DID has
+    /// `remote_did == remote_p_did`, so the persona-issued VRC still passes.
+    /// The gate binds to the identity used in the relationship, whichever it is.
+    #[test]
+    fn vrc_issued_under_the_persona_passes_when_that_is_the_relationship_did() {
+        let sender_p = "did:webvh:example:sender-persona";
+        let from = Arc::new(sender_p.to_string());
+        let rel = relationship(sender_p, sender_p, RelationshipState::Established);
+        let rels = relationships_with(&rel);
+
+        let vrc = unsigned_vrc(sender_p);
+        vet_vrc_issued(&rels, &Tasks::default(), &vrc, &from, None)
+            .expect("a relationship with no R-DID must still accept its persona-issued VRC");
     }
 
     // --- inbound VRC-issued proof verification (task R2 gate 4) ---

--- a/openvtc-core/src/relationships.rs
+++ b/openvtc-core/src/relationships.rs
@@ -136,6 +136,45 @@ fn is_false(b: &bool) -> bool {
     !*b
 }
 
+/// Verification-method id of a relationship DID's **signing** key.
+///
+/// `DID::generate_did_peer_from_secrets` rewrites each secret's id to a
+/// did:peer verification-method id as it mints the DID — `#key-1` for the
+/// verification key, `#key-2` for key agreement. That convention is already
+/// load-bearing in two places (the reload path in [`Relationships::
+/// generate_profiles`], which only re-registers a secret whose id starts with
+/// the R-DID, and [`Relationships::repair_key_info_ids`], which re-keys to it),
+/// so it is named here rather than spelled out a fourth time.
+///
+/// Only meaningful for a relationship DID. A persona's signing key is resolved
+/// from its DID document instead — see `Config::get_persona_keys`.
+pub fn relationship_signing_vm_id(r_did: &str) -> String {
+    format!("{r_did}#key-1")
+}
+
+/// Verification-method id of a relationship DID's **key-agreement** key.
+/// See [`relationship_signing_vm_id`].
+pub fn relationship_encryption_vm_id(r_did: &str) -> String {
+    format!("{r_did}#key-2")
+}
+
+/// The signing secret held for a relationship DID, or `None` when it is not in
+/// the TDK's resolver — which for an established relationship means its key
+/// material was lost (see [`Relationship::needs_reestablishment`]).
+///
+/// Lives here rather than at the call site so the `#key-1` convention and the
+/// `SecretsResolver` access stay in one crate.
+pub async fn relationship_signing_secret(
+    tdk: &affinidi_tdk::TDK,
+    r_did: &str,
+) -> Option<affinidi_tdk::secrets_resolver::secrets::Secret> {
+    use affinidi_tdk::secrets_resolver::SecretsResolver;
+    tdk.get_shared_state()
+        .secrets_resolver()
+        .get_secret(&relationship_signing_vm_id(r_did))
+        .await
+}
+
 /// Outcome of [`Relationships::repair_key_info_ids`].
 #[derive(Debug, Default)]
 pub struct KeyInfoRepairReport {

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -728,15 +728,43 @@ async fn prepare_accept_vrc_request(
     };
 
     // Create + sign the VRC on the loop thread (local crypto, not network).
+    //
+    // The VRC is issued under **the identity this relationship uses**, not the
+    // persona DID. It is the durable artifact both parties retain and may
+    // publish to the community trust graph, so a persona-attributed issuer
+    // correlated every relationship a persona had, indefinitely, from a
+    // credential that outlives the handshake that produced it. The subject was
+    // already the peer's R-DID; only the issuer half was persona-attributed,
+    // which meant the pairwise channel led straight back to the persona.
+    //
+    // This could not be fixed here until the VTC stopped requiring it: its
+    // publish path pinned the VRC issuer to the authenticated session DID, so
+    // a VRC issued under a relationship DID was rejected. Lifted in
+    // OpenVTC/verifiable-trust-infrastructure#1061.
     let valid_from = Utc::now();
     let mut vrc = DTGCredential::new_vrc(
-        config.persona_did().to_string(),
+        our_r_did.to_string(),
         their_r_did.to_string(),
         valid_from,
         None,
     );
-    let persona_keys = config.get_persona_keys(tdk).await?;
-    vrc.sign(&persona_keys.signing.secret, None).await?;
+    // `our_did` is the persona DID for a relationship established without a
+    // dedicated R-DID, so sign as whichever identity it actually is — the same
+    // discriminator `listener_id_for_did` routes sends on.
+    if config.is_persona_did(&our_r_did) {
+        let persona_keys = config.get_persona_keys(tdk).await?;
+        vrc.sign(&persona_keys.signing.secret, None).await?;
+    } else {
+        let secret = openvtc_core::relationships::relationship_signing_secret(tdk, &our_r_did)
+            .await
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no signing secret held for relationship DID {our_r_did} \
+                         — the relationship needs re-establishing"
+                )
+            })?;
+        vrc.sign(&secret, None).await?;
+    }
     let msg = vrc.message(&our_r_did, &their_r_did, Some(&task_id))?;
     let listener_id = super::didcomm::listener_id_for_did(&our_r_did, config);
 


### PR DESCRIPTION
Closes the last open half of #241 — the one the issue's own triage identified as
blocked upstream.

## What was still persona-attributed

Relationship *communication* has defaulted to a pairwise R-DID since #254. The
credential it produces did not. `prepare_accept_vrc_request` minted the VRC with
`issuer = persona_did`, signed with the persona key. The subject was already the
peer's R-DID — so only the issuer half leaked, and that was enough: the pairwise
channel led straight back to the persona.

It is also the worst place to leak it, for the reason #241 gave:

> The handshake persona DID is observed once; a published VRC correlates
> indefinitely.

The handshake DIDs are seen once, by the mediator, at establishment. The VRC is
the durable artifact both parties retain and may publish to a community trust
graph.

## Why it could not be fixed before

The VTC pinned a published VRC's issuer to the authenticated session DID, so a
VRC issued under a relationship DID was rejected outright — *the only
enforcement that existed forbade pairwise identifiers rather than requiring
them*. Lifted in OpenVTC/verifiable-trust-infrastructure#1061, which separates
membership (proven by the session) from the identifier the credential carries.

## Both ends, because they must move together

- **Issuance** signs as whichever identity the relationship actually uses, keyed
  on `is_persona_did` — the same discriminator `listener_id_for_did` routes
  sends on. A relationship established without a dedicated R-DID still signs
  with the persona key, unchanged.
- **`vet_vrc_issued` gate 2** now requires the issuer to be the sender's DID in
  *this* relationship rather than their persona DID.

Worth noting the gate change is **strictly tighter, not merely more private**.
Gate 1 already matched `from_did` — the authenticated DIDComm sender — against
the same field, so the credential is now pinned to the channel it arrived on
rather than to a persona that could have issued it anywhere.

Three tests: the pairwise form passes, a persona-issued VRC on an R-DID
relationship is refused with a specific reason, and a relationship with no R-DID
still accepts its persona-issued VRC (`remote_did == remote_p_did` there).

## Incidental cleanup

The `#key-1` verification-method convention that `generate_did_peer_from_secrets`
imposes was already load-bearing in two places and spelled out longhand in both.
Now named (`relationship_signing_vm_id`), with the secret lookup beside it in
`openvtc-core` so the TUI crate does not reach into the secrets resolver
directly.

## Docs

`docs/relationships-vrcs.md` carried a note deferring "full pairwise operation,
including the VRC issuer field" to upstream work. Replaced with what actually
happens, plus why the issuer field mattered more than the handshake routing
does. The example credential showed a `did:webvh` issuer; it now shows the
`did:peer` one it would really carry.

## Breaking

A VRC from a peer on an older build carries their persona DID and is now
refused; one from this build is refused by older peers. Nothing is published, so
no compatibility window — flagged rather than papered over.

## What #241 has left after this

Only the handshake routing, which is intrinsic: the mediator must route
request/accept/finalise before a pairwise channel exists. I'd close that as
accepted rather than leave it reading as outstanding work — and it is worth
restating acceptance criterion 4 against what pairwise identifiers actually
protect here, which the triage comment already argued is the trust graph and the
initiator's identity rather than mutual recognition.

Workspace green: 16 suites, clippy clean.
