### PR TITLE
fix(messaging): close a listener's socket when it is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Stopping a listener left its mediator socket open, so the next listener for
+  the same DID fought it forever.** `Messaging::remove_listener` dropped the
+  identity's wire and nothing more. That closes nothing:
+  `affinidi-messaging-sdk` has no `Drop` for `ATM` — the websocket task holds its
+  own state and keeps reconnecting on its timer — and the identity's outbox drain
+  still held the transport that owns the ATM. So the socket stayed up, holding the
+  mediator's one-socket-per-DID slot, invisible to `has_listener`. Anything that
+  re-added that DID (a community going inactive and then being re-joined, a
+  mediator change, the supervisor's own rebuild — which leaked another socket per
+  attempt) opened a second one, and the mediator evicted each in favour of the
+  other indefinitely. It read as a network fault: `Listener '…' disconnected (no
+  transport error reported)` every 30-60 s, `cycling rapidly` warnings, and a
+  restart as the only cure.
+
+  Removal now aborts that listener's drain and closes its websocket **before it
+  returns**, then finishes the ATM's teardown detached so the state-handler loop
+  never parks on it; `shutdown` awaits the same teardown, because a caller that
+  rebuilds the runtime would otherwise race its own orphans. Installing over an
+  existing id — which no caller should do — tears the displaced wire down and
+  warns rather than dropping it silently. Covered by a mediator-backed regression
+  test that remove/re-adds one DID and fails if the new listener is evicted.
+
 - **The admin credential was doing two irreconcilable jobs.** `ProtectedConfig`'s
   encryption key was `HKDF(admin_credential_private_key, …)`, which made one
   value both an **authorisation grant** designed to rotate (`acl/swap-key`) and

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -266,6 +266,54 @@ struct IdentityWire {
     /// used to. Rebuilding means constructing a fresh ATM, profile and transport,
     /// which needs the same inputs as the first time.
     spec: ListenerSpec,
+    /// This identity's outbox drain, held here rather than in
+    /// [`MessagingInner::tasks`] so removing the listener can abort *its* drain
+    /// and nobody else's.
+    ///
+    /// Load-bearing for teardown, not just tidiness: the drain owns a clone of
+    /// the `Arc<dyn MessageTransport>`, which owns the ATM. A drain left running
+    /// keeps the whole wire — and therefore its mediator socket — alive after the
+    /// listener is gone.
+    drain: tokio::task::JoinHandle<()>,
+}
+
+/// Stop a removed wire's drain and close its mediator websocket.
+///
+/// Everything here has to happen **before** the caller can install a listener for
+/// the same DID again, which is why it is not left to `Drop`:
+///
+/// - `affinidi-messaging-sdk` has no `Drop` for `ATM`. Dropping the handle stops
+///   nothing; the websocket task holds its own `Arc<SharedState>` and keeps
+///   running — and reconnecting — indefinitely.
+/// - The delivery layer's `remove_transport` aborts its forwarder and drops the
+///   service's `Arc` to the transport, but the drain task holds another.
+///
+/// So a removal that only forgot the wire left a live, auto-reconnecting socket
+/// holding the mediator's one-socket-per-DID slot. The next `add_listener` for
+/// that DID then opened a second one and the two evicted each other forever —
+/// which is what a user sees as a listener flapping every 30-60 s with "no
+/// transport error reported". The SDK documents the same failure on
+/// `ATM::graceful_shutdown`: an orphaned session "auto-reconnects on its own timer
+/// and holds the mediator's one-socket-per-DID slot for its profile".
+///
+/// Returns the ATM with its remaining teardown (the deletion handler) still to
+/// do. That step is bounded but not instant — up to the SDK's 5 s drain timeout —
+/// so the caller chooses whether to await it or let it finish detached. The
+/// socket, which is the part another listener contends for, is already closed
+/// either way.
+async fn quiesce_wire(listener_id: &str, wire: IdentityWire) -> ATM {
+    wire.drain.abort();
+    if let Err(e) = wire.profile.stop_websocket().await {
+        // Non-fatal and worth exactly one line: the ATM shutdown that follows
+        // stops the same websocket, so this is a "the fast path did not work"
+        // note rather than a leak in its own right.
+        debug!(
+            listener = %crate::display::truncate_did(listener_id, 32),
+            error = %e,
+            "closing the listener's websocket returned an error; the ATM shutdown will retry it"
+        );
+    }
+    wire.atm
 }
 
 /// The runtime messaging handle: one transport per identity, multiplexed through
@@ -319,7 +367,13 @@ struct MessagingInner {
     /// Listener ids with a pickup currently running, so a flapping socket
     /// cannot stack overlapping drains of the same mailbox.
     pickup_in_flight: std::sync::Mutex<std::collections::HashSet<String>>,
-    /// Dispatcher + per-identity drains, aborted on [`Messaging::shutdown`].
+    /// The runtime's own long-lived tasks — dispatcher, connection poller,
+    /// transport supervisor, pickup collector — aborted on
+    /// [`Messaging::shutdown`].
+    ///
+    /// Per-identity drains are **not** here: they live on their
+    /// [`IdentityWire`], so that removing one listener aborts its drain without
+    /// touching another's (see [`quiesce_wire`]).
     tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
 
@@ -375,13 +429,29 @@ impl Messaging {
         self.inner.identities.read().await.keys().cloned().collect()
     }
 
-    /// Remove a listener: drop its transport (closing the socket) and forget its
-    /// wire. Queued outbox entries pinned to it stay queued — they are bound to an
-    /// identity, and re-routing them would send from the wrong sender — and settle
-    /// visibly when their delivery window expires.
+    /// Remove a listener: close its mediator socket, stop its drain, and forget
+    /// its wire. Queued outbox entries pinned to it stay queued — they are bound
+    /// to an identity, and re-routing them would send from the wrong sender — and
+    /// settle visibly when their delivery window expires.
+    ///
+    /// **Returns with the socket closed**, because every caller's next move is
+    /// either to add a listener for the same DID (`reconnect_persona_listener_io`,
+    /// the supervisor's rebuild, a re-join after a community was removed) or to
+    /// leave that DID unserved. Both are wrong if the old socket is still up: see
+    // Not an intra-doc link: `quiesce_wire` is private, and a public item linking
+    // to it fails `rustdoc -D warnings`.
+    /// `quiesce_wire` for what that costs.
+    ///
+    /// The ATM's remaining teardown finishes in a detached task. It is bounded
+    /// (5 s at worst, waiting on the SDK's deletion handler) but this is called
+    /// from the state-handler loop, which must not park on it (R13).
     pub async fn remove_listener(&self, listener_id: &str) {
         self.inner.service.remove_transport(listener_id);
-        self.inner.identities.write().await.remove(listener_id);
+        let removed = self.inner.identities.write().await.remove(listener_id);
+        if let Some(wire) = removed {
+            let atm = quiesce_wire(listener_id, wire).await;
+            tokio::spawn(async move { atm.graceful_shutdown().await });
+        }
     }
 
     /// This listener's live connection state, or `None` if not installed.
@@ -586,17 +656,23 @@ impl Messaging {
         Ok(handed_off)
     }
 
-    /// Stop every drain and the dispatcher, and drop all transports.
+    /// Stop every drain and the dispatcher, and close every transport.
+    ///
+    /// Unlike [`remove_listener`](Self::remove_listener) this **awaits** each
+    /// ATM's full shutdown: a caller that shuts the runtime down and then builds
+    /// a new one (the join flow does exactly that) would otherwise race its own
+    /// orphans for the same DIDs.
     pub async fn shutdown(&self) {
         let handles: Vec<_> = std::mem::take(&mut *self.inner.tasks.lock().expect("tasks mutex"));
         for handle in handles {
             handle.abort();
         }
-        let ids: Vec<String> = self.inner.identities.read().await.keys().cloned().collect();
-        for id in ids {
+        let wires: Vec<(String, IdentityWire)> =
+            self.inner.identities.write().await.drain().collect();
+        for (id, wire) in wires {
             self.inner.service.remove_transport(&id);
+            quiesce_wire(&id, wire).await.graceful_shutdown().await;
         }
-        self.inner.identities.write().await.clear();
     }
 }
 
@@ -846,23 +922,39 @@ pub async fn add_listener(service: &Messaging, spec: &ListenerSpec) -> Result<()
         .inner
         .service
         .add_transport(spec.id.clone(), transport.clone());
-    service.inner.identities.write().await.insert(
-        spec.id.clone(),
-        IdentityWire {
-            atm,
-            profile,
-            did: spec.did.clone(),
-            spec: spec.clone(),
-        },
-    );
 
+    // The drain belongs to this identity, so its handle rides on the wire: it has
+    // to die with the listener, and it holds the transport Arc that keeps the ATM
+    // (and its socket) alive until it does.
     let drain = tokio::spawn(drain_loop_via(
         service.inner.outbox.clone(),
         spec.id.clone(),
         transport,
         DRAIN_INTERVAL,
     ));
-    service.inner.tasks.lock().expect("tasks mutex").push(drain);
+    let displaced = service.inner.identities.write().await.insert(
+        spec.id.clone(),
+        IdentityWire {
+            atm,
+            profile,
+            did: spec.did.clone(),
+            spec: spec.clone(),
+            drain,
+        },
+    );
+
+    // Nothing should reach here holding this id — every caller checks
+    // `has_listener` or removes first — but an id inserted over silently drops the
+    // old wire, and a dropped wire is a socket that never closes. Tear it down and
+    // say so, rather than leaving the two to duel over the DID.
+    if let Some(old) = displaced {
+        tracing::warn!(
+            listener = %crate::display::truncate_did(&spec.id, 32),
+            "a listener was installed over an existing one; closing the one it replaced"
+        );
+        let atm = quiesce_wire(&spec.id, old).await;
+        tokio::spawn(async move { atm.graceful_shutdown().await });
+    }
 
     debug!(listener = %spec.id, "listener installed on the delivery layer");
     Ok(())

--- a/openvtc-core/tests/didcomm_transport_e2e.rs
+++ b/openvtc-core/tests/didcomm_transport_e2e.rs
@@ -360,3 +360,75 @@ async fn the_supervisor_does_not_churn_a_healthy_transport() {
         "the listener is still connected after several supervisor ticks"
     );
 }
+
+/// Removing a listener must actually close its socket — not just forget it.
+///
+/// The regression: `remove_listener` dropped the `IdentityWire` and nothing else.
+/// The SDK has no `Drop` for `ATM`, and the identity's outbox drain still held the
+/// transport, so the websocket stayed up and kept reconnecting on its own timer.
+/// Re-adding a listener for the same DID — a community going inactive and then
+/// being re-joined, a mediator change, the supervisor's rebuild — then opened a
+/// second socket, and the mediator's one-socket-per-DID rule made the two evict
+/// each other indefinitely. It presented as a listener flapping every 30-60 s with
+/// "no transport error reported".
+///
+/// This is deliberately behavioural: the wire is gone from the map either way, so
+/// the only way to tell a closed socket from an orphaned one is to ask the
+/// mediator, by re-adding the DID and seeing whether the new listener is left
+/// alone.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "slow: spawns a real mediator and watches the re-added listener for 30s"]
+async fn a_re_added_listener_does_not_duel_with_the_removed_one() {
+    init_test_tracing();
+    let mediator = MockMediator::start().await.expect("mediator start");
+    let alice = mediator.profile("alice").expect("alice");
+    let bob_did = mediator.profile("bob").expect("bob").did;
+
+    // Built here rather than via `start_production_service`, because the same spec
+    // has to be installed twice.
+    let listener = relationship_listener_config_from_secrets(
+        &alice.did,
+        &bob_did,
+        &alice.mediator_did,
+        alice.secrets.clone(),
+    );
+    let listener_id = listener.id.clone();
+
+    let (tx, _rx) = mpsc::unbounded_channel::<DIDCommEvent>();
+    let service = Messaging::start(tx);
+    add_listener(&service, &listener)
+        .await
+        .expect("the listener installs");
+    service
+        .wait_connected(&listener_id, Duration::from_secs(20))
+        .await
+        .expect("the listener connects");
+
+    service.remove_listener(&listener_id).await;
+    add_listener(&service, &listener)
+        .await
+        .expect("the listener re-installs");
+    service
+        .wait_connected(&listener_id, Duration::from_secs(20))
+        .await
+        .expect("the re-added listener connects");
+
+    // Watch from here: an orphan is not idle, it reconnects on its own timer, so
+    // the eviction shows up as a disconnect on the listener that is still wanted.
+    let mut status = service.subscribe();
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    while let Ok(event) = status.try_recv() {
+        if let openvtc_core::didcomm::ListenerStatus::Disconnected { listener_id, .. } = event {
+            panic!(
+                "the re-added listener was evicted — the removed listener's socket is still \
+                 open and contending for the DID ({listener_id})"
+            );
+        }
+    }
+    assert_eq!(
+        service.listener_state(&listener_id),
+        Some(openvtc_core::didcomm::ConnState::Connected),
+        "the re-added listener is still connected"
+    );
+}


### PR DESCRIPTION
## The defect

`Messaging::remove_listener` dropped the `IdentityWire` and forgot the id. Neither closes the mediator connection:

- `affinidi-messaging-sdk` has **no `Drop` for `ATM`** — the websocket task holds its own `Arc<SharedState>` and keeps running, and reconnecting, on its own timer. The only teardown is `graceful_shutdown` / `profile_remove` / `stop_websocket`, none of which we called per listener.
- The delivery layer's `remove_transport` aborts its forwarder and drops the service's `Arc` to the transport, but the identity's outbox drain — spawned into the flat `tasks` vec and never aborted before process exit — still held another.

So the socket stayed up holding the mediator's one-socket-per-DID slot, while `has_listener` reported the listener gone. Every path that re-adds that DID then opened a second socket and the two evicted each other indefinitely:

- a community going inactive and then being re-joined (`deregister_inactive_community` → `join_flow`'s `has_listener` check, which cannot see the orphan),
- a mediator change or manual reconnect through `reconnect_persona_listener_io`,
- the supervisor's own rebuild, which leaked a further socket per attempt.

The `remove → add` comments in both of the latter say "drop the old transport first: one websocket per DID". The intent was right; the removal just never did it. The SDK documents this exact failure on `ATM::graceful_shutdown`: an orphaned session "auto-reconnects on its own timer and holds the mediator's one-socket-per-DID slot for its profile".

Reported from a live session — the activity log showed the persona listener disconnecting every 30-60s with "no transport error reported", two `cycling rapidly` warnings, starting at the exact moment a community was removed and then re-joined. A restart was the only cure, which is why this has read as a network fault.

## The fix

`quiesce_wire` does what a removal always owed: abort **that** listener's drain, then close its websocket.

- **`remove_listener`** returns with the socket closed — every caller either re-adds that DID immediately or wants it unserved, and both are wrong if the old one is still up. The ATM's remaining teardown runs detached: it is bounded (5s at worst, on the SDK's deletion handler) but this is called from the state-handler loop, which must not park on it (R13).
- **`shutdown`** awaits that teardown instead. A caller that tears the runtime down and builds a new one (the join flow does) would otherwise race its own orphans.
- The drain `JoinHandle` moves onto the `IdentityWire`, so a removal aborts its own drain and nobody else's — and it is the drain that kept the ATM alive.
- `add_listener` tears down a displaced wire and warns, rather than dropping one silently, if anything ever installs over a live id.

## Verification

`a_re_added_listener_does_not_duel_with_the_removed_one` remove/re-adds one DID against the test mediator and fails if the re-added listener is evicted. Deliberately behavioural: the wire is gone from the map either way, so the only way to tell a closed socket from an orphaned one is to ask the mediator.

Confirmed to fail against the pre-fix behaviour, reproducing the reported symptom exactly:

```
WARN mediator: Duplicate WebSocket connection: closing old session in favour of new one
WARN sdk: WebSocket closed by the mediator code=1008 reason=this DID already has a live connection
WARN sdk: WebSocket closed by the mediator code=1008 reason=replaced by a newer connection
```

Also run: `cargo fmt`, `clippy --workspace --all-targets` (clean), `cargo test --workspace --include-ignored`, the full 5-test `didcomm_transport_e2e` suite, `RUSTDOCFLAGS="-D warnings" cargo doc`.

## Not in scope

The sibling-device warning seen in the same log ("This account is also open on <this machine>") is a separate false positive: `device_register` takes no client-supplied id, so each launch mints a fresh binding and the previous run stays inside the 900s `LIVENESS_WINDOW`. It is diagnostic only and was not the cause of the flap.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1)
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4)
- [x] Accept/poll/listen loops survive transient errors (R1.5)
- [x] Acks/deletes happen only after durable handoff (R1.6)
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — n/a, no wire types touched
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — a removal no longer claims a socket is closed when it is not; a failed stop_websocket and a displaced wire each get a line
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — teardown is local only; a death mid-detach loses nothing the process exit does not already close
- [x] Deviations from this guide flagged explicitly with rule numbers — none
```
