### PR TITLE
chore(deps): floor vta-sdk at 0.32.2, which labels its provisioning reply 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8970,9 +8970,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc7c4aebd8001a261148b9058fc8bbd83f7c8a4d6c072244dfd113c3ef5f87c"
+checksum = "5365d2103c2c0a876c866c8ce60787e4b27e23f1a224c00f105c0dfeb82d3442"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,7 +310,19 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # index — the same shape as the `did-git-sign` `"0.4.3"` floor that quietly
 # admitted 0.4.5 and let a duplicate `vta-sdk` into the graph unnoticed. A floor
 # that exists to exclude a specific broken release has to name it.
-vta-sdk = { version = "0.32.1", features = [
+#
+# 0.32.2 is the *reply* half of that same 0.3 cut (VTI #1202). #1200 moved the
+# dispatch sites; `result_uri_for` kept a hand-written table that tested only
+# for 0.2 and fell through to 0.1, so a provisioning reply went out as a 0.3
+# body labelled `provision/integration/0.1#response` — a message that cannot
+# satisfy the schema it names. This client does not *see* it, because it derives
+# the reply type it waits for with the same function and so agrees with the
+# server, wrongly, in both directions; it takes an independent client (the
+# browser wallet, reading the URI from the registry bindings) to notice. Which
+# is the reason to take it here anyway: a wire label this repo agrees with only
+# by sharing the bug is not a contract, and the next conformance witness or
+# non-Rust peer on the other end of a provisioning run is what collects on it.
+vta-sdk = { version = "0.32.2", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses


### PR DESCRIPTION
Split out of #270, which merged before this commit was pushed.

0.32.2 is the *reply* half of the `provision/integration` 0.3 cut that 0.32.1 started (VTI #1202). #1200 moved the four dispatch sites onto 0.3; `result_uri_for` kept a hand-written table that tested only for 0.2 and fell through to 0.1, so a provisioning reply went out as a 0.3 body labelled `provision/integration/0.1#response` — a message that cannot satisfy the schema it names, since 0.1's response requires a bare-hex `digest` and closes with `additionalProperties: false`.

This client never saw it: it derives the reply type it waits for with that same function, so client and server agreed with each other and were both wrong. It takes an independent implementation — the browser wallet, which reads the URI from the trust-tasks registry bindings — to notice.

That is the reason to take the bump rather than skip it as "does not affect us": a wire label we agree with only by sharing the defect is not a contract, and what it costs when someone does collect on it is a provisioning run that fully succeeded — bundle sealed, admin rolled over, secret written — reported to the holder as a failure.

## Verification

- One lock edge moves (`vta-sdk 0.32.1 → 0.32.2`); `cargo tree -i vta-sdk` still reports exactly one, with `did-git-sign` (patched to VGI #33's head) and `vta-service` 0.23 both unifying on it.
- `cargo clippy --all-targets --all-features` and `cargo test --all` re-run on the bumped graph — clean.
- The floor names the patch, as the note above it requires: `"0.32"` would admit 0.32.0 on a stale index, and 0.32.0 cannot link this repo to a VTA at all.

Not covered: the ignored e2e suites (Coverage job only) — which is where a provisioning path against a live VTA would actually be exercised.