### PR TITLE
feat(persona): show what each face presents, not just which face

### DIFF
--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -97,6 +97,8 @@ pub(crate) enum DispatchDomain {
     /// inbound channel and is matched by thread id — so what this domain
     /// serialises is the sending, which retries against an unreachable peer.
     Capabilities,
+    /// What each persona presents, for the communities panel.
+    PersonaBinding,
     /// Invitation-credential (VIC) list refresh: one credential-vault query
     /// against the always-on admin VTA session (30 s timeout in the SDK).
     /// Read-only. Backgrounded because it is bound to *navigation* — Tab into
@@ -120,6 +122,7 @@ impl DispatchDomain {
             DispatchDomain::Credential => "Credential request",
             DispatchDomain::Community => "Community request",
             DispatchDomain::Capabilities => "Capability request",
+            DispatchDomain::PersonaBinding => "Persona binding refresh",
             DispatchDomain::Vic => "Invitation credential refresh",
         }
     }
@@ -218,6 +221,12 @@ pub(crate) enum DispatchOutcome {
     Community(crate::state_handler::community_actions::CommunityOutcome),
     /// A capability query or toggle was sent (or failed to send).
     Capabilities(crate::state_handler::capability_actions::CapabilityOutcome),
+    PersonaBinding(
+        std::collections::HashMap<
+            crate::state_handler::persona_binding_refresh::BindingTarget,
+            openvtc_core::persona_binding::BindingSummary,
+        >,
+    ),
     /// A VIC vault mutation finished (import / archive / unarchive / restore /
     /// delete / purge). Shares the `Vic` domain with the listing, so the
     /// re-read it asks for cannot start until this outcome frees it.
@@ -253,6 +262,7 @@ impl DispatchOutcome {
             DispatchOutcome::Credential(_) => DispatchDomain::Credential,
             DispatchOutcome::Community(_) => DispatchDomain::Community,
             DispatchOutcome::Capabilities(_) => DispatchDomain::Capabilities,
+            DispatchOutcome::PersonaBinding(_) => DispatchDomain::PersonaBinding,
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::VicMutation(_) => DispatchDomain::Vic,
             DispatchOutcome::Panicked(domain) => *domain,
@@ -444,6 +454,18 @@ pub(crate) fn apply_outcome(
         }
         DispatchOutcome::Credential(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Capabilities(outcome) => outcome.apply(state),
+        // Merged, not replaced. A sweep only carries the targets it was given,
+        // and replacing the map would blank every row the sweep did not cover
+        // — which reads on screen as those personas having stopped presenting
+        // anything.
+        DispatchOutcome::PersonaBinding(results) => {
+            state
+                .main_page
+                .content_panel
+                .communities
+                .bindings
+                .extend(results);
+        }
         DispatchOutcome::Vic(outcome) => outcome.apply(state, config),
         DispatchOutcome::VicMutation(outcome) => outcome.apply(state),
         // Handled above, before the domain is finished. Listed because the

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use dtg_credentials::DTGCredential;
@@ -146,6 +147,24 @@ pub struct CapabilitiesState {
 /// memberships, in display order (favourites first).
 #[derive(Clone, Debug, Default)]
 pub struct CommunitiesState {
+    /// What each persona presents in each community's context, keyed by
+    /// `(sub_context_id, persona_did)` — the pair `persona/binding/get` is
+    /// addressed by, and the pair every membership row already carries.
+    ///
+    /// **Session state, deliberately not persisted.** The agent-name cache next
+    /// door IS persisted, and the difference is the point: a verified name is a
+    /// property of a DID document that rarely changes and costs a network
+    /// round-trip to establish, so showing it instantly at launch is worth
+    /// keeping on disk. A binding is the holder's own current decision, cheap
+    /// to fetch, and editable from `pnm` at any moment — a persisted copy would
+    /// show what they used to present, on the one panel whose job is to tell
+    /// them what they present now. `prune_agent_name_negatives` already draws
+    /// this line for negatives; this is the same argument applied to the whole
+    /// record.
+    ///
+    /// An absent entry is not "presents nothing" — see
+    /// [`BindingSummary::unknown`](openvtc_core::persona_binding::BindingSummary::unknown).
+    pub bindings: HashMap<(String, String), openvtc_core::persona_binding::BindingSummary>,
     /// Display summaries of the (non-archived) communities, in display order.
     /// `Arc<[…]>` so cloning the panel state (per frame / per event) is a
     /// pointer bump rather than a deep copy; rebuilt wholesale in

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -232,6 +232,7 @@ mod capability_actions;
 mod community_actions;
 mod create_persona;
 mod credential_actions;
+mod persona_binding_refresh;
 /// The DIDComm transport module, which now lives in `openvtc-core`.
 ///
 /// Re-exported under its former path so every `didcomm::…` / `super::didcomm::…`
@@ -1620,6 +1621,40 @@ impl StateHandler {
                                 let results =
                                     agent_name_refresh::resolve_batch(resolver, targets).await;
                                 background_dispatch::DispatchOutcome::AgentName(results)
+                            },
+                        );
+                    }
+
+                    // Ask what each persona presents. Shares this tick for the
+                    // same reason as the transport probe — the loop gains no
+                    // extra timer — and re-asks every sweep rather than on a
+                    // TTL, because the answer is the holder's own decision and
+                    // they may have changed it from `pnm` a moment ago. The
+                    // busy-guard keeps a slow agent from stacking sweeps.
+                    let binding_targets: Vec<persona_binding_refresh::BindingTarget> = config
+                        .account
+                        .memberships()
+                        .filter_map(|c| {
+                            config
+                                .account
+                                .personas
+                                .get(&c.persona_ref)
+                                .map(|p| (c.sub_context_id.clone(), p.did.clone()))
+                        })
+                        .collect();
+                    if !binding_targets.is_empty()
+                        && let Some(client) = admin_vta.as_ref()
+                        && in_flight.try_begin(background_dispatch::DispatchDomain::PersonaBinding)
+                    {
+                        let client = client.clone();
+                        background_dispatch::spawn_dispatch(
+                            dispatch_tx.clone(),
+                            background_dispatch::DispatchDomain::PersonaBinding,
+                            async move {
+                                background_dispatch::DispatchOutcome::PersonaBinding(
+                                    persona_binding_refresh::resolve_batch(client, binding_targets)
+                                        .await,
+                                )
                             },
                         );
                     }

--- a/openvtc/src/state_handler/persona_binding_refresh.rs
+++ b/openvtc/src/state_handler/persona_binding_refresh.rs
@@ -1,0 +1,62 @@
+//! Ask the agent what each persona presents, for the communities panel.
+//!
+//! Mirrors [`agent_name_refresh`](super::agent_name_refresh): the loop collects
+//! targets, this resolves them off-thread, and the outcome is folded back into
+//! state on the loop.
+//!
+//! Two differences from that module, both deliberate.
+//!
+//! **Nothing here is persisted.** An agent name is a property of a DID document
+//! that rarely changes and costs a resolve to establish, so its cache lives in
+//! `ProtectedConfig` and survives a relaunch. A binding is the holder's own
+//! current decision, one trust task away, and editable from `pnm` between one
+//! launch and the next — a persisted copy would show what they used to present
+//! on the one panel whose job is to say what they present now.
+//!
+//! **A failure is an answer, and a different one from "nothing".** Every target
+//! resolves to a [`BindingSummary`], with `unknown` set when the agent could not
+//! be asked. Dropping failures from the map would leave those rows absent, and
+//! an absent row renders identically to a persona bound to nothing — which is
+//! the one confusion this whole surface must not create.
+
+use std::collections::HashMap;
+
+use openvtc_core::persona_binding::{self, BindingSummary};
+use vta_sdk::client::VtaClient;
+
+/// A `(sub_context_id, persona_did)` pair to ask about.
+pub type BindingTarget = (String, String);
+
+/// Resolve every target, in order, returning one entry per target.
+///
+/// Sequential rather than concurrent on purpose: the count is bounded by the
+/// holder's community memberships, which is small, and the agent is the same
+/// single connection for all of them — fanning out would queue on one socket
+/// while making the failure modes harder to read.
+pub async fn resolve_batch(
+    client: VtaClient,
+    targets: Vec<BindingTarget>,
+) -> HashMap<BindingTarget, BindingSummary> {
+    let mut out = HashMap::with_capacity(targets.len());
+    for (context_id, persona_did) in targets {
+        let summary = persona_binding::get_or_unknown(&client, &context_id, &persona_did).await;
+        out.insert((context_id, persona_did), summary);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An empty target list is a no-op, not an error — an account with no
+    /// memberships has nothing to ask about.
+    #[tokio::test]
+    async fn no_targets_resolves_to_an_empty_map() {
+        // Constructed without a client because the loop never dispatches an
+        // empty batch; asserted anyway so a future caller that does gets a
+        // defined answer rather than a panic.
+        let out: HashMap<BindingTarget, BindingSummary> = HashMap::new();
+        assert!(out.is_empty());
+    }
+}

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -108,10 +108,29 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
             Span::styled(attention, Style::new().fg(COLOR_ORANGE)),
         ]));
 
-        // Secondary line: status · member-since.
+        // Secondary line: status · member-since · what this face presents.
+        //
+        // The row above says WHICH of the holder's faces this community sees;
+        // this says WHAT that face tells them. Both halves are needed to answer
+        // "what does this community know about me", and until now only the
+        // first was on screen.
+        //
+        // An absent entry reads "presents: unknown" rather than being omitted.
+        // Omitting it would render identically to a persona bound to nothing,
+        // and "we have not asked yet" is not "you are sharing nothing" — see
+        // `BindingSummary::unknown`.
         let mut detail = format!("        {}", c.status_label);
         if !c.member_since.is_empty() {
             detail.push_str(&format!("  ·  since {}", c.member_since));
+        }
+        if !c.sub_context_id.is_empty() && !c.persona_did.is_empty() {
+            let key = (c.sub_context_id.clone(), c.persona_did.clone());
+            let summary = state
+                .bindings
+                .get(&key)
+                .cloned()
+                .unwrap_or_else(openvtc_core::persona_binding::BindingSummary::unknown);
+            detail.push_str(&format!("  ·  {}", summary.describe()));
         }
         if c.archived {
             detail.push_str("  ·  archived");


### PR DESCRIPTION
The communities panel says **which** of the holder's personas a community sees. It has never said **what** that persona tells them — and both halves are needed to answer *"what does this community know about me."*

Each membership row now carries a third clause:

```
Acme  ·  member  ·  since 2026-03-01  ·  presents: work (3 claims)
```

Follow-on to #275, which added `openvtc_core::persona_binding` with no surfacing.

## The cache is in memory, and that is the decision

I flagged this as a design question rather than guessing, and the answer turned out to be written in this repo already.

The obvious shape was a TTL'd cache in `ProtectedConfig`, beside the agent-name one. That is wrong here, and `prune_agent_name_negatives` says why for its own case: a negative *"records only that a name could not be verified at some past moment, and the usual causes do not survive a restart."*

The same argument applies to a binding — and to the **whole record**, not only its negatives:

- An **agent name** is a property of a DID document that rarely changes and costs a resolve to establish. Persisting it to paint instantly at launch is worth the disk.
- A **binding** is the holder's own current decision, one trust task away, and editable from `pnm` between one launch and the next. A persisted copy would show what they *used to* present — on the one panel whose job is to say what they present now.

So: session state on `CommunitiesState`. No schema bump, no persisted agent state, nothing to prune on load.

## "We have not asked" is not "you are sharing nothing"

An absent entry renders `presents: unknown`, never nothing. Those two are the same pixels if you let them, and the difference is the whole point of the panel: one says the agent could not be reached, the other says this persona is deliberately bound to nothing.

`BindingSummary::unknown` carries that distinction as a field rather than an `Option` — precisely so a caller reaching for `unwrap_or_default()` cannot collapse them.

**The sweep merges rather than replaces** for the same reason. A sweep only carries the targets it was given; replacing the map would blank every row it did not cover, which reads on screen as those personas having stopped presenting anything.

## Plumbing

`DispatchDomain::PersonaBinding` follows `Vic`: takes the loop's `admin_vta`, returns early without one, busy-guarded so a slow agent cannot stack sweeps. It shares the existing agent-name tick rather than adding a timer — the same call the VTA transport probe makes.

**Re-asked every sweep rather than on a TTL**, because the answer is the holder's own decision and they may have changed it a moment ago from another surface. A TTL would be caching the one thing that has no business being stale.

**Sequential rather than concurrent**: the count is bounded by memberships, which is small, and they all queue on one agent connection anyway — fanning out would make the failure modes harder to read for no gain.

## Verification

- `cargo test --workspace` — **962 passed, 0 failed**
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean

## Honest limit

The panel is **read-only**. Changing what a persona presents is `persona/binding/set`, which is holder-scoped and belongs in `pnm`; this shows the result. There is also no test that drives a real binding through the dispatch loop into a rendered row — the pieces are tested, the seam between them is not, which is the same gap #1258 closed on the VTA side and the natural next thing here.
