### PR TITLE
fix(deps): floor vta-sdk at 0.32.1, which can provision a VTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Setup could not link this client to a VTA at all.** The last step of the
+  wizard — "Provision integration DID + admin credential" — failed on every
+  fresh install with `unsupportedType`, against a VTA that was otherwise
+  healthy and had already authenticated the setup key.
+
+  The cause was upstream and had nothing to do with the VTA being asked. The
+  `provision/integration` trust task moved to 0.3 and 0.2 was removed rather
+  than deprecated (the two disagree about the bundle digest and both close
+  their response schema, so no single response satisfies both). The VTA moved;
+  so did the SDK's REST runner. Its TSP runner did not, and its DIDComm runners
+  did not — each held its own version literal, and each had been correct on the
+  day it was written, because the two transports genuinely used to address
+  different versions of this operation.
+
+  Setup prefers TSP, so setup got the half that was left behind. Worse, the
+  refusal arrives *after* authentication succeeds, which the SDK classifies as
+  terminal — so it never fell back to the REST leg that would have worked, and
+  the checklist showed a clean run of ticks with a failure on the last line.
+
+  Fixed upstream in vta-sdk 0.32.1, which routes every transport through one
+  version constant and guards the client/server pair with a test. This release
+  floors the dependency there.
+
 - **A community could refuse something and this client would say nothing.**
   Every inbound DIDComm problem-report went through the *join* handler, which
   correlates the thread id against a pending join request. A report threaded on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -897,7 +897,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2816,7 +2816,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3118,7 +3118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5042,7 +5042,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5593,7 +5593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5903,7 +5903,7 @@ dependencies = [
  "aes-gcm 0.10.3",
  "aes-kw",
  "argon2 0.5.3",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -6387,7 +6387,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6954,7 +6954,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7012,7 +7012,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7667,7 +7667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7879,7 +7879,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7892,7 +7892,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8970,9 +8970,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ea9dbdad04080277acd9a57224003a73bf1300980837228792620e2d46bb5"
+checksum = "8bc7c4aebd8001a261148b9058fc8bbd83f7c8a4d6c072244dfd113c3ef5f87c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9652,7 +9652,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,22 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # VTI #1191 adds `device_heartbeat_named`, which is what lets this install
 # correct its own `displayName` — set once at registration and, until now,
 # unchangeable. Taken here; used in the follow-up.
-vta-sdk = { version = "0.32", features = [
+#
+# **The floor names the patch.** 0.32.0 cannot link this repo to a VTA at all.
+# VTI #1147 cut `provision/integration` to 0.3 and removed 0.2 outright, moved
+# the server and the REST runner, and left the TSP runner on 0.2 and both
+# DIDComm runners on 0.1 — so setup's last step died with `unsupportedType`
+# against a healthy VTA. The setup wizard prefers TSP, and the failure lands
+# *after* auth as a `PostAuthFailure`, which the runner treats as terminal — so
+# it never falls back to the REST leg that would have worked. Every fresh
+# install hit it. VTI #1200 routes all four dispatch sites through
+# `ProvisionSpecVersion::CURRENT` and guards it server-side; 0.32.1 is that fix.
+#
+# `"0.32"` would admit 0.32.0 and resolve to it on any machine with a stale
+# index — the same shape as the `did-git-sign` `"0.4.3"` floor that quietly
+# admitted 0.4.5 and let a duplicate `vta-sdk` into the graph unnoticed. A floor
+# that exists to exclude a specific broken release has to name it.
+vta-sdk = { version = "0.32.1", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses


### PR DESCRIPTION
0.32.0 cannot link this client to a VTA. Setup's last step — "Provision integration DID + admin credential" — failed on every fresh install:

```
✓ Resolve VTA DID
✓ Enumerate service endpoints — TSP: yes, REST: yes, DIDCommMessaging: yes
✓ Authenticate via TSP
✗ Provision integration DID + admin credential
    trust task failed [unsupportedType]: unsupported type:
    https://trusttasks.org/spec/provision/integration/0.2
```

…against a VTA that had already authenticated the setup key and was otherwise healthy.

## What was wrong

Upstream, and not in the VTA being asked. VTI #1147 cut `provision/integration` to 0.3 and removed 0.2 rather than deprecating it — the two disagree about the bundle digest (bare-hex `digest` vs `digestMultibase`) and both close their response with `additionalProperties: false`, so no single response satisfies both. It moved the VTA and the SDK's REST runner, and left the TSP runner on 0.2 and both DIDComm runners on 0.1.

Each site held its own literal, and each had been correct when written: the two transports really did address different versions of this operation before the cut-over collapsed them onto one URI. Nothing looked wrong on inspection and nothing failed in CI — both halves were internally consistent.

Two things made it land squarely on us. The setup wizard prefers TSP, so it got the half left behind. And the refusal arrives *after* auth succeeds, which the SDK classifies as a `PostAuthFailure` and treats as terminal — so it never fell back to the REST leg that would have worked. The result is a checklist of clean ticks with a failure on the last line.

Fixed upstream in VTI #1200: all four dispatch sites now read `ProvisionSpecVersion::CURRENT`, guarded by a `vta-service` test asserting the client dispatches a version the dispatcher actually registers. Released as vta-sdk 0.32.1.

## Why the floor names the patch

`"0.32"` admits 0.32.0 and will resolve to it on a stale index. That is the same shape as the `did-git-sign` `"0.4.3"` floor that quietly admitted 0.4.5 and let a second `vta-sdk` into the graph unnoticed. A floor whose whole purpose is to exclude one broken release has to name it.

## Scope

No source change. `vta-service` stays at `"0.23"` — it declares `vta-sdk ^0.32` and unifies on 0.32.1, so the graph still holds exactly one `vta-sdk` and one `trust-tasks-rs` (checked with `cargo tree -i`). The `[patch.crates-io]` pins for `did-git-sign`/`vgi-core` are untouched and still unify.

**On the lockfile diff:** besides `vta-sdk`, it re-points some consumers of `windows-sys` 0.60.2 → 0.61.2 and `pgp`'s `base64` 0.21.7 → 0.22.1. That is cargo re-resolving, not a deliberate bump — both versions were already in the tree and both remain there, `origin/main` is `--locked` clean, and `cargo update -p vta-sdk --precise 0.32.1` produces a byte-identical lockfile.

## Verification

- `cargo clippy --workspace --all-targets --all-features` — clean
- `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features` — clean
- `cargo deny check` — advisories/bans/licenses/sources ok
- `cargo test --workspace --all-features` — green
- `cargo test --workspace --all-features -- --include-ignored` — green, including the MockVta bootstrap e2e that covers the provisioning path