### PR TITLE
fix(devices): recognise our own device binding by the DID that owns it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Every launch after the first warned that the account was open somewhere
+  else — naming this machine.** `device/register` is deliberately not
+  idempotent: a `DeviceBinding` hangs off the caller's ACL entry, there is
+  exactly one per DID, and the VTA refuses a second claim with
+  `device/register:alreadyRegistered`. OpenVTC read that refusal as a failure,
+  so from the second launch on it held no device id — and the sibling filter
+  excluded "us" by id alone. With nothing to exclude, this install reported its
+  *own* binding as another live instance, on every start, with no second process
+  anywhere. The one situation the warning exists for (two installs evicting each
+  other from the mediator's one socket per DID) was the one it stopped being
+  able to tell you about, because the same sentence appeared when nothing was
+  wrong.
+
+  A row now carries the DID that owns it (`consumerDid`), which is exact rather
+  than a guess: one binding per ACL entry means a row naming the DID we
+  authenticate as *is* us, on every launch. The already-registered refusal is
+  understood as the ordinary case it is (typed 409 over REST, either spelling of
+  the reject code over DIDComm/TSP), and the listing recovers our own device id
+  so a later launch names us the way a first one does. An install that can
+  identify itself by neither id nor DID still reports everything live — a missed
+  warning is the costlier direction.
+
 - **Every reciprocal membership credential we sent a community was rejected, and
   nothing here said so.** A community stores a member's VMC keyed by the
   credential's own top-level `id`, and refuses one that has none. Ours never had

--- a/openvtc-core/src/devices.rs
+++ b/openvtc-core/src/devices.rs
@@ -61,6 +61,18 @@ pub const LIVENESS_WINDOW: Duration = Duration::from_secs(900);
 pub struct DeviceRecord {
     /// The VTA's identifier for this binding.
     pub device_id: String,
+    /// The DID whose ACL entry owns this binding (`consumerDid` on the wire).
+    ///
+    /// This is what makes "is that row me?" answerable. A binding hangs off an
+    /// ACL entry and there is exactly one per DID, so an install that
+    /// authenticates as this DID *is* this row — no guessing from display names,
+    /// which are not unique (host + profile recurs across machines).
+    ///
+    /// Optional because a VTA predating the field omits it; a row with no
+    /// `consumerDid` simply cannot be matched this way and falls back to the
+    /// device id.
+    #[serde(default)]
+    pub consumer_did: Option<String>,
     /// Human-readable name the device chose for itself.
     #[serde(default)]
     pub display_name: String,
@@ -95,6 +107,22 @@ impl DeviceRecord {
             .as_deref()
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.with_timezone(&chrono::Utc))
+    }
+
+    /// Whether this row is this install, by either identifier we might hold.
+    ///
+    /// A `None` on our side never matches: not knowing our DID must not make
+    /// every row ours and silence the warning entirely. Likewise a row carrying
+    /// no `consumerDid` is not ours on that basis alone.
+    #[must_use]
+    pub fn is_self(&self, self_device_id: Option<&str>, self_did: Option<&str>) -> bool {
+        if self_device_id.is_some_and(|id| id == self.device_id) {
+            return true;
+        }
+        match (self.consumer_did.as_deref(), self_did) {
+            (Some(owner), Some(ours)) => owner == ours,
+            _ => false,
+        }
     }
 
     /// Whether this device has been seen within [`LIVENESS_WINDOW`] of `now`.
@@ -155,16 +183,32 @@ pub fn display_name(profile: &str) -> String {
     format!("OpenVTC on {host} ({profile})")
 }
 
-/// Claim or refresh this install's device binding.
+/// What a registration attempt found.
+#[derive(Clone, Debug)]
+pub enum Registration {
+    /// The VTA claimed a fresh binding for this DID — a first launch.
+    Claimed(DeviceRecord),
+    /// This DID already holds a binding. **The ordinary case on every launch
+    /// after the first**, and not an error.
+    AlreadyRegistered,
+}
+
+/// Claim this install's device binding.
 ///
-/// Idempotent: the caller always acts on its own binding, so re-registering on
-/// every launch simply refreshes the display name and platform.
+/// `device/register` is **deliberately not idempotent**: a `DeviceBinding` hangs
+/// off the caller's ACL entry, there is exactly one per DID, and the VTA refuses
+/// a second claim with `device/register:alreadyRegistered` (the spec's answer for
+/// a device that lost its key is to rotate and retry, not to re-register). So the
+/// second and every later launch is *expected* to be refused, and treating that
+/// refusal as a failure is what made this install invisible to itself — see
+/// [`live_siblings`].
 ///
 /// # Errors
 ///
-/// Any VTA failure. Callers log and continue — see the module docs.
-pub async fn register(client: &VtaClient, profile: &str) -> Result<DeviceRecord, OpenVTCError> {
-    let response = client
+/// Any VTA failure other than the already-registered conflict. Callers log and
+/// continue — see the module docs.
+pub async fn register(client: &VtaClient, profile: &str) -> Result<Registration, OpenVTCError> {
+    let response = match client
         .device_register(
             consumer_kind(),
             &display_name(profile),
@@ -172,10 +216,38 @@ pub async fn register(client: &VtaClient, profile: &str) -> Result<DeviceRecord,
             None,
         )
         .await
-        .map_err(|e| OpenVTCError::Vta(format!("device registration failed: {e}")))?;
+    {
+        Ok(response) => response,
+        Err(e) if is_already_registered(&e) => return Ok(Registration::AlreadyRegistered),
+        Err(e) => {
+            return Err(OpenVTCError::Vta(format!(
+                "device registration failed: {e}"
+            )));
+        }
+    };
 
     parse_binding(&response)
+        .map(Registration::Claimed)
         .ok_or_else(|| OpenVTCError::Vta("device registration returned no binding".to_string()))
+}
+
+/// Whether a `device/register` failure is "this DID is already registered".
+///
+/// Matched three ways because the answer arrives from whichever VTA this install
+/// enrolled against and the transport changes its shape: a typed `Conflict` over
+/// REST, and a protocol reject carrying the code over DIDComm/TSP — in either
+/// the current lowerCamelCase spelling or the pre-#279 snake_case one that a VTA
+/// on an older build still emits. A missed match does not crash; it silently
+/// restores the false "another instance is running" warning, which is exactly the
+/// kind of failure no smoke test catches.
+///
+/// Mirrors `vta_sdk::agent_session`'s private matcher of the same name.
+fn is_already_registered(e: &vta_sdk::error::VtaError) -> bool {
+    if e.is_conflict() {
+        return true;
+    }
+    let msg = e.to_string();
+    msg.contains("alreadyRegistered") || msg.contains("already_registered")
 }
 
 /// Refresh this install's `lastSeenAt`.
@@ -228,18 +300,32 @@ fn parse_binding(response: &serde_json::Value) -> Option<DeviceRecord> {
 
 /// Other installs currently using this account.
 ///
-/// `self_device_id` is this install's binding, excluded from the result — it is
-/// always live, and reporting it would make "another instance is running" fire
-/// on every single launch.
+/// This install's own binding is excluded — it is always live, and reporting it
+/// would make "another instance is running" fire on every single launch. It is
+/// identified two ways, and the DID is the one that matters:
+///
+/// - **`self_did`** — the DID this install authenticates to the VTA as. A binding
+///   belongs to exactly one ACL entry, so a row naming our DID *is* us. True on
+///   every launch.
+/// - **`self_device_id`** — the id returned when we claimed the binding. Only a
+///   first launch learns it, because a later `device/register` is refused rather
+///   than answered (see [`register`]). Kept as the fallback for a VTA whose rows
+///   carry no `consumerDid`.
+///
+/// Relying on the id alone is what produced the false positive: from the second
+/// launch on, the id was `None`, nothing was excluded, and this install reported
+/// *itself* as another instance — naming its own host and profile, with no second
+/// process anywhere.
 #[must_use]
 pub fn live_siblings(
     devices: &[DeviceRecord],
     self_device_id: Option<&str>,
+    self_did: Option<&str>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Vec<DeviceRecord> {
     devices
         .iter()
-        .filter(|d| Some(d.device_id.as_str()) != self_device_id)
+        .filter(|d| !d.is_self(self_device_id, self_did))
         .filter(|d| d.is_live_at(now))
         .cloned()
         .collect()
@@ -275,6 +361,7 @@ mod tests {
     fn record(id: &str, last_seen: Option<chrono::DateTime<Utc>>) -> DeviceRecord {
         DeviceRecord {
             device_id: id.to_string(),
+            consumer_did: None,
             display_name: format!("OpenVTC on {id}"),
             platform: Some("linux".to_string()),
             registered_at: None,
@@ -340,7 +427,7 @@ mod tests {
     fn our_own_binding_is_never_a_sibling() {
         let now = Utc::now();
         let devices = vec![record("self", Some(now)), record("other", Some(now))];
-        let siblings = live_siblings(&devices, Some("self"), now);
+        let siblings = live_siblings(&devices, Some("self"), None, now);
         assert_eq!(siblings.len(), 1);
         assert_eq!(siblings[0].device_id, "other");
     }
@@ -352,7 +439,7 @@ mod tests {
             record("self", Some(now)),
             record("old-laptop", Some(now - ChronoDuration::days(3))),
         ];
-        assert!(live_siblings(&devices, Some("self"), now).is_empty());
+        assert!(live_siblings(&devices, Some("self"), None, now).is_empty());
     }
 
     #[test]
@@ -401,6 +488,7 @@ mod tests {
     fn a_binding_with_no_name_falls_back_to_its_id() {
         let d = DeviceRecord {
             device_id: "dev-1".to_string(),
+            consumer_did: None,
             display_name: String::new(),
             platform: None,
             registered_at: None,
@@ -426,5 +514,98 @@ mod tests {
         let name = display_name("work");
         assert!(name.starts_with("OpenVTC on "), "{name}");
         assert!(name.ends_with("(work)"), "{name}");
+    }
+
+    /// The reported false positive, pinned. From the second launch on, this
+    /// install has **no** device id — `device/register` refuses to answer a
+    /// second claim — so identifying ourselves by id alone left us reporting our
+    /// own binding as another instance, naming our own host and profile.
+    #[test]
+    fn our_own_binding_is_ours_by_did_when_we_never_learned_its_id() {
+        let now = Utc::now();
+        let mut mine = record("dev-1", Some(now));
+        mine.consumer_did = Some("did:key:zSelf".to_string());
+
+        assert!(
+            live_siblings(&[mine], None, Some("did:key:zSelf"), now).is_empty(),
+            "the binding owned by the DID we authenticate as is this install"
+        );
+    }
+
+    /// The other half: suppressing ourselves must not suppress a real one.
+    #[test]
+    fn another_dids_binding_is_still_a_sibling() {
+        let now = Utc::now();
+        let mut mine = record("dev-1", Some(now));
+        mine.consumer_did = Some("did:key:zSelf".to_string());
+        let mut theirs = record("dev-2", Some(now));
+        theirs.consumer_did = Some("did:key:zOther".to_string());
+
+        let siblings = live_siblings(&[mine, theirs], None, Some("did:key:zSelf"), now);
+        assert_eq!(siblings.len(), 1);
+        assert_eq!(siblings[0].device_id, "dev-2");
+    }
+
+    /// Neither side of the match may be allowed to swallow the warning: an
+    /// install that knows neither its id nor its DID reports everything live,
+    /// which is the safe direction — a missed warning is the failure that costs
+    /// the user an eviction loop.
+    #[test]
+    fn an_unidentifiable_install_still_reports_what_is_live() {
+        let now = Utc::now();
+        let mut row = record("dev-1", Some(now));
+        row.consumer_did = Some("did:key:zOther".to_string());
+
+        assert_eq!(live_siblings(&[row.clone()], None, None, now).len(), 1);
+        assert_eq!(
+            live_siblings(&[row], None, Some("did:key:zSelf"), now).len(),
+            1
+        );
+    }
+
+    /// A row carrying no `consumerDid` (an older VTA) is not ours on that basis,
+    /// so the device id stays the fallback.
+    #[test]
+    fn a_row_without_an_owner_falls_back_to_the_device_id() {
+        let now = Utc::now();
+        let row = record("dev-1", Some(now));
+        assert!(row.is_self(Some("dev-1"), None));
+        assert!(!row.is_self(None, Some("did:key:zSelf")));
+    }
+
+    #[test]
+    fn the_owning_did_parses_off_the_wire() {
+        let raw = serde_json::json!({
+            "deviceId": "dev-1",
+            "consumerDid": "did:key:zSelf",
+            "displayName": "OpenVTC on host (default)",
+        });
+        let d: DeviceRecord = serde_json::from_value(raw).expect("tolerant parse");
+        assert_eq!(d.consumer_did.as_deref(), Some("did:key:zSelf"));
+    }
+
+    /// `device/register` is refused, not answered, on every launch after the
+    /// first. Reading that refusal as a failure is what left this install
+    /// unable to recognise itself, so both spellings of the code and the typed
+    /// REST conflict must all be understood.
+    #[test]
+    fn an_already_registered_refusal_is_recognised_across_transports() {
+        use vta_sdk::error::VtaError;
+
+        assert!(is_already_registered(&VtaError::Conflict("dup".into())));
+        for code in [
+            "device/register:alreadyRegistered",
+            "device/register:already_registered",
+        ] {
+            assert!(
+                is_already_registered(&VtaError::Protocol(format!(
+                    "trust task rejected: {code} — a DeviceBinding already exists"
+                ))),
+                "{code} must read as already-registered"
+            );
+        }
+        assert!(!is_already_registered(&VtaError::Protocol(
+            "trust task rejected: something else".into()
+        )));
     }
 }

--- a/openvtc/src/state_handler/device_presence.rs
+++ b/openvtc/src/state_handler/device_presence.rs
@@ -42,10 +42,19 @@ pub enum PresenceReport {
 
 /// Register this install, then heartbeat and watch for siblings until cancelled.
 ///
+/// `self_did` is the DID this install authenticates to the VTA as — the durable
+/// answer to "which of these bindings is mine", because only a first launch ever
+/// learns its device id (see [`devices::register`]).
+///
 /// Returns when `tx` closes — i.e. when the state handler exits.
-pub async fn run(client: VtaClient, profile: String, tx: UnboundedSender<PresenceReport>) {
-    let self_id = match devices::register(&client, &profile).await {
-        Ok(record) => {
+pub async fn run(
+    client: VtaClient,
+    profile: String,
+    self_did: Option<String>,
+    tx: UnboundedSender<PresenceReport>,
+) {
+    let mut self_id = match devices::register(&client, &profile).await {
+        Ok(devices::Registration::Claimed(record)) => {
             info!(device_id = %record.device_id, "registered this install with the VTA");
             if tx
                 .send(PresenceReport::Registered {
@@ -56,6 +65,12 @@ pub async fn run(client: VtaClient, profile: String, tx: UnboundedSender<Presenc
                 return;
             }
             Some(record.device_id)
+        }
+        Ok(devices::Registration::AlreadyRegistered) => {
+            // Every launch after the first. The binding is ours and still there;
+            // we just were not told its id, and the listing below recovers it.
+            debug!("this install is already registered with the VTA");
+            None
         }
         Err(e) => {
             // Not fatal: a VTA without the device slice, or one briefly
@@ -74,7 +89,33 @@ pub async fn run(client: VtaClient, profile: String, tx: UnboundedSender<Presenc
     loop {
         match devices::list(&client).await {
             Ok(all) => {
-                let live = devices::live_siblings(&all, self_id.as_deref(), chrono::Utc::now());
+                // Recover our own id from the listing when registration did not
+                // hand it to us, so the loop names us the same way a first launch
+                // does — and so a VTA that stops returning `consumerDid` still
+                // has the id to fall back on.
+                if self_id.is_none()
+                    && let Some(mine) = all
+                        .iter()
+                        .find(|d| d.is_self(None, self_did.as_deref()))
+                        .map(|d| d.device_id.clone())
+                {
+                    debug!(device_id = %mine, "recovered this install's binding from the listing");
+                    if tx
+                        .send(PresenceReport::Registered {
+                            device_id: mine.clone(),
+                        })
+                        .is_err()
+                    {
+                        return;
+                    }
+                    self_id = Some(mine);
+                }
+                let live = devices::live_siblings(
+                    &all,
+                    self_id.as_deref(),
+                    self_did.as_deref(),
+                    chrono::Utc::now(),
+                );
                 let fresh = newly_appeared(&mut announced, &live);
                 if !fresh.is_empty() && tx.send(PresenceReport::NewSiblings(fresh)).is_err() {
                     return;
@@ -124,6 +165,7 @@ mod tests {
     fn record(id: &str) -> DeviceRecord {
         DeviceRecord {
             device_id: id.to_string(),
+            consumer_did: None,
             display_name: format!("OpenVTC on {id}"),
             platform: None,
             registered_at: None,

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -719,9 +719,19 @@ impl StateHandler {
         let (presence_tx, mut presence_rx) =
             mpsc::unbounded_channel::<device_presence::PresenceReport>();
         if let Some(client) = admin_vta.as_ref() {
+            // The DID this install authenticates as. It owns our device binding,
+            // so it is how the presence task recognises our own row in the
+            // listing — the device id is only ever learned on a first launch.
+            let self_did = match &config.key_backend {
+                openvtc_core::config::KeyBackend::Vta { credential_did, .. } => {
+                    Some(credential_did.clone())
+                }
+                openvtc_core::config::KeyBackend::Bip32 { .. } => None,
+            };
             tokio::spawn(device_presence::run(
                 client.clone(),
                 self.profile.clone(),
+                self_did,
                 presence_tx,
             ));
         }


### PR DESCRIPTION
## The symptom

Every launch after the first, one second after startup:

```
[02:04:31] WARNING: This account is also open on OpenVTC on AFMac-CY7HRWN9Q1 (default).
           Both instances share one mediator connection per persona, so messaging
           may be unstable until one is closed.
```

Naming this machine, this profile, with no second process running anywhere.

## Why

`device/register` is **deliberately not idempotent**. A `DeviceBinding` hangs off the caller's ACL entry — one per DID — and `vta-service`'s `register_device` refuses a second claim:

```rust
// Re-registration is intentionally not idempotent (spec): rotate keys + retry.
if entry.device.is_some() {
    return Err(AppError::Conflict(format!(
        "device/register:alreadyRegistered — a DeviceBinding already exists for {did}"
    )));
}
```

`devices::register` mapped that refusal onto an error, and its doc comment claimed the opposite — *"Idempotent: the caller always acts on its own binding, so re-registering on every launch simply refreshes the display name and platform."* So the sequence was:

1. **First launch** — register succeeds, `self_device_id = Some(id)`, our row is excluded, no warning. This is the only launch that ever worked.
2. **Every later launch** — register is refused, `self_device_id = None`, `live_siblings` excludes nothing, and our own binding — live, because heartbeats and successful auths refresh `lastSeenAt` — is reported as another instance.

The cost is not just noise. The situation the warning exists for (two installs taking turns evicting each other from the mediator's one socket per DID) is exactly the one it lost the ability to report, because the same sentence appeared when nothing was wrong.

## The fix

Identify ourselves by the DID we authenticate as, not by an id only a first launch is ever told.

- `DeviceRecord` gains `consumer_did` (`consumerDid`, which `to_wire_binding` has always emitted). A binding belongs to exactly one ACL entry, so a row naming our DID **is** us — exact, not a display-name heuristic, and true on every launch.
- `register` returns `Registration::{Claimed, AlreadyRegistered}` and treats the refusal as the ordinary case it is. Recognised across transports: the typed 409 over REST, and either registry spelling of the reject code over DIDComm/TSP — a VTA predating trustoverip/dtgwg-trust-tasks-tf#279 still emits the snake_case local part, and `vta-sdk`'s own `agent_session` matcher accepts both for the same reason.
- The device id stays as the fallback for a VTA whose rows omit `consumerDid`, and the listing recovers our own id so `PresenceReport::Registered` still names us the way a first launch does.

**Deliberately asymmetric:** an install that can identify itself by neither id nor DID reports everything live. A false "nobody else is here" is the worse error — it is the one that lets someone walk into the eviction loop believing they are alone.

## Tests

Six new cases in `openvtc-core/src/devices.rs`, including the reported regression pinned directly (`our_own_binding_is_ours_by_did_when_we_never_learned_its_id`), its converse (`another_dids_binding_is_still_a_sibling`), the safe-direction property (`an_unidentifiable_install_still_reports_what_is_live`), and the refusal matcher across both spellings and the typed conflict.

Full sweep: `cargo fmt`, `clippy --workspace --all-targets` (clean), `cargo test --workspace -- --include-ignored`, `RUSTDOCFLAGS="-D warnings" cargo doc`.

## Note for the VTA side

Because re-registration is refused, `displayName` is frozen at first registration — a host rename or profile rename never reaches the binding. Not addressed here; flagging it as a known consequence of the spec's non-idempotent register.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no new clients
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — read-only diagnostics
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — the non-idempotent register is now recognised as refused rather than retried
- [x] Accept/poll/listen loops survive transient errors (R1.5) — the presence loop still continues past a failed list or heartbeat
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — `consumerDid` is read, not minted; verified against the VTA's `to_wire_binding` (R3.6), and the record stays tolerant of unknown fields by design
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — an unidentifiable install reports everything live rather than suppressing
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — this is the fix: the warning no longer claims a second instance it has not distinguished from itself, and an already-registered refusal is no longer reported as an unavailable device slice
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no persisted state
- [x] Deviations from this guide flagged explicitly with rule numbers — none
```
