### PR TITLE
feat: acknowledge the grant by digest, and keep the credential we sent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -897,7 +897,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2445,7 +2445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.4",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2816,7 +2816,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2873,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79320f11d8abf62975f95ff10b363598f6635ede485fa9ceafc167668d8bcd09"
+checksum = "96ca14987f0a6499c50b482764224686a204f74ba12d6713de90fde5f3d980a3"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -3118,7 +3118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5042,7 +5042,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5593,7 +5593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6387,7 +6387,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6954,7 +6954,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7012,7 +7012,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7667,7 +7667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7879,7 +7879,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7892,7 +7892,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9652,7 +9652,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ openvtc-core = { version = "0.3", path = "openvtc-core", default-features = fals
 #
 # The crate's documented VWC `digest` divergence from WD-01 does not reach
 # us either — `digest_multibase()` / `verify_digest()` have no call sites here.
-dtg-credentials = "0.3"
+dtg-credentials = "0.5"
 
 aes-gcm = "0.11"
 # The one direct requirement in this workspace that was behind its latest

--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -285,6 +285,27 @@ pub struct CommunityRecord {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub credentials: BTreeMap<CredentialKind, serde_json::Value>,
 
+    /// The membership credential **we** issued to this community — the
+    /// member → community half of the membership edge, acknowledging the grant
+    /// in [`credentials`](Self::credentials).
+    ///
+    /// Kept rather than sent and forgotten. Three things need it:
+    ///
+    /// 1. **Answering "did I consent to this?"** This is the member's own
+    ///    consent artifact, and it was the one credential in the exchange that
+    ///    nothing on this side could show.
+    /// 2. **Re-sending.** Without a copy, "send it again" means minting a
+    ///    *different* credential with a different `id` — which the community
+    ///    reads as a renewal, not a re-send.
+    /// 3. **Knowing whether the edge still stands.** Its `digest` names one
+    ///    grant. Once the community re-issues, this no longer matches and the
+    ///    member owes a fresh acknowledgement — visible here, and nowhere else.
+    ///
+    /// Stored as the signed W3C VC JSON, exactly as it went out. `None` until
+    /// we have issued one, and on configs written before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub member_vmc: Option<serde_json::Value>,
+
     /// Fields written by a newer build, preserved verbatim (D19). See
     /// [`Account::extra`] for why.
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
@@ -333,6 +354,8 @@ struct CommunityRecordShadow {
     // error; the `From` impl below instead drops unknown keys with a warning.
     #[serde(default)]
     credentials: BTreeMap<String, serde_json::Value>,
+    #[serde(default)]
+    member_vmc: Option<serde_json::Value>,
     // Legacy pre-R19 flat fields, folded into `credentials` below.
     #[serde(default)]
     membership_credential: Option<serde_json::Value>,
@@ -389,6 +412,7 @@ impl From<CommunityRecordShadow> for CommunityRecord {
             vrcs_issued: shadow.vrcs_issued,
             vrcs_received: shadow.vrcs_received,
             credentials,
+            member_vmc: shadow.member_vmc,
         }
     }
 }
@@ -444,6 +468,7 @@ impl CommunityRecord {
             vrcs_issued: Vrcs::default(),
             vrcs_received: Vrcs::default(),
             credentials: BTreeMap::new(),
+            member_vmc: None,
         }
     }
 
@@ -1045,6 +1070,7 @@ mod tests {
             vrcs_issued: Vrcs::default(),
             vrcs_received: Vrcs::default(),
             credentials: BTreeMap::new(),
+            member_vmc: None,
         }
     }
 

--- a/openvtc-core/src/identity.rs
+++ b/openvtc-core/src/identity.rs
@@ -185,6 +185,7 @@ mod tests {
 
     fn community(vtc: &str, persona_ref: PersonaId, status: CommunityStatus) -> CommunityRecord {
         CommunityRecord {
+            member_vmc: None,
             extra: serde_json::Map::new(),
             vtc_did: vtc.into(),
             display_name: None,

--- a/openvtc-core/src/members.rs
+++ b/openvtc-core/src/members.rs
@@ -10,6 +10,19 @@
 //! The VMC is a Data-Integrity VC whose `issuer` is the member persona and whose
 //! `credentialSubject.id` is the community VTC DID; the VTC verifies the proof +
 //! binding and stores it (vta-sdk `protocols::members`, type `members/vmc/1.0`).
+//!
+//! ## It carries a digest of the grant
+//!
+//! DTG Core Credentials: "A member-issued VMC whose `digest` does not match a
+//! valid community-issued VMC MUST NOT be treated as completing a membership
+//! edge." The digest is over the grant **as the community sent it** — the JSON
+//! stored on the membership record, not a re-serialisation of a parse of it,
+//! which drops members the local model does not know (`credentialStatus`, which
+//! every VMC issued against a status list carries).
+//!
+//! That binding is also what makes renewal safe: a re-issued grant has different
+//! claims and therefore a different digest, so consent to one membership cannot
+//! carry over to another.
 
 use std::sync::Arc;
 
@@ -34,32 +47,59 @@ use crate::errors::OpenVTCError;
 /// proof's `verificationMethod`). Used by both the manual "issue VMC" action and
 /// the auto-answer to a VTC `members/request-vmc/1.0`.
 ///
-/// Returns the DIDComm message id (the receipt's thread root).
+/// `grant` is the community-issued VMC as received, from the membership record.
+///
+/// Returns the DIDComm message id (the receipt's thread root) and the signed
+/// credential. The credential comes back so the caller can keep a copy: a
+/// member who cannot show what they sent cannot answer "did I acknowledge
+/// this?", and cannot re-send it without minting a different one.
 pub async fn issue_and_send_member_vmc(
-    atm: &ATM,
-    profile: &Arc<ATMProfile>,
+    route: &Delivery<'_>,
     signing_secret: &Secret,
-    member_did: &str,
-    vtc_did: &str,
-    mediator_did: &str,
+    grant: &Value,
     closes_request: Option<Uuid>,
-) -> Result<Uuid, OpenVTCError> {
-    let vc = build_member_vmc(signing_secret, member_did, vtc_did).await?;
-    submit_member_vmc(
-        atm,
-        profile,
-        member_did,
-        vtc_did,
-        mediator_did,
-        vc,
+) -> Result<(Uuid, Value), OpenVTCError> {
+    let vc = build_member_vmc(signing_secret, grant).await?;
+    let msg_id = submit_member_vmc(
+        route.atm,
+        route.profile,
+        route.member_did,
+        route.vtc_did,
+        route.mediator_did,
+        vc.clone(),
         closes_request,
     )
-    .await
+    .await?;
+    Ok((msg_id, vc))
+}
+
+/// Where a member VMC is going and who is sending it — the triple every
+/// `members` delivery needs, resolved by the caller.
+///
+/// Grouped rather than passed loose, matching [`crate::personhood::Route`]
+/// beside it. No TSP field: the `members/vmc` exchange has one transport today,
+/// and a field that is always `None` would suggest a choice the caller does not
+/// have.
+pub struct Delivery<'a> {
+    pub atm: &'a ATM,
+    pub profile: &'a Arc<ATMProfile>,
+    /// The member acting — the authcrypt sender, and so the identity the
+    /// community proves the delivery came from.
+    pub member_did: &'a str,
+    /// The community being addressed.
+    pub vtc_did: &'a str,
+    /// The member's own mediator, for the DIDComm leg.
+    pub mediator_did: &'a str,
 }
 
 /// Build + sign the reciprocal member VMC, without sending it. The signing half of
 /// [`issue_and_send_member_vmc`], split out so the credential's shape can be asserted
 /// without a mediator.
+///
+/// `grant` is the community-issued VMC **as it arrived** — the JSON on the membership
+/// record. The member and the community are read off it, so the two halves of the edge
+/// cannot disagree about who they are between, and the digest covers the document the
+/// community will recompute it over.
 ///
 /// # The credential carries its own `id`
 ///
@@ -72,20 +112,18 @@ pub async fn issue_and_send_member_vmc(
 ///
 /// The id has to be set before signing: the Data Integrity proof covers the credential
 /// minus its `proof`, so an id added afterwards leaves a document whose proof no longer
-/// verifies. `dtg-credentials` 0.3 is the first release with somewhere to put it.
+/// verifies. The same is true of the digest, which is why it is set at construction.
 pub async fn build_member_vmc(
     signing_secret: &Secret,
-    member_did: &str,
-    vtc_did: &str,
+    grant: &Value,
 ) -> Result<Value, OpenVTCError> {
-    let mut vmc = DTGCredential::new_vmc(
-        member_did.to_string(),
-        vtc_did.to_string(),
-        Utc::now(),
-        None,
-        false,
-    )
-    .with_id(format!("urn:uuid:{}", Uuid::new_v4()));
+    let mut vmc = DTGCredential::new_member_vmc(grant, Utc::now(), None)
+        .map_err(|e| {
+            OpenVTCError::Config(format!(
+                "cannot acknowledge this community's membership credential: {e}"
+            ))
+        })?
+        .with_id(format!("urn:uuid:{}", Uuid::new_v4()));
     vmc.sign(signing_secret, None)
         .await
         .map_err(|e| OpenVTCError::Config(format!("sign member VMC: {e}")))?;
@@ -143,12 +181,97 @@ mod tests {
     const MEMBER: &str = "did:example:member";
     const COMMUNITY: &str = "did:example:community";
 
+    /// A community-issued grant in the wire form a member receives — including
+    /// `credentialStatus`, which every VMC issued against a status list carries and
+    /// which `dtg-credentials` does not model. The fixture carries it deliberately:
+    /// a grant built through the local model would not exercise the case the digest
+    /// has to get right.
+    fn grant() -> Value {
+        serde_json::json!({
+            "@context": [
+                "https://www.w3.org/ns/credentials/v2",
+                "https://firstperson.network/credentials/dtg/v1"
+            ],
+            "type": ["VerifiableCredential", "DTGCredential", "MembershipCredential"],
+            "id": "urn:uuid:0d7f4d2c-1b8e-4a55-9e1f-7c4a2b9d3e60",
+            "issuer": COMMUNITY,
+            "validFrom": "2026-01-01T00:00:00Z",
+            "credentialStatus": {
+                "id": "https://community.example/status#7",
+                "type": "BitstringStatusListEntry",
+                "statusPurpose": "revocation",
+                "statusListIndex": "7"
+            },
+            "credentialSubject": { "id": MEMBER },
+            "proof": { "type": "DataIntegrityProof", "proofValue": "zCommunitySignature" }
+        })
+    }
+
     async fn signed_vmc() -> (Secret, Value) {
         let secret = Secret::generate_ed25519(None, None);
-        let vc = build_member_vmc(&secret, MEMBER, COMMUNITY)
+        let vc = build_member_vmc(&secret, &grant())
             .await
             .expect("build the member VMC");
         (secret, vc)
+    }
+
+    /// The acknowledgement binds to the grant by a digest over the grant **as it
+    /// arrived**. Digesting a parse of it instead would drop `credentialStatus` — the
+    /// model has no field for it — and the community would refuse a credential that
+    /// otherwise verifies, on a thread this client does not correlate. That is the
+    /// same silent failure the missing top-level `id` caused.
+    #[tokio::test]
+    async fn the_acknowledgement_digests_the_grant_as_received() {
+        let (_secret, vc) = signed_vmc().await;
+
+        assert_eq!(
+            vc["credentialSubject"]["digest"],
+            Value::String(dtg_credentials::digest_json(&grant()).expect("digest")),
+            "the digest must cover the grant the community sent"
+        );
+
+        // And not what a round trip through the local model would produce. Parsed
+        // without the proof, which the digest excludes anyway — the divergence being
+        // asserted is `credentialStatus`, not the signature.
+        let mut proofless = grant();
+        proofless.as_object_mut().expect("object").remove("proof");
+        let parsed: DTGCredential = serde_json::from_value(proofless).expect("parses");
+        assert_ne!(
+            vc["credentialSubject"]["digest"],
+            Value::String(parsed.digest().expect("digest")),
+            "digesting the parsed model drops credentialStatus and matches nothing"
+        );
+    }
+
+    /// The digest names one grant. A community that re-issues gets a different digest,
+    /// so an old acknowledgement no longer completes the edge and the member owes a
+    /// fresh one — which is what stops consent to one membership carrying over to
+    /// another.
+    #[tokio::test]
+    async fn a_reissued_grant_needs_a_fresh_acknowledgement() {
+        let (_secret, vc) = signed_vmc().await;
+
+        let mut renewed = grant();
+        renewed["id"] = Value::String("urn:uuid:renewed".into());
+        renewed["validFrom"] = Value::String("2027-01-01T00:00:00Z".into());
+
+        assert_ne!(
+            vc["credentialSubject"]["digest"],
+            Value::String(dtg_credentials::digest_json(&renewed).expect("digest"))
+        );
+    }
+
+    /// There is nothing to acknowledge without a grant, and saying so at construction
+    /// beats sending a credential the community will refuse.
+    #[tokio::test]
+    async fn a_non_grant_is_refused_before_it_is_sent() {
+        let secret = Secret::generate_ed25519(None, None);
+        let not_a_grant = serde_json::json!({
+            "type": ["VerifiableCredential", "DTGCredential", "RelationshipCredential"],
+            "issuer": COMMUNITY,
+            "credentialSubject": { "id": MEMBER }
+        });
+        assert!(build_member_vmc(&secret, &not_a_grant).await.is_err());
     }
 
     /// The community keys a member's VMC by its top-level `id` and refuses one that has

--- a/openvtc/src/state_handler/community_actions.rs
+++ b/openvtc/src/state_handler/community_actions.rs
@@ -31,8 +31,17 @@ pub(crate) enum Verb {
     /// and its session torn down; the community's receipt is advisory.
     Leave,
     /// `members/vmc` — issue the reciprocal membership credential, signed by the
-    /// member.
-    IssueVmc { signing_secret: Box<Secret> },
+    /// member, acknowledging `grant`.
+    ///
+    /// `grant` is the community-issued VMC as it arrived, resolved on the loop
+    /// thread with everything else this job needs. The acknowledgement carries a
+    /// digest of it, and that digest must cover the document the community will
+    /// recompute it over — so the wire form travels here rather than being
+    /// re-derived from a parse.
+    IssueVmc {
+        signing_secret: Box<Secret>,
+        grant: Box<serde_json::Value>,
+    },
     /// `members/personhood/challenge` — ask for the nonce an assertion must
     /// carry. The reply arrives asynchronously and lands via
     /// [`crate::state_handler::message_dispatch`]; nothing here waits for it.
@@ -93,6 +102,10 @@ impl CommunityJob {
             // established DIDComm leg, as the other community verbs do.
             tsp_mediator_did: None,
         };
+        // What the send produced, where it produces something worth keeping. The
+        // member's own acknowledgement is the one credential in this exchange
+        // that nothing on this side used to retain.
+        let mut issued: Option<serde_json::Value> = None;
         let result = match &self.verb {
             Verb::Leave => openvtc_core::join::submit_self_remove(
                 &self.atm,
@@ -104,18 +117,24 @@ impl CommunityJob {
             )
             .await
             .map(|_| ()),
-            Verb::IssueVmc { signing_secret } => openvtc_core::members::issue_and_send_member_vmc(
-                &self.atm,
-                &self.profile,
+            Verb::IssueVmc {
                 signing_secret,
-                &self.member_did,
-                &self.vtc_did,
-                &self.mediator,
+                grant,
+            } => openvtc_core::members::issue_and_send_member_vmc(
+                &openvtc_core::members::Delivery {
+                    atm: &self.atm,
+                    profile: &self.profile,
+                    member_did: &self.member_did,
+                    vtc_did: &self.vtc_did,
+                    mediator_did: &self.mediator,
+                },
+                signing_secret,
+                grant,
                 // Unprompted re-issue: there is no open join to close.
                 None,
             )
             .await
-            .map(|_| ()),
+            .map(|(_, vmc)| issued = Some(vmc)),
             Verb::RequestPersonhoodChallenge => {
                 // The member asks for their own. An administrator minting one
                 // for somebody else is a community-side action, not something
@@ -142,6 +161,7 @@ impl CommunityJob {
             persona: self.persona,
             performed,
             error: result.err().map(|e| format!("{e}")),
+            issued,
         }
     }
 }
@@ -153,6 +173,10 @@ pub(crate) struct CommunityOutcome {
     /// Which verb ran — a leave also changes the membership record.
     performed: Performed,
     error: Option<String>,
+    /// The credential the send produced, where it produced one — the member's
+    /// own acknowledgement. Carried back rather than written by the job, because
+    /// the job holds no `Config`: every record change happens on the apply path.
+    issued: Option<serde_json::Value>,
 }
 
 impl CommunityOutcome {
@@ -188,6 +212,14 @@ impl CommunityOutcome {
                 return Some((self.vtc_did, self.persona));
             }
             (None, Performed::IssueVmc) => {
+                // Keep our half before saying anything about it. This is the
+                // only moment the document exists on this side.
+                if let Some(vmc) = self.issued
+                    && let Some(c) = config.account.membership_mut(&self.vtc_did, self.persona)
+                {
+                    c.member_vmc = Some(vmc);
+                    save.mark_dirty();
+                }
                 // Only the *send* succeeded. A DIDComm `Ok` means the frame was
                 // accepted for delivery locally; it says nothing about whether
                 // the community took the credential, and for the entire life of
@@ -263,6 +295,7 @@ mod tests {
             persona: PersonaId(uuid::Uuid::nil()),
             performed,
             error: error.map(ToString::to_string),
+            issued: None,
         }
     }
 

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -745,9 +745,14 @@ fn collect_vrcs(
     result
 }
 
-/// Build display summaries for the membership (VMC) + role (VEC) credentials a
-/// VTC issued to us, stored on each community record. Reuses [`VrcSummary`]:
-/// `alias` carries "`<community>` — Membership/Role" and `remote_p_did` the VTC.
+/// Build display summaries for a membership edge's credentials: the membership
+/// (VMC) + role (VEC) a VTC issued to us, and the VMC we issued back.
+///
+/// Both halves, because membership is a pair. The community's grant says we were
+/// admitted; our acknowledgement is the half that says we agreed, and it was the
+/// one credential in the exchange this client could not show — it was signed,
+/// sent, and dropped. Reuses [`VrcSummary`]: `alias` carries "`<community>` —
+/// Membership/Role/Acknowledgement" and `remote_p_did` the VTC.
 fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
     let mut result = Vec::new();
     for c in config.account.memberships() {
@@ -815,6 +820,100 @@ fn collect_membership_creds(config: &Config) -> Vec<VrcSummary> {
                 status,
                 kind: Some(kind.config_key().to_string()),
                 subject_is_self: config.is_persona_did(&subject),
+                valid_from,
+                valid_until,
+            });
+        }
+
+        // Our own half of the pair. Rendered from the same shape, so the tab
+        // shows one membership edge rather than "credentials we were given" and
+        // an invisible obligation.
+        if let Some(vc) = &c.member_vmc {
+            let issuer = vc
+                .get("issuer")
+                .and_then(|i| {
+                    i.as_str()
+                        .map(str::to_string)
+                        .or_else(|| i.get("id").and_then(|x| x.as_str()).map(str::to_string))
+                })
+                .unwrap_or_default();
+            let subject = vc
+                .pointer("/credentialSubject/id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let valid_from = vc
+                .get("validFrom")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let valid_until = vc
+                .get("validUntil")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let (validity, status) =
+                format_validity(&valid_from, valid_until.as_deref(), chrono::Utc::now());
+
+            // Does it still acknowledge the grant we hold? The digest names one
+            // grant; once the community re-issues, ours no longer matches and we
+            // owe a fresh one. Saying "stale" here is the only place a member
+            // learns that — the community sees it, and until now we did not.
+            let stale = c
+                .credentials
+                .get(&openvtc_core::CredentialKind::Membership)
+                .zip(
+                    vc.pointer("/credentialSubject/digest")
+                        .and_then(|d| d.as_str()),
+                )
+                .map(|(grant, claimed)| {
+                    dtg_credentials::digest_json(grant)
+                        .map(|expected| expected != claimed)
+                        // Undigestable grant: we cannot say it is stale, so we
+                        // do not. R6.3 — claim only what was checked.
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false);
+
+            result.push(VrcSummary {
+                vrc_id: vc
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                remote_p_did: sanitize_display(&c.vtc_did, 256),
+                remote_agent_name: config
+                    .agent_name_for(&c.vtc_did)
+                    .map(|n| sanitize_display(n, 256)),
+                raw_json: content::RawCredential::Value(Arc::new(vc.clone())),
+                alias: Some(community.clone()),
+                issuer: sanitize_display(&issuer, 256),
+                issuer_agent_name: config
+                    .agent_name_for(&issuer)
+                    .map(|n| sanitize_display(n, 256)),
+                subject: sanitize_display(&subject, 256),
+                subject_agent_name: config
+                    .agent_name_for(&subject)
+                    .map(|n| sanitize_display(n, 256)),
+                validity,
+                // A stale acknowledgement is inside its own window and still
+                // completes nothing, so the window's answer would mislead. This
+                // is not a revocation check either — no status list is consulted
+                // — it is the digest binding, which is the whole of what makes
+                // this credential mean anything.
+                status: if stale {
+                    "superseded — the community re-issued".to_string()
+                } else {
+                    status
+                },
+                kind: Some(
+                    if stale {
+                        "Acknowledgement (stale)"
+                    } else {
+                        "Acknowledgement"
+                    }
+                    .to_string(),
+                ),
+                subject_is_self: false,
                 valid_from,
                 valid_until,
             });
@@ -1136,6 +1235,7 @@ mod tests {
         config.account.communities.insert(
             vtc_did.to_string(),
             vec![CommunityRecord {
+                member_vmc: None,
                 extra: serde_json::Map::new(),
                 vtc_did: vtc_did.to_string(),
                 display_name: display_name.map(str::to_owned),

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -56,8 +56,27 @@ pub(crate) async fn issue_member_vmc_for(
     vtc_did: &str,
     persona_id: openvtc_core::config::account::PersonaId,
     closes_request: Option<uuid::Uuid>,
-) -> Result<uuid::Uuid, openvtc_core::errors::OpenVTCError> {
+) -> Result<(uuid::Uuid, serde_json::Value), openvtc_core::errors::OpenVTCError> {
     use openvtc_core::errors::OpenVTCError;
+    // The grant we are acknowledging, as the community sent it. Without one
+    // there is nothing to acknowledge: an acknowledgement names a specific
+    // grant by digest, and a community that has issued us none has no
+    // membership edge for us to complete.
+    let grant = config
+        .account
+        .membership(vtc_did, persona_id)
+        .and_then(|c| {
+            c.credentials
+                .get(&openvtc_core::CredentialKind::Membership)
+                .cloned()
+        })
+        .ok_or_else(|| {
+            OpenVTCError::Config(
+                "this community has not issued us a membership credential, so there is \
+                 nothing to acknowledge"
+                    .into(),
+            )
+        })?;
     let id = config
         .identities
         .get(&persona_id)
@@ -71,12 +90,15 @@ pub(crate) async fn issue_member_vmc_for(
         .ok_or_else(|| OpenVTCError::Config("messaging (ATM) unavailable".into()))?;
     let keys = config.get_persona_keys_for(persona_id, tdk).await?;
     openvtc_core::members::issue_and_send_member_vmc(
-        atm,
-        &profile,
+        &openvtc_core::members::Delivery {
+            atm,
+            profile: &profile,
+            member_did: &member_did,
+            vtc_did,
+            mediator_did: &mediator,
+        },
         &keys.signing.secret,
-        &member_did,
-        vtc_did,
-        &mediator,
+        &grant,
         closes_request,
     )
     .await
@@ -253,11 +275,20 @@ pub async fn process_inbound_message(
         // `members/request-vmc`.
         if let Some((persona_id, request_id)) = outcome.closed_join {
             match issue_member_vmc_for(config, tdk, &from_did, persona_id, Some(request_id)).await {
-                Ok(_) => info!(
-                    vtc = %from_did,
-                    %request_id,
-                    "sent our reciprocal membership credential, closing the join request"
-                ),
+                Ok((_, vmc)) => {
+                    // Keep our half. The send is the only moment this document
+                    // exists on this side, and a member who cannot show what
+                    // they sent cannot answer whether they consented, nor
+                    // re-send it without minting a different credential.
+                    if let Some(record) = config.account.membership_mut(&from_did, persona_id) {
+                        record.member_vmc = Some(vmc);
+                    }
+                    info!(
+                        vtc = %from_did,
+                        %request_id,
+                        "sent our reciprocal membership credential, closing the join request"
+                    )
+                }
                 Err(e) => warn!(
                     vtc = %from_did,
                     %request_id,
@@ -431,10 +462,15 @@ pub async fn process_inbound_message(
                     .is_some_and(|c| c.status.is_active()) =>
             {
                 match issue_member_vmc_for(config, tdk, &from_did, persona_id, None).await {
-                    Ok(_) => info!(
-                        vtc = %from_did,
-                        "auto-issued our membership credential in response to the VTC's request"
-                    ),
+                    Ok((_, vmc)) => {
+                        if let Some(record) = config.account.membership_mut(&from_did, persona_id) {
+                            record.member_vmc = Some(vmc);
+                        }
+                        info!(
+                            vtc = %from_did,
+                            "auto-issued our membership credential in response to the VTC's request"
+                        )
+                    }
                     Err(e) => warn!(
                         vtc = %from_did,
                         error = %e,

--- a/openvtc/src/state_handler/runtime_actions.rs
+++ b/openvtc/src/state_handler/runtime_actions.rs
@@ -399,6 +399,25 @@ pub(crate) async fn handle_action(ctx: &mut ActionCtx<'_>, action: Action) -> Ha
                 .filter(|c| c.status.is_active())
                 .map(|c| (c.vtc_did.clone(), c.persona_ref));
             if let Some((vtc, persona_id)) = target {
+                // The grant we are acknowledging, as the community sent it.
+                // Read here with the key, for the same reason: the job owns its
+                // inputs rather than borrowing `Config`. Without a grant there
+                // is nothing to acknowledge — an acknowledgement names one
+                // specific grant by digest.
+                let Some(grant) = ctx
+                    .config
+                    .account
+                    .membership(&vtc, persona_id)
+                    .and_then(|c| c.credentials.get(&openvtc_core::CredentialKind::Membership))
+                    .cloned()
+                else {
+                    ctx.state.main_page.content_panel.communities.status_message = Some(
+                        "This community hasn't issued you a membership credential yet — \
+                         there is nothing to acknowledge."
+                            .to_string(),
+                    );
+                    return Handled::Continue;
+                };
                 // The signing key is read here for the same reason as
                 // the capability toggle: it comes from the in-memory
                 // secrets resolver, not the network, and reading it
@@ -434,6 +453,7 @@ pub(crate) async fn handle_action(ctx: &mut ActionCtx<'_>, action: Action) -> Ha
                             persona: persona_id,
                             verb: community_actions::Verb::IssueVmc {
                                 signing_secret: Box::new(keys.signing.secret.clone()),
+                                grant: Box::new(grant),
                             },
                         },
                     );


### PR DESCRIPTION
## Why

Two halves of the same gap.

**The acknowledgement completed nothing.** The reciprocal VMC this client issues carried no `credentialSubject.digest`, and DTG Core Credentials is explicit:

> A member-issued VMC whose `digest` does not match a valid community-issued VMC MUST NOT be treated as completing a membership edge.

**And we did not keep it.** `issue_and_send_member_vmc` built it, signed it, sent it, and dropped the value. The one credential in the exchange that says *we* consented was the one nothing on this side could show — not to answer "did I agree to this?", not to re-send without minting a different credential, not to tell whether it still stands.

## Digest the grant as it arrived

The digest covers the JSON on the membership record — the wire form the community sent — never a re-serialisation of a parse of it. This is load-bearing, not fastidiousness:

```
wire has credentialStatus:       true
round-trip has credentialStatus: false
```

`DTGCommon` does not model `credentialStatus`, and **every VMC a VTC issues against a status list carries one**. Digesting a parsed grant produces a digest over a document the community never issued. It fails silently: both credentials verify on their own, only the comparison fails, and the refusal arrives as a problem-report on a thread this client does not correlate — the same shape as the missing top-level `id` that hid this exchange's brokenness for its whole life.

So `build_member_vmc` takes the grant rather than two DIDs, and reads the member and the community off it — the two halves cannot disagree about who they are between. Where no grant is held there is nothing to acknowledge, and both entry points (the admission auto-send and the manual `m`) say so rather than sending something that will be refused.

Depends on `dtg-credentials` 0.5, whose `new_member_vmc` takes the wire form for exactly this reason.

## Keep our half

`CommunityRecord` gains `member_vmc`, written on both send paths and by the auto-answer to `members/request-vmc`. The Membership tab now shows it beside the credentials we were given, so the tab reads as one membership edge rather than a list of gifts and an invisible obligation.

It also says when ours has gone **stale**. The digest names one grant; once the community re-issues, ours no longer matches and we owe a fresh one. The community could already see that — the member could not.

## Testing

All 476 core + 382 UI tests pass; clippy clean; fmt clean.

New coverage in `openvtc-core::members`, built on a fixture that carries `credentialStatus` deliberately — a grant built through the local model would not exercise the case the digest has to get right:

- the acknowledgement digests the grant **as received**, and explicitly *not* what a round trip through the model produces
- a re-issued grant yields a different digest, so an old acknowledgement no longer completes the edge
- a non-grant is refused at construction rather than sent

## Notes

- `issue_and_send_member_vmc` takes a `Delivery` rather than five loose arguments, matching `personhood::Route` beside it — the grant pushed it past clippy's argument budget, and grouping is what this repo already does there.
- `member_vmc` is `#[serde(default, skip_serializing_if = "Option::is_none")]` and rides the `CommunityRecordShadow` load shim, so existing configs load unchanged and simply show no acknowledgement until the next one is issued.

## Related

- OpenVTC/dtg-credentials#14 — `digest_json`, and `new_member_vmc` taking the wire form
- OpenVTC/verifiable-trust-infrastructure#1213 — the VTC side: verifies the digest, and draws the completed membership edge on the trust graph