### PR TITLE
fix(messaging): report a refusal we cannot correlate instead of dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A community could refuse something and this client would say nothing.**
+  Every inbound DIDComm problem-report went through the *join* handler, which
+  correlates the thread id against a pending join request. A report threaded on
+  anything else — a `members/vmc` delivery, say — matched nothing, and was
+  dropped with a warn naming the correlation miss rather than the failure.
+
+  Paired with a send that reported success on a bare local `Ok`, that is how a
+  completely broken reciprocal-VMC exchange stayed invisible for its entire
+  life: the community rejected every delivery, said so, and the UI reported
+  each one as sent.
+
+  The join handler still declines to *interpret* a report it cannot correlate —
+  it genuinely does not know what failed — but it now hands the code and comment
+  back instead of swallowing them, and the dispatcher writes them to the
+  community log. "We don't know which request" is not a reason to say nothing.
+
+  Two related honesty fixes: issuing a membership credential now says "sent —
+  waiting for the community to acknowledge it" rather than claiming it was
+  received, matching the personhood verbs beside it; and the community's
+  acknowledgement receipt, previously an `info!` in a log file, is written to
+  the community log, since it is the only positive evidence the member ever gets
+  that their half of the pair landed.
+
 - **A reciprocal membership credential never closed the join request it
   answered.** `vtc/members/vmc/0.1` carries an optional `requestId` — the
   retired `join-requests/accept` semantics — and this client always sent

--- a/openvtc-core/src/messaging.rs
+++ b/openvtc-core/src/messaging.rs
@@ -247,6 +247,42 @@ impl CredentialIssueOutcome {
     };
 }
 
+/// What an inbound DIDComm problem-report meant to the join handler.
+///
+/// A problem-report says "I refused the thing you sent me". This handler can
+/// only interpret one kind: a refusal threaded on a *pending join request*. It
+/// used to return an empty [`StatusOutcome`] for everything else and log a warn
+/// naming the correlation miss — so a community refusing anything else at all
+/// produced, on this client, nothing a user could see.
+///
+/// That is how the broken reciprocal-VMC exchange stayed invisible for its
+/// entire life: the VTC rejected every delivery, said so in a problem-report
+/// threaded on the delivery, and this client discarded each one as "not a join
+/// I know about" while the UI reported the send as a success.
+///
+/// So the miss is now reportable rather than swallowed. This handler still
+/// declines to *interpret* a report it cannot correlate — it genuinely does not
+/// know what failed — but it hands the code and comment back so the caller can
+/// put them where somebody will read them.
+pub struct ProblemReportOutcome {
+    /// The record change, if this report was a join refusal.
+    pub status: StatusOutcome,
+    /// `Some((code, comment))` when the report could not be matched to a
+    /// pending join — i.e. it refused something else this client sent, and
+    /// nothing here knows what. Surface it; do not drop it.
+    pub unclaimed: Option<(String, String)>,
+}
+
+impl ProblemReportOutcome {
+    /// A report this handler recognised and acted on.
+    fn claimed(status: StatusOutcome) -> Self {
+        Self {
+            status,
+            unclaimed: None,
+        }
+    }
+}
+
 /// Outcome of applying a VTC `join-requests/status-response` to a community.
 pub struct StatusOutcome {
     /// The community record changed and the config needs saving.
@@ -484,20 +520,23 @@ pub fn handle_join_problem_report(
     account: &mut Account,
     message: &Message,
     from_did: &str,
-) -> StatusOutcome {
+) -> ProblemReportOutcome {
     use vta_sdk::protocols::problem_report_codes as codes;
 
+    let (code, comment) = vta_sdk::protocols::extract_problem_report(&message.body);
+    let unclaimed = || ProblemReportOutcome {
+        status: StatusOutcome::NONE,
+        unclaimed: Some((code.clone(), comment.clone())),
+    };
+
     let Some(thid) = message.thid.as_deref() else {
-        warn!("join problem-report without thid — ignoring");
-        return StatusOutcome::NONE;
+        return unclaimed();
     };
     let Ok(placeholder) = Uuid::parse_str(thid) else {
-        return StatusOutcome::NONE;
+        return unclaimed();
     };
-    let (code, comment) = vta_sdk::protocols::extract_problem_report(&message.body);
     let Some(record) = account.membership_by_pending_request(from_did, placeholder) else {
-        warn!(vtc = %from_did, code = %code, "problem-report did not match a pending request id — ignoring");
-        return StatusOutcome::NONE;
+        return unclaimed();
     };
     let persona = record.persona_ref;
 
@@ -508,15 +547,15 @@ pub fn handle_join_problem_report(
             comment = %comment,
             "join rejected by VTC — invitation not accepted (now Rejected)"
         );
-        StatusOutcome {
+        ProblemReportOutcome::claimed(StatusOutcome {
             changed: true,
             inactivated: Some(persona),
-        }
+        })
     } else {
         // bad-request / internal / other: the submit didn't admit, but it's not a
         // policy rejection — surface the detail and leave the record Pending.
         warn!(vtc = %from_did, code = %code, comment = %comment, "join submit failed — left Pending");
-        StatusOutcome::NONE
+        ProblemReportOutcome::claimed(StatusOutcome::NONE)
     }
 }
 
@@ -1605,6 +1644,67 @@ mod tests {
         .finalize()
     }
 
+    /// A problem-report on a thread no pending join matches must be reported,
+    /// not swallowed.
+    ///
+    /// This is the exact shape that hid the broken reciprocal-VMC exchange: the
+    /// community refused every delivery and said so in a report threaded on the
+    /// delivery, which correlates to no join, so the handler returned "nothing
+    /// happened" and the only trace was a warn naming the correlation miss
+    /// rather than the failure.
+    #[test]
+    fn a_report_matching_no_pending_join_is_handed_back_not_dropped() {
+        let vtc = "did:webvh:example:vtc";
+        let rid = Uuid::new_v4();
+        let mut acct = pending_account(vtc, rid);
+
+        // Threaded on something else entirely — a members/vmc delivery, say.
+        let unrelated = Uuid::new_v4();
+        let out = handle_join_problem_report(
+            &mut acct,
+            &problem_report(
+                &unrelated.to_string(),
+                vtc,
+                "e.p.msg.bad-request",
+                "member vmc has no top-level `id`",
+            ),
+            vtc,
+        );
+
+        let (code, comment) = out
+            .unclaimed
+            .expect("an uncorrelated report must be reported");
+        assert_eq!(code, "e.p.msg.bad-request");
+        assert!(
+            comment.contains("member vmc"),
+            "the community's own words must survive: {comment}"
+        );
+        assert!(
+            !out.status.changed,
+            "it still must not touch the pending join it does not belong to"
+        );
+        assert!(matches!(
+            only(&acct, vtc).status,
+            CommunityStatus::Pending { .. }
+        ));
+    }
+
+    /// A report with no thread id at all cannot be correlated either, and is
+    /// equally not a reason to stay quiet.
+    #[test]
+    fn a_report_with_no_thread_id_is_still_reported() {
+        let vtc = "did:webvh:example:vtc";
+        let mut acct = pending_account(vtc, Uuid::new_v4());
+        let mut msg = problem_report("ignored", vtc, "e.p.msg.internal", "boom");
+        msg.thid = None;
+
+        let out = handle_join_problem_report(&mut acct, &msg, vtc);
+        assert!(
+            out.unclaimed.is_some(),
+            "no thid is not a reason to drop it"
+        );
+    }
+
     #[test]
     fn problem_report_forbidden_rejects() {
         let vtc = "did:webvh:example:vtc";
@@ -1621,8 +1721,8 @@ mod tests {
             ),
             vtc,
         );
-        assert!(out.changed);
-        assert!(out.inactivated.is_some());
+        assert!(out.status.changed);
+        assert!(out.status.inactivated.is_some());
         assert!(matches!(only(&acct, vtc).status, CommunityStatus::Rejected));
     }
 
@@ -1638,8 +1738,12 @@ mod tests {
             vtc,
         );
         assert!(
-            !out.changed,
+            !out.status.changed,
             "a client/transient error must not mark Rejected"
+        );
+        assert!(
+            out.unclaimed.is_none(),
+            "a report threaded on a known pending join is this handler's to interpret"
         );
         assert!(matches!(
             only(&acct, vtc).status,

--- a/openvtc/src/state_handler/community_actions.rs
+++ b/openvtc/src/state_handler/community_actions.rs
@@ -188,9 +188,17 @@ impl CommunityOutcome {
                 return Some((self.vtc_did, self.persona));
             }
             (None, Performed::IssueVmc) => {
+                // Only the *send* succeeded. A DIDComm `Ok` means the frame was
+                // accepted for delivery locally; it says nothing about whether
+                // the community took the credential, and for the entire life of
+                // this feature it did not — every delivery was rejected and this
+                // line said otherwise. The wording now matches the two
+                // personhood verbs beside it, which have always been honest
+                // about the difference.
                 status(
                     state,
-                    "Membership credential issued and sent to the community.".to_string(),
+                    "Membership credential sent — waiting for the community to acknowledge it."
+                        .to_string(),
                 );
             }
             (None, Performed::RequestPersonhoodChallenge) => {
@@ -328,7 +336,10 @@ mod tests {
                 .communities
                 .status_message
                 .as_deref()
-                .is_some_and(|m| m.contains("issued")),
+                // The status must say the credential was *sent*, not accepted:
+                // a DIDComm `Ok` is a local hand-off. This assertion used to
+                // look for "issued", which is what the old wording claimed.
+                .is_some_and(|m| m.contains("sent") && m.contains("waiting")),
         );
     }
 

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -305,10 +305,37 @@ pub async fn process_inbound_message(
     // is no longer silently dropped into a stuck `Pending`.
     if message.typ == PROBLEM_REPORT_TYPE {
         let outcome = handle_join_problem_report(&mut config.account, message, &from_did);
-        if let Some(persona) = outcome.inactivated {
+
+        // A report the join handler cannot claim refused *something else* we
+        // sent. This client does not know what — it keeps no record of
+        // outstanding requests by thread id — but "we don't know which" is not
+        // a reason to say nothing. Every problem-report is a community telling
+        // us it refused us, and the one thing worse than an unattributed
+        // rejection is an invisible one.
+        //
+        // This is how the reciprocal-VMC exchange stayed broken for its whole
+        // life: the VTC rejected every delivery and said so here, on a thread
+        // no join matched, and each report went into a `warn!` naming the
+        // correlation miss rather than the failure.
+        if let Some((code, comment)) = outcome.unclaimed {
+            warn!(
+                vtc = %from_did,
+                code = %code,
+                comment = %comment,
+                thid = message.thid.as_deref().unwrap_or("none"),
+                "community refused something we sent"
+            );
+            config.public.logs.insert(
+                LogFamily::Community,
+                format!("Community ({from_did}) refused something we sent [{code}]: {comment}"),
+            );
+            return Ok(true);
+        }
+
+        if let Some(persona) = outcome.status.inactivated {
             inactivated.push((from_did.to_string(), persona));
         }
-        return Ok(outcome.changed);
+        return Ok(outcome.status.changed);
     }
 
     // VTC trust-task-error: the framework failure document for a Trust Task join
@@ -380,7 +407,14 @@ pub async fn process_inbound_message(
     // the reciprocal VMC we sent. Informational — log and move on.
     if message.typ == MEMBER_VMC_RESPONSE_TYPE {
         info!(vtc = %from_did, "VTC acknowledged our membership credential (member VMC receipt)");
-        return Ok(false);
+        // The send reports only that a frame was accepted locally. This is the
+        // first and only evidence the community actually took the credential,
+        // so it belongs where the member can see it rather than in a log file.
+        config.public.logs.insert(
+            LogFamily::Community,
+            format!("Community ({from_did}) acknowledged your membership credential."),
+        );
+        return Ok(true);
     }
 
     // VTC → member: "please issue + send your VMC" (`members/request-vmc/1.0`).


### PR DESCRIPTION
Every inbound DIDComm problem-report went through the **join** handler, which correlates the thread id against a pending join request. A report threaded on anything else matched nothing and was dropped with a warn naming the correlation miss rather than the failure.

## Why this matters more than it looks

Paired with a send that reports success on a bare local `Ok`, this is how a completely broken reciprocal-VMC exchange stayed invisible for its entire life:

1. The community rejected **every** delivery (the credential had no `id` — openvtc#260).
2. It said so, in a problem-report threaded on that delivery.
3. This client discarded each one as "not a join I recognise".
4. The UI reported each send as *"Membership credential issued and sent to the community."*

Two independent silences over one broken exchange, and between them not a single thing a user could see. The bug is fixed; the blindness that hid it was not, until now.

## What changed

The join handler still declines to *interpret* a report it cannot correlate — it genuinely does not know what failed, because this client keeps no record of outstanding requests by thread id. But it hands the code and comment back instead of swallowing them, and the dispatcher writes them to the community log:

```
Community (did:webvh:…) refused something we sent [e.p.msg.bad-request]: member vmc has no top-level `id`
```

**Deliberately not a general outstanding-request registry.** That would let the message name *which* request, and is the better answer eventually — but it is new state to keep correct at every send site, and the harm here was never that the message is vague. It was that there was no message.

Two related honesty fixes in the same shape:

- Issuing a membership credential now says **"sent — waiting for the community to acknowledge it"** rather than claiming it was received. A DIDComm `Ok` means the frame was accepted for delivery *locally*; the two personhood verbs beside it in the same match have always been honest about that difference, and this one now matches them.
- The community's acknowledgement receipt, previously an `info!` in a log file, is written to the community log. It is the only positive evidence the member ever gets that their half of the pair actually landed.

## Tests

Two, covering both ways correlation fails: a report threaded on an unrelated id is handed back with the community's own words intact *and* leaves the unrelated pending join untouched; and a report with no thread id at all is still reported, since being uncorrelatable is not a reason to go quiet.

`cargo test -p openvtc-core --lib messaging::tests` 58/58, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check` clean.

Note: this, #265 and #266 all add a bullet to the shared `CHANGELOG.md` — whichever merge second and third need a trivial rebase there.