### PR TITLE
fix(tsp): start the hop list at our own mediator, so a cross-mediator join sends

### DIFF
--- a/openvtc-core/src/tsp.rs
+++ b/openvtc-core/src/tsp.rs
@@ -14,6 +14,15 @@
  * unconditionally, so it cannot carry a Trust Task document as TSP. This module
  * is that one missing call and nothing more.
  *
+ * ## The peer is not on our mediator
+ *
+ * A community is addressed by the mediator *it* advertises, which is only our
+ * own in a single-mediator deployment. Everywhere else the send is a federated
+ * one: we post to our mediator, it forwards to theirs, theirs delivers. That is
+ * carried entirely by the hop list — see `hops` (not an intra-doc link: it is
+ * private) — and it is the part this module got wrong for as long as every
+ * deployment shared one mediator.
+ *
  * Send-only is also why there is **no second websocket**. The mediator permits
  * one channel per DID and evicts a second as `duplicate-channel`; a TSP send is
  * an HTTP post through the mediator, holding no socket of its own, so it cannot
@@ -47,16 +56,53 @@ use serde_json::Value;
 
 use crate::errors::OpenVTCError;
 
+/// Build the TSP hop list for a send from `our_mediator` to `to_did`, whose
+/// advertised TSP mediator is `their_mediator`.
+///
+/// `route[0]` must be **our own** mediator. `send_routed` posts the frame to the
+/// profile's mediator `/inbound`, and that mediator has to be the routing
+/// layer's receiver in order to hold the key that unwraps it. A hop list opening
+/// with the peer's mediator arrives at ours as an envelope addressed to someone
+/// else, which it can only take as an opaque message for one of its own
+/// accounts — so a cross-mediator send died at the *first* hop with
+/// `404 e.p.direct_delivery.recipient.unknown`, "TSP recipient is not local to
+/// this mediator (remote forwarding not yet enabled)". Nothing was wrong with
+/// the peer's mediator; ours was never asked to forward.
+///
+/// Naming ours first is what turns the send into a forward: our mediator unwraps
+/// its layer, sees a next hop that is not one of its accounts, resolves that
+/// hop's `TSPTransport` endpoint and POSTs onward. The peer's mediator is then
+/// the routing-layer receiver of the frame it actually gets, and delivers the
+/// end-to-end-sealed inner to `to_did` locally.
+///
+/// When the two mediators coincide — every single-mediator deployment, which is
+/// why this held up for so long — the list stays two hops: ours already *is* the
+/// peer's, and naming it twice would ask it to forward to itself
+/// (`protocol.forwarding.loop_detected`).
+fn hops(our_mediator: &str, their_mediator: &str, to_did: &str) -> Vec<String> {
+    if our_mediator == their_mediator {
+        vec![their_mediator.to_string(), to_did.to_string()]
+    } else {
+        vec![
+            our_mediator.to_string(),
+            their_mediator.to_string(),
+            to_did.to_string(),
+        ]
+    }
+}
+
 /// Seal a Trust Task `document` to `to_did` and route it through that peer's
 /// advertised TSP mediator.
 ///
 /// The TSP counterpart of [`crate::pack_and_send`], and deliberately the same
 /// signature shape so the two are directly comparable at a call site.
 ///
-/// `tsp_mediator_did` is the peer's **advertised** `#tsp` mediator — the hop the
-/// routing layer is sealed to — not ours. That is the addressing information the
-/// peer published for exactly this purpose (`discover_tsp_mediator`), and using
-/// ours instead would only work while the two happen to coincide.
+/// `tsp_mediator_did` is the peer's **advertised** `#tsp` mediator — the hop that
+/// hands the document to the peer — not ours. That is the addressing information
+/// the peer published for exactly this purpose (`discover_tsp_mediator`). It is
+/// the *last* mediator on the route rather than the first: the private `hops`
+/// explains why the route has to open with our own mediator, and what it cost
+/// when it did not.
 ///
 /// Unlike the DIDComm path the caller does **not** pack: `send_routed` seals the
 /// payload end-to-end to `route.last()` and wraps that in a routing layer sealed
@@ -64,18 +110,20 @@ use crate::errors::OpenVTCError;
 ///
 /// # Errors
 ///
-/// Returns [`OpenVTCError`] if the document will not serialise, or if the
-/// mediator did not accept the frame. The message names the peer, the routing
-/// hop, **and the mediator the frame was actually posted to** (R6.4), so an
-/// operator can tell a wrong advertised mediator from a refused send from an
-/// unreachable hop.
+/// Returns [`OpenVTCError`] if the profile cannot name the mediator the route is
+/// built from, if the document will not serialise, or if the mediator did not
+/// accept the frame. The message names the peer, the routing hop, **and the
+/// mediator the frame was actually posted to** (R6.4), so an operator can tell a
+/// wrong advertised mediator from a refused send from an unreachable hop.
 ///
 /// Naming all three is not belt-and-braces. `send_routed` posts to the
-/// *profile's* mediator — `route[0]` is sealed into the frame, not dialled — so
-/// a rejection quoting only the advertised mediator sends an operator to inspect
-/// a host that never received the request. That happened: a mediator built
-/// without its `tsp` feature answered `400 w.m.message.deserialize` (it fed the
-/// CESR frame to the DIDComm JSON parser), under an error naming the peer's
+/// *profile's* mediator — the onward hops are sealed into the frame, not dialled
+/// — so a rejection quoting only the advertised mediator sends an operator to
+/// inspect a host that never received the request. That happened twice: a
+/// mediator built without its `tsp` feature answered `400
+/// w.m.message.deserialize` (it fed the CESR frame to the DIDComm JSON parser),
+/// and our own mediator answered `404 direct_delivery.recipient.unknown` for a
+/// hop list that did not start with it — both under an error naming the peer's
 /// perfectly healthy TSP mediator.
 pub async fn send_trust_task(
     atm: &ATM,
@@ -84,20 +132,26 @@ pub async fn send_trust_task(
     to_did: &str,
     tsp_mediator_did: &str,
 ) -> Result<(), OpenVTCError> {
+    // Not best-effort any more: our mediator is the first hop, so a profile that
+    // cannot name it has no route to build and must fail before the send.
+    let our_mediator = profile
+        .dids()
+        .map(|(_, mediator)| mediator.to_string())
+        .map_err(|e| {
+            OpenVTCError::Config(format!(
+                "TSP send to {to_did}: profile cannot name its own mediator, \
+                 which the route has to start from: {e}"
+            ))
+        })?;
+
     let payload = serde_json::to_vec(document)
         .map_err(|e| OpenVTCError::Config(format!("serialise Trust Task document for TSP: {e}")))?;
-    let route = [tsp_mediator_did.to_string(), to_did.to_string()];
+    let route = hops(&our_mediator, tsp_mediator_did, to_did);
 
     atm.tsp()
         .send_routed(profile, &route, &payload)
         .await
         .map_err(|e| {
-            // Best-effort: a profile that cannot name its own mediator is not a
-            // reason to lose the send error we actually have to report.
-            let our_mediator = profile
-                .dids()
-                .map(|(_, mediator)| mediator.to_string())
-                .unwrap_or_else(|_| "unknown".to_string());
             OpenVTCError::Config(format!(
                 "TSP send to {to_did} (routed via its advertised mediator \
                  {tsp_mediator_did}, posted through our own mediator \
@@ -108,22 +162,44 @@ pub async fn send_trust_task(
 
 #[cfg(test)]
 mod tests {
+    use super::hops;
 
-    /// The hop order is the part that is easy to get backwards and impossible to
-    /// see in a signature: `route[0]` is the mediator the routing layer is sealed
-    /// to, `route.last()` the final recipient the payload is sealed to. Reversed,
-    /// the mediator would receive a frame it cannot forward.
+    const OURS: &str = "did:webvh:example:our-mediator";
+    const THEIRS: &str = "did:webvh:example:their-mediator";
+    const TO: &str = "did:webvh:example:vtc";
+
+    /// The invariant the whole module turns on, and the one that is impossible
+    /// to see in a signature: whatever else the route contains, it opens with
+    /// the mediator the frame is posted to, because only that mediator holds the
+    /// key to the routing layer.
     #[test]
-    fn route_is_mediator_then_recipient() {
-        let to = "did:webvh:example:vtc";
-        let mediator = "did:webvh:example:mediator";
-        let route = [mediator.to_string(), to.to_string()];
+    fn route_always_starts_at_our_own_mediator() {
+        for (ours, theirs) in [(OURS, THEIRS), (OURS, OURS)] {
+            let route = hops(ours, theirs, TO);
+            assert_eq!(
+                route[0], ours,
+                "route[0] must be the mediator we post to ({ours} → {theirs})"
+            );
+            assert_eq!(
+                route.last().map(String::as_str),
+                Some(TO),
+                "route.last() must be the final recipient ({ours} → {theirs})"
+            );
+        }
+    }
 
-        assert_eq!(route[0], mediator, "route[0] must be the routing hop");
-        assert_eq!(
-            route.last().map(String::as_str),
-            Some(to),
-            "route.last() must be the final recipient"
-        );
+    /// A peer on another mediator needs the forwarding hop spelled out: ours
+    /// unwraps and forwards to theirs, theirs delivers locally. Without the
+    /// middle hop ours has nobody to forward to and refuses the send.
+    #[test]
+    fn cross_mediator_route_names_both_mediators() {
+        assert_eq!(hops(OURS, THEIRS, TO), vec![OURS, THEIRS, TO]);
+    }
+
+    /// A peer on our own mediator stays two hops. Repeating the mediator would
+    /// ask it to forward to itself, which it rejects as a routing loop.
+    #[test]
+    fn same_mediator_route_does_not_repeat_the_hop() {
+        assert_eq!(hops(OURS, OURS, TO), vec![OURS, TO]);
     }
 }


### PR DESCRIPTION
## The report

Joining a community failed at "Submitting join request…":

```
ERROR: Failed to submit join request: Config Error: TSP send to
did:webvh:Qmb…:dids.eu.openvtc.net:vtc (routed via its advertised mediator
did:webvh:QmV…:dids.eu.openvtc.net:mediator, posted through our own mediator
did:webvh:Qmb…:dids.firstperson.dev:firstperson-mediator): Transport (HTTP(S))
error: Mediator rejected TSP message: status(404 Not Found),
body({… "errorCode":58, "errorCodeStr":"DIDCommProblemReport",
"message":"{\"code\":\"e.p.direct_delivery.recipient.unknown\",
\"comment\":\"TSP recipient is not local to this mediator
(remote forwarding not yet enabled)\"}"})
```

The persona is homed on `firstperson-mediator`; the community is on
`eu.openvtc.net`'s mediator. Everything before this step succeeded — the
persona, its DID, its mediator connection — so the failure is the send itself.

## What actually happened

The error names the community's mediator, which is healthy and never received
anything. The 404 came from **our own** mediator, one hop earlier.

`atm.tsp().send_routed` posts the frame to the *profile's* mediator `/inbound`
and seals the routing layer to `route[0]`. So `route[0]` must be that same
mediator — it is the only party holding the key to unwrap the layer. We were
passing the peer's advertised mediator as `route[0]`:

```rust
let route = [tsp_mediator_did.to_string(), to_did.to_string()];
```

`firstperson-mediator` therefore received an envelope whose cleartext receiver
is a DID it does not own. Its TSP inbound handler takes `receiver != self` as
an opaque pass-through for one of its **local** accounts, looked one up, found
none, and returned `direct_delivery.recipient.unknown`. Its remote-forwarding
path (`forward_tsp_remote`) exists and works — it was never reached, because
nothing ever asked our mediator to forward.

This is invisible in a single-mediator deployment: there the peer's advertised
mediator *is* ours, and the two-hop list is accidentally correct. It surfaces
the first time a persona on one mediator joins a community on another, which is
the ordinary federated case.

## The fix

Build the hop list from our mediator outward:

| topology | route |
|---|---|
| peer on another mediator | `[ours, theirs, recipient]` |
| peer on our mediator | `[ours, recipient]` |

Our mediator unwraps its layer, sees a next hop that is not one of its
accounts, resolves that hop's `TSPTransport` endpoint from its DID document and
POSTs onward; the peer's mediator is then the routing-layer receiver of the
frame it actually receives, and delivers the end-to-end-sealed inner to the VTC
locally.

This is the shape the mediator's own federation test asserts
(`tsp_federation.rs`: *"`route[0]` … must be alice's own mediator A, since the
SDK posts the routed message to A's `/inbound`"*) and the one `ATM::send_to`
builds for the same situation. It is also what `vta-sdk` has always done for the
VTA leg — `[self.mediator_did, vta_did]`, ours first.

The same-mediator case must stay two hops: repeating the mediator would ask it
to forward to itself, which it rejects as `protocol.forwarding.loop_detected`.

Naming our own mediator is no longer best-effort error decoration — it is the
first hop, so a profile that cannot name it now fails before the send instead of
building a route without it.

All three TSP senders — join submit, join status poll, and the personhood
`Route` — go through `send_trust_task`, so all three are fixed by this.

## Tests

The test being replaced built its route inline rather than calling the code, so
it asserted the hop order of a literal and passed regardless of what
`send_trust_task` did. The replacements drive `hops` directly and pin the
invariant that the route starts at the mediator we post to, in both topologies.

## Server-side prerequisites

The client fix is sufficient only where the two mediators can actually federate,
so on a live deployment also confirm:

- **Our mediator can forward.** `forward_tsp_remote` landed in
  affinidi-tdk-rs #502; a mediator older than that will refuse the middle hop.
- **The community's mediator advertises a reachable `TSPTransport` endpoint**,
  since ours resolves the onward POST target from its DID document.
- **The VTC's access list admits the forwarded sender.** After the hop the
  `from_vid` our mediator presents is *its own* VID, not the persona's — the TDK
  federation test spells this out ("both relay-enabled with an allow-all default
  ACL, so the cross-mediator forward sender is accepted"). A restrictive
  access list on the VTC side will turn the 404 into a 403
  `authorization.access_list.denied`, which is a different, correctly-named
  failure.

## Checks

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test --workspace -- --include-ignored` (MockVta e2es)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] DCO signed off

### Pre-merge checklist (`vti-stack-development-guide.md`)

- **R6.4** — the error already named peer, routing hop and the mediator actually
  posted to, which is what made this diagnosable at all; it now also
  distinguishes "profile cannot name its mediator" as its own failure. The
  misleading part was not the message but the route it described.
- **R3.6** — the route shape was verified against the current mediator source
  and its federation tests rather than assumed.
- R1.2 / R1.4 — no new outbound client or polling loop.
