### PR TITLE
feat(devices): send this install's current name on the heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A renamed machine kept announcing its old name.** `displayName` is written
+  once, at registration, and `device/register` is intentionally refused from the
+  second launch on — so nothing could ever change it. Rename the machine, or run
+  the install under a different profile, and its binding went on identifying it
+  by a name that no longer picked it out of the list the name exists for.
+
+  The heartbeat now carries the current name (vta-sdk 0.32 /
+  `device_heartbeat_named`), which the VTA applies only when it differs and only
+  to the binding the caller authenticated as. A drift spotted in the listing is
+  corrected immediately rather than on the next beat: the correction only travels
+  on a heartbeat, so an install opened and closed inside five minutes would
+  otherwise never send one and the stale name would outlive every launch.
+
 - **The activity log reported the mediator's scheduled reconnect as a fault,
   every twelve minutes.** The messaging stack reconnects on purpose: the
   mediator's access token is refreshed at 80% of its ~900 s life and the SDK's

--- a/openvtc-core/src/devices.rs
+++ b/openvtc-core/src/devices.rs
@@ -250,17 +250,41 @@ fn is_already_registered(e: &vta_sdk::error::VtaError) -> bool {
     msg.contains("alreadyRegistered") || msg.contains("already_registered")
 }
 
-/// Refresh this install's `lastSeenAt`.
+/// Refresh this install's `lastSeenAt`, and its `displayName` if it has drifted.
+///
+/// The name rides here because there is nowhere else it can. It is written once,
+/// at registration, and [`register`] is refused from the second launch on — so a
+/// renamed machine, or a profile renamed under it, would otherwise announce a
+/// name that no longer picks it out of the list the name exists for. The VTA
+/// applies it only when it differs, and only to the binding the caller
+/// authenticated as (VTI #1191).
+///
+/// Sent on every beat rather than only when we believe it changed: this side
+/// cannot know what the maintainer holds without asking, the payload is one short
+/// string on a five-minute timer, and a correction that depends on a local
+/// belief is one that stays wrong when the belief is.
 ///
 /// # Errors
 ///
 /// Any VTA failure.
-pub async fn heartbeat(client: &VtaClient) -> Result<(), OpenVTCError> {
+pub async fn heartbeat(client: &VtaClient, profile: &str) -> Result<(), OpenVTCError> {
     client
-        .device_heartbeat(Some(std::env::consts::OS))
+        .device_heartbeat_named(Some(std::env::consts::OS), Some(&display_name(profile)))
         .await
         .map(|_| ())
         .map_err(|e| OpenVTCError::Vta(format!("device heartbeat failed: {e}")))
+}
+
+/// Whether `row` — this install's own binding — is showing a stale name.
+///
+/// Split out so the presence loop can correct a drifted name *promptly* instead
+/// of waiting out a heartbeat interval. That matters more than it sounds: the
+/// correction only travels on a heartbeat, so an install that is opened and
+/// closed inside five minutes would never send one, and the stale name would
+/// survive every launch.
+#[must_use]
+pub fn name_correction_due(row: &DeviceRecord, profile: &str) -> bool {
+    row.display_name != display_name(profile)
 }
 
 /// Every device registered against this account.
@@ -507,6 +531,45 @@ mod tests {
             consumer_kind(),
             serde_json::json!({ "kind": "companion", "formFactor": "desktop" })
         );
+    }
+
+    /// A machine renamed since it registered is the case this exists for:
+    /// `displayName` is written once and re-registration is refused, so without
+    /// a correction the binding announces the old name forever.
+    #[test]
+    fn a_drifted_name_is_a_correction_due() {
+        let mut row = record("dev-1", Some(Utc::now()));
+        row.display_name = "OpenVTC on old-host (default)".to_string();
+        assert!(name_correction_due(&row, "default"));
+    }
+
+    /// And the steady state must be quiet: a name that already matches is not a
+    /// correction, or every listing would fire a heartbeat.
+    #[test]
+    fn a_current_name_is_not_a_correction() {
+        let mut row = record("dev-1", Some(Utc::now()));
+        row.display_name = display_name("default");
+        assert!(!name_correction_due(&row, "default"));
+    }
+
+    /// The profile is half the name, so switching profiles on one machine
+    /// drifts it just as a hostname change does.
+    #[test]
+    fn the_profile_half_of_the_name_drifts_too() {
+        let mut row = record("dev-1", Some(Utc::now()));
+        row.display_name = display_name("work");
+        assert!(name_correction_due(&row, "personal"));
+        assert!(!name_correction_due(&row, "work"));
+    }
+
+    /// A binding the VTA returned with no name at all still needs correcting —
+    /// `label()` would fall back to the device id, which is not a name anyone
+    /// can pick their laptop out of a list with.
+    #[test]
+    fn a_nameless_binding_is_a_correction_due() {
+        let mut row = record("dev-1", Some(Utc::now()));
+        row.display_name = String::new();
+        assert!(name_correction_due(&row, "default"));
     }
 
     #[test]

--- a/openvtc/src/state_handler/device_presence.rs
+++ b/openvtc/src/state_handler/device_presence.rs
@@ -14,6 +14,11 @@
 //! instance while the first is running. Listing on each heartbeat costs one
 //! extra trust task per interval and turns the mediator's mutual-eviction loop
 //! from a mystery into a sentence.
+//!
+//! The listing has a second use: it is where this install sees the name its own
+//! binding is showing. `displayName` is written once, at registration, and
+//! re-registration is refused — so the heartbeat is the only thing that can
+//! correct a machine that has been renamed since.
 
 use openvtc_core::devices::{self, DeviceRecord};
 use std::collections::BTreeSet;
@@ -89,26 +94,38 @@ pub async fn run(
     loop {
         match devices::list(&client).await {
             Ok(all) => {
+                let mine = all
+                    .iter()
+                    .find(|d| d.is_self(self_id.as_deref(), self_did.as_deref()));
+
                 // Recover our own id from the listing when registration did not
                 // hand it to us, so the loop names us the same way a first launch
                 // does — and so a VTA that stops returning `consumerDid` still
                 // has the id to fall back on.
                 if self_id.is_none()
-                    && let Some(mine) = all
-                        .iter()
-                        .find(|d| d.is_self(None, self_did.as_deref()))
-                        .map(|d| d.device_id.clone())
+                    && let Some(recovered) = mine.map(|d| d.device_id.clone())
                 {
-                    debug!(device_id = %mine, "recovered this install's binding from the listing");
+                    debug!(device_id = %recovered, "recovered this install's binding from the listing");
                     if tx
                         .send(PresenceReport::Registered {
-                            device_id: mine.clone(),
+                            device_id: recovered.clone(),
                         })
                         .is_err()
                     {
                         return;
                     }
-                    self_id = Some(mine);
+                    self_id = Some(recovered);
+                }
+
+                // Correct a drifted `displayName` now rather than on the next
+                // beat. The name only travels on a heartbeat, so an install
+                // opened and closed inside one interval would never send one and
+                // the stale name would outlive every launch.
+                if mine.is_some_and(|d| devices::name_correction_due(d, &profile)) {
+                    debug!("this install's binding shows a stale name; correcting it");
+                    if let Err(e) = devices::heartbeat(&client, &profile).await {
+                        debug!("name correction failed; it will retry on the next beat: {e}");
+                    }
                 }
                 let live = devices::live_siblings(
                     &all,
@@ -128,7 +145,7 @@ pub async fn run(
         if tx.is_closed() {
             return;
         }
-        if let Err(e) = devices::heartbeat(&client).await {
+        if let Err(e) = devices::heartbeat(&client, &profile).await {
             // A missed beat is recoverable — the liveness window tolerates one
             // — so this is debug, not a warning the user needs to see.
             debug!("device heartbeat failed: {e}");


### PR DESCRIPTION
The client half of [verifiable-trust-infrastructure#1191](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1191), unblocked by #263.

## The gap

`displayName` is written once, at registration, and `device/register` is intentionally refused from the second launch on (`device/register:alreadyRegistered`) — so nothing this install could do would ever change it. Rename the machine, or run the install under a different profile, and its binding goes on identifying it by a name that no longer picks it out of the list the name exists for.

## The change

The heartbeat carries the current name through `device_heartbeat_named`. The VTA applies it only when it differs, and only to the binding the caller authenticated as, so this cannot touch another device's row.

Two decisions worth stating:

**Sent on every beat, not only when we think it changed.** This side cannot know what the maintainer holds without asking. The payload is one short string on a five-minute timer, and a correction that depends on a local belief is one that stays wrong exactly when the belief is.

**A drift seen in the listing is corrected immediately, not on the next beat.** Not an optimisation — the name only travels on a heartbeat, so an install opened and closed inside one interval would never send one and the stale name would survive every launch. That is precisely the case a rename produces: you rename the machine, restart, and look at the list. The listing is already fetched for the sibling check and our own row already identified there by `consumerDid`, so this costs nothing new on the wire.

## Tests

`name_correction_due` is a pure predicate, so the drift cases are pinned directly: a renamed host, a switched profile (the name is host *and* profile, so both drift it), a binding the VTA returned with no name at all, and — the one that keeps the steady state quiet — a name that already matches, which must not fire a heartbeat on every listing.

Full sweep: `cargo fmt`, `clippy --workspace --all-targets`, `cargo test --workspace -- --include-ignored`, `RUSTDOCFLAGS="-D warnings" cargo doc`.

## Pre-merge checklist

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2) — reuses the presence task's client; the trust task keeps the SDK's DEVICE_TT_TIMEOUT
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect, or the flow is resumable with an idempotency key (R2.1) — nothing is persisted locally; the name is re-sent every beat, so a lost correction self-heals
- [x] Every retry is bounded + backed off; non-idempotent ops are not blind-retried (R1.4) — the immediate correction is one attempt, and a failure falls through to the ordinary interval rather than looping
- [x] Accept/poll/listen loops survive transient errors (R1.5) — a failed correction is logged at debug and the loop continues; the heartbeat's own failure handling is unchanged
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types: camelCase, deny_unknown_fields where security-relevant, schema registered, all consumers (incl. JS) updated (R3.*) — none authored here; the `ext` member and its key are defined in vta-sdk and validated against the generated ExtKey pattern on the VTA side
- [x] Config absence = most restrictive; fail-closed if enforcement can't start (R5.*) — a VTA that does not understand the extension ignores it and the name stays as it was
- [x] Logs/status claim only what was verified; background-job failures are surfaced (R6.*) — the correction logs at debug either way; nothing claims the name was applied, because only the VTA decides that
- [x] "Process dies on the next line" answered for every mutation touched (R2.1) — the only mutation is at the VTA, and it is idempotent: the next beat sends the same name
- [x] Deviations from this guide flagged explicitly with rule numbers — none
```
