### PR TITLE
fix(secure-store): store the profile secret as one line, not pretty JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Saving a profile on Linux corrupted the whole login keyring.** Not just the
+  OpenVTC entry — every secret in the collection became unreadable, and the
+  next unlock prompt from any application was really a *create a new keyring*
+  prompt, which orphaned the original one.
+
+  OpenVTC stored its `SecuredConfig` envelope pretty-printed, so the secret
+  handed to the credential store contained real newlines. gnome-keyring writes
+  an item's secret into its `.keyring` file verbatim but reads it back through
+  `GKeyFile` unescaping, so those newlines came back as extra lines of the
+  file, and the daemon rejected the file entirely:
+  `keyring was in an invalid or unrecognized format`.
+
+  Nothing about that is visible on macOS or Windows, whose stores treat a
+  secret as opaque bytes — which is why a formatting choice with no reader
+  survived this long.
+
+  The envelope is now written as compact single-line JSON, and the encoder
+  refuses to hand the store a secret containing a line break, a control
+  character, a backslash, or any non-ASCII byte at all: its payloads are
+  BASE64URL, so anything else is our bug, and it now fails the save instead of
+  corrupting a keyring. Existing entries are read back unchanged.
+
+  An already-corrupted keyring is orphaned, not destroyed;
+  `docs/secured-configuration-management.md` has the recovery steps.
+
 - **Setup could not link this client to a VTA at all.** The last step of the
   wizard — "Provision integration DID + admin credential" — failed on every
   fresh install with `unsupportedType`, against a VTA that was otherwise

--- a/docs/secured-configuration-management.md
+++ b/docs/secured-configuration-management.md
@@ -60,3 +60,51 @@ When the tool later needs to retrieve the configuration:
 ## Plaintext
 
 The plaintext option stores the configuration in plaintext format in the OS's secure storage. The plaintext option is not part of the OpenVTC setup by default.
+
+## Storage format (and why it is one line)
+
+Whichever of the three protections is in use, the value handed to the OS
+credential store is the same shape: a single-line, compact JSON envelope whose
+payloads are all BASE64URL. `openvtc-core/src/config/secured_config.rs`
+(`encode_blob`) is the only place that writes it, and it refuses to emit a
+secret containing a line break, a control character, a backslash, or any
+non-ASCII byte.
+
+That is a hard requirement, not a style preference. gnome-keyring writes an
+item's secret into `~/.local/share/keyrings/*.keyring` verbatim, but reads it
+back through `GKeyFile` *unescaping*. A secret with a raw newline in it
+therefore comes back as extra lines of the keyring file, and the daemon fails
+to parse the file at all:
+
+```text
+keyring was in an invalid or unrecognized format: .../Default_keyring.keyring
+```
+
+The blast radius is the whole collection, not just the OpenVTC item — every
+other secret in the user's login keyring becomes unreadable too.
+
+### Recovering a keyring OpenVTC has already corrupted
+
+Releases before this fix stored the envelope pretty-printed, so on a Secret
+Service backend the first save would break the login keyring. The data is
+orphaned, not destroyed. To recover:
+
+1. Stop the daemon so it cannot rewrite anything under you:
+   `systemctl --user stop gnome-keyring-daemon.service` (or log out).
+2. Copy the whole `~/.local/share/keyrings/` directory somewhere safe before
+   touching it.
+3. Look at the `default` file — a small pointer naming the active keyring. If
+   the unlock prompt was answered at some point after the breakage, the answer
+   created a *new* empty keyring and repointed `default` at it; note the
+   original name so you can point it back.
+4. In the original `.keyring` file, find the OpenVTC item's secret: it is the
+   value that spills across several lines instead of one. Either join it back
+   into a single line or delete that item's block entirely — the rest of the
+   file parses again either way.
+5. Point `default` back at the original keyring, restart the daemon, and
+   confirm with `secret-tool search --all service openvtc`.
+
+If the OpenVTC item itself cannot be salvaged, the profile's secret half is
+gone and the config file alone will not start it — see
+[backup-restore.md](backup-restore.md) for what that costs and what can be
+recovered from the VTA.

--- a/openvtc-core/src/config/secured_config.rs
+++ b/openvtc-core/src/config/secured_config.rs
@@ -74,6 +74,47 @@ pub fn require_encrypted_blob(bytes: &[u8]) -> Result<(), String> {
     }
 }
 
+/// Serialize a `SecuredConfigFormat` envelope into the exact bytes handed to
+/// the OS credential store: **compact, single-line JSON**.
+///
+/// The formatting is not cosmetic. gnome-keyring writes an item's secret into
+/// its `.keyring` file verbatim, but reads it back through `GKeyFile`
+/// *unescaping*, so a secret containing a raw newline reads back as extra
+/// lines of the keyring file and makes the whole file — every item in it, not
+/// just ours — unparseable:
+///
+/// ```text
+/// keyring was in an invalid or unrecognized format: .../Default_keyring.keyring
+/// ```
+///
+/// openvtc stored this envelope with `to_string_pretty`, so every save on a
+/// Secret Service backend wrote a multi-line secret and took the user's login
+/// keyring down with it. The guard below is the invariant the fix rests on:
+/// the envelope's payloads are all BASE64URL, so its compact encoding is pure
+/// ASCII with no control characters and no backslashes. Anything else is a bug
+/// on our side, and we fail the save rather than corrupt a keyring with it.
+fn encode_blob(format: &SecuredConfigFormat) -> Result<Vec<u8>, OpenVTCError> {
+    let bytes = serde_json::to_vec(format)?;
+
+    if let Some(pos) = bytes
+        .iter()
+        .position(|b| !b.is_ascii() || b.is_ascii_control() || *b == b'\\')
+    {
+        return Err(OpenVTCError::SecureStore {
+            fault: crate::errors::SecureStoreFault::Corrupt,
+            profile: String::new(),
+            detail: format!(
+                "refusing to write a secret containing a byte the OS credential store \
+                 cannot round-trip (0x{:02x} at offset {pos}); storing it would corrupt \
+                 the keyring",
+                bytes[pos]
+            ),
+        });
+    }
+
+    Ok(bytes)
+}
+
 /// Returns the `keyring` service name openvtc stores its `SecuredConfig`
 /// under. Used by sibling modules that need to address the same entry.
 #[must_use]
@@ -504,7 +545,7 @@ impl SecuredConfig {
 
         // Save this to the OS Secure Store
         entry
-            .set_secret(serde_json::to_string_pretty(&formatted)?.as_bytes())
+            .set_secret(&encode_blob(&formatted)?)
             .map_err(|e| OpenVTCError::from_keyring(&e, profile))?;
         Ok(())
     }
@@ -894,6 +935,64 @@ mod tests {
             assert!(serde_json::from_str::<SecuredConfigFormat>(blob).is_err());
             assert!(serde_json::from_str::<LegacySecuredConfigFormat>(blob).is_ok());
         }
+    }
+
+    // ── Keyring round-trip safety ─────────────────────────────────────────────
+
+    /// The stored secret must be a single line. gnome-keyring writes a secret
+    /// into its `.keyring` file verbatim and reads it back with `GKeyFile`
+    /// unescaping, so one raw newline in our blob makes the *whole file*
+    /// unparseable and takes every other item in the user's login keyring with
+    /// it. This is the regression test for that: the payloads are all
+    /// BASE64URL, so a correct encoding has no newline anywhere.
+    #[test]
+    fn encoded_blob_is_a_single_line() {
+        let formats = [
+            SecuredConfigFormat::PlainText {
+                text: BASE64_URL_SAFE_NO_PAD.encode(vec![0xffu8; 512]),
+            },
+            SecuredConfigFormat::PasswordEncrypted {
+                data: BASE64_URL_SAFE_NO_PAD.encode(vec![0x00u8; 512]),
+            },
+            SecuredConfigFormat::TokenEncrypted {
+                esk: BASE64_URL_SAFE_NO_PAD.encode([7u8; 32]),
+                data: BASE64_URL_SAFE_NO_PAD.encode(vec![0x0au8; 512]),
+            },
+        ];
+
+        for format in &formats {
+            let bytes = encode_blob(format).unwrap();
+            assert!(
+                !bytes.contains(&b'\n') && !bytes.contains(&b'\r'),
+                "stored secret must not contain a line break"
+            );
+            assert!(
+                bytes.iter().all(|b| b.is_ascii() && !b.is_ascii_control()),
+                "stored secret must be printable ASCII"
+            );
+            assert!(!bytes.contains(&b'\\'), "stored secret must not escape");
+            // Still the same envelope the loader expects.
+            assert!(SecuredConfig::parse(&bytes).is_ok());
+        }
+    }
+
+    /// A blob the credential store could not round-trip must fail the save
+    /// rather than reach the keyring. Reproduced by handing the encoder a
+    /// payload that is not base64 — which can only happen if a future variant
+    /// stops encoding its field.
+    #[test]
+    fn encode_blob_refuses_a_non_round_trippable_secret() {
+        let bad = SecuredConfigFormat::PlainText {
+            text: "line one\nline two".to_string(),
+        };
+        let err = encode_blob(&bad).unwrap_err();
+        assert!(matches!(
+            err,
+            OpenVTCError::SecureStore {
+                fault: crate::errors::SecureStoreFault::Corrupt,
+                ..
+            }
+        ));
     }
 
     /// Layer-2 gate: a tagged-but-weaker blob (e.g. PlainText where


### PR DESCRIPTION
## What was wrong

Saving a profile on Linux corrupted the user's whole login keyring — every
secret in the collection, not just the OpenVTC one. From the daemon log:

```
keyring was in an invalid or unrecognized format: .../Default_keyring.keyring
```

`SecuredConfig::save` wrote the envelope with `serde_json::to_string_pretty`,
so the secret handed to the Secret Service contained real newlines.
gnome-keyring writes an item's secret into its `.keyring` file verbatim but
reads it back through GKeyFile *unescaping*, so those newlines came back as
extra lines of the file and made the whole file unparseable.

The cascade from there is worse than a lost entry: with no readable default
collection, the next application's unlock prompt is really a *create a new
keyring* prompt. Answer it and you get a fresh `Default_Keyring.keyring`, the
`default` pointer repointed at it, and the real keyring orphaned.

macOS and Windows treat a secret as opaque bytes, so a formatting choice that
had no reader survived this long. Only the Secret Service backend parses it.

## The fix

One encoder, `encode_blob`, is now the only thing that produces the bytes the
credential store sees: compact single-line JSON. It also refuses to emit a
secret containing a line break, a control character, a backslash, or any
non-ASCII byte — the envelope's payloads are all BASE64URL, so anything else
is a bug on our side, and the save fails loudly instead of corrupting a
keyring quietly.

Existing entries are unaffected on read: serde ignores the old whitespace, so
a profile written by an earlier build loads and is rewritten single-line on
its next save.

## Recovery for anyone already hit

The data is orphaned, not destroyed. `docs/secured-configuration-management.md`
gains the steps: stop the daemon, copy `~/.local/share/keyrings/`, rejoin or
delete the item whose secret spills across lines, point `default` back at the
original keyring.

## Tests

- `encoded_blob_is_a_single_line` — all three envelope variants, over payloads
  chosen to be awkward (`0xff`, `0x00`, `0x0a`): no line break, printable
  ASCII only, no backslash, and still parses as the envelope the loader
  expects.
- `encode_blob_refuses_a_non_round_trippable_secret` — a payload that isn't
  base64 fails the save with `SecureStoreFault::Corrupt`.

Local gates green: `cargo fmt --check`, `clippy --workspace --all-targets`,
`test --workspace`, `test --workspace -- --ignored` (the MockVta/mediator
e2es), and `RUSTDOCFLAGS="-D warnings" cargo doc`.

