### PR TITLE
fix(join)!: require the DTG common structure on an ingested invitation

### DIFF
--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -398,6 +398,17 @@ pub fn invitation_is_expired(vic: &Value, now: DateTime<Utc>) -> bool {
     }
 }
 
+/// The two `@context` entries DTG Credentials §Common Structure requires of
+/// every DTG credential, and the base `type` every one of them carries.
+///
+/// `dtg-credentials` builds all three into the credentials it mints but does
+/// not export them, so they are named here rather than spelled out inline.
+/// Removing this duplication needs a public constant upstream —
+/// OpenVTC/dtg-credentials#10.
+pub const W3C_VC_V2_CONTEXT: &str = "https://www.w3.org/ns/credentials/v2";
+pub const DTG_CONTEXT: &str = "https://firstperson.network/credentials/dtg/v1";
+pub const DTG_BASE_TYPE: &str = "DTGCredential";
+
 /// Whether a JSON value is an InvitationCredential (its `type` array carries
 /// the `InvitationCredential` tag). Used to validate a pasted/loaded VIC
 /// before stashing it (join flow) or storing it in the vault (VIC manager).
@@ -435,11 +446,19 @@ pub fn is_invitation_credential(value: &Value) -> bool {
 pub fn validate_invitation_credential(vic: &Value) -> Result<(), String> {
     let mut missing: Vec<&str> = Vec::new();
 
-    // @context — present, an array, first element the v2 base URL.
-    match vic.get("@context").and_then(Value::as_array) {
-        Some(ctx)
-            if ctx.first().and_then(Value::as_str) == Some("https://www.w3.org/ns/credentials/v2") => {}
-        _ => missing.push("@context (must be an array whose first item is \"https://www.w3.org/ns/credentials/v2\")"),
+    // @context — an array whose first element is the W3C v2 base URL, and
+    // which carries the DTG context. Both are REQUIRED of every DTG credential
+    // by §Common Structure; only the W3C half was checked until now, so a
+    // credential that was not a DTG credential at all could pass as a VIC.
+    let ctx = vic.get("@context").and_then(Value::as_array);
+    match ctx {
+        Some(c) if c.first().and_then(Value::as_str) == Some(W3C_VC_V2_CONTEXT) => {}
+        _ => missing.push(
+            "@context (must be an array whose first item is \"https://www.w3.org/ns/credentials/v2\")",
+        ),
+    }
+    if !ctx.is_some_and(|c| c.iter().any(|v| v.as_str() == Some(DTG_CONTEXT))) {
+        missing.push("@context entry \"https://firstperson.network/credentials/dtg/v1\"");
     }
     if !is_invitation_credential(vic) {
         missing
@@ -450,6 +469,13 @@ pub fn validate_invitation_credential(vic: &Value) -> Result<(), String> {
         .is_some_and(|t| t.iter().any(|v| v.as_str() == Some("VerifiableCredential")))
     {
         missing.push("type entry \"VerifiableCredential\"");
+    }
+    if !vic
+        .get("type")
+        .and_then(Value::as_array)
+        .is_some_and(|t| t.iter().any(|v| v.as_str() == Some(DTG_BASE_TYPE)))
+    {
+        missing.push("type entry \"DTGCredential\"");
     }
     if invitation_issuer(vic).is_none() {
         missing.push("issuer (a DID string or an object with an `id`)");
@@ -625,9 +651,16 @@ mod tests {
     /// requires. Distinct from [`sample_vic`], which is intentionally minimal.
     fn complete_vic() -> Value {
         json!({
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            // The DTG wire form, as `dtg-credentials` mints it. This fixture
+            // previously carried only the W3C half and still called itself
+            // complete — the validator agreed, because it checked only the
+            // same half.
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://firstperson.network/credentials/dtg/v1"
+            ],
             "id": "urn:uuid:vic-1",
-            "type": ["VerifiableCredential", "InvitationCredential"],
+            "type": ["VerifiableCredential", "DTGCredential", "InvitationCredential"],
             "issuer": "did:webvh:example.com:community",
             "credentialSubject": { "id": "did:webvh:example.com:alice" },
             "validUntil": "2099-01-01T00:00:00Z",
@@ -643,6 +676,29 @@ mod tests {
         let mut v = complete_vic();
         v["issuer"] = json!({ "id": "did:webvh:example.com:community" });
         assert!(validate_invitation_credential(&v).is_ok());
+    }
+
+    /// DTG Credentials §Common Structure is normative for *every* DTG
+    /// credential: `@context` MUST include the DTG context and `type` MUST
+    /// include `DTGCredential`. A credential carrying neither is not a DTG
+    /// credential at all, whatever its subtype claims.
+    #[test]
+    fn validate_rejects_a_vic_missing_the_dtg_common_structure() {
+        let mut no_ctx = complete_vic();
+        no_ctx["@context"] = json!(["https://www.w3.org/ns/credentials/v2"]);
+        let err = validate_invitation_credential(&no_ctx).expect_err("missing DTG context");
+        assert!(
+            err.contains("firstperson.network/credentials/dtg/v1"),
+            "error should name the missing context: {err}"
+        );
+
+        let mut no_base = complete_vic();
+        no_base["type"] = json!(["VerifiableCredential", "InvitationCredential"]);
+        let err = validate_invitation_credential(&no_base).expect_err("missing DTGCredential");
+        assert!(
+            err.contains("DTGCredential"),
+            "error should name the missing base type: {err}"
+        );
     }
 
     #[test]

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -1864,9 +1864,15 @@ mod tests {
     /// requires, issued by [`COMMUNITY`] and not yet expired.
     fn pasteable_vic(id: &str) -> serde_json::Value {
         json!({
-            "@context": ["https://www.w3.org/ns/credentials/v2"],
+            // The DTG wire form, as `dtg-credentials` mints it — both required
+            // contexts and the `DTGCredential` base type. A fixture that omits
+            // them is not a VIC a community could have issued.
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://firstperson.network/credentials/dtg/v1"
+            ],
             "id": id,
-            "type": ["VerifiableCredential", "InvitationCredential"],
+            "type": ["VerifiableCredential", "DTGCredential", "InvitationCredential"],
             "issuer": COMMUNITY,
             "credentialSubject": { "id": "did:webvh:example.com:alice" },
             "validUntil": "2099-01-01T00:00:00Z",


### PR DESCRIPTION
Client-side counterpart to the ingress work in
OpenVTC/verifiable-trust-infrastructure#1064 (audit finding F2), found by
running the same conformance pass over openvtc that turned up
verifiable-trust-infrastructure#1062.

## The gap

`validate_invitation_credential` is genuinely careful — it checks the W3C VC
Data Model 2.0 mandatory properties *and* the VIC profile the receiving VTC
enforces, and documents why each is required. It checked neither half of DTG
Credentials §Common Structure, which is normative for **every** DTG credential:

- `@context` MUST include `https://firstperson.network/credentials/dtg/v1`
- `type` MUST include `DTGCredential`

`grep` for that context string across openvtc returns **nothing**. It is never
required and never checked — because everything openvtc *mints* goes through
`dtg-credentials`, which supplies it. So the one place a credential arrives
from outside was also the one place nothing verified it was a DTG credential at
all. A document with the right subtype tag and neither common-structure element
passed as a VIC.

## Why nothing noticed

The fixtures agreed with the validator. `complete_vic` and `pasteable_vic` both
called themselves complete while carrying only the W3C half — so the test
encoded the implementation's belief about the wire form rather than the
specification's definition of it. Exactly the F4 pattern
(verifiable-trust-infrastructure#1066), and the reason `validate_accepts_a_complete_vic`
failed the moment the validator was tightened.

Both fixtures now use the form `new_vic` actually emits. That is what makes the
new checks a regression test rather than a restatement: **revert the validator
and nothing fails; revert the fixtures and the validator catches them.**

## Real invitations are unaffected

The VTC mints VICs through `DTGCredential::new_vic`, and its `catalog_wire_shape`
guard pins both contexts and all three `type` entries. A credential any
community actually issued already satisfies this — the change refuses documents
that were never valid.

## Constants

Named in `openvtc-core` rather than spelled inline. `dtg-credentials` builds all
three into what it mints but exports none of them; removing the duplication
needs a public constant upstream, requested in OpenVTC/dtg-credentials#10.

## Breaking

A pasted invitation lacking the DTG context or the `DTGCredential` type is now
refused at ingest, with a message naming what is missing, rather than accepted
and submitted to the community.

Workspace green: 16 suites, 0 failures, clippy clean.

## Note on scope

This is the VIC path only — the one ingress point openvtc validates thoroughly.
Whether the other received-credential paths need the same treatment is worth a
separate look; I did not want to widen a small, high-confidence fix into a
speculative sweep.
