### PR TITLE
chore(deps): take vta-sdk 0.32 and vta-service 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -897,7 +897,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2705,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "did-git-sign"
 version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=462032cfd4adcec9bc00ee957e2e60b7e42c7dac#462032cfd4adcec9bc00ee957e2e60b7e42c7dac"
+source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=d2c091d795168357d8bf3d1c4fffce645f2415de#d2c091d795168357d8bf3d1c4fffce645f2415de"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -2816,7 +2816,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3118,7 +3118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5042,7 +5042,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5593,7 +5593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5903,7 +5903,7 @@ dependencies = [
  "aes-gcm 0.10.3",
  "aes-kw",
  "argon2 0.5.3",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -6387,7 +6387,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6954,7 +6954,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7012,7 +7012,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7667,7 +7667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7879,7 +7879,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7892,7 +7892,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8804,7 +8804,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vgi-core"
 version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=462032cfd4adcec9bc00ee957e2e60b7e42c7dac#462032cfd4adcec9bc00ee957e2e60b7e42c7dac"
+source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=d2c091d795168357d8bf3d1c4fffce645f2415de#d2c091d795168357d8bf3d1c4fffce645f2415de"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -8822,9 +8822,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vta-audit"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7b52eea6de7f1f6f439318c8373915ecaeb5e629f924442e49792cb1f35cd3"
+checksum = "44dfc15f430f88946d9d5e51c399466d5fd167a5e98b08492cc5a36103a68ac0"
 dependencies = [
  "async-trait",
  "tracing",
@@ -8835,9 +8835,9 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d85dad4ef9cb4eb4173d73f9b0e914ce8a02423f7c1add58ab21bc2c734e53e"
+checksum = "06ebe2bf5befdaa6dc6508aa0c91f8fe3b4b9f454c0f8771f780870b0b1abd6a"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -8863,9 +8863,9 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f69eed55985ca22c3d853a2b9c109d5e0325c425bb9c4af6bc78e347a5af548"
+checksum = "99fbda0ef51b72b83a904e4c23a57410bb3f417324389836530b876a7b1775c6"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -8890,9 +8890,9 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6ea0c404f464e523dee02ee41390722448a8594c6221d13e5b6026c1e395df"
+checksum = "f2f7460d682620da4bc1e266670273c39431eed305c4aac072091b1571aa91fd"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -8907,9 +8907,9 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a342c621e5adf6da124202c63e8d5a6ebb65248addb1f363568e6b2eda1ef00f"
+checksum = "8d443fc7cbfff9ceef6b170231268884d2861c812a3c7d35c7a2351ab8bdbeee"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -8941,18 +8941,18 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16bae9120d392e35a37fe7ca91af4096153875c9564d05c4490b847fd35b170"
+checksum = "dfa351226581a21904769b8a5afda65eae669ab8da5b52dcae2e94b3718196f2"
 dependencies = [
  "vti-common",
 ]
 
 [[package]]
 name = "vta-policy"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3e8b25bcac11ceb5bdeb27c2cce145a101c1b6b9a1394604cfcf2986c1d254"
+checksum = "0b360c5d30623464a511a9e5b81ae37abc1819bd96f60b15f8737aa87b458c8c"
 dependencies = [
  "hex",
  "multibase",
@@ -8970,9 +8970,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2818125eb879e7e0eb6781cfa2d5995295c9902eb0c8ee3ecf526eb2473af6ad"
+checksum = "8f3ea9dbdad04080277acd9a57224003a73bf1300980837228792620e2d46bb5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9021,9 +9021,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1faabaa26d3e83f0c0a2dfc88e186db5e217871d2624d8fea7e0515ed8f7c04f"
+checksum = "98b30050ba6b525df677325d525e95710da874968351fd2b8a8111d4c030b222"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9115,9 +9115,9 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2299220b9c74dbc18a0ec0da181118f1f75ee26ec1e53ccfd0dc2a95ab9dcf"
+checksum = "fa10c2dfbcdcb98f6d109e2b4c45963387f568d575f699f20f806f352be7e43a"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9136,9 +9136,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3ec960e21ff6d5b53f063e7f3c7fb6118fa9e037f21f511c51d5821d812917"
+checksum = "ba96705f6033cc969144f4bb2846cde9106aaa16820203f35f8ad2a93acf3005"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9151,9 +9151,9 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee819c5a5ce76339f1ef92c45c645a5eddf3642da5d0bb899556bb779f0247a6"
+checksum = "bce1901fadd56979db07518271f17197c48d619da86fbb8ceb2090225bd771b7"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9183,9 +9183,9 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e83d2449347afcd5fd4f98d6a7961cab81010ca9800f21ced25e3c02a5a89"
+checksum = "0e61c8c6b6b3f2d96cdae050ce6422198d45cfd5b8ef9fa2ef80f47c2c4f8cfe"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -9202,14 +9202,15 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2997c488b86b412273996c9c3f2996cdb49b33ba0f33b9c2a9797ec818444f1f"
+checksum = "5dfa515ec97e37cb1b978d3e7c006c81e004574f41b8c5ce60c8eb2c210d0e97"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-delivery",
+ "affinidi-secrets-resolver",
  "affinidi-tdk",
  "async-trait",
  "axum",
@@ -9245,9 +9246,9 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0be8da801005d62beee0147698c0081dd75b3caa19545e65189b7265527d3b6"
+checksum = "4038c534f077f7553ca0e27f16c49887fb6a3eba8bf80348b01f8b504202ee41"
 dependencies = [
  "hex",
  "serde",
@@ -9651,7 +9652,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,39 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # 0.25.1 beside 0.27.0. That is the third consecutive cycle it has done so — see
 # the floor note on `did-git-sign` in `openvtc/Cargo.toml`, which is where the
 # obligation is written down.
-vta-sdk = { version = "0.31", features = [
+#
+# 0.31 → 0.32 is the fifth. Two upstream edges declare `vta-sdk` and both had to
+# move first, because `"0.31"` on a 0.x crate excludes 0.32: `did-git-sign`
+# (VGI #33, whose head this workspace already patches to) and `vta-service`,
+# which `openvtc-core` dev-depends on for `MockVta` — 0.22 is built on 0.31, so
+# the dev graph would have split even with the shipped one clean. Both are moved
+# in this change. `trql-client`, the third git-pinned edge, does **not** depend
+# on `vta-sdk` at all, so trust-registry stays where it is.
+#
+# What 0.32 buys, all of it reaching this repo through calls it already makes:
+#
+# VTI #1184 + #1192 are one defect in two halves. `didcomm_transport` and
+# `tsp_transport` built every client with `identity: None`, so a dispatched
+# Trust Task carried no `issuer`, no `recipient` and no proof — which the VTA's
+# dispatch spine refuses as `malformedRequest` over DIDComm and, because the TSP
+# paths back-fill those two members, as `proofRequired` over TSP. Same bug, two
+# names, depending on transport. #1192 then stopped `address_trust_task`
+# rewriting `issuer`/`recipient` *after* signing, which had been turning a valid
+# proof into `proofInvalid` at the far end. Every Trust Task this repo dispatches
+# — agent names, devices, keys, join — goes through those transports.
+#
+# VTI #1193 lifts Trust-Task signing off `did:key`. The signer derived the
+# verification method as `<did>#<multibase>`, which only a `did:key` has, so a
+# provisioned `did:webvh` integration could not sign any of the 210
+# proof-requiring tasks. `ClientIdentity` gains `verification_method` for the
+# methods that must name one; the two sites here that built it by hand now use
+# `ClientIdentity::did_key`, which is the constructor for the one method whose
+# key *is* its identifier.
+#
+# VTI #1191 adds `device_heartbeat_named`, which is what lets this install
+# correct its own `displayName` — set once at registration and, until now,
+# unchangeable. Taken here; used in the follow-up.
+vta-sdk = { version = "0.32", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses
@@ -309,11 +341,15 @@ strip = "symbols"
 # `vti-common` 0.15, so the whole workspace fails to build.
 #
 # OpenVTC/verifiable-git-infrastructure#33 is the release that ends it — the VGI
-# workspace onto vta-sdk 0.31 and TDK 0.10, no source change, green on its own
+# workspace onto vta-sdk 0.32 and TDK 0.10, no source change, green on its own
 # pipeline. Its head is a better dependency than the stale published crate, so
 # this workspace takes it directly rather than waiting on the publish: the
 # requirement in `openvtc/Cargo.toml` still names `0.4.6` (the version VGI carries
 # at that rev), and this patch is what decides where that 0.4.6 comes from.
+#
+# The rev moved with the vta-sdk 0.32 bump. That is the whole reason this block
+# is cheap: a published `did-git-sign` would have made 0.32 wait on a full VGI
+# release cycle, as 0.23, 0.25 and 0.27 each did.
 #
 # Pinned by `rev`, never by `branch` — a further push to that PR must not silently
 # change what this builds against. VGI's own manifest pins `trql-client` the same
@@ -325,5 +361,5 @@ strip = "symbols"
 # it is still a dependency on an unmerged branch, which is a thing to unwind
 # rather than to keep.
 [patch.crates-io]
-did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "462032cfd4adcec9bc00ee957e2e60b7e42c7dac" }
-vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "462032cfd4adcec9bc00ee957e2e60b7e42c7dac" }
+did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "d2c091d795168357d8bf3d1c4fffce645f2415de" }
+vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "d2c091d795168357d8bf3d1c4fffce645f2415de" }

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -118,7 +118,7 @@ affinidi-messaging-test-mediator = "0.4"
 # ApproveScope, ContextDirection}` as its own public API, so a graph holding two
 # sdks has two distinct `ApproveScope` types that do not unify. VTI republished
 # this crate for exactly this reason (see its Cargo.toml note on `publish`).
-vta-service = { version = "0.22", default-features = false, features = ["test-support", "rest", "didcomm"] }
+vta-service = { version = "0.23", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc-core/tests/mockvta_bootstrap_e2e.rs
+++ b/openvtc-core/tests/mockvta_bootstrap_e2e.rs
@@ -102,11 +102,11 @@ async fn bootstrap_creates_top_context_and_lists_webvh_server() {
     let token = mock.ctx.mint_token(&admin.did, "admin", vec![]).await;
     let client = VtaClient::authenticated(
         mock.base_url(),
-        ClientIdentity {
-            client_did: admin.did.clone(),
-            private_key_multibase: admin.private_key_multibase().to_string(),
-            vta_did: mock.vta_did().to_string(),
-        },
+        ClientIdentity::did_key(
+            admin.did.clone(),
+            admin.private_key_multibase(),
+            mock.vta_did(),
+        ),
         token,
     )
     .await;
@@ -157,11 +157,11 @@ async fn persona_did_webvh_mint_round_trips() {
     let token = mock.ctx.mint_token(&admin.did, "admin", vec![]).await;
     let client = VtaClient::authenticated(
         mock.base_url(),
-        ClientIdentity {
-            client_did: admin.did.clone(),
-            private_key_multibase: admin.private_key_multibase().to_string(),
-            vta_did: mock.vta_did().to_string(),
-        },
+        ClientIdentity::did_key(
+            admin.did.clone(),
+            admin.private_key_multibase(),
+            mock.vta_did(),
+        ),
         token,
     )
     .await;

--- a/openvtc/src/state_handler/setup_vta_actions.rs
+++ b/openvtc/src/state_handler/setup_vta_actions.rs
@@ -460,13 +460,22 @@ pub(crate) async fn handle_vta_start_provision(
                     // ClientIdentity". `connect_auto`'s REST arm builds exactly
                     // this; this branch is hand-rolled only because the wizard
                     // needs the token itself to cache.
+                    //
+                    // `did_key`, not a struct literal: vta-sdk 0.32 lifted
+                    // Trust-Task signing off `did:key` (VTI #1193), so an
+                    // identity now says which verification method its proof
+                    // names — `None` meaning "derive it", which only a
+                    // `did:key` can. Provisioning mints the admin as a
+                    // `did:key` (the bootstrap e2e asserts it), so this is the
+                    // constructor that fits, and it puts that assumption in the
+                    // call rather than leaving it implicit in an absent field.
                     VtaClient::authenticated(
                         &vta_url,
-                        ClientIdentity {
-                            client_did: admin.admin_did.clone(),
-                            private_key_multibase: admin.admin_private_key_mb.clone(),
-                            vta_did: vta_did.clone(),
-                        },
+                        ClientIdentity::did_key(
+                            admin.admin_did.clone(),
+                            admin.admin_private_key_mb.clone(),
+                            vta_did.clone(),
+                        ),
                         token_result.access_token,
                     )
                     .await


### PR DESCRIPTION
Takes the VTI release cut by [verifiable-trust-infrastructure#1187](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1187).

## What it buys, all of it on paths this repo already uses

**VTI #1184 + #1192 — one defect in two halves.** `didcomm_transport` and `tsp_transport` built every client with `identity: None`, so a dispatched Trust Task carried no `issuer`, no `recipient` and no proof. The VTA's dispatch spine refuses that as `malformedRequest` over DIDComm and — because the TSP paths back-fill those two members — as `proofRequired` over TSP. Same bug, two names, depending on transport. #1192 then stopped `address_trust_task` rewriting `issuer`/`recipient` *after* signing, which had been turning a valid proof into `proofInvalid` at the far end.

Every Trust Task this repo dispatches — agent names, devices, keys, join — goes through those transports.

**VTI #1193** lifts Trust-Task signing off `did:key`. The signer derived the verification method as `<did>#<multibase>`, which only a `did:key` has, so a provisioned `did:webvh` integration could not sign any of the 210 proof-requiring tasks.

**VTI #1191** adds `device_heartbeat_named` — what lets this install correct its own `displayName`, set once at registration and until now unchangeable. Taken here, used in the follow-up.

## Two upstream edges had to move first

`vta-sdk` is 0.x, so a requirement of `"0.31"` **excludes** 0.32: any consumer that keeps one ends up with two copies in the graph, and they don't unify.

| Edge | Was | Now |
|---|---|---|
| `did-git-sign` / `vgi-core` | patched to VGI #33 @ `462032c` (vta-sdk 0.31) | patched to VGI #33 @ `d2c091d` (vta-sdk 0.32) |
| `vta-service` (MockVta dev-dep) | 0.22, built on vta-sdk 0.31 | 0.23 |
| its eleven siblings | vta-audit 0.3.0, vta-keys 0.4.0, … | 0.3.1, 0.4.1, … |
| `trql-client` (trust-registry) | pinned rev | **unchanged** |

- **did-git-sign** is the fifth consecutive cycle this crate has been the thing in the way — 0.23, 0.25, 0.27, 0.31, 0.32 — and the second where the patch block absorbed it instead of a full VGI release cycle. The VGI side is [verifiable-git-infrastructure#33](https://github.com/OpenVTC/verifiable-git-infrastructure/pull/33), which now carries the 0.32 bump (manifest + lockfile, no source change, green on its own pipeline).
- **vta-service** matters because leaving it at 0.22 splits the **dev** graph while the shipped one looks clean — the exact shape the note above `trust-tasks-rs` records from the 0.6 → 0.9 move. Its siblings had to follow too: the versions cargo had locked also ask for vta-sdk 0.31, so updating only the two named crates left 0.31.1 in the tree.
- **trust-registry does not need a commit.** `trql-client` doesn't depend on `vta-sdk` at all — its dependencies are `trust-tasks-rs`, the TDK and the messaging SDK. (The `vta-sdk = "0.31"` line in that repo is its workspace table, used by other crates there.) Nothing else moves either: vta-sdk 0.32 keeps trust-tasks-rs 0.17, affinidi-tdk 0.10 and affinidi-messaging-sdk 0.21.

## The one source change

`ClientIdentity` gained `verification_method` (#1193), so the two sites that built it as a struct literal now use `ClientIdentity::did_key`.

Not purely mechanical: that constructor is for the one DID method whose key *is* its identifier, which is exactly what both sites have — provisioning mints the admin as a `did:key`, and the bootstrap e2e asserts `admin_did.starts_with("did:key:")`. The assumption now sits in the call instead of being implicit in a field that happens to be absent.

## Verification

- `cargo tree -d -e normal,build,dev` — no `vta-sdk`, `trust-tasks-rs`, `affinidi-tdk`, `affinidi-messaging-sdk`, `vti-common` or `vta-service` duplicate. One `vta-sdk v0.32.0`.
- `cargo test --workspace -- --include-ignored` — this is what actually exercises the bumped server, through the MockVta suites; a green `Test` job alone would say nothing about them.
- fmt, `clippy --workspace --all-targets`, `RUSTDOCFLAGS="-D warnings" cargo doc`, and `cargo deny check sources` (which the moved git rev has to keep passing).

## Still to unwind

The `[patch.crates-io]` block stays until VGI publishes 0.4.7 — now on vta-sdk 0.32 — at which point it is deleted and the floor in `openvtc/Cargo.toml` names that release. VGI #33 can't publish while it pins `trql-client` by git (cargo publish rejects git deps), which waits on affinidi-trust-registry-rs#128. Unchanged by this PR; recorded so it doesn't get lost.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — no new clients
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — no flow changes
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — unchanged
- [x] Accept/poll/listen loops survive transient errors (R1.5) — unchanged
- [x] Acks/deletes happen only after durable handoff (R1.6) — unchanged
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — none authored here; the point of the bump is that the SDK now emits the envelope members the spec requires (R3.6: verified against the current services, which is what the MockVta suites run)
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — n/a
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — unchanged
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — no mutations
- [x] Deviations from this guide flagged explicitly with rule numbers — none. The git-patched dependency is pre-existing and documented in the manifest with its unwind condition
```
