### PR TITLE
fix(log): report the mediator's scheduled reconnect as one calm line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The activity log reported the mediator's scheduled reconnect as a fault,
+  every twelve minutes.** The messaging stack reconnects on purpose: the
+  mediator's access token is refreshed at 80% of its ~900 s life and the SDK's
+  websocket transport re-establishes the socket as part of that refresh — one
+  drop per token per listener, back inside a second or two. That arrived as
+  `Listener '…' disconnected (no transport error reported)` followed by a
+  reconnect, which made the log's most alarming line the one it printed most
+  often. A real disconnect looked exactly like the routine one, so the line
+  stopped carrying information.
+
+  A drop is now held for 15 seconds before it is reported. If the listener
+  returns first, the pair becomes one calm line — `Listener '…' reconnected
+  after 2.1s` — which states what was observed and not a cause the transport
+  never surfaces. If it does not return, the line still appears and now says the
+  listener is *still* disconnected, which is the thing worth acting on. Nothing
+  is quietened that shouldn't be: the rapid-cycling warning still fires on the
+  drop itself, before any grace can absorb it, so duelling sockets shout as
+  loudly as before.
+
 - **Every launch after the first warned that the account was open somewhere
   else — naming this machine.** `device/register` is deliberately not
   idempotent: a `DeviceBinding` hangs off the caller's ACL entry, there is

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -162,6 +162,32 @@ const LIFECYCLE_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_m
 /// usually a duplicate connection fighting itself for one DID.
 const CYCLING_WINDOW: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// A drop that recovers within this is reported as a **reconnect**, not a fault.
+///
+/// The messaging stack reconnects on purpose, on a schedule. The mediator's
+/// access token lives ~900 s and the SDK's websocket transport refreshes it
+/// proactively at 80% of that, tearing the socket down and bringing it back as
+/// part of the refresh: one drop per token per listener, every ~12 minutes, back
+/// inside a second or two. That is the healthy steady state — it is what
+/// affinidi-tdk-rs #716 *reduced* the count to, from four — and it is not
+/// something an operator can act on.
+///
+/// Reporting it as `disconnected (no transport error reported)` made the
+/// activity log's most alarming line the one it printed most often, which is the
+/// failure mode that costs a real disconnect its meaning. So a drop is held
+/// briefly before it is reported: if the listener returns first, the pair
+/// becomes one calm line, and the `Disconnected` line keeps its meaning of "it
+/// is *still* down".
+///
+/// 15 s is chosen to sit far above what a refresh costs (1-2 s observed) and far
+/// below the supervisor's [`REBUILD_GRACE`] of 90 s, so nothing this suppresses
+/// is anything the supervisor would have acted on either.
+const RECONNECT_GRACE: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// How often held-back drops are re-examined. Bounds how late a real
+/// disconnect can be reported: [`RECONNECT_GRACE`] plus one of these.
+const PENDING_DROP_SWEEP: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Buffered connection transitions per subscriber. Transitions are rare (a
 /// listener connects, drops, reconnects), so this is generous; a subscriber that
 /// still lags reports the gap rather than silently missing a state change.
@@ -1505,6 +1531,17 @@ pub enum LifecycleLog {
         listener_id: String,
         error: Option<String>,
     },
+    /// A listener dropped and came back quickly — reported as the single event
+    /// it is, rather than as a fault followed by a recovery.
+    // Not an intra-doc link: `RECONNECT_GRACE` is private, and a public item
+    // linking to it fails `rustdoc -D warnings`.
+    /// The window is `RECONNECT_GRACE`.
+    Reconnected {
+        listener_id: String,
+        /// How long it was down, so the line is evidence rather than a claim
+        /// about why.
+        down_for: std::time::Duration,
+    },
     /// A listener dropped again within the cycling window — usually a duplicate
     /// connection fighting itself.
     CyclingRapidly { listener_id: String },
@@ -1518,45 +1555,137 @@ pub enum LifecycleLog {
     Missed { count: u64 },
 }
 
+/// A drop that has happened but has not been reported yet — see
+/// [`RECONNECT_GRACE`].
+#[derive(Debug, Clone)]
+struct HeldDrop {
+    at: std::time::Instant,
+    error: Option<String>,
+}
+
+/// Turns raw connection transitions into the lines an operator should see.
+///
+/// Split out of the logger task, and driven by an explicit `now`, because the
+/// interesting behaviour is entirely about *timing* — which is the one thing a
+/// spawned task with a real clock cannot be asked about in a test.
+#[derive(Debug, Default)]
+struct DropDebounce {
+    held: HashMap<String, HeldDrop>,
+    /// Drop timestamps, for the rapid-cycling heuristic. Independent of what is
+    /// held: cycling is about how often a listener drops, not about how the
+    /// drops are reported.
+    last_disconnect: HashMap<String, std::time::Instant>,
+}
+
+impl DropDebounce {
+    /// A listener dropped. Emits `CyclingRapidly` immediately when this is the
+    /// second drop inside [`CYCLING_WINDOW`] — a duelling connection is exactly
+    /// what must not be held back — and holds the drop itself.
+    fn on_disconnect(
+        &mut self,
+        listener_id: String,
+        error: Option<String>,
+        now: std::time::Instant,
+    ) -> Vec<LifecycleLog> {
+        let mut out = Vec::new();
+        if let Some(previous) = self.last_disconnect.get(&listener_id)
+            && now.duration_since(*previous) < CYCLING_WINDOW
+        {
+            tracing::warn!(
+                listener = %crate::display::truncate_did(&listener_id, 32),
+                "rapid disconnect cycling detected"
+            );
+            out.push(LifecycleLog::CyclingRapidly {
+                listener_id: listener_id.clone(),
+            });
+        }
+        self.last_disconnect.insert(listener_id.clone(), now);
+        // A second drop with one already held keeps the *earlier* timestamp:
+        // the listener has been down since then, and reporting the later one
+        // would restart a clock that never stopped.
+        self.held
+            .entry(listener_id)
+            .or_insert(HeldDrop { at: now, error });
+        out
+    }
+
+    /// A listener connected. One line either way: the pair when a held drop is
+    /// still inside its grace, a plain connect otherwise (a first connect, or a
+    /// recovery from an outage already reported).
+    fn on_connect(&mut self, listener_id: String, now: std::time::Instant) -> LifecycleLog {
+        match self.held.remove(&listener_id) {
+            Some(drop) if now.duration_since(drop.at) < RECONNECT_GRACE => {
+                LifecycleLog::Reconnected {
+                    listener_id,
+                    down_for: now.duration_since(drop.at),
+                }
+            }
+            _ => LifecycleLog::Connected { listener_id },
+        }
+    }
+
+    /// Drops that have outlived their grace: the listener is *still* down, so
+    /// now the line is worth printing.
+    fn due(&mut self, now: std::time::Instant) -> Vec<LifecycleLog> {
+        let expired: Vec<String> = self
+            .held
+            .iter()
+            .filter(|(_, drop)| now.duration_since(drop.at) >= RECONNECT_GRACE)
+            .map(|(id, _)| id.clone())
+            .collect();
+        expired
+            .into_iter()
+            .map(|listener_id| {
+                let drop = self.held.remove(&listener_id).expect("just listed");
+                LifecycleLog::Disconnected {
+                    listener_id,
+                    error: drop.error,
+                }
+            })
+            .collect()
+    }
+}
+
 /// Subscribe to listener lifecycle transitions and forward them as
 /// structured log events via the provided sender. Detects rapid reconnect
-/// cycling. Returns the spawned task handle.
+/// cycling, and coalesces the routine reconnect the mediator's token refresh
+/// performs into one line (see the private `RECONNECT_GRACE`). Returns the
+/// spawned task handle.
 pub fn spawn_lifecycle_logger(
     service: &Messaging,
     log_tx: mpsc::UnboundedSender<LifecycleLog>,
 ) -> tokio::task::JoinHandle<()> {
     let mut status_rx = service.subscribe();
     tokio::spawn(async move {
-        // Disconnect timestamps, for the rapid-cycling heuristic.
-        let mut last_disconnect: HashMap<String, std::time::Instant> = HashMap::new();
+        let mut debounce = DropDebounce::default();
+        let mut sweep = tokio::time::interval(PENDING_DROP_SWEEP);
 
         loop {
-            match status_rx.recv().await {
-                Ok(ListenerStatus::Connected { listener_id }) => {
-                    let _ = log_tx.send(LifecycleLog::Connected { listener_id });
-                }
-                Ok(ListenerStatus::Disconnected { listener_id, error }) => {
-                    let now = std::time::Instant::now();
-                    let _ = log_tx.send(LifecycleLog::Disconnected {
-                        listener_id: listener_id.clone(),
-                        error,
-                    });
-                    if let Some(previous_drop) = last_disconnect.get(&listener_id)
-                        && now.duration_since(*previous_drop) < CYCLING_WINDOW
-                    {
-                        tracing::warn!(
-                            listener = %crate::display::truncate_did(&listener_id, 32),
-                            "rapid disconnect cycling detected"
+            tokio::select! {
+                event = status_rx.recv() => match event {
+                    Ok(ListenerStatus::Connected { listener_id }) => {
+                        let _ = log_tx.send(
+                            debounce.on_connect(listener_id, std::time::Instant::now()),
                         );
-                        let _ = log_tx.send(LifecycleLog::CyclingRapidly {
-                            listener_id: listener_id.clone(),
-                        });
                     }
-                    last_disconnect.insert(listener_id, now);
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
-                    let _ = log_tx.send(LifecycleLog::Missed { count });
+                    Ok(ListenerStatus::Disconnected { listener_id, error }) => {
+                        for log in debounce.on_disconnect(
+                            listener_id,
+                            error,
+                            std::time::Instant::now(),
+                        ) {
+                            let _ = log_tx.send(log);
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
+                        let _ = log_tx.send(LifecycleLog::Missed { count });
+                    }
+                },
+                _ = sweep.tick() => {
+                    for log in debounce.due(std::time::Instant::now()) {
+                        let _ = log_tx.send(log);
+                    }
                 }
             }
         }
@@ -1927,6 +2056,196 @@ pub fn relationship_listener_config_from_secrets(
             crate::display::truncate_did(remote_p_did, 32)
         ),
         secrets,
+    }
+}
+
+#[cfg(test)]
+mod drop_debounce_tests {
+    use super::{CYCLING_WINDOW, DropDebounce, LifecycleLog, RECONNECT_GRACE};
+    use std::time::{Duration, Instant};
+
+    const LISTENER: &str = "did:webvh:QmListener";
+
+    /// The reported noise: one drop per mediator token, ~12 minutes apart, back
+    /// inside a couple of seconds. It must read as one reconnect, not as a
+    /// disconnect plus a recovery — and above all not as a fault, because there
+    /// is nothing an operator can do about a scheduled token refresh.
+    #[test]
+    fn a_routine_refresh_reconnect_is_one_calm_line() {
+        let mut debounce = DropDebounce::default();
+        let dropped = Instant::now();
+
+        assert!(
+            debounce
+                .on_disconnect(LISTENER.into(), None, dropped)
+                .is_empty(),
+            "a first drop is held, not reported"
+        );
+        assert!(
+            debounce.due(dropped + Duration::from_secs(1)).is_empty(),
+            "and stays held while it is still inside the grace"
+        );
+
+        let back = dropped + Duration::from_secs(2);
+        match debounce.on_connect(LISTENER.into(), back) {
+            LifecycleLog::Reconnected {
+                listener_id,
+                down_for,
+            } => {
+                assert_eq!(listener_id, LISTENER);
+                assert_eq!(down_for, Duration::from_secs(2));
+            }
+            other => panic!("expected one Reconnected line, got {other:?}"),
+        }
+
+        assert!(
+            debounce.due(back + RECONNECT_GRACE * 2).is_empty(),
+            "nothing is left to report once the pair has been reported"
+        );
+    }
+
+    /// The other half: a listener that does not come back must still be
+    /// reported, or the suppression would cost the log the one line that
+    /// matters.
+    #[test]
+    fn a_drop_that_does_not_recover_is_reported() {
+        let mut debounce = DropDebounce::default();
+        let dropped = Instant::now();
+        debounce.on_disconnect(LISTENER.into(), None, dropped);
+
+        assert!(
+            debounce
+                .due(dropped + RECONNECT_GRACE - Duration::from_millis(1))
+                .is_empty(),
+            "not yet — this is still within the grace"
+        );
+
+        let due = debounce.due(dropped + RECONNECT_GRACE);
+        assert!(
+            matches!(&due[..], [LifecycleLog::Disconnected { listener_id, error: None }] if listener_id == LISTENER),
+            "got {due:?}"
+        );
+        assert!(
+            debounce.due(dropped + RECONNECT_GRACE * 2).is_empty(),
+            "reported once, not on every sweep"
+        );
+    }
+
+    /// A transport error is the evidence for the line, so holding the drop must
+    /// not lose it.
+    #[test]
+    fn a_held_drop_keeps_its_transport_error() {
+        let mut debounce = DropDebounce::default();
+        let dropped = Instant::now();
+        debounce.on_disconnect(LISTENER.into(), Some("connection reset".into()), dropped);
+
+        let due = debounce.due(dropped + RECONNECT_GRACE);
+        assert!(
+            matches!(&due[..], [LifecycleLog::Disconnected { error: Some(e), .. }] if e == "connection reset"),
+            "got {due:?}"
+        );
+    }
+
+    /// A recovery after the outage was already reported is a plain connect —
+    /// the pair line would be a lie, because the drop was not brief.
+    #[test]
+    fn a_late_recovery_is_a_plain_connect() {
+        let mut debounce = DropDebounce::default();
+        let dropped = Instant::now();
+        debounce.on_disconnect(LISTENER.into(), None, dropped);
+        let _reported = debounce.due(dropped + RECONNECT_GRACE);
+
+        assert!(matches!(
+            debounce.on_connect(
+                LISTENER.into(),
+                dropped + RECONNECT_GRACE + Duration::from_secs(5)
+            ),
+            LifecycleLog::Connected { .. }
+        ));
+    }
+
+    /// A first connect has no drop behind it.
+    #[test]
+    fn a_first_connect_is_a_plain_connect() {
+        let mut debounce = DropDebounce::default();
+        assert!(matches!(
+            debounce.on_connect(LISTENER.into(), Instant::now()),
+            LifecycleLog::Connected { .. }
+        ));
+    }
+
+    /// Duelling sockets are exactly what must NOT be quietened: the cycling
+    /// warning fires on the drop, before any grace can absorb it.
+    #[test]
+    fn rapid_cycling_still_warns_immediately() {
+        let mut debounce = DropDebounce::default();
+        let first = Instant::now();
+        assert!(
+            debounce
+                .on_disconnect(LISTENER.into(), None, first)
+                .is_empty()
+        );
+        debounce.on_connect(LISTENER.into(), first + Duration::from_millis(500));
+
+        let second = first + Duration::from_secs(3);
+        let out = debounce.on_disconnect(LISTENER.into(), None, second);
+        assert!(
+            matches!(&out[..], [LifecycleLog::CyclingRapidly { listener_id }] if listener_id == LISTENER),
+            "a second drop inside the cycling window must warn at once, got {out:?}"
+        );
+    }
+
+    /// Two drops far enough apart are the healthy refresh cadence, not cycling.
+    #[test]
+    fn drops_outside_the_cycling_window_do_not_warn() {
+        let mut debounce = DropDebounce::default();
+        let first = Instant::now();
+        debounce.on_disconnect(LISTENER.into(), None, first);
+        debounce.on_connect(LISTENER.into(), first + Duration::from_secs(2));
+
+        let later = first + CYCLING_WINDOW + Duration::from_secs(1);
+        assert!(
+            debounce
+                .on_disconnect(LISTENER.into(), None, later)
+                .is_empty(),
+            "a drop outside the window is not cycling"
+        );
+    }
+
+    /// A second drop while one is already held must not restart the clock: the
+    /// listener has been down since the first, and re-dating it would let a
+    /// listener that drops every 14 s never be reported at all.
+    #[test]
+    fn a_repeated_drop_does_not_extend_the_grace() {
+        let mut debounce = DropDebounce::default();
+        let first = Instant::now();
+        debounce.on_disconnect(LISTENER.into(), None, first);
+        debounce.on_disconnect(LISTENER.into(), None, first + RECONNECT_GRACE / 2);
+
+        assert_eq!(
+            debounce.due(first + RECONNECT_GRACE).len(),
+            1,
+            "the hold is dated from the first drop"
+        );
+    }
+
+    /// Listeners are independent: one going quiet must not hold another's line.
+    #[test]
+    fn listeners_are_held_independently() {
+        let mut debounce = DropDebounce::default();
+        let now = Instant::now();
+        debounce.on_disconnect("a".into(), None, now);
+        debounce.on_disconnect("b".into(), None, now + RECONNECT_GRACE);
+
+        let due = debounce.due(now + RECONNECT_GRACE);
+        assert!(
+            matches!(&due[..], [LifecycleLog::Disconnected { listener_id, .. }] if listener_id == "a"),
+            "only the one past its grace, got {due:?}"
+        );
+        assert!(matches!(
+            debounce.on_connect("b".into(), now + RECONNECT_GRACE + Duration::from_secs(1)),
+            LifecycleLog::Reconnected { .. }
+        ));
     }
 }
 

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -129,17 +129,44 @@ pub(crate) fn format_lifecycle_log(
                 None => " (no transport error reported)".to_string(),
             };
             LifecycleLine {
-                summary: format!("Listener {} disconnected{reason}", who(config, listener_id)),
+                // "still" is load-bearing: a drop is held for the reconnect
+                // grace before it reaches here, so this line means the listener
+                // did not come back on its own, not merely that it dropped.
+                summary: format!(
+                    "Listener {} is still disconnected{reason}",
+                    who(config, listener_id)
+                ),
                 detail: Some(match error {
                     Some(e) => format!("{}\nerror: {e}", detail_for(config, listener_id)),
                     None => format!(
                         "{}\nerror: none reported — the connection closed without a transport \
-                         error",
+                         error, and did not come back within the reconnect grace period",
                         detail_for(config, listener_id)
                     ),
                 }),
             }
         }
+        LifecycleLog::Reconnected {
+            listener_id,
+            down_for,
+        } => LifecycleLine {
+            // One calm line for the pair. Says what was observed and nothing
+            // more: the *cause* is not on the wire, so naming one here would be
+            // a claim this code cannot back.
+            summary: format!(
+                "Listener {} reconnected after {:.1}s",
+                who(config, listener_id),
+                down_for.as_secs_f64()
+            ),
+            detail: Some(format!(
+                "{}\ndown for: {:.1}s\nA drop this brief is the expected reconnect: the \
+                 mediator's access token is refreshed before it expires and the socket is \
+                 re-established as part of that, roughly every 12 minutes per listener. A drop \
+                 that does not come back is reported as a disconnect instead.",
+                detail_for(config, listener_id),
+                down_for.as_secs_f64()
+            )),
+        },
         LifecycleLog::CyclingRapidly { listener_id } => LifecycleLine {
             summary: format!(
                 "WARNING: Listener {} cycling rapidly — possible duplicate connection",
@@ -3521,6 +3548,64 @@ mod tests {
                 .is_some_and(|d| d.contains("none reported")),
             "{:?}",
             line.detail
+        );
+    }
+
+    /// The routine reconnect gets one calm line. It used to arrive as a
+    /// disconnect *plus* a recovery every ~12 minutes — making the log's most
+    /// alarming line the one it printed most often, which is how a real
+    /// disconnect loses its meaning.
+    #[test]
+    fn a_brief_reconnect_reads_as_one_event_not_a_fault() {
+        const DID: &str = "did:webvh:QmScidDDDDDDDDDDDDDDDDDDDDDDDD:example.com:brief";
+        let config = crate::state_handler::dispatch_util::test_config();
+
+        let line = format_lifecycle_log(
+            &config,
+            &didcomm::LifecycleLog::Reconnected {
+                listener_id: DID.to_string(),
+                down_for: std::time::Duration::from_millis(2100),
+            },
+        );
+        assert!(
+            line.summary.contains("reconnected after 2.1s"),
+            "{}",
+            line.summary
+        );
+        assert!(
+            !line.summary.to_lowercase().contains("warning")
+                && !line.summary.contains("disconnected"),
+            "a routine reconnect must not read as a fault: {}",
+            line.summary
+        );
+        assert!(
+            line.detail
+                .as_deref()
+                .is_some_and(|d| d.contains("token is refreshed")),
+            "{:?}",
+            line.detail
+        );
+    }
+
+    /// A drop only reaches the log after the reconnect grace, so the line has to
+    /// say the listener is *still* down — otherwise it reads as the transient it
+    /// has already been proven not to be.
+    #[test]
+    fn a_reported_drop_says_it_is_still_down() {
+        const DID: &str = "did:webvh:QmScidEEEEEEEEEEEEEEEEEEEEEEEE:example.com:gone";
+        let config = crate::state_handler::dispatch_util::test_config();
+
+        let line = format_lifecycle_log(
+            &config,
+            &didcomm::LifecycleLog::Disconnected {
+                listener_id: DID.to_string(),
+                error: None,
+            },
+        );
+        assert!(
+            line.summary.contains("is still disconnected"),
+            "{}",
+            line.summary
         );
     }
 


### PR DESCRIPTION
## It is normal, and it should not have looked like a fault

```
[02:40:44] Listener 'did:webvh:QmeqJz…' connected
[02:40:42] Listener 'did:webvh:QmeqJz…' disconnected (no transpo…
[02:28:41] Listener 'did:webvh:QmeqJz…' connected
[02:28:40] Listener 'did:webvh:QmeqJz…' disconnected (no transpo…
[02:16:39] Listener 'did:webvh:QmeqJz…' connected
[02:16:37] Listener 'did:webvh:QmeqJz…' disconnected (no transpo…
```

12m02s apart, back inside 1–2 seconds. That is the messaging stack reconnecting **on purpose**: the mediator's access token lives ~900 s, the SDK's websocket transport refreshes it proactively at 80% of that, and re-establishing the socket is part of the refresh. One drop per token per listener is the healthy steady state — it is what affinidi-tdk-rs #716 reduced the count *to*, from four.

The cost of reporting it as a fault is not just noise. It made the log's most alarming line the one it printed most often, so a listener that is genuinely gone and a scheduled refresh rendered **identically** — the only way to tell them apart was to watch for the second line. That is how a real disconnect loses its meaning.

## The change

A drop is held for `RECONNECT_GRACE` (15 s) before it is reported.

- **Comes back first** → one line for the pair: `Listener '…' reconnected after 2.1s`.
- **Does not come back** → the `Disconnected` line still appears, and now says the listener is **still** disconnected — which is exactly what surviving the grace proves.

15 s sits far above what a refresh costs (1–2 s observed) and far below the supervisor's `REBUILD_GRACE` of 90 s, so nothing suppressed here is anything the supervisor would have acted on either.

**The line claims only what was observed.** The transport surfaces a *state*, not a cause — `ListenerStatus::Disconnected.error` is always `None` on the delivery layer — so naming the token refresh in the summary would be a claim this code cannot back. The explanation sits in the `Enter` detail view, hedged, where an operator who wants it can find it.

## Nothing that should be loud gets quieter

- `CyclingRapidly` is emitted from the **drop itself**, before any grace can absorb it, so two drops inside the cycling window still warn at once. Duelling sockets (openvtc#259) shout exactly as before — pinned by `rapid_cycling_still_warns_immediately`.
- A second drop while one is already held keeps the **earlier** timestamp, so a listener flapping just under the grace cannot dodge being reported by resetting the clock — `a_repeated_drop_does_not_extend_the_grace`.
- Listeners are held independently; one going quiet cannot hold another's line.
- Only the activity-log surface changes. The `ListenerStatus` broadcast the session manager and connection state consume is untouched.

## Testing the timing

The decision logic is a `DropDebounce` driven by an explicit `now`, not logic buried in the spawned task — the whole behaviour is about *timing*, which is the one thing a task holding a real clock cannot be asked about in a test. Nine cases pin it, including the two that matter: the routine reconnect collapsing to one line, and an outage still being reported.

Plus two rendering tests: the reconnect line reads as an event rather than a fault, and a reported drop says it is still down.

`cargo fmt`, `clippy --workspace --all-targets`, `cargo test --workspace -- --include-ignored`, `RUSTDOCFLAGS="-D warnings" cargo doc` — all clean. Rebased on main (post #261).

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — n/a
- [x] No lock held across a network await (R1.3) — the debounce holds no lock and does no I/O
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — n/a
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — reconnect/rebuild policy is unchanged; only its reporting moved
- [x] Accept/poll/listen loops survive transient errors (R1.5) — the logger loop keeps its Closed/Lagged arms, now under select! with the sweep
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — n/a, no wire types
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — this is the point: the reconnect line reports the observed downtime and no cause, and a drop that outlives the grace is still surfaced
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — the only state is in-memory reporting state; a death loses a log line, not a fact
- [x] Deviations from this guide flagged explicitly with rule numbers — none
```
