### PR TITLE
fix(settings): make the mediator DID read-only, and stop reporting saves that did not happen

### DIFF
--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -643,17 +643,35 @@ impl Config {
 
     /// Set the active persona's mediator DID, updating both the persisted
     /// `account` record and the runtime `IdentityContext` so subsequent reads
-    /// (and the next save) see the new value. No-op if no identity is active.
-    pub fn set_active_mediator_did(&mut self, did: &str) {
+    /// (and the next save) see the new value.
+    ///
+    /// Returns `false` when there is no active identity to set it on — a
+    /// State-A config carries an account but no persona (see
+    /// [`Config::mediator_did`], which reads back `""` there), and a mediator
+    /// DID is a *per-persona* field with nowhere to live until one exists.
+    ///
+    /// The caller must not report success on `false`. Swallowing it is what
+    /// made this look like a working setting that "did not take": the write
+    /// vanished, the field read back empty, and the UI still said "Setting
+    /// saved".
+    #[must_use = "a false return means the mediator DID was NOT set; do not report success"]
+    pub fn set_active_mediator_did(&mut self, did: &str) -> bool {
         let Some(id) = self.active_identity().map(|i| i.persona_id) else {
-            return;
+            return false;
         };
-        if let Some(persona) = self.account.personas.get_mut(&id) {
-            persona.mediator_did = Some(did.to_string());
-        }
+        // The account record is the half that survives a restart, so it decides
+        // the answer: updating only the runtime context would report a success
+        // the operator loses on next launch. Load builds `identities` by walking
+        // `account.personas`, so a missing record here is not reachable — this
+        // is what keeps the `true` honest rather than assumed.
+        let Some(persona) = self.account.personas.get_mut(&id) else {
+            return false;
+        };
+        persona.mediator_did = Some(did.to_string());
         if let Some(ctx) = self.identities.get_mut(&id) {
             ctx.mediator_did = Some(did.to_string());
         }
+        true
     }
 
     /// Whether `did` is one of our resolved persona DIDs (vs. a relationship
@@ -1787,6 +1805,64 @@ mod tests {
         assert!(config.active_identity().is_none());
         assert_eq!(config.persona_did(), "");
         assert_eq!(config.mediator_did(), "");
+    }
+
+    /// The *write* side of the State-A case. Reading back `""` was already
+    /// pinned above; what was not was that the write reports having done
+    /// nothing. It used to return `()`, so the settings panel said "Setting
+    /// saved" over a value that had gone nowhere.
+    #[test]
+    fn setting_mediator_did_without_a_persona_reports_that_it_did_not_apply() {
+        let mut config = test_config(BTreeMap::new());
+
+        assert!(
+            !config.set_active_mediator_did("did:webvh:example:mediator"),
+            "no persona to set a mediator on, so the write must report failure"
+        );
+        assert_eq!(
+            config.mediator_did(),
+            "",
+            "and must not have invented somewhere to store it"
+        );
+    }
+
+    /// The same write with a persona resolved applies to *both* the runtime
+    /// identity and the persisted account record — the next read and the next
+    /// save have to agree, or the setting reverts on restart.
+    #[test]
+    fn setting_mediator_did_with_a_persona_applies_to_runtime_and_account() {
+        let pid = account::PersonaId(uuid::Uuid::from_u128(1));
+        let mut identities = BTreeMap::new();
+        identities.insert(pid, test_identity(pid, "did:example:persona"));
+        let mut config = test_config(identities);
+        // Seed the account half too: load derives `identities` from
+        // `account.personas`, so a real config always has both.
+        config.account.personas.insert(
+            pid,
+            account::PersonaRecord {
+                persona_id: pid,
+                did: "did:example:persona".to_string(),
+                did_document: None,
+                key_refs: Vec::new(),
+                mediator_did: None,
+                origin_context_id: "openvtc/test".to_string(),
+                created_at: chrono::Utc::now(),
+                label: None,
+                extra: serde_json::Map::new(),
+            },
+        );
+
+        assert!(config.set_active_mediator_did("did:webvh:example:mediator"));
+        assert_eq!(config.mediator_did(), "did:webvh:example:mediator");
+        assert_eq!(
+            config
+                .account
+                .personas
+                .get(&pid)
+                .and_then(|p| p.mediator_did.as_deref()),
+            Some("did:webvh:example:mediator"),
+            "the persisted record must move too, or the change is lost on restart"
+        );
     }
 
     /// R7: with multiple personas resolved, `active_identity()` must be

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -625,8 +625,16 @@ pub fn create_termination() -> (Terminator, broadcast::Receiver<Interrupted>) {
 pub fn apply_env_overrides(config: &mut Config) {
     use openvtc_core::config::KeyBackend;
 
-    if let Ok(val) = std::env::var("OPENVTC_MEDIATOR_DID") {
-        config.set_active_mediator_did(&val);
+    if let Ok(val) = std::env::var("OPENVTC_MEDIATOR_DID")
+        && !config.set_active_mediator_did(&val)
+    {
+        // The override hangs off the active persona, so a State-A profile has
+        // nowhere to put it. Silently dropping an override the operator set on
+        // purpose is how it becomes a mystery later.
+        tracing::warn!(
+            did = %val,
+            "OPENVTC_MEDIATOR_DID ignored: this profile has no persona to set a mediator on"
+        );
     }
     if let Ok(val) = std::env::var("OPENVTC_VTA_URL")
         && let KeyBackend::Vta {

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -1135,8 +1135,6 @@ pub enum SettingsMode {
     View,
     /// Editing the friendly name
     EditFriendlyName { input: String },
-    /// Editing the mediator DID
-    EditMediatorDid { input: String },
     /// Editing the org DID
     EditOrgDid { input: String },
     /// Export config form (path + passphrase length for masked display)

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -30,34 +30,11 @@ pub fn update_friendly_name(config: &mut Config, name: &str) {
     info!(name = %name, "friendly name updated");
 }
 
-/// Update the mediator DID. Returns `false` when there was no persona to set it
-/// on, so the caller can say so instead of reporting a save that did not happen.
-///
-/// R11: mutates + logs only (see [`update_friendly_name`]). The subsequent
-/// reconnect (R13 background dispatch) does not depend on the file being on disk
-/// yet — it reads the in-memory config — so coalescing the save is safe.
-#[must_use = "a false return means nothing was written; do not report success"]
-pub fn update_mediator_did(config: &mut Config, did: &str) -> bool {
-    if !config.set_active_mediator_did(did) {
-        // R6.4: name the reason, not just the failure. The mediator DID hangs
-        // off a persona, and a State-A profile has none — so this is "not yet",
-        // not "rejected", and the log has to distinguish them.
-        config.public.logs.insert(
-            LogFamily::Config,
-            "Mediator DID not changed: this profile has no persona yet, and the \
-             mediator DID belongs to one"
-                .to_string(),
-        );
-        info!(did = %did, "mediator DID change ignored — no active persona");
-        return false;
-    }
-    config.public.logs.insert(
-        LogFamily::Config,
-        format!("Mediator DID changed to '{}'", did),
-    );
-    info!(did = %did, "mediator DID updated (reconnect needed)");
-    true
-}
+// There is deliberately no `update_mediator_did`. A persona's mediator is chosen
+// when the persona is minted and published in its DID document, so the Settings
+// row is read-only (see `settings_panel::MEDIATOR_ROW`). The one remaining write
+// path is the `OPENVTC_MEDIATOR_DID` override in `main.rs`, which calls
+// `Config::set_active_mediator_did` directly and warns when it does not apply.
 
 /// Update the organization DID.
 ///
@@ -194,9 +171,8 @@ fn handle_start_edit(state: &mut State) {
         0 => SettingsMode::EditFriendlyName {
             input: s.friendly_name.clone(),
         },
-        1 => SettingsMode::EditMediatorDid {
-            input: s.mediator_did.clone(),
-        },
+        // `MEDIATOR_ROW` (1) is deliberately absent: the mediator is read-only,
+        // so Enter on it falls through to `View` like any other unedittable row.
         2 => SettingsMode::EditOrgDid {
             input: s.org_did.clone(),
         },
@@ -216,9 +192,7 @@ fn handle_start_edit(state: &mut State) {
 
 fn handle_field_update(state: &mut State, value: String) {
     match &mut state.main_page.content_panel.settings.mode {
-        SettingsMode::EditFriendlyName { input }
-        | SettingsMode::EditMediatorDid { input }
-        | SettingsMode::EditOrgDid { input } => {
+        SettingsMode::EditFriendlyName { input } | SettingsMode::EditOrgDid { input } => {
             *input = value;
         }
         _ => {}
@@ -298,60 +272,37 @@ fn handle_protection_tab_switch(state: &mut State, next_field: usize) {
     }
 }
 
-/// Returns `true` if the mediator DID was actually changed and a reconnect is
-/// needed.
+/// Commit the in-progress settings edit.
 ///
-/// R11: the per-setting save is now coalesced (`Persist::SaveAndSync` marks the
+/// R11: the per-setting save is coalesced (`Persist::SaveAndSync` marks the
 /// config dirty rather than saving inline).
 ///
-/// The mediator DID is the one setting here that can decline to apply: it hangs
-/// off the active persona, and a State-A profile has none. That used to be
-/// swallowed — the write vanished, and the panel reported "Setting saved" over a
-/// field that read back empty, which is exactly how it was reported ("it did not
-/// take"). It also asked for a mediator reconnect that could not do anything,
-/// leaving the header on "Connecting…". Both now hang off whether the write
-/// landed.
+/// No row here can decline to apply, and none triggers a mediator reconnect. The
+/// mediator DID used to be the exception on both counts: it is a *per-persona*
+/// field, so on a profile with no persona the write vanished while the panel
+/// still said "Setting saved" over a field that read back empty ("it did not
+/// take"), and it still asked for a reconnect that had nothing new to dial —
+/// leaving the header on "Connecting…" under a success message. The row is now
+/// read-only (`MEDIATOR_ROW` never opens an edit mode), so that whole shape is
+/// gone rather than merely reported honestly.
 fn handle_submit_edit(
     config: &mut Box<Config>,
     state: &mut State,
     save: &mut SaveScheduler,
     value: &str,
-) -> bool {
+) {
     let idx = state.main_page.content_panel.settings.selected_index;
-    let applied = match idx {
-        0 => {
-            update_friendly_name(config, value);
-            true
-        }
-        1 => update_mediator_did(config, value),
-        2 => {
-            update_org_did(config, value);
-            true
-        }
-        _ => true,
-    };
+    match idx {
+        0 => update_friendly_name(config, value),
+        2 => update_org_did(config, value),
+        _ => {}
+    }
     let setting_name = match idx {
         0 => "Friendly name",
-        1 => "Mediator DID",
         2 => "Organization DID",
         _ => "Setting",
     };
     state.main_page.content_panel.settings.mode = SettingsMode::View;
-
-    if !applied {
-        // Nothing was written, so nothing is dirty: no save, no sync, and no
-        // reconnect. Say what would make the setting available instead of
-        // leaving the operator to infer it from a blank field.
-        state.main_page.content_panel.settings.status_message = Some(
-            "Mediator DID not changed — this profile has no persona yet. \
-             A persona gets its mediator when it is created."
-                .to_string(),
-        );
-        state
-            .main_page
-            .log("Mediator DID unchanged: no persona in this profile");
-        return false;
-    }
 
     dispatch_util::save_and_sync(
         &mut state.main_page,
@@ -362,8 +313,6 @@ fn handle_submit_edit(
         "Setting saved",
         dispatch_util::SyncLog::Plain(format!("{} updated", setting_name)),
     );
-    // Mediator DID is index 1 — caller should trigger reconnect
-    idx == 1
 }
 
 async fn handle_export_config_action(
@@ -799,14 +748,10 @@ pub(crate) async fn dispatch(
             handle_protection_tab_switch(state, next_field)
         }
         SettingsAction::PassphraseLen(len) => handle_passphrase_len(state, len),
-        SettingsAction::SubmitEdit { value } => {
-            if handle_submit_edit(config, state, save, &value) {
-                // The mediator DID was changed. Set the synchronous "Connecting"
-                // state now; the loop spawns the slow reconnect I/O (R13).
-                begin_reconnect_status(state);
-                return SettingsOutcome::ReconnectMediator;
-            }
-        }
+        // No editable setting changes the mediator any more, so committing one
+        // never implies a reconnect. `SettingsAction::ReconnectMediator` is the
+        // remaining (explicit, operator-driven) way to ask for one.
+        SettingsAction::SubmitEdit { value } => handle_submit_edit(config, state, save, &value),
         SettingsAction::ExportConfig { path, passphrase } => {
             handle_export_config_action(config, state, state_tx, save, profile, &path, &passphrase)
                 .await
@@ -878,54 +823,59 @@ mod tests {
         assert!(validate_file_path("/tmp/safe/../../../etc/shadow").is_err());
     }
 
-    /// The reported bug: on a profile with no persona, editing the Mediator DID
-    /// wrote nothing, and the panel said "Setting saved" over a field that read
-    /// back empty — so the operator was told the DID had taken when it had not.
-    /// It also asked for a mediator reconnect that had nothing new to dial.
+    /// The reported bug, closed at the source: pressing Enter on the Mediator
+    /// DID row must not open an edit mode at all. It used to, and on a profile
+    /// with no persona the write then vanished while the panel said "Setting
+    /// saved" over a field that read back empty ("it did not take").
     #[test]
-    fn mediator_did_edit_without_a_persona_does_not_claim_a_save() {
-        let mut config = Box::new(crate::state_handler::dispatch_util::test_config());
+    fn mediator_row_does_not_open_an_edit_mode() {
         let mut state = State::default();
-        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
-        // Index 1 is the Mediator DID row.
-        state.main_page.content_panel.settings.selected_index = 1;
+        state.main_page.content_panel.settings.mediator_did = "did:webvh:example:mediator".into();
+        state.main_page.content_panel.settings.selected_index =
+            crate::ui::pages::main::components::settings_panel::MEDIATOR_ROW;
 
-        let needs_reconnect = handle_submit_edit(
-            &mut config,
-            &mut state,
-            &mut save,
-            "did:webvh:example:mediator",
-        );
+        handle_start_edit(&mut state);
 
         assert!(
-            !needs_reconnect,
-            "nothing changed, so there is nothing to reconnect to"
-        );
-        let status = state
-            .main_page
-            .content_panel
-            .settings
-            .status_message
-            .as_deref()
-            .expect("the panel says something");
-        assert!(
-            !status.contains("Setting saved"),
-            "must not report a save that did not happen, got: {status}"
-        );
-        assert!(
-            status.contains("no persona"),
-            "must say why it did not apply, got: {status}"
-        );
-        assert_eq!(
-            config.mediator_did(),
-            "",
-            "and the value really is still unset"
+            matches!(settings(&state), SettingsMode::View),
+            "the mediator row is read-only, so Enter stays in View"
         );
     }
 
-    /// The other half: a row that *can* always apply still reports success and
-    /// keeps the existing coalesced-save behaviour. Guards against the honest
-    /// failure path swallowing the ordinary one.
+    /// A committed edit no longer implies a mediator reconnect — nothing
+    /// editable can move the mediator, so the reconnect that used to fire (and
+    /// hang on "Connecting…") has no trigger left.
+    #[tokio::test]
+    async fn submitting_an_edit_never_asks_for_a_reconnect() {
+        let mut config = Box::new(crate::state_handler::dispatch_util::test_config());
+        let mut state = State::default();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
+        let (state_tx, _rx) = watch::channel(State::default());
+
+        for idx in [0usize, 1, 2] {
+            state.main_page.content_panel.settings.selected_index = idx;
+            let outcome = dispatch(
+                SettingsAction::SubmitEdit {
+                    value: "value".to_string(),
+                },
+                &mut config,
+                &mut state,
+                &state_tx,
+                &mut save,
+                "test",
+            )
+            .await;
+            assert!(
+                matches!(outcome, SettingsOutcome::Continue),
+                "row {idx} must not request a mediator reconnect"
+            );
+        }
+        assert_eq!(config.mediator_did(), "", "and no row wrote a mediator DID");
+    }
+
+    /// The other half: an editable row still reports success and keeps the
+    /// existing coalesced-save behaviour, so removing the mediator edit has not
+    /// disturbed the ordinary path.
     #[test]
     fn friendly_name_edit_still_reports_a_save() {
         let mut config = Box::new(crate::state_handler::dispatch_util::test_config());
@@ -933,9 +883,8 @@ mod tests {
         let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
         state.main_page.content_panel.settings.selected_index = 0;
 
-        let needs_reconnect = handle_submit_edit(&mut config, &mut state, &mut save, "Alice");
+        handle_submit_edit(&mut config, &mut state, &mut save, "Alice");
 
-        assert!(!needs_reconnect, "only the mediator row reconnects");
         assert_eq!(
             state
                 .main_page
@@ -973,9 +922,9 @@ mod tests {
             (0, || SettingsMode::EditFriendlyName {
                 input: String::new(),
             }),
-            (1, || SettingsMode::EditMediatorDid {
-                input: String::new(),
-            }),
+            // Row 1 is the read-only Mediator DID: it falls through to `View`
+            // like any other unedittable row.
+            (1, || SettingsMode::View),
             (2, || SettingsMode::EditOrgDid {
                 input: String::new(),
             }),
@@ -1016,15 +965,12 @@ mod tests {
         ));
     }
 
-    /// `handle_field_update` writes the single-line input for the three edit
-    /// modes and is a no-op elsewhere.
+    /// `handle_field_update` writes the single-line input for the two remaining
+    /// edit modes and is a no-op elsewhere.
     #[test]
     fn field_update_writes_edit_input() {
         let edit_modes: &[ModeFn] = &[
             || SettingsMode::EditFriendlyName {
-                input: String::new(),
-            },
-            || SettingsMode::EditMediatorDid {
                 input: String::new(),
             },
             || SettingsMode::EditOrgDid {
@@ -1036,9 +982,9 @@ mod tests {
             state.main_page.content_panel.settings.mode = make();
             handle_field_update(&mut state, "new-value".to_string());
             let input = match settings(&state) {
-                SettingsMode::EditFriendlyName { input }
-                | SettingsMode::EditMediatorDid { input }
-                | SettingsMode::EditOrgDid { input } => input.clone(),
+                SettingsMode::EditFriendlyName { input } | SettingsMode::EditOrgDid { input } => {
+                    input.clone()
+                }
                 other => panic!("unexpected mode {other:?}"),
             };
             assert_eq!(input, "new-value");

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -30,18 +30,33 @@ pub fn update_friendly_name(config: &mut Config, name: &str) {
     info!(name = %name, "friendly name updated");
 }
 
-/// Update the mediator DID.
+/// Update the mediator DID. Returns `false` when there was no persona to set it
+/// on, so the caller can say so instead of reporting a save that did not happen.
 ///
 /// R11: mutates + logs only (see [`update_friendly_name`]). The subsequent
 /// reconnect (R13 background dispatch) does not depend on the file being on disk
 /// yet — it reads the in-memory config — so coalescing the save is safe.
-pub fn update_mediator_did(config: &mut Config, did: &str) {
-    config.set_active_mediator_did(did);
+#[must_use = "a false return means nothing was written; do not report success"]
+pub fn update_mediator_did(config: &mut Config, did: &str) -> bool {
+    if !config.set_active_mediator_did(did) {
+        // R6.4: name the reason, not just the failure. The mediator DID hangs
+        // off a persona, and a State-A profile has none — so this is "not yet",
+        // not "rejected", and the log has to distinguish them.
+        config.public.logs.insert(
+            LogFamily::Config,
+            "Mediator DID not changed: this profile has no persona yet, and the \
+             mediator DID belongs to one"
+                .to_string(),
+        );
+        info!(did = %did, "mediator DID change ignored — no active persona");
+        return false;
+    }
     config.public.logs.insert(
         LogFamily::Config,
         format!("Mediator DID changed to '{}'", did),
     );
     info!(did = %did, "mediator DID updated (reconnect needed)");
+    true
 }
 
 /// Update the organization DID.
@@ -283,12 +298,19 @@ fn handle_protection_tab_switch(state: &mut State, next_field: usize) {
     }
 }
 
-/// Returns `true` if the mediator DID was changed and a reconnect is needed.
+/// Returns `true` if the mediator DID was actually changed and a reconnect is
+/// needed.
 ///
 /// R11: the per-setting save is now coalesced (`Persist::SaveAndSync` marks the
-/// config dirty rather than saving inline). The mutation can no longer fail
-/// (the `update_*` helpers are infallible now that they don't persist), so the
-/// former `Err` arm is gone.
+/// config dirty rather than saving inline).
+///
+/// The mediator DID is the one setting here that can decline to apply: it hangs
+/// off the active persona, and a State-A profile has none. That used to be
+/// swallowed — the write vanished, and the panel reported "Setting saved" over a
+/// field that read back empty, which is exactly how it was reported ("it did not
+/// take"). It also asked for a mediator reconnect that could not do anything,
+/// leaving the header on "Connecting…". Both now hang off whether the write
+/// landed.
 fn handle_submit_edit(
     config: &mut Box<Config>,
     state: &mut State,
@@ -296,12 +318,18 @@ fn handle_submit_edit(
     value: &str,
 ) -> bool {
     let idx = state.main_page.content_panel.settings.selected_index;
-    match idx {
-        0 => update_friendly_name(config, value),
+    let applied = match idx {
+        0 => {
+            update_friendly_name(config, value);
+            true
+        }
         1 => update_mediator_did(config, value),
-        2 => update_org_did(config, value),
-        _ => {}
-    }
+        2 => {
+            update_org_did(config, value);
+            true
+        }
+        _ => true,
+    };
     let setting_name = match idx {
         0 => "Friendly name",
         1 => "Mediator DID",
@@ -309,6 +337,22 @@ fn handle_submit_edit(
         _ => "Setting",
     };
     state.main_page.content_panel.settings.mode = SettingsMode::View;
+
+    if !applied {
+        // Nothing was written, so nothing is dirty: no save, no sync, and no
+        // reconnect. Say what would make the setting available instead of
+        // leaving the operator to infer it from a blank field.
+        state.main_page.content_panel.settings.status_message = Some(
+            "Mediator DID not changed — this profile has no persona yet. \
+             A persona gets its mediator when it is created."
+                .to_string(),
+        );
+        state
+            .main_page
+            .log("Mediator DID unchanged: no persona in this profile");
+        return false;
+    }
+
     dispatch_util::save_and_sync(
         &mut state.main_page,
         config,
@@ -832,6 +876,76 @@ mod tests {
     #[test]
     fn test_validate_file_path_rejects_hidden_traversal() {
         assert!(validate_file_path("/tmp/safe/../../../etc/shadow").is_err());
+    }
+
+    /// The reported bug: on a profile with no persona, editing the Mediator DID
+    /// wrote nothing, and the panel said "Setting saved" over a field that read
+    /// back empty — so the operator was told the DID had taken when it had not.
+    /// It also asked for a mediator reconnect that had nothing new to dial.
+    #[test]
+    fn mediator_did_edit_without_a_persona_does_not_claim_a_save() {
+        let mut config = Box::new(crate::state_handler::dispatch_util::test_config());
+        let mut state = State::default();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
+        // Index 1 is the Mediator DID row.
+        state.main_page.content_panel.settings.selected_index = 1;
+
+        let needs_reconnect = handle_submit_edit(
+            &mut config,
+            &mut state,
+            &mut save,
+            "did:webvh:example:mediator",
+        );
+
+        assert!(
+            !needs_reconnect,
+            "nothing changed, so there is nothing to reconnect to"
+        );
+        let status = state
+            .main_page
+            .content_panel
+            .settings
+            .status_message
+            .as_deref()
+            .expect("the panel says something");
+        assert!(
+            !status.contains("Setting saved"),
+            "must not report a save that did not happen, got: {status}"
+        );
+        assert!(
+            status.contains("no persona"),
+            "must say why it did not apply, got: {status}"
+        );
+        assert_eq!(
+            config.mediator_did(),
+            "",
+            "and the value really is still unset"
+        );
+    }
+
+    /// The other half: a row that *can* always apply still reports success and
+    /// keeps the existing coalesced-save behaviour. Guards against the honest
+    /// failure path swallowing the ordinary one.
+    #[test]
+    fn friendly_name_edit_still_reports_a_save() {
+        let mut config = Box::new(crate::state_handler::dispatch_util::test_config());
+        let mut state = State::default();
+        let mut save = crate::state_handler::save_coalesce::SaveScheduler::new("test");
+        state.main_page.content_panel.settings.selected_index = 0;
+
+        let needs_reconnect = handle_submit_edit(&mut config, &mut state, &mut save, "Alice");
+
+        assert!(!needs_reconnect, "only the mediator row reconnects");
+        assert_eq!(
+            state
+                .main_page
+                .content_panel
+                .settings
+                .status_message
+                .as_deref(),
+            Some("Setting saved")
+        );
+        assert_eq!(config.public.friendly_name, "Alice");
     }
 
     // ----------------------------------------------------------------

--- a/openvtc/src/ui/pages/main/components/settings_panel.rs
+++ b/openvtc/src/ui/pages/main/components/settings_panel.rs
@@ -30,7 +30,6 @@ impl Panel for SettingsPanel {
 pub fn render(state: &SettingsState) -> Vec<Line<'static>> {
     match &state.mode {
         SettingsMode::EditFriendlyName { input } => render_edit("Friendly Name", input),
-        SettingsMode::EditMediatorDid { input } => render_edit("Mediator DID", input),
         SettingsMode::EditOrgDid { input } => render_edit("Org DID", input),
         SettingsMode::ExportConfig {
             path_input,
@@ -66,6 +65,10 @@ const WIPE_CONFIRM_TOKEN: &str = "WIPE";
 
 /// Width the settings rows truncate their values to.
 const VALUE_WIDTH: usize = 50;
+
+/// Index of the Mediator DID row in the settings list. Shared with
+/// `settings_actions`, which must not open an edit mode for it.
+pub(crate) const MEDIATOR_ROW: usize = 1;
 
 fn render_wipe_confirm(confirm_input: &str) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from("")];
@@ -140,9 +143,24 @@ fn render_view(state: &SettingsState) -> Vec<Line<'static>> {
         VALUE_WIDTH,
     )
     .into_owned();
+    // The mediator is read-only: it is chosen when a persona is minted and baked
+    // into that persona's published DID document (the `#public-didcomm` service
+    // endpoint IS the mediator DID). Editing it here would move only where *we*
+    // connect, while everyone else keeps resolving the document, finding the old
+    // mediator, and delivering to a mailbox we no longer read — so the row shows
+    // the value and says where it comes from rather than offering an edit that
+    // silently desynchronises the profile from its own published address.
+    //
+    // An empty value is the no-persona case, which is a "not yet", not a blank
+    // setting; say so, because a bare empty row is what read as "it did not take".
+    let mediator = if state.mediator_did.is_empty() {
+        "— no persona yet".to_string()
+    } else {
+        state.mediator_did.clone()
+    };
     let settings = [
         ("Friendly Name", state.friendly_name.clone(), true),
-        ("Mediator DID", state.mediator_did.clone(), true),
+        ("Mediator DID", mediator, false),
         ("Org DID", state.org_did.clone(), true),
         ("Persona", persona, false),
     ];
@@ -183,6 +201,17 @@ fn render_view(state: &SettingsState) -> Vec<Line<'static>> {
             ),
             Span::styled(edit_hint, Style::new().fg(COLOR_DARK_GRAY)),
         ]));
+
+        // "(read-only)" answers *whether* it can be changed but not *why not*,
+        // which is the question a mediator row invites. Answer it on selection,
+        // where the operator is already looking, rather than in a doc nobody
+        // reaches from here.
+        if i == MEDIATOR_ROW && is_selected {
+            lines.push(Line::from(Span::styled(
+                "      set when the persona was created, and published in its DID document",
+                Style::new().fg(COLOR_DARK_GRAY),
+            )));
+        }
     }
 
     lines.push(Line::from(""));

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -257,7 +257,6 @@ impl Component for MainPage {
             MainMenu::Settings => {
                 match &self.props.main_page.content_panel.settings.mode {
                     SettingsMode::EditFriendlyName { input }
-                    | SettingsMode::EditMediatorDid { input }
                     | SettingsMode::EditOrgDid { input } => {
                         let updated = format!("{}{}", input, trimmed);
                         let _ = self
@@ -1509,9 +1508,7 @@ impl MainPage {
         let settings = &self.props.main_page.content_panel.settings;
 
         match &settings.mode {
-            SettingsMode::EditFriendlyName { input }
-            | SettingsMode::EditMediatorDid { input }
-            | SettingsMode::EditOrgDid { input } => {
+            SettingsMode::EditFriendlyName { input } | SettingsMode::EditOrgDid { input } => {
                 let current = input.clone();
                 match key.code {
                     KeyCode::Esc => {
@@ -2097,7 +2094,6 @@ fn view_id(page: &MainPageState) -> String {
         MainMenu::Settings => match &page.content_panel.settings.mode {
             SettingsMode::View => "view",
             SettingsMode::EditFriendlyName { .. } => "edit-name",
-            SettingsMode::EditMediatorDid { .. } => "edit-mediator",
             SettingsMode::EditOrgDid { .. } => "edit-org",
             SettingsMode::ExportConfig { .. } => "export",
             SettingsMode::ImportConfig { .. } => "import",


### PR DESCRIPTION
## The report

> FYI, I tried plugging in your mediator DID to this openvtc profile but it did
> not take.
>
> What would happen if I put in a different mediator to what I am using?

The panel said **"Setting saved"**, the Mediator DID row read back **blank**, and
the header sat on **"Connecting…"**. All three were the same bug — and the second
question turns out to be the reason the setting should not have been editable at
all.

## Why it did not take

The mediator DID is a **per-persona** field. The setter opened with a bare early
return and told nobody:

```rust
pub fn set_active_mediator_did(&mut self, did: &str) {
    let Some(id) = self.active_identity().map(|i| i.persona_id) else {
        return;                     // <- silently
    };
```

A State-A profile carries an account but **no persona**, so this is every profile
before its first persona — and every profile after a failed join, which is how it
was hit here. `handle_submit_edit` then reported "Setting saved" unconditionally
and returned `true` for "mediator changed", spawning a reconnect that had nothing
new to dial. Hence the success message over a blank field, and the stuck
"Connecting…".

The *read* side was already correct and even pinned by a test —
`config.mediator_did()` returns `""` with no persona. Only the write agreed to
something it did not do.

## Why the edit could not be right

A persona's mediator is published in its **DID document**: `config/did.rs` builds
a `#public-didcomm` service whose `serviceEndpoint` *is* the mediator DID, at mint
time. Editing the setting changes only where **we** connect. It does not re-mint
the document and does not register the persona at the new mediator.

So a successful edit would have been worse than a failed one:

| direction | effect |
|---|---|
| outbound | moves to the new mediator (which then forwards on — the ordinary federated hop, working as of #273) |
| **inbound** | **breaks** — everyone else resolves your DID document, finds the **old** mediator, and delivers into a mailbox you no longer read |

A community's join reply lands in exactly that gap. The edit could not be
correct; it could only be quiet about being wrong.

Note this never affected the **VTA** connection: that mediator lives in a separate
field (`KeyBackend::Vta { mediator_did }`) and was untouched by this setting.

## The change

**The row is now read-only**, showing the value and where it came from:

```
  Mediator DID: did:webvh:Qmb…:firstperson-mediator (read-only)
                set when the persona was created, and published in its DID document
```

"(read-only)" answers *whether* it can be changed but not *why not*, which is the
question this row invites — so the explanation sits under it on selection, where
the operator is already looking. An unset value renders as **"— no persona yet"**
rather than blank; a bare empty row is precisely what read as "it did not take".

**The write reports itself.** `set_active_mediator_did` returns `bool` and is
`#[must_use]` with a message saying a `false` return must not be reported as
success. The answer is tied to the **account record**, not the runtime
`IdentityContext`: that is the half that survives a restart, so updating only
`identities` would report a save the operator loses on next launch. Load derives
`identities` by walking `account.personas`, so a missing record is unreachable —
which is what makes the `true` honest rather than assumed.

`OPENVTC_MEDIATOR_DID` — now the only write path — swallowed the identical
failure. An override an operator set deliberately now warns when it is dropped
instead of becoming a mystery later.

**Removals that follow:** `SettingsMode::EditMediatorDid` and its render arm,
keystroke arms and panel-mode label (nothing can produce it, and leaving the
variant would leave three exhaustive matches carrying a dead state — cf. #236);
`update_mediator_did`, replaced by a note saying why there is no such helper; and
the `handle_submit_edit -> bool` reconnect signal, since no editable row can move
the mediator now. `SettingsAction::ReconnectMediator` remains the explicit,
operator-driven way to ask for a reconnect.

## Tests

- Enter on the mediator row stays in `View`.
- Submitting an edit on any row returns `Continue` rather than requesting a
  reconnect, and writes no mediator DID.
- State-A write reports `false` and stores nothing.
- With a persona, the write reaches **both** the runtime identity and the
  persisted record — the assertion that caught that the return value should hang
  off the durable half.
- The friendly-name row still saves normally, so removing the mediator edit has
  not disturbed the ordinary path.

## What this does not do

It does not make *moving* mediator possible. That needs a real migration —
register at the new mediator, publish a did:webvh update pointing
`#public-didcomm` at it, then reconnect, with rollback if any step fails — and
likely VTA-side support. Until then, minting a new persona is the supported way,
and the panel no longer implies otherwise.

## Checks

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace -- --include-ignored`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- [x] DCO signed off
