### PR TITLE
feat(join): close the join request with the reciprocal membership credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A reciprocal membership credential never closed the join request it
+  answered.** `vtc/members/vmc/0.1` carries an optional `requestId` — the
+  retired `join-requests/accept` semantics — and this client always sent
+  `None`, so a community's join request sat `Approved` indefinitely after the
+  member was admitted and had sent their half back.
+
+  Not an oversight in the wire body: the id was *destroyed* before anything
+  could read it. `activate` replaces `Pending { request_id }` with `Active`, so
+  by the time the caller looked there was nothing to find.
+  `handle_credential_issue` now returns a `CredentialIssueOutcome` (modelled on
+  the `StatusOutcome` beside it) reporting the join it closed, captured before
+  activation, and admission sends the reciprocal VMC naming it.
+
+  **Behaviour change:** receiving the community's membership credential now
+  auto-issues ours back. That is what admission means — membership is a pair,
+  and the community is holding the request open waiting for our half — and this
+  client already auto-answers `members/request-vmc` the same way. Best-effort:
+  a failure is logged and leaves the join open, recoverable by issuing manually
+  or by the community asking.
+
 - **A relationship credential carried no identifier of its own.** `new_vrc`
   leaves `id` unset, so every VRC this client issued went out without one. A
   credential with no identifier cannot be stored under one — a peer keying

--- a/openvtc-core/src/members.rs
+++ b/openvtc-core/src/members.rs
@@ -42,9 +42,19 @@ pub async fn issue_and_send_member_vmc(
     member_did: &str,
     vtc_did: &str,
     mediator_did: &str,
+    closes_request: Option<Uuid>,
 ) -> Result<Uuid, OpenVTCError> {
     let vc = build_member_vmc(signing_secret, member_did, vtc_did).await?;
-    submit_member_vmc(atm, profile, member_did, vtc_did, mediator_did, vc).await
+    submit_member_vmc(
+        atm,
+        profile,
+        member_did,
+        vtc_did,
+        mediator_did,
+        vc,
+        closes_request,
+    )
+    .await
 }
 
 /// Build + sign the reciprocal member VMC, without sending it. The signing half of
@@ -97,14 +107,19 @@ pub async fn submit_member_vmc(
     vtc_did: &str,
     mediator_did: &str,
     vc: Value,
+    closes_request: Option<Uuid>,
 ) -> Result<Uuid, OpenVTCError> {
-    // `request_id` closes an *approved join request* as a side effect of the
-    // delivery. Neither caller here is join-time — this is the manual "issue
-    // VMC" action and the auto-answer to a VTC `members/request-vmc` — so the
-    // delivery carries no request to close.
+    // `closes_request` closes an *approved join request* as a side effect of
+    // the delivery — `vtc/members/vmc/0.1`'s `requestId`, carrying the retired
+    // `join-requests/accept` semantics.
+    //
+    // It is `Some` only on the join-time delivery, where the community is
+    // still holding the request open waiting for our half. The manual "issue
+    // VMC" action and the auto-answer to a `members/request-vmc` have no
+    // request to close, and pass `None`.
     let body = serde_json::to_value(MemberVmcBody {
         vc,
-        request_id: None,
+        request_id: closes_request.map(|id| id.to_string()),
     })
     .map_err(|e| OpenVTCError::Config(format!("member vmc body serialize: {e}")))?;
 

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -215,6 +215,38 @@ pub fn handle_join_submit_receipt(
     true
 }
 
+/// What a `credential-exchange/issue` did, beyond mutating the account.
+///
+/// A `bool` could not carry the one thing the caller needs: membership between
+/// a persona and a VTC is a *pair* of credentials, and receiving the
+/// community's half is the moment the member owes theirs back. Closing the
+/// join that way is what `vtc/members/vmc/0.1`'s `requestId` is for.
+///
+/// The id has to be reported from here because activation destroys it —
+/// `activate` replaces `Pending { request_id }` with `Active`, so by the time
+/// the caller looks, there is nothing to read. That is why every reciprocal
+/// VMC this client has ever sent carried `requestId: None`, leaving the
+/// community's join request sitting `Approved` forever.
+///
+/// Modelled on [`StatusOutcome`], for the same reason it exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CredentialIssueOutcome {
+    /// A record changed and the config needs saving.
+    pub changed: bool,
+    /// The membership just went Active, closing this join request — the
+    /// persona that owes the community its reciprocal VMC, and the request id
+    /// that delivery should name. `None` when this credential did not admit
+    /// anyone (a role VEC on an already-active membership, say).
+    pub closed_join: Option<(PersonaId, uuid::Uuid)>,
+}
+
+impl CredentialIssueOutcome {
+    pub const NONE: CredentialIssueOutcome = CredentialIssueOutcome {
+        changed: false,
+        closed_join: None,
+    };
+}
+
 /// Outcome of applying a VTC `join-requests/status-response` to a community.
 pub struct StatusOutcome {
     /// The community record changed and the config needs saving.
@@ -595,8 +627,15 @@ pub fn handle_join_trust_task_error(
 /// matching community and, for the membership credential (VMC), flip the
 /// membership to `Active`. The issuing VTC is the authcrypt sender; the
 /// credential must be issued by that VTC and to the community's own persona
-/// (anti-misdelivery). Returns `true` if a record was updated.
-pub fn handle_credential_issue(account: &mut Account, message: &Message, from_did: &str) -> bool {
+/// (anti-misdelivery).
+///
+/// See [`CredentialIssueOutcome`] for why this reports the join request it
+/// closed rather than just whether anything changed.
+pub fn handle_credential_issue(
+    account: &mut Account,
+    message: &Message,
+    from_did: &str,
+) -> CredentialIssueOutcome {
     // The known-holder delivery carries the VC at `credential_response.credential`.
     // `sealed` issues (invite / air-gap) are not handled here.
     let Some(credential) = message
@@ -606,7 +645,7 @@ pub fn handle_credential_issue(account: &mut Account, message: &Message, from_di
         .cloned()
     else {
         warn!(vtc = %from_did, "credential-issue without credential_response.credential — ignoring");
-        return false;
+        return CredentialIssueOutcome::NONE;
     };
 
     // Anti-misdelivery: issuer must be this community's VTC. The credential's
@@ -619,7 +658,7 @@ pub fn handle_credential_issue(account: &mut Account, message: &Message, from_di
     });
     if issuer != Some(from_did) {
         warn!(vtc = %from_did, ?issuer, "issued credential's issuer is not the community VTC — ignoring");
-        return false;
+        return CredentialIssueOutcome::NONE;
     }
     let Some(subject) = credential
         .get("credentialSubject")
@@ -627,30 +666,43 @@ pub fn handle_credential_issue(account: &mut Account, message: &Message, from_di
         .and_then(Value::as_str)
     else {
         warn!(vtc = %from_did, "issued credential has no subject — ignoring");
-        return false;
+        return CredentialIssueOutcome::NONE;
     };
     // The subject must be one of our personas, and that persona must hold a
     // membership with this community.
     let Some(persona_id) = account.persona_id_for_did(subject) else {
         warn!(vtc = %from_did, "issued credential subject is not our persona — ignoring");
-        return false;
+        return CredentialIssueOutcome::NONE;
     };
 
     // Classify the credential against the typed registry — the one place that
     // knows credential kinds, so a new kind is handled here without edits.
     let Some(kind) = crate::CredentialKind::from_credential(&credential) else {
         warn!(vtc = %from_did, "issued credential is of no known kind — ignoring");
-        return false;
+        return CredentialIssueOutcome::NONE;
     };
 
     let Some(record) = account.membership_mut(from_did, persona_id) else {
         warn!(vtc = %from_did, "credential-issue for a community we don't hold a matching membership with — ignoring");
-        return false;
+        return CredentialIssueOutcome::NONE;
     };
     record.credentials.insert(kind, credential);
-    if kind.activates_membership() && !record.status.is_active() {
+
+    // Capture the join request id *before* activating. `activate` replaces
+    // `Pending { request_id }` with `Active`, so this is the last moment the
+    // id exists — which is why a caller could not simply read it back
+    // afterwards and why the reciprocal VMC has always gone out with
+    // `requestId: None`.
+    let closed_join = if kind.activates_membership() && !record.status.is_active() {
+        let request_id = match record.status {
+            crate::config::account::CommunityStatus::Pending { request_id } => Some(request_id),
+            _ => None,
+        };
         record.activate(chrono::Utc::now());
-    }
+        request_id.map(|id| (persona_id, id))
+    } else {
+        None
+    };
     info!(
         vtc = %from_did,
         credential_kind = %kind.config_key(),
@@ -659,7 +711,10 @@ pub fn handle_credential_issue(account: &mut Account, message: &Message, from_di
         activates_membership = kind.activates_membership(),
         "stored issued credential",
     );
-    true
+    CredentialIssueOutcome {
+        changed: true,
+        closed_join,
+    }
 }
 
 /// Vet an inbound `VRCIssued` message against local state (task R2).
@@ -1670,6 +1725,89 @@ mod tests {
         })
     }
 
+    /// Admission must report the join request it closed.
+    ///
+    /// This is the whole reason the handler returns a struct rather than a
+    /// bool: `activate` replaces `Pending { request_id }` with `Active`, so the
+    /// id is destroyed by the very call that makes it relevant. A caller
+    /// looking afterwards finds nothing — which is why every reciprocal VMC
+    /// this client ever sent carried `requestId: None`, leaving the community's
+    /// join request `Approved` forever.
+    #[test]
+    fn admission_reports_the_join_request_it_closed() {
+        let vtc = "did:webvh:example:vtc";
+        let persona = "did:webvh:example:persona";
+        let mut acct = account_with_persona(vtc, persona);
+
+        // The id the fixture's pending membership is waiting on.
+        let pending_id = match only(&acct, vtc).status {
+            crate::config::account::CommunityStatus::Pending { request_id } => request_id,
+            ref other => panic!("fixture should start Pending, got {other:?}"),
+        };
+        let persona_id = only(&acct, vtc).persona_ref;
+
+        let m = issue(
+            vtc,
+            vc(
+                &["VerifiableCredential", "MembershipCredential"],
+                vtc,
+                persona,
+            ),
+        );
+        let outcome = handle_credential_issue(&mut acct, &m, vtc);
+
+        assert_eq!(
+            outcome.closed_join,
+            Some((persona_id, pending_id)),
+            "the outcome must carry the request id and the persona that owes the reciprocal"
+        );
+        // And the id really is gone from the record by now — the point of
+        // capturing it rather than reading it back.
+        assert!(only(&acct, vtc).status.is_active());
+    }
+
+    /// A credential that does not admit anyone closes no join. A role VEC
+    /// landing on an already-active membership must not re-send a reciprocal
+    /// VMC naming a request that was closed long ago.
+    #[test]
+    fn a_credential_that_admits_nobody_closes_no_join() {
+        let vtc = "did:webvh:example:vtc";
+        let persona = "did:webvh:example:persona";
+        let mut acct = account_with_persona(vtc, persona);
+
+        // Admit first, so the membership is already Active.
+        let vmc = issue(
+            vtc,
+            vc(
+                &["VerifiableCredential", "MembershipCredential"],
+                vtc,
+                persona,
+            ),
+        );
+        assert!(
+            handle_credential_issue(&mut acct, &vmc, vtc)
+                .closed_join
+                .is_some()
+        );
+
+        // A second membership credential on an active membership: stored, but
+        // it admits nobody, so there is no join to close.
+        let again = issue(
+            vtc,
+            vc(
+                &["VerifiableCredential", "MembershipCredential"],
+                vtc,
+                persona,
+            ),
+        );
+        let outcome = handle_credential_issue(&mut acct, &again, vtc);
+        assert!(outcome.changed, "the credential is still stored");
+        assert_eq!(
+            outcome.closed_join, None,
+            "an already-active membership has no open join to close"
+        );
+    }
+
     #[test]
     fn credential_issue_vmc_activates_and_stores() {
         let vtc = "did:webvh:example:vtc";
@@ -1684,7 +1822,7 @@ mod tests {
                 persona,
             ),
         );
-        assert!(handle_credential_issue(&mut acct, &m, vtc));
+        assert!(handle_credential_issue(&mut acct, &m, vtc).changed);
 
         let rec = only(&acct, vtc);
         assert!(rec.status.is_active());
@@ -1708,7 +1846,7 @@ mod tests {
                 persona,
             ),
         );
-        assert!(handle_credential_issue(&mut acct, &m, vtc));
+        assert!(handle_credential_issue(&mut acct, &m, vtc).changed);
 
         let rec = only(&acct, vtc);
         assert!(
@@ -1734,7 +1872,7 @@ mod tests {
                 vc(&["VerifiableCredential", kind.vc_type()], vtc, persona),
             );
             assert!(
-                handle_credential_issue(&mut acct, &m, vtc),
+                handle_credential_issue(&mut acct, &m, vtc).changed,
                 "kind {kind:?} should be accepted",
             );
             let rec = only(&acct, vtc);
@@ -1765,7 +1903,7 @@ mod tests {
                 persona,
             ),
         );
-        assert!(!handle_credential_issue(&mut acct, &m, vtc));
+        assert!(!handle_credential_issue(&mut acct, &m, vtc).changed);
         assert!(!only(&acct, vtc).status.is_active());
     }
 
@@ -1784,7 +1922,7 @@ mod tests {
                 "did:webvh:someone-else",
             ),
         );
-        assert!(!handle_credential_issue(&mut acct, &m, vtc));
+        assert!(!handle_credential_issue(&mut acct, &m, vtc).changed);
         assert!(!only(&acct, vtc).status.is_active());
     }
 

--- a/openvtc/src/state_handler/community_actions.rs
+++ b/openvtc/src/state_handler/community_actions.rs
@@ -111,6 +111,8 @@ impl CommunityJob {
                 &self.member_did,
                 &self.vtc_did,
                 &self.mediator,
+                // Unprompted re-issue: there is no open join to close.
+                None,
             )
             .await
             .map(|_| ()),

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -55,6 +55,7 @@ pub(crate) async fn issue_member_vmc_for(
     tdk: &TDK,
     vtc_did: &str,
     persona_id: openvtc_core::config::account::PersonaId,
+    closes_request: Option<uuid::Uuid>,
 ) -> Result<uuid::Uuid, openvtc_core::errors::OpenVTCError> {
     use openvtc_core::errors::OpenVTCError;
     let id = config
@@ -76,6 +77,7 @@ pub(crate) async fn issue_member_vmc_for(
         &member_did,
         vtc_did,
         &mediator,
+        closes_request,
     )
     .await
 }
@@ -237,7 +239,35 @@ pub async fn process_inbound_message(
             .memberships_for(&from_did)
             .iter()
             .any(|m| m.status.is_active());
-        let changed = handle_credential_issue(&mut config.account, message, &from_did);
+        let outcome = handle_credential_issue(&mut config.account, message, &from_did);
+        // Admission is the moment the member owes the community its half of
+        // the membership pair. Sending it here — naming the join request it
+        // closes — is what `vtc/members/vmc/0.1`'s `requestId` is for; without
+        // it the community's request sits `Approved` indefinitely, waiting for
+        // a reciprocal that only ever arrived unlinked, if at all.
+        //
+        // Best-effort by nature: the credential we just received is already
+        // stored and the membership is already Active. A failure to send ours
+        // back is logged and leaves the join open — recoverable, either by the
+        // member issuing manually or by the community asking with
+        // `members/request-vmc`.
+        if let Some((persona_id, request_id)) = outcome.closed_join {
+            match issue_member_vmc_for(config, tdk, &from_did, persona_id, Some(request_id)).await {
+                Ok(_) => info!(
+                    vtc = %from_did,
+                    %request_id,
+                    "sent our reciprocal membership credential, closing the join request"
+                ),
+                Err(e) => warn!(
+                    vtc = %from_did,
+                    %request_id,
+                    error = %e,
+                    "could not send our reciprocal membership credential — the community's \
+                     join request stays open"
+                ),
+            }
+        }
+        let changed = outcome.changed;
         if changed {
             let now_active = config
                 .account
@@ -366,7 +396,7 @@ pub async fn process_inbound_message(
                     .membership(&from_did, persona_id)
                     .is_some_and(|c| c.status.is_active()) =>
             {
-                match issue_member_vmc_for(config, tdk, &from_did, persona_id).await {
+                match issue_member_vmc_for(config, tdk, &from_did, persona_id, None).await {
                     Ok(_) => info!(
                         vtc = %from_did,
                         "auto-issued our membership credential in response to the VTC's request"


### PR DESCRIPTION
`vtc/members/vmc/0.1` carries an optional `requestId` — the retired `join-requests/accept` semantics — and this client always sent `None`. So a community's join request sat `Approved` indefinitely, *after* the member had been admitted and had sent their half of the membership pair back.

## It was not a missing parameter

The id was **destroyed** before anything could read it:

```rust
record.activate(chrono::Utc::now());   // Pending { request_id } -> Active
```

By the time a caller looked, there was nothing to find. Any fix that only threaded a parameter through `submit_member_vmc` would have threaded a `None`.

`handle_credential_issue` now returns a `CredentialIssueOutcome` — modelled on the `StatusOutcome` directly beside it in the same file, for the same reason that one exists — carrying the join it closed, captured immediately *before* activation. Admission then sends the reciprocal VMC naming that request.

## Behaviour change — please read

**Receiving the community's membership credential now auto-issues ours back.**

I think that is right: membership is a pair, the community is holding the request open waiting for our half, the VTC documents `members/vmc` + `requestId` as how a join closes, and this client already auto-answers `members/request-vmc` in exactly this way. But it is a policy choice rather than a bug fix, and easy to reverse if you would rather it stayed a manual action.

It is best-effort by construction: the credential we received is already stored and the membership is already Active, so a send failure is logged and leaves the join open — recoverable either by the member issuing manually (`m`) or by the community asking with `members/request-vmc`.

## Tests

Two, pinning the part that made this more than a parameter:

- The outcome carries the request id **and** the persona that owes the reciprocal, and the record is *already Active* by the time it is asserted on — which is the proof that capturing beats reading back.
- A credential that admits nobody closes no join, so a role VEC landing on an already-active membership cannot re-send a reciprocal naming a request closed long ago.

`cargo test -p openvtc-core --lib messaging::tests` 58/58, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` clean.

Note: this, #265, and the two-silences change all add a bullet to the shared `CHANGELOG.md` — whichever merge second and third need a trivial rebase there.