### PR TITLE
fix(session): seed connection status from the live listener, not an edge

### DIFF
--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -993,8 +993,22 @@ impl StateHandler {
             }
         }
 
+        // Seed the indicator from the messaging layer's *live* state rather than
+        // assuming nothing is up yet. `ListenerStatus` is edge-triggered, and a
+        // State-A join has already brought its persona listener up and connected
+        // by the time this loop subscribes — the install step above binds to that
+        // socket instead of reinstalling it, so no second `Connected` edge is
+        // coming. Without this seed the session sits `Connecting` for the life of
+        // the process over a perfectly live socket, which is the "Inbox:
+        // Connecting…" that only a restart appeared to fix.
         state.connection.status = state::MediatorStatus::Connecting;
-        state.main_page.log("Connecting to the mediator…");
+        state.connection.messaging_active = false;
+        reconcile_sessions(&mut session_manager, &didcomm_service, &mut state);
+        if matches!(state.connection.status, state::MediatorStatus::Connected) {
+            state.main_page.log("Connected to the mediator.");
+        } else {
+            state.main_page.log("Connecting to the mediator…");
+        }
         let _ = self.state_tx.send(state.clone());
 
         // Track when a manual trust-ping was sent (for activity log latency display).
@@ -1029,6 +1043,13 @@ impl StateHandler {
         // Reply-window sweep for the capabilities view (cheap no-op when the
         // view is closed or idle).
         let mut capabilities_sweep = tokio::time::interval(std::time::Duration::from_secs(5));
+        // Backstop for the edge-triggered listener-status stream. A transition
+        // that reaches nobody — the broadcast receiver lagging, a listener
+        // adopted after its connect — would otherwise latch a session's status
+        // (and the indicator) wrong until the next real edge, which for a healthy
+        // socket may never come. Cheap: a read of the transports' live state, no
+        // I/O and no allocation beyond the listener ids.
+        let mut session_reconcile_tick = tokio::time::interval(std::time::Duration::from_secs(15));
         // Agent-name refresh sweep. The first tick fires immediately so names
         // resolve shortly after launch; thereafter it picks up newly-added DIDs
         // (a fresh relationship/contact) and re-verifies stale entries every few
@@ -1492,20 +1513,17 @@ impl StateHandler {
                         };
                         // Derive the global connection indicator from the
                         // aggregate of all persona-sessions (a per-community
-                        // status panel is future UI work). Leave a
-                        // `NoActiveCommunity` state untouched when no session
-                        // exists.
+                        // status panel is future UI work).
                         if changed {
-                            if session_manager.any_connected() {
-                                state.connection.status = state::MediatorStatus::Connected;
-                                state.connection.messaging_active = true;
-                            } else if session_manager.session_count() > 0 {
-                                state.connection.status = state::MediatorStatus::Connecting;
-                                state.connection.messaging_active = false;
-                            }
+                            apply_session_aggregate(&session_manager, &mut state);
                         }
                     }
                 },
+                _ = session_reconcile_tick.tick() => {
+                    // The loop tail broadcasts `state`, so a change here reaches
+                    // the UI without an explicit send.
+                    reconcile_sessions(&mut session_manager, &didcomm_service, &mut state);
+                }
                 // Coalesced-save debounce (R11). Fires when the debounce window
                 // since the first dirty mark of a burst elapses. Builds an owned
                 // snapshot on this (the single mutator) thread and runs the heavy
@@ -3266,6 +3284,40 @@ async fn deregister_inactive_community(
 /// `has_ctx` gates both: there is nothing to hand back without a runtime context.
 fn must_hand_off(joined_a_community: bool, holds_listener: bool, has_ctx: bool) -> bool {
     (joined_a_community || holds_listener) && has_ctx
+}
+
+/// Reconcile every registered session against the messaging layer's live
+/// connection state and re-derive the global indicator. Returns `true` if any
+/// session's status changed. See [`session_manager::SessionManager::reconcile`]
+/// for why the event stream alone is not enough.
+fn reconcile_sessions(
+    session_manager: &mut session_manager::SessionManager,
+    service: &openvtc_core::didcomm::Messaging,
+    state: &mut State,
+) -> bool {
+    let mut changed = false;
+    for lid in session_manager.listener_ids() {
+        let connected =
+            service.listener_state(&lid) == Some(openvtc_core::didcomm::ConnState::Connected);
+        changed |= session_manager.reconcile(&lid, connected);
+    }
+    if changed {
+        apply_session_aggregate(session_manager, state);
+    }
+    changed
+}
+
+/// Drive the global connection indicator from the aggregate of all
+/// persona-sessions. A `NoActiveCommunity` state is left untouched when no
+/// session exists — "no community" is not "not connected".
+fn apply_session_aggregate(session_manager: &session_manager::SessionManager, state: &mut State) {
+    if session_manager.any_connected() {
+        state.connection.status = state::MediatorStatus::Connected;
+        state.connection.messaging_active = true;
+    } else if session_manager.session_count() > 0 {
+        state.connection.status = state::MediatorStatus::Connecting;
+        state.connection.messaging_active = false;
+    }
 }
 
 async fn register_joined_session(

--- a/openvtc/src/state_handler/session_manager.rs
+++ b/openvtc/src/state_handler/session_manager.rs
@@ -197,6 +197,40 @@ impl SessionManager {
         self.sessions.len()
     }
 
+    /// The listener id of every registered session — the input to a reconcile
+    /// sweep against the messaging layer.
+    pub fn listener_ids(&self) -> Vec<String> {
+        self.sessions
+            .values()
+            .map(|s| s.listener_id.clone())
+            .collect()
+    }
+
+    /// Adopt the messaging layer's live view of whether `listener_id` is up.
+    ///
+    /// The `ListenerStatus` stream is **edge-triggered** by a poller that runs for
+    /// the life of the messaging runtime, so a listener that connected *before*
+    /// its session was registered here — the persona listener a State-A join
+    /// already brought up, which the install step binds to rather than
+    /// reinstalling — has had its one `Connected` event delivered to nobody, and
+    /// no further edge is coming while the socket stays up. Reconciling reads the
+    /// live state instead of waiting for an edge that has already gone by.
+    ///
+    /// `connected` is adopted directly; a session that is *not* live is only
+    /// downgraded from `Connected`, so a recorded `Failed` reason survives and a
+    /// retry already in progress (`Connecting`) is not re-reported as a fresh
+    /// drop. Returns `true` if the status changed.
+    pub fn reconcile(&mut self, listener_id: &str, connected: bool) -> bool {
+        if connected {
+            return self.mark_connected(listener_id);
+        }
+        let was_connected = self
+            .sessions
+            .values()
+            .any(|s| s.listener_id == listener_id && s.status.is_connected());
+        was_connected && self.mark_disconnected(listener_id)
+    }
+
     /// The bounded maximum number of concurrent sessions (D15).
     pub fn max_sessions(&self) -> usize {
         self.max_sessions
@@ -320,5 +354,69 @@ mod tests {
 
         // Deregistering something unknown is a harmless no-op.
         assert!(mgr.deregister(a, "vtc-unknown").is_none());
+    }
+
+    #[test]
+    fn reconcile_adopts_a_connect_that_never_produced_an_event() {
+        let mut mgr = SessionManager::new(8);
+        let a = pid();
+        mgr.register(a, "lid-a", "vtc-1".into());
+
+        // The listener was already up when the session was registered, so its
+        // one Connected edge went to nobody: without reconciling, this session
+        // stays Connecting for the life of the process over a live socket.
+        assert!(!mgr.any_connected());
+        assert!(mgr.reconcile("lid-a", true));
+        assert!(mgr.any_connected());
+
+        // Idempotent — a repeated sweep over an unchanged state reports nothing.
+        assert!(!mgr.reconcile("lid-a", true));
+    }
+
+    #[test]
+    fn reconcile_downgrades_only_from_connected() {
+        let mut mgr = SessionManager::new(8);
+        let a = pid();
+        let b = pid();
+        mgr.register(a, "lid-a", "vtc-1".into());
+        mgr.register(b, "lid-b", "vtc-2".into());
+        mgr.mark_connected("lid-a");
+        mgr.mark_failed("lid-b", "mediator refused auth");
+
+        // A live session that is no longer up drops to Disconnected.
+        assert!(mgr.reconcile("lid-a", false));
+        assert_eq!(mgr.sessions[&a].status, SessionStatus::Disconnected);
+
+        // A session that was never up keeps the reason it recorded — a sweep
+        // must not overwrite "why it failed" with a bare "not connected".
+        assert!(!mgr.reconcile("lid-b", false));
+        assert_eq!(
+            mgr.sessions[&b].status,
+            SessionStatus::Failed("mediator refused auth".to_string())
+        );
+
+        // A retry in progress is likewise left alone.
+        mgr.reconcile("lid-a", true);
+        assert!(mgr.sessions[&a].status.is_connected());
+
+        // An unknown listener matches nothing, in either direction.
+        assert!(!mgr.reconcile("lid-unknown", true));
+        assert!(!mgr.reconcile("lid-unknown", false));
+    }
+
+    #[test]
+    fn listener_ids_lists_one_id_per_session() {
+        let mut mgr = SessionManager::new(8);
+        let a = pid();
+        let b = pid();
+        // A reused persona serves two communities over one listener, so the
+        // sweep visits it once, not once per community.
+        mgr.register(a, "lid-a", "vtc-1".into());
+        mgr.register(a, "lid-a", "vtc-2".into());
+        mgr.register(b, "lid-b", "vtc-3".into());
+
+        let mut ids = mgr.listener_ids();
+        ids.sort();
+        assert_eq!(ids, vec!["lid-a".to_string(), "lid-b".to_string()]);
     }
 }


### PR DESCRIPTION
## The report

First run: set up, joined a community, everything worked — but the header and inbox read `Connecting...` and stayed there. After restarting OpenVTC the same profile reads `Connected`.

The socket was live the whole time (mail was being delivered); only the indicator was wrong.

## Cause

The listener status stream is **edge-triggered**. `poll_listener_status` (`openvtc-core/src/didcomm.rs`) keeps its own `seen` map and broadcasts only on a *change*, and a `tokio::broadcast` subscriber never sees anything sent before it subscribed.

On the first-run path the join happens in the State-A degraded loop, which brings the persona listener up and connected. Only afterwards does `run()` reach:

- `spawn_install_listeners` → `connect_listeners`, which `continue`s over the already-installed listener (correctly — one socket per DID),
- `didcomm_service.subscribe()`,
- the `SessionManager` registration block, creating the session at its default `SessionStatus::Connecting`.

So that listener's one `Connected` edge fired before anyone was listening, and no further edge is coming while the socket stays healthy — the session stays `Connecting` for the life of the process. On a restart the listener is installed *after* the subscribe, the edge lands, and it reads `Connected`.

The runtime-join path already knew about this: `register_joined_session` seeds from `service.listener_state(&lid)` when it adopts an existing listener. Startup did not.

## Fix

- `SessionManager::reconcile(listener_id, connected)` + `listener_ids()` — adopt the messaging layer's live view of a listener. A connect is adopted directly; a session that is *not* live is only downgraded **from** `Connected`, so a recorded `Failed(reason)` is not flattened into a bare "not connected" and a retry already in progress is not re-reported as a fresh drop.
- `reconcile_sessions` / `apply_session_aggregate` in `state_handler/mod.rs` — seed every registered session from live state right after startup registration (and log "Connected to the mediator." instead of a false "Connecting…"), with the aggregate derivation now shared with the lifecycle-event arm rather than duplicated.
- A 15 s reconcile sweep as a backstop. It costs a read of the transports' live state, and it also covers a lagged broadcast receiver — `if let Ok(ev)` silently drops a `Lagged`, which would latch the indicator in exactly the same way.
- Three unit tests over the reconcile semantics (adopting a missed connect, refusing to overwrite a failure reason, one id per shared persona session).

## Verification

- `cargo fmt --all`, `cargo clippy --all-targets --all-features` — clean
- `cargo test --all` — all suites pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean

Not covered: the ignored e2e suites (Coverage job only). The startup seed itself is not unit-testable without standing up `run()`; the reconcile semantics it depends on are.

## Pre-merge checklist (`vti-stack-development-guide.md`)

- **R1.2** timeouts — no new outbound client; the sweep is a local state read.
- **R1.4** bounded polling — fixed 15 s tick, no growth, no retry storm.
- **R6.4** diagnostics — a failed session keeps its own reason instead of being overwritten by the sweep.
- **R3.6** endpoint shapes — unchanged.