### PR TITLE
fix(members): give the reciprocal membership credential an id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Every reciprocal membership credential we sent a community was rejected, and
+  nothing here said so.** A community stores a member's VMC keyed by the
+  credential's own top-level `id`, and refuses one that has none. Ours never had
+  one: `dtg-credentials` had no field for it at all, so a VMC built with
+  `new_vmc()` could not carry the W3C VC Data Model's credential identifier —
+  the property was not merely unset, there was nowhere to put it. Every
+  submission therefore failed the community's last check, *after* the issuer,
+  subject and Data Integrity proof checks had all passed. The member → community
+  half of the membership pair has never once landed, whether sent by hand or
+  auto-issued in answer to a `members/request-vmc`.
+
+  It was silent from both ends. The send reports success as soon as the frame is
+  accepted locally — "Membership credential issued and sent to the community." —
+  which says nothing about whether the community took it. The community's
+  rejection comes back as a problem-report threaded on the delivery, and this
+  client routes every inbound problem-report through the join handler, which
+  correlates against pending *join request* ids; a VMC's thread matches none, so
+  the report was discarded with a warn that names the correlation miss rather
+  than the failure. Two independent silences over one broken exchange.
+
+  `dtg-credentials` 0.3 adds the field (`with_id()`), and the member VMC now
+  gets a fresh `urn:uuid:` identifier before it is signed — before, necessarily,
+  since the proof covers it and an id spliced in afterwards would leave a
+  document whose proof no longer verifies. Regression tests assert the id is
+  present, fresh per issuance, and inside what the proof covers.
+
+  The two silences are not fixed here and are worth their own change: a send
+  `Ok` still reads as acceptance, and a problem-report on any thread other than a
+  join is still dropped.
+
 - **Stopping a listener left its mediator socket open, so the next listener for
   the same DID fought it forever.** `Messaging::remove_listener` dropped the
   identity's wire and nothing more. That closes nothing:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c722ab4e0ca0f145c0e391320fe28d9043c889a0a5ba8d186bc527cf0ce2cace"
+checksum = "79320f11d8abf62975f95ff10b363598f6635ede485fa9ceafc167668d8bcd09"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ openvtc-core = { version = "0.3", path = "openvtc-core", default-features = fals
 #
 # The crate's documented VWC `digest` divergence from WD-01 does not reach
 # us either — `digest_multibase()` / `verify_digest()` have no call sites here.
-dtg-credentials = "0.2"
+dtg-credentials = "0.3"
 
 aes-gcm = "0.11"
 # The one direct requirement in this workspace that was behind its latest

--- a/openvtc-core/src/members.rs
+++ b/openvtc-core/src/members.rs
@@ -43,19 +43,44 @@ pub async fn issue_and_send_member_vmc(
     vtc_did: &str,
     mediator_did: &str,
 ) -> Result<Uuid, OpenVTCError> {
+    let vc = build_member_vmc(signing_secret, member_did, vtc_did).await?;
+    submit_member_vmc(atm, profile, member_did, vtc_did, mediator_did, vc).await
+}
+
+/// Build + sign the reciprocal member VMC, without sending it. The signing half of
+/// [`issue_and_send_member_vmc`], split out so the credential's shape can be asserted
+/// without a mediator.
+///
+/// # The credential carries its own `id`
+///
+/// A community stores a member's VMC keyed by that `id`: it is what makes a re-sent
+/// credential idempotent rather than a duplicate, and a *different* one a renewal rather
+/// than a conflict. A VMC without one is refused, and the refusal comes back as a
+/// problem-report threaded on the delivery — which is not a thread this client correlates,
+/// so the rejection is invisible from here and the membership pair silently stays half
+/// formed.
+///
+/// The id has to be set before signing: the Data Integrity proof covers the credential
+/// minus its `proof`, so an id added afterwards leaves a document whose proof no longer
+/// verifies. `dtg-credentials` 0.3 is the first release with somewhere to put it.
+pub async fn build_member_vmc(
+    signing_secret: &Secret,
+    member_did: &str,
+    vtc_did: &str,
+) -> Result<Value, OpenVTCError> {
     let mut vmc = DTGCredential::new_vmc(
         member_did.to_string(),
         vtc_did.to_string(),
         Utc::now(),
         None,
         false,
-    );
+    )
+    .with_id(format!("urn:uuid:{}", Uuid::new_v4()));
     vmc.sign(signing_secret, None)
         .await
         .map_err(|e| OpenVTCError::Config(format!("sign member VMC: {e}")))?;
-    let vc = serde_json::to_value(&vmc)
-        .map_err(|e| OpenVTCError::Config(format!("serialize member VMC: {e}")))?;
-    submit_member_vmc(atm, profile, member_did, vtc_did, mediator_did, vc).await
+    serde_json::to_value(&vmc)
+        .map_err(|e| OpenVTCError::Config(format!("serialize member VMC: {e}")))
 }
 
 /// Send a member-issued VMC to the community's VTC over DIDComm
@@ -93,4 +118,93 @@ pub async fn submit_member_vmc(
 
     crate::pack_and_send(atm, profile, &msg, member_did, vtc_did, mediator_did).await?;
     Ok(msg_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_tdk::secrets_resolver::secrets::Secret;
+
+    const MEMBER: &str = "did:example:member";
+    const COMMUNITY: &str = "did:example:community";
+
+    async fn signed_vmc() -> (Secret, Value) {
+        let secret = Secret::generate_ed25519(None, None);
+        let vc = build_member_vmc(&secret, MEMBER, COMMUNITY)
+            .await
+            .expect("build the member VMC");
+        (secret, vc)
+    }
+
+    /// The community keys a member's VMC by its top-level `id` and refuses one that has
+    /// none. Every VMC this client ever issued lacked it, because `dtg-credentials` had no
+    /// field for it — so every delivery was rejected, and the rejection arrived on a thread
+    /// this client does not correlate.
+    #[tokio::test]
+    async fn a_member_vmc_carries_a_top_level_id() {
+        let (_secret, vc) = signed_vmc().await;
+
+        let id = vc
+            .get("id")
+            .and_then(Value::as_str)
+            .expect("the VMC carries a top-level `id`");
+        assert!(
+            id.starts_with("urn:uuid:"),
+            "the id should be a urn:uuid: URN, got {id}"
+        );
+        // `credentialSubject.id` names the *community*. It is a different property and does
+        // not stand in for the credential's own identifier.
+        assert_eq!(vc["credentialSubject"]["id"], COMMUNITY);
+    }
+
+    /// Two deliveries must not collide: the community treats a repeat of the same `id` as
+    /// idempotent and a different one as a renewal, so a fixed id would make every
+    /// re-issuance a no-op.
+    #[tokio::test]
+    async fn each_member_vmc_gets_a_fresh_id() {
+        let (_, first) = signed_vmc().await;
+        let (_, second) = signed_vmc().await;
+        assert_ne!(first["id"], second["id"]);
+    }
+
+    /// The id is inside what the proof covers, which is why it has to be set before signing
+    /// rather than spliced into the JSON on the way out. Parsing the delivered credential
+    /// back and verifying it is what the community does; it must pass.
+    #[tokio::test]
+    async fn the_signed_vmc_verifies_with_its_id_in_place() {
+        let (secret, vc) = signed_vmc().await;
+
+        let parsed: DTGCredential = serde_json::from_value(vc.clone()).expect("parse back");
+        parsed
+            .verify_proof_with_public_key(secret.get_public_bytes())
+            .expect("the delivered credential verifies as sent");
+
+        // Tampering with the id — or adding one after the fact, the same operation — breaks
+        // the proof, so there is no post-signing workaround for an issuer that omits it.
+        let mut tampered = vc;
+        tampered["id"] = Value::String("urn:uuid:00000000-0000-0000-0000-000000000000".into());
+        let parsed: DTGCredential = serde_json::from_value(tampered).expect("parse back");
+        assert!(
+            parsed
+                .verify_proof_with_public_key(secret.get_public_bytes())
+                .is_err(),
+            "a changed id must invalidate the proof"
+        );
+    }
+
+    /// The issuer / subject direction is what the community verifies the pair by: the member
+    /// issues, the community is the subject. Reversing it is a different credential.
+    #[tokio::test]
+    async fn the_member_issues_and_the_community_is_the_subject() {
+        let (_secret, vc) = signed_vmc().await;
+        assert_eq!(vc["issuer"], MEMBER);
+        assert_eq!(vc["credentialSubject"]["id"], COMMUNITY);
+        assert!(
+            vc["type"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|t| t == "MembershipCredential")
+        );
+    }
 }


### PR DESCRIPTION
## The break

A community stores a member's VMC keyed by the credential's own **top-level `id`**, and refuses one that has none (`vtc-service/src/members/inbound_vmc.rs`, `verify_member_vmc`). Ours never had one: `dtg-credentials` had no field for it, so a VMC built with `new_vmc()` could not carry the W3C VC Data Model's credential identifier at all — the property was not merely unset, there was nowhere to put it.

Every reciprocal VMC this client has ever sent was therefore rejected — and rejected at the *last* check, after the issuer, subject and Data Integrity proof checks had all passed. The member → community half of the membership pair has never landed, whether issued by hand (`m`) or auto-issued in answer to a `members/request-vmc`.

## Why it was invisible

Two independent silences over one broken exchange:

1. **The send reports success on a local `Ok`.** `"Membership credential issued and sent to the community."` is printed as soon as the DIDComm frame is accepted for delivery, which says nothing about whether the community took it.
2. **The rejection is discarded.** The community answers with a problem-report threaded on the delivery. This client routes *every* inbound problem-report through `handle_join_problem_report`, which correlates the `thid` against pending **join request** ids. A VMC's thread matches none, so the report is dropped with a warn naming the correlation miss rather than the failure.

## The fix

Takes `dtg-credentials` 0.3 (OpenVTC/dtg-credentials#12), which adds the field, and sets a fresh `urn:uuid:` id **before signing**.

Before, necessarily. A Data Integrity proof covers the credential minus its `proof`, so an id added afterwards leaves a document whose proof no longer verifies — there was no way to patch this at the wire, which is why it needed the library release first.

Splits the build half out as `build_member_vmc()` so the credential's shape can be asserted without a mediator. New tests pin that the id is present and a `urn:uuid:`, that it is fresh per issuance (a fixed id would make every renewal look like a no-op to the community), and that it is inside what the proof covers — including that tampering with it after signing breaks verification.

## Deliberately not in this PR

- **The two silences.** A send `Ok` still reads as acceptance, and a problem-report on any thread but a join is still discarded. Both are worth fixing and are a different change; without them, the *next* wire-shape disagreement will be just as invisible as this one.
- **`request_id` is still always `None`** on the submission, so a member VMC never closes an approved join request the way `vtc/members/vmc/0.1` allows. Pre-existing and separate.
- **VRCs have no `id` either** (`prepare_accept_vrc_request`). Nothing currently rejects them for it, and adding one changes what a witness credential digests, so it is not folded in here.

## Testing

`cargo test --workspace` green. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all` clean.