### PR TITLE
fix(vrc): give a relationship credential its own identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A relationship credential carried no identifier of its own.** `new_vrc`
+  leaves `id` unset, so every VRC this client issued went out without one. A
+  credential with no identifier cannot be stored under one — a peer keying
+  relationship credentials by `id` cannot make a re-issue idempotent, tell a
+  renewal from a duplicate, or reference the VRC from a witness credential's
+  `digest`.
+
+  Nothing rejects a VRC for it today, which is the point: that is exactly what
+  the reciprocal membership credential looked like right up until a community
+  started keying on it and every delivery began failing silently. VRC issuance
+  now goes through `openvtc_core::vrc::new_identified_vrc`, which sets a fresh
+  `urn:uuid:` id — before signing, since a Data Integrity proof covers it and
+  one added afterwards would leave a document whose proof no longer verifies.
+
 - **A renamed machine kept announcing its old name.** `displayName` is written
   once, at registration, and `device/register` is intentionally refused from the
   second launch on — so nothing could ever change it. Rename the machine, or run

--- a/openvtc-core/src/vrc.rs
+++ b/openvtc-core/src/vrc.rs
@@ -224,9 +224,69 @@ impl VRCRequestReject {
     }
 }
 
+/// Build an unsigned VRC that carries its own identifier.
+///
+/// `DTGCredential::new_vrc` leaves `id` unset, and a credential with no
+/// identifier cannot be stored under one — so a peer that keys relationship
+/// credentials by `id` cannot make a re-issue idempotent, tell a renewal from a
+/// duplicate, or reference this VRC from a witness credential's `digest`.
+///
+/// Nothing rejects a VRC for a missing `id` *today*. That is exactly what the
+/// reciprocal membership credential looked like, right up until a community
+/// started keying on it and every delivery began failing silently — so this is
+/// a gap being closed before it bites rather than after.
+///
+/// The id is set here, before signing, because it has to be: a Data Integrity
+/// proof covers every member but `proof`, so one spliced in afterwards leaves a
+/// document whose proof no longer verifies. Building and identifying in one
+/// call is what stops the two being separated later.
+pub fn new_identified_vrc(
+    issuer: &str,
+    subject: &str,
+    valid_from: chrono::DateTime<chrono::Utc>,
+    valid_until: Option<chrono::DateTime<chrono::Utc>>,
+) -> DTGCredential {
+    DTGCredential::new_vrc(
+        issuer.to_string(),
+        subject.to_string(),
+        valid_from,
+        valid_until,
+    )
+    .with_id(format!("urn:uuid:{}", uuid::Uuid::new_v4()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A VRC must carry a top-level `id`, distinct from
+    /// `credentialSubject.id` (which names the *subject*).
+    #[test]
+    fn an_issued_vrc_carries_its_own_identifier() {
+        let vrc = new_identified_vrc(
+            "did:key:zIssuerR",
+            "did:key:zSubjectR",
+            chrono::Utc::now(),
+            None,
+        );
+        let value = serde_json::to_value(&vrc).expect("serialise");
+
+        let id = value["id"].as_str().expect("a top-level id");
+        assert!(id.starts_with("urn:uuid:"), "got {id}");
+        assert_eq!(value["credentialSubject"]["id"], "did:key:zSubjectR");
+        assert_eq!(value["issuer"], "did:key:zIssuerR");
+    }
+
+    /// Two issuances must not collide, or a peer keying by `id` would read
+    /// every re-issue as a repeat of the first.
+    #[test]
+    fn each_issued_vrc_gets_a_fresh_identifier() {
+        let now = chrono::Utc::now();
+        let a = new_identified_vrc("did:key:zI", "did:key:zS", now, None);
+        let b = new_identified_vrc("did:key:zI", "did:key:zS", now, None);
+        assert_ne!(a.id(), b.id());
+        assert!(a.id().is_some());
+    }
 
     #[test]
     fn test_vrcs_default_empty() {

--- a/openvtc/src/state_handler/inbox_actions.rs
+++ b/openvtc/src/state_handler/inbox_actions.rs
@@ -699,7 +699,6 @@ async fn prepare_accept_vrc_request(
     state: &mut State,
     task_id: &str,
 ) -> Result<InboxJob> {
-    use dtg_credentials::DTGCredential;
     use openvtc_core::vrc::DtgCredentialMessage;
 
     let task_id = Arc::new(task_id.to_string());
@@ -742,12 +741,20 @@ async fn prepare_accept_vrc_request(
     // a VRC issued under a relationship DID was rejected. Lifted in
     // OpenVTC/verifiable-trust-infrastructure#1061.
     let valid_from = Utc::now();
-    let mut vrc = DTGCredential::new_vrc(
-        our_r_did.to_string(),
-        their_r_did.to_string(),
-        valid_from,
-        None,
-    );
+    // The VRC carries its own identifier, set before signing.
+    //
+    // Same shape as the membership-credential bug: `new_vrc` leaves `id`
+    // unset, and a credential with no identifier cannot be stored under one —
+    // so a peer that keys relationship credentials by `id` cannot make a
+    // re-issue idempotent, tell a renewal from a duplicate, or reference this
+    // VRC from a witness credential. Nothing rejects a VRC for it *today*,
+    // which is exactly what the reciprocal VMC looked like right up until a
+    // community started keying on it.
+    //
+    // Before signing, necessarily: a Data Integrity proof covers every member
+    // but `proof`, so an id spliced in afterwards leaves a document whose
+    // proof no longer verifies.
+    let mut vrc = openvtc_core::vrc::new_identified_vrc(&our_r_did, &their_r_did, valid_from, None);
     // `our_did` is the persona DID for a relationship established without a
     // dedicated R-DID, so sign as whichever identity it actually is — the same
     // discriminator `listener_id_for_did` routes sends on.


### PR DESCRIPTION
`DTGCredential::new_vrc` leaves `id` unset, so every VRC this client has issued went out without one.

A credential with no identifier cannot be stored under one. A peer that keys relationship credentials by `id` cannot make a re-issue idempotent, cannot tell a renewal from a duplicate, and cannot reference the VRC from a witness credential's `digest`.

## Why now, when nothing rejects it

Nothing rejects a VRC for a missing `id` today. That is the reason to fix it, not the reason to wait.

It is exactly what the reciprocal membership credential looked like — right up until a community started keying on it, at which point every delivery failed, silently, on both sides (openvtc#260, dtg-credentials#12). The same latent shape, one credential type over. Closing it before it bites costs a line; closing it after cost two repos and a release.

## The change

Issuance goes through a new `openvtc_core::vrc::new_identified_vrc`, which builds and identifies in one call.

Set **before signing**, necessarily: a Data Integrity proof covers every member but `proof`, so an id added afterwards leaves a document whose proof no longer verifies. Building and identifying together is what stops the two being separated by a later edit — the previous construction was `new_vrc(...)` followed some lines later by `sign(...)`, with nothing tying them.

The helper also gives the behaviour a seam to test through. The old construction was inline in a TUI action that needs a live relationship, a persona keyring and a signing secret to reach, which is why it had no coverage.

## Tests

Two: an issued VRC carries a top-level `urn:uuid:` id distinct from `credentialSubject.id` (which names the *subject* — a different property that has always been set, and the reason this gap was easy to miss); and two issuances do not collide, since a fixed id would make every re-issue read as a repeat of the first.

`cargo test -p openvtc-core --lib vrc::` 8/8, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` clean.

Note: this and the other two openvtc changes in flight all add a bullet to the shared `CHANGELOG.md`, so whichever merges second and third will need a trivial rebase there.