### PR TITLE
feat(persona): read what each face presents, and say when we could not ask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ environments.json
 # Logs and OS artifacts
 *.log
 Thumbs.db
+
+# Redis dump written into the repo root by a local dev stack. Untracked and
+# unignored, it sits in `git status` looking like something to commit — and
+# `git add -A` duly swept it into a persona commit, which is how this line
+# came to exist.
+*.rdb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10123,13 +10123,14 @@ dependencies = [
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff 0.14.0",
  "group 0.14.0",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-mdoc"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a923616197dc73661b1b57ad8dfaef7d9297c51c137062c9435b6edd6c98a3"
+checksum = "d69ac8bedce32dcf6798e480166e3601b73b0408e2d51ae40964d09de3457ebc"
 dependencies = [
  "aes-gcm 0.10.3",
  "ciborium",
@@ -520,7 +520,7 @@ dependencies = [
  "affinidi-messaging-mediator-common",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
- "affinidi-tdk",
+ "affinidi-tdk 0.10.0",
  "async-trait",
  "jsonwebtoken 10.4.0",
  "ring",
@@ -691,6 +691,31 @@ name = "affinidi-tdk"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715c365fa19276fb50332e10b922822b25d52d6119721f28abb6cac02029a365"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-data-integrity",
+ "affinidi-did-authentication",
+ "affinidi-did-common",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-meeting-place",
+ "affinidi-messaging-didcomm",
+ "affinidi-messaging-sdk",
+ "affinidi-secrets-resolver",
+ "affinidi-tdk-common",
+ "clap",
+ "rustls",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "affinidi-tdk"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abceec2e934dfffbc31924d970d650c972660125cd26fe7ecd14e4552713f43f"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -886,7 +911,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -897,7 +922,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1990,9 +2015,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coset"
-version = "0.3.8"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
+checksum = "1eb98d5e9155e2cf7cd942c8b3033097d4563b6fb0a00b9caecb74669555c058"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -2816,7 +2841,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3118,7 +3143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4420,11 +4445,38 @@ dependencies = [
  "getrandom 0.3.4",
  "idna",
  "itoa",
- "jsonschema-regex",
+ "jsonschema-regex 0.46.10",
  "num-cmp",
  "num-traits",
  "percent-encoding",
- "referencing",
+ "referencing 0.46.10",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.18.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex 0.47.0",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing 0.47.0",
  "regex",
  "serde",
  "serde_json",
@@ -4437,6 +4489,15 @@ name = "jsonschema-regex"
 version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
 dependencies = [
  "regex-syntax",
 ]
@@ -5042,7 +5103,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5459,7 +5520,7 @@ version = "0.3.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
- "affinidi-tdk",
+ "affinidi-tdk 0.10.0",
  "anyhow",
  "apple-native-keyring-store",
  "arboard",
@@ -5522,7 +5583,7 @@ dependencies = [
  "affinidi-messaging-delivery",
  "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
- "affinidi-tdk",
+ "affinidi-tdk 0.10.0",
  "agent-names",
  "anyhow",
  "arbitrary",
@@ -5593,7 +5654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6387,7 +6448,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6740,6 +6801,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6781,7 +6859,7 @@ dependencies = [
  "globset",
  "indexmap 2.14.0",
  "ipnet",
- "jsonschema",
+ "jsonschema 0.46.10",
  "lazy_static",
  "lru",
  "msvc_spectre_libs",
@@ -6796,6 +6874,39 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "spin 0.10.1",
+ "thiserror 2.0.20",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "regorus"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc4dc91481b1d4001ba7f2e81f7faf674142e0ac36d37d79e5f02764d06571e"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "chrono-tz",
+ "data-encoding",
+ "globset",
+ "indexmap 2.14.0",
+ "ipnet",
+ "jsonschema 0.47.0",
+ "lazy_static",
+ "lru",
+ "msvc_spectre_libs",
+ "num-bigint 0.5.1",
+ "num-traits",
+ "parking_lot",
+ "postcard",
+ "rand 0.10.2",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "spin 0.12.3",
  "thiserror 2.0.20",
  "url",
  "uuid",
@@ -6954,7 +7065,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7012,7 +7123,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7667,7 +7778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7684,6 +7795,12 @@ name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+
+[[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
 
 [[package]]
 name = "spinning_top"
@@ -7879,7 +7996,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7892,7 +8009,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8493,7 +8610,7 @@ checksum = "41d841bf16638473fed22f94ce446cadcc932afc60ca3f623eef184d546d945b"
 dependencies = [
  "async-trait",
  "chrono",
- "jsonschema",
+ "jsonschema 0.46.10",
  "regress",
  "serde",
  "serde_json",
@@ -8863,13 +8980,13 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.12.1"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fbda0ef51b72b83a904e4c23a57410bb3f417324389836530b876a7b1775c6"
+checksum = "5e0579191869b5151e84d35dd1d88e0d5202887685400806be9db8f08b4cb19a"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "dialoguer",
  "ed25519-dalek 3.0.0",
@@ -8913,7 +9030,7 @@ checksum = "8d443fc7cbfff9ceef6b170231268884d2861c812a3c7d35c7a2351ab8bdbeee"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
- "affinidi-tdk",
+ "affinidi-tdk 0.10.0",
  "base64 0.22.1",
  "bip39",
  "chrono",
@@ -8956,7 +9073,7 @@ checksum = "0b360c5d30623464a511a9e5b81ae37abc1819bd96f60b15f8737aa87b458c8c"
 dependencies = [
  "hex",
  "multibase",
- "regorus",
+ "regorus 0.10.1",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
@@ -8970,9 +9087,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.32.2"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5365d2103c2c0a876c866c8ce60787e4b27e23f1a224c00f105c0dfeb82d3442"
+checksum = "b124bc8519ad8894325a0ce1a6349c352f79eba1b996164d84a512e6b24f8f72"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8985,11 +9102,11 @@ dependencies = [
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-secrets-resolver",
- "affinidi-tdk",
+ "affinidi-tdk 0.11.0",
  "affinidi-vc",
  "agent-names",
  "apple-native-keyring-store",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "ciborium",
  "curve25519-dalek 5.0.0",
@@ -9021,9 +9138,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.23.0"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b30050ba6b525df677325d525e95710da874968351fd2b8a8111d4c030b222"
+checksum = "dfa89d1f331e7fa24fc8c643a971641e791032f6d7daa37fd94f0a05b7b54e9b"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9039,13 +9156,13 @@ dependencies = [
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk",
+ "affinidi-tdk 0.11.0",
  "affinidi-tdk-common",
  "argon2 0.6.0",
  "async-trait",
  "axum",
  "axum-extra",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bip39",
  "chrono",
  "ciborium",
@@ -9065,7 +9182,7 @@ dependencies = [
  "multibase",
  "p256 0.14.0",
  "rand 0.10.2",
- "regorus",
+ "regorus 0.11.0",
  "reqwest",
  "serde",
  "serde_ignored",
@@ -9151,9 +9268,9 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce1901fadd56979db07518271f17197c48d619da86fbb8ceb2090225bd771b7"
+checksum = "06628eaaf5a7af3e5bab76016e37aa1de46bb6b5ed412b1f2aebb1216f29a5a3"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9164,7 +9281,7 @@ dependencies = [
  "affinidi-secrets-resolver",
  "affinidi-status-list",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "coset",
  "ed25519-dalek 3.0.0",
@@ -9187,7 +9304,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e61c8c6b6b3f2d96cdae050ce6422198d45cfd5b8ef9fa2ef80f47c2c4f8cfe"
 dependencies = [
- "affinidi-tdk",
+ "affinidi-tdk 0.10.0",
  "chrono",
  "reqwest",
  "serde",
@@ -9202,20 +9319,20 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa515ec97e37cb1b978d3e7c006c81e004574f41b8c5ce60c8eb2c210d0e97"
+checksum = "2145c8913e002c56cc25d5b993407e4f74e1cbe8e0f20d74e52a781f73526afb"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-delivery",
  "affinidi-secrets-resolver",
- "affinidi-tdk",
+ "affinidi-tdk 0.11.0",
  "async-trait",
  "axum",
  "axum-extra",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9652,7 +9769,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,7 +322,7 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # is the reason to take it here anyway: a wire label this repo agrees with only
 # by sharing the bug is not a contract, and the next conformance witness or
 # non-Rust peer on the other end of a provisioning run is what collects on it.
-vta-sdk = { version = "0.32.2", features = [
+vta-sdk = { version = "0.32.4", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod members;
 pub mod messaging;
 #[cfg(feature = "openpgp-card")]
 pub mod openpgp_card;
+pub mod persona_binding;
 pub mod personhood;
 pub mod presentation;
 pub mod process_lock;

--- a/openvtc-core/src/persona_binding.rs
+++ b/openvtc-core/src/persona_binding.rs
@@ -234,6 +234,9 @@ mod tests {
             claim_count: 2,
             ..Default::default()
         };
-        assert_eq!(bare.describe(), "presents: an unlabelled profile (2 claims)");
+        assert_eq!(
+            bare.describe(),
+            "presents: an unlabelled profile (2 claims)"
+        );
     }
 }

--- a/openvtc-core/src/persona_binding.rs
+++ b/openvtc-core/src/persona_binding.rs
@@ -1,0 +1,239 @@
+//! What each of your faces actually says — the profile a persona presents in
+//! one community's context.
+//!
+//! # Two meanings of "persona", and they compose
+//!
+//! This crate already has a [`PersonaRecord`](crate::config::account::PersonaRecord):
+//! a `did:webvh`, its key references, its mediator. That is a face as an
+//! *identity* — the DID a community sees and the connection material behind
+//! it.
+//!
+//! The agent's `persona/*` Trust Tasks use the same word for the same thing one
+//! layer up: a persona DID that a **profile** of identity attributes is bound
+//! to, within a trust context. The two are not competing definitions. This
+//! crate holds the face; the agent holds what the face says.
+//!
+//! They join on the pair this module takes. A community membership already
+//! carries both halves — `CommunityRecord::sub_context_id` is the VTA context,
+//! and the persona it presents has the DID — which is exactly the key
+//! `persona/binding/get` is addressed by. Every membership row in the
+//! communities panel is already a `(context, persona)` pair; this is what that
+//! pair looks up.
+//!
+//! # Thin on purpose
+//!
+//! A binding read reports **whether** a persona is bound, the profile's label,
+//! and how many claims it carries. Never the claim contents. Those reach a
+//! consumer only through `persona/disclosure/*`, after a preview a human can be
+//! shown — a binding read that returned values would make that gate
+//! decorative. So there is nothing here that renders an attribute, and adding
+//! one would be reaching around the disclosure path rather than extending this
+//! module.
+//!
+//! # Everything here is best-effort
+//!
+//! Same rule as [`crate::devices`]: a VTA that does not serve the persona slice,
+//! or a call that times out, must never stop OpenVTC starting or a panel
+//! drawing. A membership works whether or not we can say what it presents, and
+//! [`BindingSummary::unknown`] is the honest thing to draw while we cannot —
+//! distinct from "bound to nothing", which is an answer.
+
+use serde::{Deserialize, Serialize};
+use vta_sdk::client::VtaClient;
+
+use crate::errors::OpenVTCError;
+
+/// What one persona presents in one context.
+///
+/// [`bound`](Self::bound) is the field to read. Do not infer it from
+/// [`profile_name`](Self::profile_name) being empty: a profile may legitimately
+/// carry no label, and "unlabelled" and "unbound" are different answers to
+/// different questions.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct BindingSummary {
+    /// Whether this persona presents anything at all in this context.
+    pub bound: bool,
+    /// The holder's label for the bound profile, if it has one.
+    pub profile_name: Option<String>,
+    /// Identifier of the bound profile.
+    pub profile_id: Option<String>,
+    /// How many claims the binding carries. `0` for an unbound persona — a
+    /// count of nothing is still a count.
+    pub claim_count: u64,
+    /// When the binding was last written.
+    pub bound_at: Option<String>,
+    /// True when the agent could not be asked, as distinct from having
+    /// answered "nothing is bound".
+    ///
+    /// Kept as a field rather than modelled as an absent `BindingSummary`,
+    /// because a caller that has to unwrap an `Option` reaches for
+    /// `unwrap_or_default()` and that would render "we could not ask" as
+    /// "presents nothing" — a confident wrong answer about the user's own
+    /// identity, which is the one thing this panel must not give.
+    pub unknown: bool,
+}
+
+impl BindingSummary {
+    /// The summary to draw when the agent could not be asked.
+    #[must_use]
+    pub fn unknown() -> Self {
+        Self {
+            unknown: true,
+            ..Self::default()
+        }
+    }
+
+    /// A one-line description for a panel row.
+    ///
+    /// Three distinct readings, deliberately worded so they cannot be confused:
+    /// we do not know; we know nothing is bound; we know what is bound.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        if self.unknown {
+            return "presents: unknown".to_string();
+        }
+        if !self.bound {
+            return "presents: nothing".to_string();
+        }
+        let label = self
+            .profile_name
+            .clone()
+            .or_else(|| self.profile_id.clone())
+            .unwrap_or_else(|| "an unlabelled profile".to_string());
+        let claims = if self.claim_count == 1 {
+            "1 claim".to_string()
+        } else {
+            format!("{} claims", self.claim_count)
+        };
+        format!("presents: {label} ({claims})")
+    }
+}
+
+/// Ask the agent what `persona_did` presents in `context_id`.
+///
+/// Errors are the caller's to log and move past; see the module header.
+pub async fn get(
+    client: &VtaClient,
+    context_id: &str,
+    persona_did: &str,
+) -> Result<BindingSummary, OpenVTCError> {
+    let value = client
+        .persona_binding_get(context_id, persona_did)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona binding read failed: {e}")))?;
+
+    Ok(BindingSummary {
+        bound: value
+            .get("bound")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+        profile_name: value
+            .get("profileName")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        profile_id: value
+            .get("profileId")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        claim_count: value
+            .get("claimCount")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+        bound_at: value
+            .get("boundAt")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        unknown: false,
+    })
+}
+
+/// Ask once, and fall back to [`BindingSummary::unknown`] rather than failing.
+///
+/// The form a panel wants: it has a row to draw either way, and the question is
+/// only whether it can say anything true about what that row presents.
+pub async fn get_or_unknown(
+    client: &VtaClient,
+    context_id: &str,
+    persona_did: &str,
+) -> BindingSummary {
+    match get(client, context_id, persona_did).await {
+        Ok(summary) => summary,
+        Err(e) => {
+            tracing::debug!(
+                context_id,
+                persona_did,
+                error = %e,
+                "persona binding unavailable; drawing as unknown"
+            );
+            BindingSummary::unknown()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_is_not_the_same_as_unbound() {
+        assert_eq!(BindingSummary::unknown().describe(), "presents: unknown");
+        assert_eq!(BindingSummary::default().describe(), "presents: nothing");
+    }
+
+    /// The distinction the `unknown` flag exists to preserve.
+    ///
+    /// `BindingSummary::default()` is a *known* empty answer. If "could not
+    /// ask" were modelled as an absent value, the natural
+    /// `unwrap_or_default()` would collapse the two and tell the user their
+    /// persona presents nothing when the truth is that nobody asked.
+    #[test]
+    fn a_default_summary_never_reads_as_unknown() {
+        assert!(!BindingSummary::default().unknown);
+        assert!(BindingSummary::unknown().unknown);
+    }
+
+    #[test]
+    fn a_bound_profile_is_described_by_label_and_count() {
+        let s = BindingSummary {
+            bound: true,
+            profile_name: Some("work".into()),
+            claim_count: 3,
+            ..Default::default()
+        };
+        assert_eq!(s.describe(), "presents: work (3 claims)");
+    }
+
+    /// One claim is not "1 claims". Small, and the kind of thing that makes a
+    /// panel look unfinished.
+    #[test]
+    fn a_single_claim_is_singular() {
+        let s = BindingSummary {
+            bound: true,
+            profile_name: Some("gaming".into()),
+            claim_count: 1,
+            ..Default::default()
+        };
+        assert_eq!(s.describe(), "presents: gaming (1 claim)");
+    }
+
+    /// A profile with no label falls back to its id, and then to a phrase —
+    /// never to the empty string, which would render as "presents:  (2
+    /// claims)".
+    #[test]
+    fn an_unlabelled_profile_still_describes_itself() {
+        let by_id = BindingSummary {
+            bound: true,
+            profile_id: Some("01J8".into()),
+            claim_count: 2,
+            ..Default::default()
+        };
+        assert_eq!(by_id.describe(), "presents: 01J8 (2 claims)");
+
+        let bare = BindingSummary {
+            bound: true,
+            claim_count: 2,
+            ..Default::default()
+        };
+        assert_eq!(bare.describe(), "presents: an unlabelled profile (2 claims)");
+    }
+}


### PR DESCRIPTION
`openvtc_core::persona_binding` — given a community's `sub_context_id` and the persona DID it presents, ask the agent which profile that persona is bound to. Against `persona/binding/get/1.0`, specced at [dtgwg-trust-tasks-tf#360](https://github.com/trustoverip/dtgwg-trust-tasks-tf/pull/360) and implemented at [verifiable-trust-infrastructure#1255](https://github.com/OpenVTC/verifiable-trust-infrastructure/pull/1255).

## Two meanings of "persona", and they compose

This crate already has `PersonaRecord`: a `did:webvh`, its key references, its mediator — a face as an **identity**. The agent's `persona/*` family uses the same word for the same thing one layer up: a persona DID that a **profile** of identity attributes is bound to, within a trust context.

They are not competing definitions. This crate holds the face; the agent holds what the face says. That reconciliation wasn't written down anywhere, and the naming overlap reads as a collision until you check — so it is now in the module header.

**They join on a pair this crate already has.** `CommunityRecord` carries `sub_context_id`; the persona it references carries the DID. That is exactly how `persona/binding/get` is addressed. Every membership row in the communities panel already reads *"as &lt;persona&gt;"* — this is what that pair looks up.

## The `unknown` flag is the point of the type

A binding read has three outcomes a user must not see conflated:

1. we could not ask;
2. we asked, and nothing is bound;
3. we asked, and here is what is bound.

Modelling "could not ask" as an absent `BindingSummary` would put an `Option` in front of every caller, and the natural `unwrap_or_default()` renders it as **"presents nothing"** — a confident wrong answer about the user's own identity, which is the one thing this must not give. So it is a field on the struct, `describe()` words the three readings so they cannot be confused, and a test asserts a default summary never reads as unknown.

Best-effort throughout, same rule as `devices`: a VTA that does not serve the persona slice, or a call that times out, must never stop OpenVTC starting or a panel drawing. `get_or_unknown` is the form a panel wants — it has a row either way, and the only question is whether it can say anything true about it.

**Thin by design**: whether bound, the profile's label, a claim count. Never contents. Those reach a consumer only through `persona/disclosure/*`, after a preview a human can be shown; a binding read that returned values would make that gate decorative. There is deliberately nothing here that renders an attribute.

## Dependencies move as a set

Three bumps, and the second and third are consequences of the first:

- **`vta-sdk` 0.32.2 → 0.32.4** — where the `persona_*` client methods live.
- **`vta-cli-common` → 0.12.4** — 0.12.3 predates the `ext` members added to the SDK's wire bodies and fails to construct them (`missing field ext in initializer of UpdateConfigBody`). It arrives via the `vta-service` dev-dependency for `MockVta`.
- **`vta-vault` → 0.5.2** — removes a `coset` duplicate. `vta-service` 0.23.4 wants `affinidi-mdoc` 0.3 while `vta-vault` 0.5.1 still wanted 0.2.7, so the two halves saw different `CoseSign1` and `MobileSecurityObject` types.

Worth recording how that last one read at first: it looks exactly like a broken published pair, and I nearly reported it as one. It was the **lockfile holding an old vault**, not the registry publishing something that cannot build. Letting `vta-vault` move resolved it.

## Verification

- `cargo test --workspace` — **961 passed, 0 failed**
- `cargo clippy --workspace --all-targets` — clean
- 5 new tests, over the three-way distinction and the `describe()` wording

## Not in this PR

**No UI.** Surfacing this in the communities panel needs a TTL'd cache read synchronously during render — the shape `agent_name_for` already uses — and that touches persisted config. It deserves its own change rather than riding along here, and there is a design question in it worth asking separately: a persisted binding summary is a cache of *agent* state, and the reason the binding lives at the agent is that editing the pool refreshes every context at once. A local copy has to be visibly stale rather than quietly authoritative.

## Also here

**`wnaf` 0.14.0 → 0.14.1.** cargo-deny failed on `error[yanked]`. Not introduced here — `wnaf 0.14.0` is in `main`'s lockfile too, and its publisher yanked it upstream; `main`'s green runs simply predate the yank, so this PR is the first run to see it. Any PR opened now would fail the same way. `cargo deny check advisories` passes locally after the bump.


One unrelated line: `*.rdb` added to `.gitignore`. A local dev stack drops a Redis dump in the repo root, where it sits untracked and unignored looking like something to commit — and `git add -A` duly swept it into the persona commit before I caught it. The line is why that cannot happen again.

