### PR TITLE
feat(persona): one pane for the holder's own identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **One pane for your own identity — "My Identity" on the main menu.** Everything
+  a holder can do with their persona now lives in one place, with five tabs in
+  the order the concepts build on each other: **Faces** (the persona DIDs),
+  **Attributes** (the pool of facts behind them), **Profiles** (named subsets of
+  that pool), **Communities** (which face each community sees and what it
+  presents there) and **Disclosures** (the read-only record of what has actually
+  left).
+
+  Before this, minting a persona DID was a menu item that fired an action, the
+  list of personas was a section of the VTA Service panel, and the three layers
+  above them — the attribute pool, the profiles over it, and the bindings that
+  decide what a community is shown — were reachable only from `pnm persona`.
+
+  Four decisions worth knowing:
+
+  - **Values are opt-in and cost a round-trip.** The attribute list is read
+    without values; `v` re-reads *with* them. It is not a display flag over data
+    already in memory, because a listing that holds values has read the holder's
+    identity whether or not the panel painted it.
+  - **"We could not ask" is never drawn as "you hold nothing."** Every
+    agent-served tab renders the failure and its reason instead of an empty
+    list. An unreachable agent and an empty pool are one pixel apart, and only
+    one of them is a confident wrong answer about the holder's own data.
+  - **Destructive questions are asked once, correctly.** Deleting an attribute a
+    profile uses, or a profile a face presents, needs a cascade or an unbind —
+    and the pane knows which from data it already holds, so the first prompt
+    names the real consequence rather than being refused and re-asked.
+  - **The editor authors what it can honestly author.** Self-asserted attributes
+    and live profile references. A credential-backed attribute is shown but not
+    editable (retyping its value would turn an attested claim into a typed one),
+    and a profile's pinned, overridden and inline entries are read, carried
+    through a save untouched, and left to `pnm` to change.
+
+- **A face's linkage is on screen.** A membership row says when the same face is
+  shown to other communities — the fact that lets two of them compare notes and
+  find one person behind both, and the one thing a holder cannot work out by
+  looking at a single row.
+
+### Changed
+
+- **The VTA Service panel is about the agent again.** Its Context Identities
+  list, and the `n` / `g` / `d` verbs that acted on it, moved to the identity
+  pane; a persona DID is the holder's identity, not a property of the agent that
+  hosts its keys. With one list left on the panel, `Tab` no longer switches
+  focus — it asks for the invitation-credential listing, which is all it ever
+  did besides move the cursor.
+
 ### Fixed
 
 - **Saving a profile on Linux corrupted the whole login keyring.** Not just the

--- a/docs/design/tui-architecture.md
+++ b/docs/design/tui-architecture.md
@@ -77,6 +77,7 @@ the real work is decomposed into focused modules (declared at `mod.rs:50`):
 | `save_coalesce.rs` | Coalesced, off-runtime `Config` persistence (see §4). |
 | `agent_name_refresh.rs` | Off-loop batch resolution of agent names (DID→name), applied via background-dispatch (see §4). |
 | `inbox_actions.rs`, `relationship_actions.rs`, `credential_actions.rs`, `settings_actions.rs` | Per-panel business logic — each exposes a `dispatch(...)` entry point the matching `Action` arm calls. |
+| `persona_actions.rs` | The identity pane. `apply(&mut State, &PersonaAction)` is pure and returns a `PersonaEffect` naming any network work; the loop spawns it and folds the result back through `PersonaOutcome::apply`. Reads and writes share one `DispatchDomain`. |
 | `didcomm.rs` | `DIDCommService` integration: service start, listener config/ids, the `DIDCommEvent` enum, lifecycle logging. |
 | `main_page/` | Maps `Config` → display state (`sync_from_config`), menu/content models. |
 | `setup_wizard.rs`, `setup_sequence/`, `setup_*_actions.rs`, `join.rs`, `join_flow.rs` | The setup and join sub-flows (each runs its own scoped `select!` loop, then returns control to `main_loop`). |

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -38,7 +38,7 @@ pub mod members;
 pub mod messaging;
 #[cfg(feature = "openpgp-card")]
 pub mod openpgp_card;
-pub mod persona_binding;
+pub mod persona;
 pub mod personhood;
 pub mod presentation;
 pub mod process_lock;

--- a/openvtc-core/src/persona/binding.rs
+++ b/openvtc-core/src/persona/binding.rs
@@ -194,7 +194,6 @@ pub async fn set(
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/openvtc-core/src/persona/binding.rs
+++ b/openvtc-core/src/persona/binding.rs
@@ -1,24 +1,12 @@
 //! What each of your faces actually says — the profile a persona presents in
-//! one community's context.
+//! one community's context. **Context-scoped**; see the [module header](super)
+//! for the boundary this sits on the low side of.
 //!
-//! # Two meanings of "persona", and they compose
-//!
-//! This crate already has a [`PersonaRecord`](crate::config::account::PersonaRecord):
-//! a `did:webvh`, its key references, its mediator. That is a face as an
-//! *identity* — the DID a community sees and the connection material behind
-//! it.
-//!
-//! The agent's `persona/*` Trust Tasks use the same word for the same thing one
-//! layer up: a persona DID that a **profile** of identity attributes is bound
-//! to, within a trust context. The two are not competing definitions. This
-//! crate holds the face; the agent holds what the face says.
-//!
-//! They join on the pair this module takes. A community membership already
-//! carries both halves — `CommunityRecord::sub_context_id` is the VTA context,
-//! and the persona it presents has the DID — which is exactly the key
-//! `persona/binding/get` is addressed by. Every membership row in the
-//! communities panel is already a `(context, persona)` pair; this is what that
-//! pair looks up.
+//! A membership already carries both halves of the key: a
+//! `CommunityRecord::sub_context_id` is the VTA context, and the persona it
+//! presents has the DID. Every row in the communities panel is a
+//! `(context, persona)` pair, and that pair is exactly what
+//! `persona/binding/get` is addressed by.
 //!
 //! # Thin on purpose
 //!
@@ -28,15 +16,21 @@
 //! shown — a binding read that returned values would make that gate
 //! decorative. So there is nothing here that renders an attribute, and adding
 //! one would be reaching around the disclosure path rather than extending this
-//! module.
+//! module. [`crate::persona::profile::get`] is where a holder looks at their
+//! own values, above the boundary and before anything is pushed across it.
 //!
-//! # Everything here is best-effort
+//! # Reads are best-effort; [`set`] is not
 //!
 //! Same rule as [`crate::devices`]: a VTA that does not serve the persona slice,
 //! or a call that times out, must never stop OpenVTC starting or a panel
 //! drawing. A membership works whether or not we can say what it presents, and
 //! [`BindingSummary::unknown`] is the honest thing to draw while we cannot —
 //! distinct from "bound to nothing", which is an answer.
+//!
+//! [`set`] is the exception, and it has to be: it is a decision the holder just
+//! made about what a community sees. A write that quietly failed would leave
+//! them believing a face presents something it does not, so its error is
+//! returned rather than softened.
 
 use serde::{Deserialize, Serialize};
 use vta_sdk::client::VtaClient;
@@ -169,6 +163,37 @@ pub async fn get_or_unknown(
         }
     }
 }
+
+/// Decide what one persona presents in one context.
+///
+/// `profile_id: None` clears the binding — a persona that presents nothing is a
+/// legitimate, common state (a throwaway face), not an absence to be inferred,
+/// so clearing is a first-class call rather than a delete.
+///
+/// This is the push across the boundary. The VTA resolves the profile *above*
+/// the context and writes a materialised projection into it: the context
+/// receives values, never pool identifiers, so nothing inside it can walk back
+/// to the holder's other faces. That is why there is no "read the pool from a
+/// context" counterpart to this function anywhere in the module.
+///
+/// `publicEntries` is deliberately sent empty. It publishes attributes on the
+/// persona's own public surface, where every relying party sees one identical
+/// value — a permanent correlation point, and the exact thing per-verifier
+/// projection exists to avoid. Offering it behind a keystroke would make it the
+/// accidental default; a holder who wants it can say so through `pnm`.
+pub async fn set(
+    client: &VtaClient,
+    context_id: &str,
+    persona_did: &str,
+    profile_id: Option<&str>,
+) -> Result<(), OpenVTCError> {
+    client
+        .persona_binding_set(context_id, persona_did, profile_id, Vec::new(), None)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona binding write failed: {e}")))?;
+    Ok(())
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/openvtc-core/src/persona/disclosure.rs
+++ b/openvtc-core/src/persona/disclosure.rs
@@ -1,0 +1,200 @@
+//! What has actually left — the permanent record of every release.
+//! **Holder-scoped**, and the one read in this module family that deliberately
+//! spans every context at once.
+//!
+//! # Read-only here, and that is the design
+//!
+//! The two writing halves of `persona/disclosure/*` are a preview and the
+//! present it authorises, and they exist to be driven by a verifier's request:
+//! a site asks, a human is shown exactly what would go, and only then is
+//! anything signed. OpenVTC is not a verifier and has nothing asking, so a
+//! "disclose something now" button here would be a request with no requester —
+//! the one shape the two-call gate exists to prevent.
+//!
+//! What the TUI can usefully answer is the question after the fact: what does
+//! anyone already know, and how did they come to know it. That is this module.
+//!
+//! # A rung is not a detail
+//!
+//! The same claim type released at two proof rungs is two very different
+//! disclosures — `whole` hands every verifier an identical issuer signature to
+//! join on, while `predicate` proves a statement without handing over the
+//! claim. A history that listed types and dropped rungs would show two
+//! materially different acts as one line repeated.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use vta_sdk::client::VtaClient;
+
+use crate::errors::OpenVTCError;
+
+/// One claim in a release, as the history reports it.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DisclosedClaim {
+    /// The vocabulary token — `email.work`.
+    pub claim_type: String,
+    /// How strongly it was hidden: `predicate`, `derived`, `selective`,
+    /// `whole`, ordered most private first.
+    pub rung: String,
+}
+
+/// One release, already reduced to what a panel row needs.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DisclosureRow {
+    pub disclosure_id: String,
+    /// The trust context it happened in.
+    pub context_id: String,
+    /// Who it went to.
+    pub verifier_did: String,
+    /// The face it was made as.
+    pub persona_did: String,
+    pub claims: Vec<DisclosedClaim>,
+    /// What the verifier said it was for, if they said.
+    pub purpose: Option<String>,
+    /// Set when the release minted a durable credential — the one kind that is
+    /// still live and still revocable, which is why it is named rather than
+    /// folded in with the rest.
+    pub durable_credential_id: Option<String>,
+    pub disclosed_at: String,
+}
+
+impl DisclosureRow {
+    fn from_wire(value: &Value) -> Self {
+        let string_at = |key: &str| {
+            value
+                .get(key)
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_default()
+        };
+        Self {
+            disclosure_id: string_at("disclosureId"),
+            context_id: string_at("contextId"),
+            verifier_did: string_at("verifierDid"),
+            persona_did: string_at("personaDid"),
+            claims: value
+                .get("claims")
+                .and_then(Value::as_array)
+                .map(|claims| {
+                    claims
+                        .iter()
+                        .map(|claim| DisclosedClaim {
+                            claim_type: claim
+                                .get("type")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string(),
+                            // An unrecorded rung reads as `whole`, the least
+                            // private answer. The conservative reading for an
+                            // unassessed disclosure is the one that overstates
+                            // exposure — claiming an unlinkability the proof
+                            // may not have provided is the error that cannot be
+                            // undone.
+                            rung: claim
+                                .get("rung")
+                                .and_then(Value::as_str)
+                                .unwrap_or("whole")
+                                .to_string(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            purpose: value
+                .get("purpose")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            durable_credential_id: value
+                .get("durableCredentialId")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            disclosed_at: string_at("disclosedAt"),
+        }
+    }
+
+    /// The claims as one line: `email.work (whole), age.over18 (predicate)`.
+    ///
+    /// The rung travels with every type rather than being summarised, because
+    /// there is no summary of a mixed release that is not misleading in one
+    /// direction or the other.
+    #[must_use]
+    pub fn describe_claims(&self) -> String {
+        if self.claims.is_empty() {
+            return "no claims recorded".to_string();
+        }
+        self.claims
+            .iter()
+            .map(|c| format!("{} ({})", c.claim_type, c.rung))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+/// Every release, newest first, across every context.
+///
+/// `limit` caps the read: a history is append-only and unbounded, and a panel
+/// that asked for all of it would grow slower for the whole life of the
+/// account.
+pub async fn history(
+    client: &VtaClient,
+    limit: std::num::NonZeroU64,
+) -> Result<Vec<DisclosureRow>, OpenVTCError> {
+    let value = client
+        .persona_disclosure_history(None, None, None, None, Some(limit), None)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona disclosure history failed: {e}")))?;
+
+    let mut rows: Vec<DisclosureRow> = value
+        .get("disclosures")
+        .and_then(Value::as_array)
+        .map(|rows| rows.iter().map(DisclosureRow::from_wire).collect())
+        .unwrap_or_default();
+    // Newest first: the question a holder opens this with is almost always
+    // "what just went out", not "what went out when I set the account up".
+    rows.sort_by(|a, b| b.disclosed_at.cmp(&a.disclosed_at));
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_claim_carries_its_rung_into_the_row() {
+        let row = DisclosureRow::from_wire(&serde_json::json!({
+            "disclosureId": "01D",
+            "contextId": "ctx",
+            "verifierDid": "did:webvh:example.com:acme",
+            "claims": [
+                { "type": "email.work", "rung": "whole" },
+                { "type": "age.over18", "rung": "predicate" },
+            ],
+            "disclosedAt": "2026-09-06T10:00:00Z",
+        }));
+        assert_eq!(
+            row.describe_claims(),
+            "email.work (whole), age.over18 (predicate)"
+        );
+    }
+
+    /// An unrecorded rung reads as `whole`.
+    ///
+    /// It is the least private of the four, and the conservative answer for an
+    /// unassessed release is the one that *overstates* what left. Defaulting
+    /// the other way would tell a holder a claim was proved without being
+    /// handed over, when nothing in the record says so.
+    #[test]
+    fn an_unrecorded_rung_reads_as_the_least_private_one() {
+        let row = DisclosureRow::from_wire(&serde_json::json!({
+            "claims": [{ "type": "email.work" }],
+        }));
+        assert_eq!(row.claims[0].rung, "whole");
+    }
+
+    /// A release with nothing recorded says so, rather than rendering as a
+    /// blank line that reads like a release of nothing.
+    #[test]
+    fn a_claimless_record_says_so() {
+        let row = DisclosureRow::default();
+        assert_eq!(row.describe_claims(), "no claims recorded");
+    }
+}

--- a/openvtc-core/src/persona/mod.rs
+++ b/openvtc-core/src/persona/mod.rs
@@ -1,0 +1,44 @@
+//! The holder's own identity — the faces, the facts behind them, and what each
+//! face presents where.
+//!
+//! # Two meanings of "persona", and they compose
+//!
+//! [`config::account::PersonaRecord`](crate::config::account::PersonaRecord) is
+//! a face as an *identity*: a `did:webvh`, its keys, its mediator. That record
+//! is local, and the TUI has always been able to mint one.
+//!
+//! The agent's `persona/*` Trust Tasks use the same word one layer up: a pool
+//! of identity attributes, named projections over that pool ([`profile`]), and
+//! the assignment of a projection to a persona DID within one trust context
+//! ([`binding`]). Those live in the VTA, not in `Config`, and every function
+//! here is a round-trip to it.
+//!
+//! This crate holds the face; the agent holds what the face says. They join on
+//! the `(context_id, persona_did)` pair every community membership already
+//! carries.
+//!
+//! # The boundary this module sits astride
+//!
+//! [`pool`] and [`profile`] are **holder-scoped**: they read across every trust
+//! context and the VTA gates them on *unrestricted* authority. [`binding`] is
+//! **context-scoped**. That asymmetry is the design, not an accident of the
+//! API — the holder pushes a materialised projection down into a context, and a
+//! context never pulls from the pool. Everything in [`binding`] therefore names
+//! a context; nothing in [`pool`] or [`profile`] can.
+//!
+//! An OpenVTC operator holds the account's admin credential, which is
+//! unrestricted, so all three work from the TUI. A caller holding anything
+//! narrower will see `e.p.msg.forbidden` from the holder-scoped half, and that
+//! is the boundary working rather than a misconfiguration.
+//!
+//! # Reads are best-effort; writes are not
+//!
+//! A read failure must never stop OpenVTC starting or a panel drawing — a
+//! membership works whether or not we can say what it presents, and
+//! [`binding::BindingSummary::unknown`] is the honest thing to draw while we
+//! cannot. A *write* is a decision the operator just made about their own
+//! identity, so it returns its error and the panel says so.
+
+pub mod binding;
+pub mod pool;
+pub mod profile;

--- a/openvtc-core/src/persona/mod.rs
+++ b/openvtc-core/src/persona/mod.rs
@@ -19,9 +19,9 @@
 //!
 //! # The boundary this module sits astride
 //!
-//! [`pool`] and [`profile`] are **holder-scoped**: they read across every trust
-//! context and the VTA gates them on *unrestricted* authority. [`binding`] is
-//! **context-scoped**. That asymmetry is the design, not an accident of the
+//! [`pool`], [`profile`] and [`disclosure`] are **holder-scoped**: they read
+//! across every trust context and the VTA gates them on *unrestricted*
+//! authority. [`binding`] is **context-scoped**. That asymmetry is the design, not an accident of the
 //! API — the holder pushes a materialised projection down into a context, and a
 //! context never pulls from the pool. Everything in [`binding`] therefore names
 //! a context; nothing in [`pool`] or [`profile`] can.
@@ -40,5 +40,6 @@
 //! identity, so it returns its error and the panel says so.
 
 pub mod binding;
+pub mod disclosure;
 pub mod pool;
 pub mod profile;

--- a/openvtc-core/src/persona/pool.rs
+++ b/openvtc-core/src/persona/pool.rs
@@ -131,10 +131,7 @@ impl PoolAttribute {
             value_type: str_field("valueType"),
             value: value.get("value").cloned(),
             provenance: ProvenanceKind::parse_wire(value.get("provenance")),
-            stale: value
-                .get("stale")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
+            stale: value.get("stale").and_then(Value::as_bool).unwrap_or(false),
             version: value.get("version").and_then(Value::as_u64).unwrap_or(0),
             updated_at: str_field("updatedAt"),
         }
@@ -267,10 +264,7 @@ pub async fn list(
 /// Create or update a self-asserted attribute.
 ///
 /// A create is a `put` with no `attributeId`; the VTA mints one and returns it.
-pub async fn put(
-    client: &VtaClient,
-    draft: AttributeDraft,
-) -> Result<AttributeEdit, OpenVTCError> {
+pub async fn put(client: &VtaClient, draft: AttributeDraft) -> Result<AttributeEdit, OpenVTCError> {
     let response = client
         .persona_attribute_put(
             &draft.claim_type,
@@ -349,8 +343,9 @@ pub fn parse_typed_value(text: &str, value_type: ValueType) -> Result<Value, Str
             "false" | "no" | "n" | "0" => Ok(Value::Bool(false)),
             _ => Err(format!("`{trimmed}` is not true or false")),
         },
-        ValueType::Object => serde_json::from_str(trimmed)
-            .map_err(|e| format!("not valid JSON: {e}")),
+        ValueType::Object => {
+            serde_json::from_str(trimmed).map_err(|e| format!("not valid JSON: {e}"))
+        }
     }
 }
 
@@ -451,7 +446,11 @@ mod tests {
         let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
         assert_eq!(attr.display_name(), "email.work");
         attr.label = Some("  ".into());
-        assert_eq!(attr.display_name(), "email.work", "a blank label is no label");
+        assert_eq!(
+            attr.display_name(),
+            "email.work",
+            "a blank label is no label"
+        );
         attr.label = Some("Work email".into());
         assert_eq!(attr.display_name(), "Work email");
     }

--- a/openvtc-core/src/persona/pool.rs
+++ b/openvtc-core/src/persona/pool.rs
@@ -1,0 +1,458 @@
+//! The attribute pool — the facts themselves, held once and projected many
+//! times. **Holder-scoped**: above every trust context, and never readable
+//! from inside one.
+//!
+//! # Values are opt-in, at every layer
+//!
+//! [`list`] takes `include_values` and defaults callers towards `false` for the
+//! same reason the Trust Task does: "how many phone numbers do I hold" and "read
+//! me the holder's identity" are different questions, and only one of them needs
+//! plaintext. A picker needs type and label; a panel that renders values needs
+//! the operator to have asked.
+//!
+//! # What this module will and will not author
+//!
+//! [`put`] writes **self-asserted** attributes only, and [`AttributeDraft`]
+//! has no `provenance` field at all — the constraint is structural rather than
+//! a default someone can pass a different value for.
+//!
+//! A credential-backed attribute names a `credentialId` and a `claimPath` into
+//! it, and its value is re-derived from the credential rather than stored: an
+//! editor that let a holder type over one would be manufacturing an attested
+//! claim out of a typed string, which is precisely the escalation provenance
+//! exists to prevent. A generated attribute is minted by the agent per verifier
+//! and has no plaintext to edit at all. Both are returned by [`list`] — a
+//! holder must see everything they hold — and both are refused by [`put`],
+//! which returns [`AttributeEdit::refusal`] naming why. Changing one is a `pnm`
+//! operation against its source.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use vta_sdk::client::VtaClient;
+use vta_sdk::protocols::persona::{Provenance, ValueType};
+
+use crate::errors::OpenVTCError;
+
+/// Where an attribute's value came from, reduced to what a panel can act on.
+///
+/// The SDK's [`Provenance`] carries the credential id, claim path and proof
+/// rung. None of those are editable here and all of them are long, so this
+/// keeps the distinction that governs behaviour — may the holder retype the
+/// value? — and drops the rest.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProvenanceKind {
+    /// The holder typed it. The only kind this module authors.
+    #[default]
+    SelfAsserted,
+    /// Backed by a credential the holder holds; the value is derived from it.
+    CredentialBacked,
+    /// Minted by the agent, usually per verifier (a relay address, an alias).
+    Generated,
+}
+
+impl ProvenanceKind {
+    /// Parse the `provenance` member of a wire attribute.
+    ///
+    /// An unrecognised discriminator resolves to [`CredentialBacked`], not
+    /// [`SelfAsserted`]: this value gates editing, and the safe answer for a
+    /// provenance a newer VTA introduced is "this build does not know how to
+    /// author it". Guessing the other way would let a future attested kind be
+    /// overwritten with a typed string by a build that never heard of it.
+    ///
+    /// [`CredentialBacked`]: ProvenanceKind::CredentialBacked
+    /// [`SelfAsserted`]: ProvenanceKind::SelfAsserted
+    pub(crate) fn parse_wire(value: Option<&Value>) -> Self {
+        match value.and_then(|p| p.get("kind")).and_then(Value::as_str) {
+            Some("selfAsserted") => Self::SelfAsserted,
+            Some("generated") => Self::Generated,
+            _ => Self::CredentialBacked,
+        }
+    }
+
+    /// Whether this build may rewrite the attribute's value. See the module
+    /// header for why only one kind qualifies.
+    #[must_use]
+    pub fn is_editable_here(self) -> bool {
+        matches!(self, Self::SelfAsserted)
+    }
+
+    /// One word for a panel row.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::SelfAsserted => "self-asserted",
+            Self::CredentialBacked => "credential-backed",
+            Self::Generated => "generated",
+        }
+    }
+}
+
+/// One attribute in the holder's pool, as a panel needs it.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct PoolAttribute {
+    /// Stable identifier — what a profile entry references.
+    pub attribute_id: String,
+    /// Vocabulary token: `name.legal`, `phone.mobile`. The store's own.
+    pub claim_type: String,
+    /// The holder's own words for their own picker. Never disclosed.
+    pub label: Option<String>,
+    /// `string` / `number` / `boolean` / `date` / `object`, as the VTA spells it.
+    pub value_type: String,
+    /// The value, present only when the read asked for values **and** the store
+    /// could produce one.
+    pub value: Option<Value>,
+    pub provenance: ProvenanceKind,
+    /// A credential-backed value that could not be re-derived. Distinct from an
+    /// absent [`value`](Self::value), which usually just means the read did not
+    /// ask for one.
+    pub stale: bool,
+    /// Optimistic-concurrency token, passed back on edit so two editors cannot
+    /// silently overwrite each other.
+    pub version: u64,
+    pub updated_at: String,
+}
+
+impl PoolAttribute {
+    fn from_wire(value: &Value) -> Self {
+        let str_field = |key: &str| {
+            value
+                .get(key)
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_default()
+        };
+        Self {
+            attribute_id: str_field("attributeId"),
+            claim_type: str_field("type"),
+            label: value
+                .get("label")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            value_type: str_field("valueType"),
+            value: value.get("value").cloned(),
+            provenance: ProvenanceKind::parse_wire(value.get("provenance")),
+            stale: value
+                .get("stale")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            version: value.get("version").and_then(Value::as_u64).unwrap_or(0),
+            updated_at: str_field("updatedAt"),
+        }
+    }
+
+    /// The name to show: the holder's label, else the vocabulary token. Never
+    /// empty, so a row cannot render as a blank line.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        match self.label.as_deref() {
+            Some(label) if !label.trim().is_empty() => label,
+            _ if !self.claim_type.is_empty() => &self.claim_type,
+            _ => "(unnamed attribute)",
+        }
+    }
+
+    /// The value as one line, or the reason there is none.
+    ///
+    /// Three readings kept apart on purpose, because collapsing any two of them
+    /// misinforms the holder about their own data: we did not ask; we asked and
+    /// the source could not answer; here it is.
+    #[must_use]
+    pub fn display_value(&self, values_requested: bool) -> String {
+        if self.stale {
+            return "(unavailable — its credential could not be read)".to_string();
+        }
+        match &self.value {
+            Some(Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+            None if values_requested => "(no value)".to_string(),
+            None => "(hidden)".to_string(),
+        }
+    }
+}
+
+/// What [`put`] needs to write a self-asserted attribute.
+///
+/// Carries no provenance: see the module header.
+#[derive(Clone, Debug)]
+pub struct AttributeDraft {
+    /// `None` creates; `Some` updates that attribute.
+    pub attribute_id: Option<String>,
+    /// The version the editor was opened against, so a concurrent edit is
+    /// refused rather than silently overwritten. `None` when creating.
+    pub expected_version: Option<u64>,
+    pub claim_type: String,
+    pub label: Option<String>,
+    pub value: Value,
+    pub value_type: ValueType,
+}
+
+impl Default for AttributeDraft {
+    /// An empty, self-asserted string attribute — what an editor opens on.
+    /// [`ValueType`] has no `Default` of its own, and `String` is the only
+    /// honest choice here: it is the one type a blank text field can hold
+    /// without the form having to guess what the holder meant.
+    fn default() -> Self {
+        Self {
+            attribute_id: None,
+            expected_version: None,
+            claim_type: String::new(),
+            label: None,
+            value: Value::Null,
+            value_type: ValueType::String,
+        }
+    }
+}
+
+/// The outcome of an attempted write.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AttributeEdit {
+    /// The attribute the VTA created or updated.
+    Written(String),
+    /// This build declined to author the change, with the reason to show.
+    Refused(String),
+}
+
+impl AttributeEdit {
+    /// The refusal a non-self-asserted attribute earns, worded for the panel.
+    #[must_use]
+    pub fn refusal(kind: ProvenanceKind) -> Self {
+        Self::Refused(match kind {
+            ProvenanceKind::CredentialBacked => {
+                "This attribute's value comes from a credential — editing it here would turn an \
+                 attested claim into a typed one. Change it at its source, or replace the \
+                 credential."
+                    .to_string()
+            }
+            ProvenanceKind::Generated => {
+                "This attribute is minted by the agent, usually a fresh value per verifier. There \
+                 is no single value to edit."
+                    .to_string()
+            }
+            ProvenanceKind::SelfAsserted => {
+                "This attribute is editable; nothing should have refused it.".to_string()
+            }
+        })
+    }
+}
+
+/// Enumerate the pool.
+///
+/// `include_values` is the whole of the difference between a picker and a read
+/// of the holder's identity — see the module header.
+pub async fn list(
+    client: &VtaClient,
+    include_values: bool,
+) -> Result<Vec<PoolAttribute>, OpenVTCError> {
+    let value = client
+        .persona_attribute_list(None, include_values, None, None, None)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona attribute list failed: {e}")))?;
+
+    let mut attributes: Vec<PoolAttribute> = value
+        .get("attributes")
+        .and_then(Value::as_array)
+        .map(|rows| rows.iter().map(PoolAttribute::from_wire).collect())
+        .unwrap_or_default();
+    // Display order the holder can predict. The store returns insertion order,
+    // which is the order things happened to be typed in — fine for a machine,
+    // useless for finding "the work email" in a list of thirty.
+    attributes.sort_by(|a, b| {
+        a.claim_type
+            .cmp(&b.claim_type)
+            .then_with(|| a.display_name().cmp(b.display_name()))
+    });
+    Ok(attributes)
+}
+
+/// Create or update a self-asserted attribute.
+///
+/// A create is a `put` with no `attributeId`; the VTA mints one and returns it.
+pub async fn put(
+    client: &VtaClient,
+    draft: AttributeDraft,
+) -> Result<AttributeEdit, OpenVTCError> {
+    let response = client
+        .persona_attribute_put(
+            &draft.claim_type,
+            draft.value,
+            draft.value_type,
+            Provenance::SelfAsserted,
+            draft.label.as_deref(),
+            draft.attribute_id.as_deref(),
+            draft.expected_version,
+        )
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona attribute write failed: {e}")))?;
+
+    Ok(AttributeEdit::Written(
+        response
+            .get("attributeId")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .or(draft.attribute_id)
+            .unwrap_or_default(),
+    ))
+}
+
+/// Remove an attribute.
+///
+/// Without `cascade` the VTA refuses while a profile still references it — the
+/// alternative is profiles quietly presenting a dangling reference. The caller
+/// is expected to surface that refusal and ask, rather than retrying with
+/// `cascade` on the holder's behalf: cascading edits every profile that used
+/// the attribute, and that is not a consequence to infer from a `d` keypress.
+pub async fn delete(
+    client: &VtaClient,
+    attribute_id: &str,
+    cascade: bool,
+) -> Result<(), OpenVTCError> {
+    client
+        .persona_attribute_delete(attribute_id, cascade, None)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona attribute delete failed: {e}")))?;
+    Ok(())
+}
+
+/// Parse the `valueType` string a [`PoolAttribute`] carries back into the typed
+/// form [`put`] needs. Unknown types read as [`ValueType::String`], which is
+/// what an editor can actually offer a text field for.
+#[must_use]
+pub fn value_type_from_str(s: &str) -> ValueType {
+    match s {
+        "number" => ValueType::Number,
+        "boolean" => ValueType::Boolean,
+        "date" => ValueType::Date,
+        "object" => ValueType::Object,
+        _ => ValueType::String,
+    }
+}
+
+/// Turn typed text into the JSON value its declared type calls for.
+///
+/// Returns the parse failure as text a form can show next to the field. A
+/// `number` field that quietly stored `"12"` as a string would present a value
+/// no predicate proof could ever compare against.
+pub fn parse_typed_value(text: &str, value_type: ValueType) -> Result<Value, String> {
+    let trimmed = text.trim();
+    match value_type {
+        ValueType::String | ValueType::Date => Ok(Value::String(trimmed.to_string())),
+        ValueType::Number => trimmed
+            .parse::<f64>()
+            .map_err(|_| format!("`{trimmed}` is not a number"))
+            .and_then(|n| {
+                serde_json::Number::from_f64(n)
+                    .map(Value::Number)
+                    .ok_or_else(|| format!("`{trimmed}` is not a finite number"))
+            }),
+        ValueType::Boolean => match trimmed.to_ascii_lowercase().as_str() {
+            "true" | "yes" | "y" | "1" => Ok(Value::Bool(true)),
+            "false" | "no" | "n" | "0" => Ok(Value::Bool(false)),
+            _ => Err(format!("`{trimmed}` is not true or false")),
+        },
+        ValueType::Object => serde_json::from_str(trimmed)
+            .map_err(|e| format!("not valid JSON: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wire(provenance: &str) -> Value {
+        serde_json::json!({
+            "attributeId": "01J8",
+            "type": "email.work",
+            "valueType": "string",
+            "provenance": { "kind": provenance },
+            "version": 3,
+            "updatedAt": "2026-09-06T00:00:00Z",
+        })
+    }
+
+    /// The three provenance kinds the panel branches on, round-tripped from the
+    /// shape the VTA actually sends.
+    #[test]
+    fn provenance_parses_from_its_discriminator() {
+        assert_eq!(
+            PoolAttribute::from_wire(&wire("selfAsserted")).provenance,
+            ProvenanceKind::SelfAsserted
+        );
+        assert_eq!(
+            PoolAttribute::from_wire(&wire("generated")).provenance,
+            ProvenanceKind::Generated
+        );
+        assert_eq!(
+            PoolAttribute::from_wire(&wire("credentialBacked")).provenance,
+            ProvenanceKind::CredentialBacked
+        );
+    }
+
+    /// A provenance this build has never heard of must not become editable.
+    ///
+    /// The failure this guards is quiet and one-directional: a newer VTA adds
+    /// an attested kind, an older build parses it as self-asserted, and the
+    /// holder retypes an attested value into a typed one from a panel that
+    /// believed it was allowed to.
+    #[test]
+    fn an_unknown_provenance_is_not_editable() {
+        let attr = PoolAttribute::from_wire(&wire("someFutureKind"));
+        assert!(!attr.provenance.is_editable_here());
+        let missing = PoolAttribute::from_wire(&serde_json::json!({ "attributeId": "01J8" }));
+        assert!(!missing.provenance.is_editable_here());
+    }
+
+    /// "We did not ask", "there is nothing", and "the source failed" are three
+    /// different sentences. A holder reading their own pool has to be able to
+    /// tell them apart — collapsing them is how a panel says "you hold no phone
+    /// number" about a value it simply never requested.
+    #[test]
+    fn the_three_reasons_for_an_absent_value_read_differently() {
+        let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
+        assert_eq!(attr.display_value(false), "(hidden)");
+        assert_eq!(attr.display_value(true), "(no value)");
+        attr.stale = true;
+        assert!(attr.display_value(true).contains("could not be read"));
+    }
+
+    /// A string value renders as itself, not as a quoted JSON string — the
+    /// panel shows `alice@example.com`, never `"alice@example.com"`.
+    #[test]
+    fn a_string_value_renders_unquoted() {
+        let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
+        attr.value = Some(Value::String("alice@example.com".into()));
+        assert_eq!(attr.display_value(true), "alice@example.com");
+    }
+
+    /// A typed field stores the type it declares. The number case is the one
+    /// that matters: `"30"` and `30` compare differently, and a predicate proof
+    /// over the string form can never be satisfied.
+    #[test]
+    fn typed_values_parse_to_their_declared_type() {
+        assert_eq!(
+            parse_typed_value("30", ValueType::Number).unwrap(),
+            serde_json::json!(30.0)
+        );
+        assert_eq!(
+            parse_typed_value(" yes ", ValueType::Boolean).unwrap(),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            parse_typed_value(r#"{"a":1}"#, ValueType::Object).unwrap(),
+            serde_json::json!({"a": 1})
+        );
+        assert!(parse_typed_value("thirty", ValueType::Number).is_err());
+        assert!(parse_typed_value("maybe", ValueType::Boolean).is_err());
+    }
+
+    /// A label is what the holder sees; falling back to the vocabulary token
+    /// keeps an unlabelled row identifiable rather than blank.
+    #[test]
+    fn display_name_falls_back_to_the_type() {
+        let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
+        assert_eq!(attr.display_name(), "email.work");
+        attr.label = Some("  ".into());
+        assert_eq!(attr.display_name(), "email.work", "a blank label is no label");
+        attr.label = Some("Work email".into());
+        assert_eq!(attr.display_name(), "Work email");
+    }
+}

--- a/openvtc-core/src/persona/profile.rs
+++ b/openvtc-core/src/persona/profile.rs
@@ -1,0 +1,436 @@
+//! Profiles — named projections over the pool, and the unit a persona is bound
+//! to. **Holder-scoped**, like the pool they draw from.
+//!
+//! A profile is a whitelist: omission is exclusion. There is no removal marker,
+//! because a blacklist over a growing pool leaks by default the first time an
+//! attribute is added.
+//!
+//! # This build authors live references, and preserves everything else
+//!
+//! The Trust Task's profile entry has four forms — a live `ref` to a pool
+//! attribute, a `pinVersion` pin of one, an `override` of its value, and an
+//! `inline` value that never enters the pool. [`put`] from here writes the
+//! first, and a picker over the pool is exactly what that form is: tick the
+//! facts this face shows. It keeps "edit once, everywhere" true, which is the
+//! property a holder is relying on when they correct their address in one
+//! place.
+//!
+//! The other three are divergences — a value this profile shows that the pool
+//! does not — and each is a decision worth naming out loud rather than
+//! producing as a side effect of a checkbox. They are made through `pnm`.
+//!
+//! **But they are never silently discarded.** [`get`] parses every entry it
+//! reads and hands the non-`ref` ones back in
+//! [`ProfileDetail::other_entries`]; [`put`] takes them and writes them
+//! through unchanged. Rebuilding a profile from only the ticked boxes would
+//! delete a holder's pinned or overridden values the first time they renamed
+//! it, and the deletion would be invisible — the profile would still resolve,
+//! just to less than it did.
+//!
+//! An entry this build cannot parse at all (a form a newer VTA introduced) is
+//! counted in [`ProfileDetail::unreadable_entries`] and makes the profile
+//! **read-only here**: a save that cannot round-trip an entry cannot preserve
+//! it, and dropping it is precisely the silent loss above.
+
+use serde_json::Value;
+use vta_sdk::client::VtaClient;
+use vta_sdk::protocols::persona::ProfileEntry;
+
+use crate::errors::OpenVTCError;
+use crate::persona::pool::ProvenanceKind;
+
+/// A profile as a list row.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ProfileSummary {
+    pub profile_id: String,
+    /// The holder's name for it — "Work", "Gaming". Never disclosed.
+    pub name: String,
+    /// How many entries it carries, all forms counted.
+    pub entry_count: usize,
+    /// Credentials listed as this profile's inventory — what the face can
+    /// prove, as distinct from the evidence behind a credential-backed value.
+    pub credential_ref_count: usize,
+    pub version: u64,
+    pub updated_at: String,
+}
+
+impl ProfileSummary {
+    fn from_wire(value: &Value) -> Self {
+        Self {
+            profile_id: string_at(value, "profileId"),
+            name: string_at(value, "name"),
+            entry_count: value
+                .get("entries")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len),
+            credential_ref_count: value
+                .get("credentialRefs")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len),
+            version: value.get("version").and_then(Value::as_u64).unwrap_or(0),
+            updated_at: string_at(value, "updatedAt"),
+        }
+    }
+
+    /// The name to show. Never empty: an unnamed profile still has to be
+    /// selectable in a list.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        if self.name.trim().is_empty() {
+            "(unnamed profile)"
+        } else {
+            &self.name
+        }
+    }
+}
+
+/// One claim a profile would present, as [`get`] with `resolve` returns it.
+///
+/// A *distinct type* from a pool attribute, and deliberately so at the source:
+/// a resolved claim has nowhere to put a pool identifier when it does not have
+/// one, which is what makes an inline value describable rather than a lie about
+/// where it lives.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ResolvedClaim {
+    pub claim_type: String,
+    pub value: Option<Value>,
+    pub value_type: String,
+    pub provenance: ProvenanceKind,
+    /// A credential-backed value that could not be re-derived.
+    pub stale: bool,
+    /// The pool attribute behind this claim. Absent for a value that lives only
+    /// in this profile.
+    pub attribute_id: Option<String>,
+}
+
+impl ResolvedClaim {
+    fn from_wire(value: &Value) -> Self {
+        Self {
+            claim_type: string_at(value, "type"),
+            value: value.get("value").cloned().filter(|v| !v.is_null()),
+            value_type: string_at(value, "valueType"),
+            provenance: ProvenanceKind::parse_wire(value.get("provenance")),
+            stale: value.get("stale").and_then(Value::as_bool).unwrap_or(false),
+            attribute_id: value
+                .get("attributeId")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        }
+    }
+
+    /// The value as one line. Mirrors
+    /// [`PoolAttribute::display_value`](crate::persona::pool::PoolAttribute::display_value),
+    /// minus the "hidden" case: a resolve was asked for, so an absent value is
+    /// an answer rather than a question that was never put.
+    #[must_use]
+    pub fn display_value(&self) -> String {
+        if self.stale {
+            return "(unavailable — its credential could not be read)".to_string();
+        }
+        match &self.value {
+            Some(Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+            None => "(no value)".to_string(),
+        }
+    }
+}
+
+/// One profile, read in full.
+#[derive(Clone, Debug, Default)]
+pub struct ProfileDetail {
+    pub summary: ProfileSummary,
+    /// Pool attributes referenced live — the set this build's editor owns.
+    pub live_refs: Vec<String>,
+    /// Pinned, overridden and inline entries, kept exactly as read so a save
+    /// writes them back untouched.
+    pub other_entries: Vec<ProfileEntry>,
+    /// Entries this build could not parse. Non-zero makes the profile
+    /// read-only here — see the module header.
+    pub unreadable_entries: usize,
+    /// What the profile would present, when the read asked for it.
+    pub resolved: Vec<ResolvedClaim>,
+}
+
+impl ProfileDetail {
+    /// Whether this build may write the profile back.
+    ///
+    /// False only when an entry could not be parsed, because a save then cannot
+    /// preserve it. The refusal is the point: a profile that quietly lost an
+    /// entry still resolves, just to less than the holder believes it shows.
+    #[must_use]
+    pub fn is_editable_here(&self) -> bool {
+        self.unreadable_entries == 0
+    }
+
+    /// The sentence to show when it is not.
+    #[must_use]
+    pub fn refusal(&self) -> String {
+        format!(
+            "This profile has {} entr{} this version of OpenVTC cannot read, so saving would drop \
+             {}. Edit it with `pnm persona profile`, or upgrade.",
+            self.unreadable_entries,
+            if self.unreadable_entries == 1 {
+                "y"
+            } else {
+                "ies"
+            },
+            if self.unreadable_entries == 1 {
+                "it"
+            } else {
+                "them"
+            },
+        )
+    }
+}
+
+/// Enumerate the holder's profiles.
+///
+/// Metadata only, and there is no option to change that: resolving every
+/// profile at once would decrypt the entire pool to answer a question about
+/// names. [`get`] resolves the one the holder opened.
+pub async fn list(client: &VtaClient) -> Result<Vec<ProfileSummary>, OpenVTCError> {
+    let value = client
+        .persona_profile_list(None, None)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona profile list failed: {e}")))?;
+
+    let mut profiles: Vec<ProfileSummary> = value
+        .get("profiles")
+        .and_then(Value::as_array)
+        .map(|rows| rows.iter().map(ProfileSummary::from_wire).collect())
+        .unwrap_or_default();
+    profiles.sort_by(|a, b| a.display_name().cmp(b.display_name()));
+    Ok(profiles)
+}
+
+/// Read one profile, optionally resolving what it would present.
+///
+/// `resolve` is opt-in for the same reason `include_values` is on the pool: it
+/// decrypts values and re-derives credential-backed ones. A holder opening a
+/// profile to see what it shows has asked; a list rebuilding itself has not.
+pub async fn get(
+    client: &VtaClient,
+    profile_id: &str,
+    resolve: bool,
+) -> Result<ProfileDetail, OpenVTCError> {
+    let value = client
+        .persona_profile_get(profile_id, resolve)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona profile read failed: {e}")))?;
+
+    let profile = value.get("profile").unwrap_or(&Value::Null).clone();
+    let mut detail = ProfileDetail {
+        summary: ProfileSummary::from_wire(&profile),
+        resolved: value
+            .get("resolved")
+            .and_then(Value::as_array)
+            .map(|rows| rows.iter().map(ResolvedClaim::from_wire).collect())
+            .unwrap_or_default(),
+        ..ProfileDetail::default()
+    };
+
+    for entry in profile
+        .get("entries")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        match serde_json::from_value::<ProfileEntry>(entry.clone()) {
+            Ok(ProfileEntry::Ref { attribute_id }) => detail.live_refs.push(attribute_id),
+            Ok(other) => detail.other_entries.push(other),
+            // Counted, never dropped-and-forgotten: this is what makes the
+            // profile read-only rather than silently rewritable.
+            Err(_) => detail.unreadable_entries += 1,
+        }
+    }
+    Ok(detail)
+}
+
+/// Create or update a profile.
+///
+/// `live_refs` are the pool attributes the holder ticked; `other_entries` are
+/// the pinned/overridden/inline entries [`get`] read, passed straight back. A
+/// caller that drops them deletes them.
+///
+/// The ticked entries are written first and in the order given, so the profile
+/// resolves in the order the holder saw — entry order is display order.
+pub async fn put(
+    client: &VtaClient,
+    profile_id: Option<&str>,
+    name: &str,
+    live_refs: &[String],
+    other_entries: &[ProfileEntry],
+    expected_version: Option<u64>,
+) -> Result<String, OpenVTCError> {
+    let entries: Vec<ProfileEntry> = live_refs
+        .iter()
+        .map(|id| ProfileEntry::Ref {
+            attribute_id: id.clone(),
+        })
+        .chain(other_entries.iter().cloned())
+        .collect();
+
+    let response = client
+        .persona_profile_put(name, entries, Vec::new(), profile_id, expected_version)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona profile write failed: {e}")))?;
+
+    Ok(response
+        .get("profileId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| profile_id.map(str::to_string))
+        .unwrap_or_default())
+}
+
+/// Remove a profile.
+///
+/// Without `unbind` the VTA refuses while a persona still presents under it. A
+/// context losing its identity mid-relationship is not something to do by
+/// omission, so the refusal is surfaced and the holder is asked — the caller
+/// must not retry with `unbind` on their behalf.
+pub async fn delete(
+    client: &VtaClient,
+    profile_id: &str,
+    unbind: bool,
+) -> Result<(), OpenVTCError> {
+    client
+        .persona_profile_delete(profile_id, unbind, None)
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona profile delete failed: {e}")))?;
+    Ok(())
+}
+
+/// Read a string member, defaulting to empty rather than failing the whole
+/// parse: one missing label must not cost the holder the entire listing.
+fn string_at(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile_wire(entries: Value) -> Value {
+        serde_json::json!({
+            "profile": {
+                "profileId": "01J9",
+                "name": "Work",
+                "entries": entries,
+                "version": 2,
+                "updatedAt": "2026-09-06T00:00:00Z",
+            }
+        })
+    }
+
+    /// The four entry forms split into the two buckets a save has to keep
+    /// apart: what the editor owns, and what it must carry through untouched.
+    #[test]
+    fn entries_split_into_editable_refs_and_preserved_forms() {
+        let wire = profile_wire(serde_json::json!([
+            { "ref": "01A" },
+            { "ref": "01B", "pinVersion": 3 },
+            { "ref": "01C", "override": { "value": "other" } },
+            { "inline": {
+                "type": "nickname",
+                "valueType": "string",
+                "value": "Ace",
+                "provenance": { "kind": "selfAsserted" }
+            }},
+        ]));
+        let profile = wire.get("profile").unwrap().clone();
+        let mut detail = ProfileDetail {
+            summary: ProfileSummary::from_wire(&profile),
+            ..ProfileDetail::default()
+        };
+        for entry in profile.get("entries").unwrap().as_array().unwrap() {
+            match serde_json::from_value::<ProfileEntry>(entry.clone()) {
+                Ok(ProfileEntry::Ref { attribute_id }) => detail.live_refs.push(attribute_id),
+                Ok(other) => detail.other_entries.push(other),
+                Err(_) => detail.unreadable_entries += 1,
+            }
+        }
+
+        assert_eq!(detail.live_refs, vec!["01A".to_string()]);
+        assert_eq!(
+            detail.other_entries.len(),
+            3,
+            "a pin, an override and an inline value are not the editor's to rewrite"
+        );
+        assert!(detail.is_editable_here());
+        assert_eq!(detail.summary.entry_count, 4);
+    }
+
+    /// An entry form this build has never seen makes the profile read-only.
+    ///
+    /// The alternative is the silent loss the module header describes: the save
+    /// succeeds, the profile still resolves, and it presents less than the
+    /// holder thinks it does.
+    #[test]
+    fn an_unreadable_entry_makes_the_profile_read_only() {
+        let detail = ProfileDetail {
+            unreadable_entries: 2,
+            ..ProfileDetail::default()
+        };
+        assert!(!detail.is_editable_here());
+        assert!(detail.refusal().contains("2 entries"));
+        assert!(detail.refusal().contains("pnm"));
+    }
+
+    /// A resolved claim with no `attributeId` is an inline value, and saying so
+    /// is the whole reason it is a distinct type from a pool attribute.
+    #[test]
+    fn a_resolved_claim_without_an_attribute_id_is_inline() {
+        let claim = ResolvedClaim::from_wire(&serde_json::json!({
+            "type": "nickname",
+            "value": "Ace",
+            "valueType": "string",
+            "provenance": { "kind": "selfAsserted" },
+            "stale": false,
+        }));
+        assert!(claim.attribute_id.is_none());
+        assert_eq!(claim.display_value(), "Ace");
+    }
+
+    /// A resolved read that came back without a value says so, rather than
+    /// reading as "hidden" — nothing was withheld; the resolve was asked for.
+    #[test]
+    fn a_resolved_claim_with_no_value_says_so() {
+        let claim = ResolvedClaim::from_wire(&serde_json::json!({
+            "type": "email.work",
+            "value": Value::Null,
+            "stale": true,
+        }));
+        assert!(claim.display_value().contains("could not be read"));
+    }
+
+    /// The put ordering: ticked entries first, preserved forms after, so the
+    /// profile resolves in the order the holder saw in the picker.
+    #[test]
+    fn a_saved_profile_puts_the_ticked_entries_first() {
+        let refs = vec!["01A".to_string(), "01B".to_string()];
+        let other = vec![ProfileEntry::Inline {
+            inline: serde_json::from_value(serde_json::json!({
+                "type": "nickname",
+                "valueType": "string",
+                "value": "Ace",
+                "provenance": { "kind": "selfAsserted" }
+            }))
+            .unwrap(),
+        }];
+        let entries: Vec<ProfileEntry> = refs
+            .iter()
+            .map(|id| ProfileEntry::Ref {
+            attribute_id: id.clone(),
+        })
+            .chain(other.iter().cloned())
+            .collect();
+        assert_eq!(entries.len(), 3);
+        assert!(matches!(&entries[0], ProfileEntry::Ref { attribute_id } if attribute_id == "01A"));
+        assert!(matches!(entries[2], ProfileEntry::Inline { .. }));
+    }
+}

--- a/openvtc-core/src/persona/profile.rs
+++ b/openvtc-core/src/persona/profile.rs
@@ -47,6 +47,14 @@ pub struct ProfileSummary {
     pub name: String,
     /// How many entries it carries, all forms counted.
     pub entry_count: usize,
+    /// The pool attributes this profile draws on, in any entry form.
+    ///
+    /// Carried on the summary because the listing already contains it and one
+    /// question depends on it: deleting an attribute a profile references is
+    /// refused unless the caller cascades, and a caller that has to *discover*
+    /// that from a rejection asks the holder the wrong question first. With
+    /// this, the one question put is the right one.
+    pub referenced: Vec<String>,
     /// Credentials listed as this profile's inventory — what the face can
     /// prove, as distinct from the evidence behind a credential-backed value.
     pub credential_ref_count: usize,
@@ -63,6 +71,17 @@ impl ProfileSummary {
                 .get("entries")
                 .and_then(Value::as_array)
                 .map_or(0, Vec::len),
+            referenced: value
+                .get("entries")
+                .and_then(Value::as_array)
+                .map(|entries| {
+                    entries
+                        .iter()
+                        .filter_map(|e| e.get("ref").and_then(Value::as_str))
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default(),
             credential_ref_count: value
                 .get("credentialRefs")
                 .and_then(Value::as_array)
@@ -412,8 +431,8 @@ mod tests {
     /// profile resolves in the order the holder saw in the picker.
     #[test]
     fn a_saved_profile_puts_the_ticked_entries_first() {
-        let refs = vec!["01A".to_string(), "01B".to_string()];
-        let other = vec![ProfileEntry::Inline {
+        let refs = ["01A".to_string(), "01B".to_string()];
+        let other = [ProfileEntry::Inline {
             inline: serde_json::from_value(serde_json::json!({
                 "type": "nickname",
                 "valueType": "string",
@@ -425,8 +444,8 @@ mod tests {
         let entries: Vec<ProfileEntry> = refs
             .iter()
             .map(|id| ProfileEntry::Ref {
-            attribute_id: id.clone(),
-        })
+                attribute_id: id.clone(),
+            })
             .chain(other.iter().cloned())
             .collect();
         assert_eq!(entries.len(), 3);

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -188,6 +188,66 @@ pub enum SettingsAction {
     ClipboardCopied(String),
 }
 
+/// Identity-pane actions — the holder's own faces, pool, profiles and bindings.
+///
+/// One sub-enum for a pane with four tabs, rather than four: every one of them
+/// shares the pane's selection, its confirmation slot and its single load
+/// domain, and splitting them would put that shared state behind four names.
+pub enum PersonaAction {
+    /// Move to the next / previous tab.
+    TabNext,
+    TabPrev,
+    /// Move the selection within the active tab.
+    Select(usize),
+    /// Re-read the agent-served tabs.
+    Refresh,
+    /// Ask for the pool *with* values, or stop asking. A re-read either way —
+    /// a listing fetched without values does not hold them, which is what makes
+    /// this an opt-in rather than a blindfold.
+    ToggleValues,
+
+    // ── Attributes ───────────────────────────────────────────────────────
+    /// Open the editor on a new attribute.
+    AttributeNew,
+    /// Open the editor on an existing one.
+    AttributeEdit(usize),
+    /// Arm its deletion.
+    AttributeDeleteArm(usize),
+
+    // ── Profiles ─────────────────────────────────────────────────────────
+    /// Read one profile and show what it would present.
+    ProfileOpen(usize),
+    /// Close that view.
+    ProfileClose,
+    ProfileNew,
+    ProfileEdit(usize),
+    ProfileDeleteArm(usize),
+
+    // ── Communities ──────────────────────────────────────────────────────
+    /// Open the picker: what should this face present here?
+    BindOpen(usize),
+    /// Arm "present nothing here".
+    UnbindArm(usize),
+
+    // ── The shared confirmation slot ─────────────────────────────────────
+    ConfirmYes,
+    ConfirmNo,
+
+    // ── Whichever form or picker is open ─────────────────────────────────
+    /// A key for the open form's focused field. Carried whole, like
+    /// [`Action::CreatePersonaInput`], so text editing stays in `tui_input`
+    /// rather than being re-implemented one `KeyCode` at a time.
+    FormKey(crossterm::event::KeyEvent),
+    /// Move between fields (`true` = forwards).
+    FormField(bool),
+    /// Cycle the value type, or move the entry cursor (`true` = forwards).
+    FormCycle(bool),
+    /// Tick or untick the entry under the cursor.
+    FormToggleEntry,
+    FormSubmit,
+    FormCancel,
+}
+
 // ============================================================================
 // Top-level Action enum
 // ============================================================================
@@ -216,6 +276,8 @@ pub enum Action {
     Relationship(RelationshipAction),
     Credential(CredentialAction),
     Settings(SettingsAction),
+    /// Identity pane (faces / pool / profiles / bindings).
+    Persona(PersonaAction),
 
     /// Dismiss the startup loading screen (Enter, once loading has completed) and
     /// reveal the main page. Phase-2 connections are already running in the
@@ -451,8 +513,6 @@ pub enum Action {
     VicRefresh,
     /// Move the VIC-list selection to this index.
     VicSelect(usize),
-    /// Toggle keyboard focus between the Context Identities and VIC lists (Tab).
-    VicFocusToggle,
     /// Toggle whether archived + soft-deleted VICs are listed (`i`); triggers a
     /// re-query.
     VicToggleInactive,

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -99,6 +99,10 @@ pub(crate) enum DispatchDomain {
     Capabilities,
     /// What each persona presents, for the communities panel.
     PersonaBinding,
+    /// The identity pane's own reads and writes — the attribute pool, the
+    /// profiles over it, and the bindings it sets. One domain for both
+    /// directions, so a listing cannot overtake the write that invalidated it.
+    PersonaManage,
     /// Invitation-credential (VIC) list refresh: one credential-vault query
     /// against the always-on admin VTA session (30 s timeout in the SDK).
     /// Read-only. Backgrounded because it is bound to *navigation* — Tab into
@@ -123,6 +127,7 @@ impl DispatchDomain {
             DispatchDomain::Community => "Community request",
             DispatchDomain::Capabilities => "Capability request",
             DispatchDomain::PersonaBinding => "Persona binding refresh",
+            DispatchDomain::PersonaManage => "Identity request",
             DispatchDomain::Vic => "Invitation credential refresh",
         }
     }
@@ -231,6 +236,8 @@ pub(crate) enum DispatchOutcome {
     /// delete / purge). Shares the `Vic` domain with the listing, so the
     /// re-read it asks for cannot start until this outcome frees it.
     VicMutation(crate::state_handler::vic::VicMutationOutcome),
+    /// An identity-pane read or write finished.
+    PersonaManage(crate::state_handler::persona_actions::PersonaOutcome),
     /// A VIC list refresh finished. [`VicRefreshOutcome::apply`](crate::state_handler::vic::VicRefreshOutcome::apply)
     /// swaps in the
     /// listing (or logs why it could not be read); display-only, so it touches
@@ -263,6 +270,7 @@ impl DispatchOutcome {
             DispatchOutcome::Community(_) => DispatchDomain::Community,
             DispatchOutcome::Capabilities(_) => DispatchDomain::Capabilities,
             DispatchOutcome::PersonaBinding(_) => DispatchDomain::PersonaBinding,
+            DispatchOutcome::PersonaManage(_) => DispatchDomain::PersonaManage,
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::VicMutation(_) => DispatchDomain::Vic,
             DispatchOutcome::Panicked(domain) => *domain,
@@ -462,10 +470,11 @@ pub(crate) fn apply_outcome(
             state
                 .main_page
                 .content_panel
-                .communities
+                .personas
                 .bindings
                 .extend(results);
         }
+        DispatchOutcome::PersonaManage(outcome) => outcome.apply(state),
         DispatchOutcome::Vic(outcome) => outcome.apply(state, config),
         DispatchOutcome::VicMutation(outcome) => outcome.apply(state),
         // Handled above, before the domain is finished. Listed because the

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -224,7 +224,7 @@ pub(crate) enum DispatchOutcome {
     PersonaBinding(
         std::collections::HashMap<
             crate::state_handler::persona_binding_refresh::BindingTarget,
-            openvtc_core::persona_binding::BindingSummary,
+            openvtc_core::persona::binding::BindingSummary,
         >,
     ),
     /// A VIC vault mutation finished (import / archive / unarchive / restore /

--- a/openvtc/src/state_handler/create_persona.rs
+++ b/openvtc/src/state_handler/create_persona.rs
@@ -10,7 +10,7 @@
 //! minus the community/submit parts: pick a WebVH server, mint the DID via the
 //! VTA, then persist through the shared [`ConfigExtension::mint_persona_into`].
 //! The minted persona is an orphan (no community) until a join reuses it, and
-//! shows in the VTA panel's Context Identities list.
+//! shows in the identity pane's Faces list.
 
 use affinidi_tdk::TDK;
 use anyhow::Result;

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -518,22 +518,46 @@ pub enum PersonaConfirm {
     #[default]
     None,
     /// Remove an orphan persona DID (index into `faces`).
+    ///
+    /// The one variant still addressed by index, because it hands off to the
+    /// existing identity-deletion path, which takes one and re-resolves the DID
+    /// under its own guards before anything is removed.
     DeleteFace(usize),
-    /// Delete a pool attribute (index into `attributes`).
+    /// Delete a pool attribute, named by what it is rather than by where it sat.
     ///
-    /// `cascade` is the *escalated* ask, offered only after the VTA has refused
-    /// the plain one because profiles still reference the attribute. It is
-    /// never the first question: cascading edits every profile that used the
-    /// value, and that is not a consequence to infer from a `d` keypress.
-    DeleteAttribute { index: usize, cascade: bool },
-    /// Delete a profile (index into `profiles`).
+    /// **Not an index.** An armed question survives across a listing that
+    /// arrives while it is on screen, and an index into the old listing points
+    /// at a different attribute in the new one — which would delete something
+    /// the operator never selected while showing them the name of something
+    /// else. The name is carried for the same reason: the prompt has to name
+    /// what was armed, not whatever now occupies that row.
     ///
-    /// `unbind` is the same escalation one layer up — offered after a refusal,
-    /// because it makes every persona presenting under the profile present
-    /// nothing.
-    DeleteProfile { index: usize, unbind: bool },
-    /// Clear what one membership's face presents (index into `memberships`).
-    Unbind(usize),
+    /// `cascade` is decided when the question is put, from the profile listing
+    /// the pane already holds: the VTA refuses a plain delete while a profile
+    /// references the attribute, so cascading is what will actually happen and
+    /// the prompt says so the first time.
+    DeleteAttribute {
+        attribute_id: String,
+        name: String,
+        cascade: bool,
+    },
+    /// Delete a profile. Named, not indexed, for the reason above.
+    ///
+    /// `unbind` is the same decision one layer up: it makes every face
+    /// presenting under this profile present nothing, and it is decided from
+    /// the binding map rather than discovered from a refusal.
+    DeleteProfile {
+        profile_id: String,
+        name: String,
+        unbind: bool,
+    },
+    /// Clear what one face presents in one context — the pair the binding is
+    /// addressed by, carried whole for the same reason as above.
+    Unbind {
+        context_id: String,
+        persona_did: String,
+        community: String,
+    },
 }
 
 /// Which field of the attribute editor has the keyboard.

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -69,6 +69,9 @@ pub struct ContentPanelState {
     pub communities: CommunitiesState,
     /// Per-community capabilities view (opened from Communities with `c`).
     pub capabilities: CapabilitiesState,
+    /// The holder's own identity: faces, pool, profiles, and what each face
+    /// presents where.
+    pub personas: PersonasState,
 }
 
 // ****************************************************************************
@@ -147,24 +150,6 @@ pub struct CapabilitiesState {
 /// memberships, in display order (favourites first).
 #[derive(Clone, Debug, Default)]
 pub struct CommunitiesState {
-    /// What each persona presents in each community's context, keyed by
-    /// `(sub_context_id, persona_did)` — the pair `persona/binding/get` is
-    /// addressed by, and the pair every membership row already carries.
-    ///
-    /// **Session state, deliberately not persisted.** The agent-name cache next
-    /// door IS persisted, and the difference is the point: a verified name is a
-    /// property of a DID document that rarely changes and costs a network
-    /// round-trip to establish, so showing it instantly at launch is worth
-    /// keeping on disk. A binding is the holder's own current decision, cheap
-    /// to fetch, and editable from `pnm` at any moment — a persisted copy would
-    /// show what they used to present, on the one panel whose job is to tell
-    /// them what they present now. `prune_agent_name_negatives` already draws
-    /// this line for negatives; this is the same argument applied to the whole
-    /// record.
-    ///
-    /// An absent entry is not "presents nothing" — see
-    /// [`BindingSummary::unknown`](openvtc_core::persona::binding::BindingSummary::unknown).
-    pub bindings: HashMap<(String, String), openvtc_core::persona::binding::BindingSummary>,
     /// Display summaries of the (non-archived) communities, in display order.
     /// `Arc<[…]>` so cloning the panel state (per frame / per event) is a
     /// pointer bump rather than a deep copy; rebuilt wholesale in
@@ -413,6 +398,374 @@ pub struct CommunitySummary {
 }
 
 // ****************************************************************************
+// Personas State — the holder's own identity
+// ****************************************************************************
+
+/// Which part of the identity story the pane is showing.
+///
+/// The order is the story: who I am, what I know about myself, what I choose to
+/// show, and who sees which of it. Every tab after the first depends on the one
+/// before it, so a holder who reads them in order never meets a term that has
+/// not been introduced.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PersonaTab {
+    /// The persona DIDs themselves — a face as an *identity*.
+    #[default]
+    Faces,
+    /// The attribute pool: the facts, held once.
+    Attributes,
+    /// Named projections over the pool.
+    Profiles,
+    /// Which face each community sees, and what it presents there.
+    Communities,
+    /// What has actually left, and to whom.
+    Disclosures,
+}
+
+impl PersonaTab {
+    /// Every tab, in display order.
+    #[must_use]
+    pub fn all() -> [PersonaTab; 5] {
+        [
+            PersonaTab::Faces,
+            PersonaTab::Attributes,
+            PersonaTab::Profiles,
+            PersonaTab::Communities,
+            PersonaTab::Disclosures,
+        ]
+    }
+
+    /// The tab's name in the header strip.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            PersonaTab::Faces => "Faces",
+            PersonaTab::Attributes => "Attributes",
+            PersonaTab::Profiles => "Profiles",
+            PersonaTab::Communities => "Communities",
+            PersonaTab::Disclosures => "Disclosures",
+        }
+    }
+
+    /// Whether this tab's contents come from the agent rather than `Config`.
+    ///
+    /// Drives which tabs a refresh has anything to do, and which can draw
+    /// before the agent has ever answered. Faces are local: an account with no
+    /// VTA session still has personas, and a pane that showed nothing until the
+    /// network answered would be lying about the ones on disk.
+    #[must_use]
+    pub fn needs_agent(self) -> bool {
+        matches!(
+            self,
+            PersonaTab::Attributes
+                | PersonaTab::Profiles
+                | PersonaTab::Communities
+                | PersonaTab::Disclosures
+        )
+    }
+
+    #[must_use]
+    pub fn next(self) -> PersonaTab {
+        match self {
+            PersonaTab::Faces => PersonaTab::Attributes,
+            PersonaTab::Attributes => PersonaTab::Profiles,
+            PersonaTab::Profiles => PersonaTab::Communities,
+            PersonaTab::Communities => PersonaTab::Disclosures,
+            PersonaTab::Disclosures => PersonaTab::Faces,
+        }
+    }
+
+    #[must_use]
+    pub fn prev(self) -> PersonaTab {
+        match self {
+            PersonaTab::Faces => PersonaTab::Disclosures,
+            PersonaTab::Attributes => PersonaTab::Faces,
+            PersonaTab::Profiles => PersonaTab::Attributes,
+            PersonaTab::Communities => PersonaTab::Profiles,
+            PersonaTab::Disclosures => PersonaTab::Communities,
+        }
+    }
+}
+
+/// One community membership, as the Communities tab needs it: which face this
+/// community sees, and enough to look up what that face presents.
+#[derive(Clone, Debug, Default)]
+pub struct PersonaMembership {
+    /// Display name of the community.
+    pub community_name: String,
+    /// The VTA context the binding lives in.
+    pub sub_context_id: String,
+    /// The persona DID this community sees.
+    pub persona_did: String,
+    /// The holder's label for that face (or its agent name / DID).
+    pub face_label: String,
+    /// Membership lifecycle, already worded for display.
+    pub status_label: String,
+    /// How many *other* communities are shown this same face.
+    ///
+    /// The linkage number. Two communities shown one face can compare notes and
+    /// discover they are talking to the same person, which is the single most
+    /// consequential fact about a persona arrangement and the one a holder
+    /// cannot recompute by looking at one row.
+    pub shared_with: usize,
+}
+
+/// A confirmation the pane is waiting on. One at a time, because the panel has
+/// one prompt line and a holder answering `y` must never be able to wonder
+/// which question they answered.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum PersonaConfirm {
+    #[default]
+    None,
+    /// Remove an orphan persona DID (index into `faces`).
+    DeleteFace(usize),
+    /// Delete a pool attribute (index into `attributes`).
+    ///
+    /// `cascade` is the *escalated* ask, offered only after the VTA has refused
+    /// the plain one because profiles still reference the attribute. It is
+    /// never the first question: cascading edits every profile that used the
+    /// value, and that is not a consequence to infer from a `d` keypress.
+    DeleteAttribute { index: usize, cascade: bool },
+    /// Delete a profile (index into `profiles`).
+    ///
+    /// `unbind` is the same escalation one layer up — offered after a refusal,
+    /// because it makes every persona presenting under the profile present
+    /// nothing.
+    DeleteProfile { index: usize, unbind: bool },
+    /// Clear what one membership's face presents (index into `memberships`).
+    Unbind(usize),
+}
+
+/// Which field of the attribute editor has the keyboard.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum AttributeField {
+    /// The vocabulary token (`email.work`).
+    #[default]
+    ClaimType,
+    /// The holder's own label.
+    Label,
+    /// String / number / boolean / date / object.
+    ValueType,
+    /// The value itself.
+    Value,
+}
+
+impl AttributeField {
+    #[must_use]
+    pub fn next(self) -> AttributeField {
+        match self {
+            AttributeField::ClaimType => AttributeField::Label,
+            AttributeField::Label => AttributeField::ValueType,
+            AttributeField::ValueType => AttributeField::Value,
+            AttributeField::Value => AttributeField::ClaimType,
+        }
+    }
+
+    #[must_use]
+    pub fn prev(self) -> AttributeField {
+        match self {
+            AttributeField::ClaimType => AttributeField::Value,
+            AttributeField::Label => AttributeField::ClaimType,
+            AttributeField::ValueType => AttributeField::Label,
+            AttributeField::Value => AttributeField::ValueType,
+        }
+    }
+}
+
+/// The attribute editor — create when `attribute_id` is `None`, else edit.
+#[derive(Clone, Debug, Default)]
+pub struct AttributeForm {
+    /// The attribute being edited; `None` creates a new one.
+    pub attribute_id: Option<String>,
+    /// The version the form was opened against, sent back as the write's
+    /// precondition so an edit made elsewhere in the meantime is refused rather
+    /// than silently overwritten.
+    pub expected_version: Option<u64>,
+    pub claim_type: tui_input::Input,
+    pub label: tui_input::Input,
+    /// Index into [`VALUE_TYPES`].
+    pub value_type: usize,
+    pub value: tui_input::Input,
+    pub field: AttributeField,
+    /// Why the last submit did not go through — a parse failure on the value,
+    /// or the VTA's own refusal. Shown against the form, not the list, so the
+    /// holder keeps what they typed.
+    pub error: Option<String>,
+    /// A write is in flight; the form is read-only until it lands.
+    pub working: bool,
+}
+
+/// The value types the editor offers, in the order it cycles them. Mirrors the
+/// SDK's `ValueType`; kept as strings because the form is a UI object and the
+/// conversion belongs at the write, in `persona::pool::value_type_from_str`.
+pub const VALUE_TYPES: [&str; 5] = ["string", "number", "boolean", "date", "object"];
+
+/// Which half of the profile editor has the keyboard.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ProfileFormFocus {
+    #[default]
+    Name,
+    Entries,
+}
+
+/// The profile editor: a name, and a tick-list over the pool.
+#[derive(Clone, Debug, Default)]
+pub struct ProfileForm {
+    /// The profile being edited; `None` creates a new one.
+    pub profile_id: Option<String>,
+    pub expected_version: Option<u64>,
+    pub name: tui_input::Input,
+    /// Attribute ids the holder has ticked, in the order they were ticked —
+    /// which is the order the profile will present them in.
+    pub ticked: Vec<String>,
+    /// Cursor into the pool list.
+    pub cursor: usize,
+    pub focus: ProfileFormFocus,
+    /// Pinned / overridden / inline entries read from the profile, carried here
+    /// so the save writes them back untouched.
+    ///
+    /// This build's editor owns live references and nothing else. Rebuilding
+    /// the profile from only the ticked boxes would delete the other forms the
+    /// first time a holder renamed it, and the deletion would be invisible —
+    /// the profile would still resolve, just to less than it did.
+    pub preserved: Vec<vta_sdk::protocols::persona::ProfileEntry>,
+    pub error: Option<String>,
+    pub working: bool,
+}
+
+/// The profile picker for one membership: what should this face present here?
+#[derive(Clone, Debug, Default)]
+pub struct BindPicker {
+    /// Index into `memberships`.
+    pub membership: usize,
+    /// Cursor over the options, where 0 is always "present nothing" — a
+    /// first-class choice rather than the absence of one, because a face that
+    /// deliberately shows nothing is a common and legitimate arrangement.
+    pub cursor: usize,
+    pub working: bool,
+    pub error: Option<String>,
+}
+
+/// What owns the keyboard inside the pane.
+#[derive(Clone, Debug, Default)]
+pub enum PersonaMode {
+    #[default]
+    View,
+    Attribute(AttributeForm),
+    Profile(ProfileForm),
+    Bind(BindPicker),
+}
+
+/// The persona pane: every surface for the holder's own identity, in one place.
+///
+/// Three of the four tabs are served by the agent and one by `Config`, and the
+/// difference is load-bearing rather than incidental. Faces are on disk, so
+/// they draw at launch with no session; the pool, the profiles and the bindings
+/// are the agent's, so each of them has to be able to say "I could not ask"
+/// distinctly from "you hold nothing" — see [`load_error`](Self::load_error).
+#[derive(Clone, Debug, Default)]
+pub struct PersonasState {
+    pub tab: PersonaTab,
+
+    // ── Faces (from `Config`) ────────────────────────────────────────────
+    /// Every persona DID in the account, with how many communities present it.
+    pub faces: Arc<[ManagedDid]>,
+    pub face_selected: usize,
+
+    // ── Communities (from `Config`, annotated from the agent) ────────────
+    pub memberships: Arc<[PersonaMembership]>,
+    pub membership_selected: usize,
+    /// What each persona presents in each community's context, keyed by
+    /// `(sub_context_id, persona_did)` — the pair `persona/binding/get` is
+    /// addressed by, and the pair every membership row already carries.
+    ///
+    /// **Session state, deliberately not persisted.** The agent-name cache is
+    /// persisted, and the difference is the point: a verified name is a
+    /// property of a DID document that rarely changes and costs a network
+    /// round-trip to establish, so showing it instantly at launch is worth
+    /// keeping on disk. A binding is the holder's own current decision, cheap
+    /// to fetch, and editable from `pnm` at any moment — a persisted copy would
+    /// show what they used to present, on the one surface whose job is to tell
+    /// them what they present now. `prune_agent_name_negatives` already draws
+    /// this line for negatives; this is the same argument applied to the whole
+    /// record.
+    ///
+    /// An absent entry is not "presents nothing" — see
+    /// [`BindingSummary::unknown`](openvtc_core::persona::binding::BindingSummary::unknown).
+    /// Read by the communities panel too, which renders the same fact on its
+    /// own rows; it lives here because this is the pane that changes it.
+    pub bindings: HashMap<(String, String), openvtc_core::persona::binding::BindingSummary>,
+
+    // ── The pool (from the agent) ────────────────────────────────────────
+    pub attributes: Arc<[openvtc_core::persona::pool::PoolAttribute]>,
+    pub attribute_selected: usize,
+    /// Whether the listing asked for values.
+    ///
+    /// Off by default, and it re-reads rather than filtering what it already
+    /// holds: a list fetched without values does not *have* them, which is the
+    /// difference between an opt-in and a blindfold. Toggling it is the
+    /// holder asking to see their own identity, so it is a keypress they make
+    /// on purpose and a network round-trip, not a display flag.
+    pub show_values: bool,
+
+    // ── Profiles (from the agent) ────────────────────────────────────────
+    pub profiles: Arc<[openvtc_core::persona::profile::ProfileSummary]>,
+    pub profile_selected: usize,
+    /// The profile opened with Enter, resolved to what it would present.
+    pub open_profile: Option<openvtc_core::persona::profile::ProfileDetail>,
+
+    // ── Disclosures (from the agent) ─────────────────────────────────────
+    /// What has actually left, newest first, across every context.
+    ///
+    /// Read-only, and capped: the record is append-only and unbounded, so the
+    /// pane asks for a page of it rather than all of it. See
+    /// [`crate::state_handler::persona_actions::DISCLOSURE_PAGE`].
+    pub disclosures: Arc<[openvtc_core::persona::disclosure::DisclosureRow]>,
+    pub disclosure_selected: usize,
+
+    // ── Shared ───────────────────────────────────────────────────────────
+    /// A read is in flight.
+    pub loading: bool,
+    /// Why the last read failed, kept until one succeeds.
+    ///
+    /// An empty pool and an unreachable agent look identical on screen unless
+    /// something says otherwise, and of the two, "you have no attributes" is
+    /// the confident wrong answer about the holder's own data (VTI R6.4).
+    pub load_error: Option<String>,
+    /// Whether the agent-served tabs have ever been read in this session.
+    pub loaded: bool,
+    /// A refresh was asked for while one was in flight. Re-issued when the
+    /// domain frees, rather than dropped: the request that prompted it (a write
+    /// that just landed) is exactly when a stale list misleads most.
+    pub refresh_queued: bool,
+    pub confirm: PersonaConfirm,
+    pub mode: PersonaMode,
+    /// Transient status line.
+    pub status_message: Option<String>,
+}
+
+impl PersonasState {
+    /// What one membership's face presents, as far as we know.
+    ///
+    /// Falls back to `unknown` rather than a default summary: the two render
+    /// differently on purpose, and a caller reaching for `unwrap_or_default()`
+    /// would turn "we have not asked" into "you are sharing nothing".
+    #[must_use]
+    pub fn binding_for(
+        &self,
+        membership: &PersonaMembership,
+    ) -> openvtc_core::persona::binding::BindingSummary {
+        self.bindings
+            .get(&(
+                membership.sub_context_id.clone(),
+                membership.persona_did.clone(),
+            ))
+            .cloned()
+            .unwrap_or_else(openvtc_core::persona::binding::BindingSummary::unknown)
+    }
+}
+
+// ****************************************************************************
 // VTA State
 // ****************************************************************************
 
@@ -453,16 +806,6 @@ pub struct VtaState {
     /// DIDs in use (persona + relationship R-DIDs). `Arc<[…]>` for cheap
     /// per-frame clones; rebuilt wholesale in `sync_from_config`.
     pub active_dids: Arc<[ActiveDid]>,
-    /// Every persona DID minted in this context, with how many communities
-    /// present it — the manageable set for the DID manager. A persona bound to
-    /// zero communities is an orphan (e.g. left by a failed join).
-    /// `Arc<[…]>` for cheap per-frame clones; rebuilt in `sync_from_config`.
-    pub context_dids: Arc<[ManagedDid]>,
-    /// Selected index into [`Self::context_dids`] (DID manager navigation).
-    pub did_selected_index: usize,
-    /// When `Some(index)`, a deletion of that context DID is awaiting `y`/`n`
-    /// confirmation.
-    pub confirm_delete_did: Option<usize>,
 
     /// Invitation credentials (VICs) the holder holds in the VTA credential
     /// vault, for the VIC manager. Populated by an async query (not derived from
@@ -490,9 +833,6 @@ pub struct VtaState {
     /// request instead would leave an archived VIC rendered as active until the
     /// next manual refresh.
     pub vic_refresh_queued: bool,
-    /// Which of the two manageable lists (Context Identities vs Invitation
-    /// Credentials) has keyboard focus, so `↑/↓` and the verbs apply to it.
-    pub focus: VtaFocus,
 }
 
 /// How this process reaches the VTA, and what the VTA says it offers.
@@ -567,16 +907,6 @@ pub struct AdvertisedTransports {
     /// absent. Rendered as an explicit "could not check" so an unreachable
     /// publication endpoint never reads as "the VTA offers nothing".
     pub error: Option<String>,
-}
-
-/// Which manageable list in the VTA panel has keyboard focus (toggled by `Tab`).
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum VtaFocus {
-    /// The Context Identities (persona DID) list.
-    #[default]
-    Dids,
-    /// The Invitation Credentials (VIC) list.
-    Vics,
 }
 
 /// Display summary of one held VIC, mapped from the VTA credential-vault

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -660,8 +660,16 @@ pub struct ProfileForm {
 /// The profile picker for one membership: what should this face present here?
 #[derive(Clone, Debug, Default)]
 pub struct BindPicker {
-    /// Index into `memberships`.
-    pub membership: usize,
+    /// The binding this picker will write, named rather than indexed. The
+    /// membership list is rebuilt from `Config` on every sync — an inbound
+    /// message is enough — and an index into the old list would point at a
+    /// different membership in the new one, sending the holder's identity to a
+    /// community they were not looking at.
+    pub context_id: String,
+    pub persona_did: String,
+    /// Display only: who is being shown something, and as whom.
+    pub community: String,
+    pub face_label: String,
     /// Cursor over the options, where 0 is always "present nothing" — a
     /// first-class choice rather than the absence of one, because a face that
     /// deliberately shows nothing is a common and legitimate arrangement.

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -163,8 +163,8 @@ pub struct CommunitiesState {
     /// record.
     ///
     /// An absent entry is not "presents nothing" — see
-    /// [`BindingSummary::unknown`](openvtc_core::persona_binding::BindingSummary::unknown).
-    pub bindings: HashMap<(String, String), openvtc_core::persona_binding::BindingSummary>,
+    /// [`BindingSummary::unknown`](openvtc_core::persona::binding::BindingSummary::unknown).
+    pub bindings: HashMap<(String, String), openvtc_core::persona::binding::BindingSummary>,
     /// Display summaries of the (non-archived) communities, in display order.
     /// `Arc<[…]>` so cloning the panel state (per frame / per event) is a
     /// pointer bump rather than a deep copy; rebuilt wholesale in

--- a/openvtc/src/state_handler/main_page/menu.rs
+++ b/openvtc/src/state_handler/main_page/menu.rs
@@ -29,11 +29,17 @@ pub enum MainMenu {
     Inbox,
     Relationships,
     Credentials,
+    /// The holder's own identity — faces, the attribute pool behind them, the
+    /// profiles over that pool, and what each face presents in each community.
+    ///
+    /// Sits beside the other "my …" panels rather than under the VTA service,
+    /// which is where its parts used to live: minting a persona DID was a menu
+    /// action, the list of them was a section of the VTA panel, and everything
+    /// above them was reachable only from `pnm`. Identity is not a property of
+    /// the agent that hosts its keys.
+    Personas,
     Settings,
     Vta,
-    /// Action item (not a panel): opens the create-persona overlay on Enter,
-    /// mirroring how `Quit` triggers an action rather than switching panels.
-    CreatePersona,
     Logs,
     Help,
     Quit,
@@ -46,9 +52,9 @@ impl Display for MainMenu {
             MainMenu::Inbox => write!(f, "Inbox"),
             MainMenu::Relationships => write!(f, "My Relationships"),
             MainMenu::Credentials => write!(f, "My Credentials"),
+            MainMenu::Personas => write!(f, "My Identity"),
             MainMenu::Settings => write!(f, "Settings"),
             MainMenu::Vta => write!(f, "VTA Service"),
-            MainMenu::CreatePersona => write!(f, "Create Persona DID"),
             MainMenu::Logs => write!(f, "Logs"),
             MainMenu::Help => write!(f, "Help / Status"),
             MainMenu::Quit => write!(f, "Quit"),
@@ -64,10 +70,10 @@ impl MainMenu {
             MainMenu::Inbox => MainMenu::Communities,
             MainMenu::Relationships => MainMenu::Inbox,
             MainMenu::Credentials => MainMenu::Relationships,
-            MainMenu::Settings => MainMenu::Credentials,
+            MainMenu::Personas => MainMenu::Credentials,
+            MainMenu::Settings => MainMenu::Personas,
             MainMenu::Vta => MainMenu::Settings,
-            MainMenu::CreatePersona => MainMenu::Vta,
-            MainMenu::Logs => MainMenu::CreatePersona,
+            MainMenu::Logs => MainMenu::Vta,
             MainMenu::Help => MainMenu::Logs,
             MainMenu::Quit => MainMenu::Help,
         }
@@ -79,10 +85,10 @@ impl MainMenu {
             MainMenu::Communities => MainMenu::Inbox,
             MainMenu::Inbox => MainMenu::Relationships,
             MainMenu::Relationships => MainMenu::Credentials,
-            MainMenu::Credentials => MainMenu::Settings,
+            MainMenu::Credentials => MainMenu::Personas,
+            MainMenu::Personas => MainMenu::Settings,
             MainMenu::Settings => MainMenu::Vta,
-            MainMenu::Vta => MainMenu::CreatePersona,
-            MainMenu::CreatePersona => MainMenu::Logs,
+            MainMenu::Vta => MainMenu::Logs,
             MainMenu::Logs => MainMenu::Help,
             MainMenu::Help => MainMenu::Quit,
             MainMenu::Quit => MainMenu::Communities,

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -496,11 +496,16 @@ impl MainPageState {
         }
         self.content_panel.vta.active_dids = active_dids.into();
 
-        // Context identities: every persona in the account, with how many
-        // communities present it. A persona bound to zero communities is an
-        // orphan (e.g. left by a failed join before the rollback fix) —
-        // surfaced so the operator can spot and manage it.
-        let mut context_dids: Vec<content::ManagedDid> = config
+        // Faces: every persona in the account, with how many communities
+        // present it. A persona bound to zero communities is an orphan (e.g.
+        // left by a failed join before the rollback fix) — surfaced so the
+        // operator can spot and manage it.
+        //
+        // These live on the persona pane rather than the VTA panel: a persona
+        // DID is the holder's identity, not a property of the agent that
+        // happens to host its keys, and the pane that manages it is the pane
+        // that should list it.
+        let mut faces: Vec<content::ManagedDid> = config
             .account
             .personas
             .values()
@@ -518,19 +523,17 @@ impl MainPageState {
                 is_active: p.did.as_str() == persona_did,
             })
             .collect();
-        context_dids.sort_by(|a, b| a.did.cmp(&b.did));
+        faces.sort_by(|a, b| a.did.cmp(&b.did));
         // Clamp the selection to the rebuilt list. Nothing else does: the list is
         // rebuilt wholesale on every sync, so deleting a persona (or loading a
         // profile with fewer than the last one had) could leave the index past
         // the end — where the panel draws no cursor and every list-scoped key
-        // (`d`, and until it moved, `g`) silently does nothing, since each is
-        // guarded on `did_selected < did_count`. Restarting "fixed" it only
-        // because the index starts at 0.
-        let vta = &mut self.content_panel.vta;
-        vta.did_selected_index = vta
-            .did_selected_index
-            .min(context_dids.len().saturating_sub(1));
-        vta.context_dids = context_dids.into();
+        // (`d`, `g`) silently does nothing, since each is guarded on
+        // `face_selected < face count`. Restarting "fixed" it only because the
+        // index starts at 0.
+        let personas = &mut self.content_panel.personas;
+        personas.face_selected = personas.face_selected.min(faces.len().saturating_sub(1));
+        personas.faces = faces.into();
 
         // The VIC list is not derived from `Config` (it comes from the VTA
         // credential vault), so it is annotated rather than rebuilt here.
@@ -621,6 +624,66 @@ impl MainPageState {
         if self.content_panel.communities.selected_index >= community_count {
             self.content_panel.communities.selected_index = community_count.saturating_sub(1);
         }
+
+        // The persona pane's Communities tab: one row per membership, not per
+        // community. A community the holder joined twice under two faces is two
+        // rows here, because the question this tab answers — which face does
+        // this relationship use, and what does it say — has two different
+        // answers in that case.
+        //
+        // Archived memberships are included, unlike the communities panel's
+        // own list. An archived membership still has a live binding in the
+        // agent, so hiding it would hide identity the holder is still
+        // disclosing.
+        let mut memberships = Vec::new();
+        for c in config.account.memberships() {
+            let persona = config.account.personas.get(&c.persona_ref);
+            // How many *other* memberships show this same face. Computed per
+            // row rather than per persona because it is read that way: the
+            // holder is looking at one community and asking "who else sees
+            // this me".
+            let shared_with = config
+                .account
+                .memberships()
+                .filter(|other| other.persona_ref == c.persona_ref)
+                .count()
+                .saturating_sub(1);
+            memberships.push(content::PersonaMembership {
+                community_name: c
+                    .display_name
+                    .clone()
+                    .or_else(|| config.agent_name_for(&c.vtc_did).map(str::to_owned))
+                    .unwrap_or_else(|| shorten_did(&c.vtc_did, 40)),
+                sub_context_id: c.sub_context_id.clone(),
+                persona_did: persona.map(|p| p.did.clone()).unwrap_or_default(),
+                // Same precedence as everywhere else a DID is named: the
+                // holder's own label, then a *verified* agent name, then the
+                // DID itself. An unverified `alsoKnownAs` claim never reaches
+                // the cache this reads.
+                face_label: persona
+                    .and_then(|p| p.label.clone())
+                    .or_else(|| {
+                        persona.and_then(|p| config.agent_name_for(&p.did).map(str::to_owned))
+                    })
+                    .or_else(|| persona.map(|p| shorten_did(&p.did, 24)))
+                    .unwrap_or_default(),
+                status_label: community_status_label(&c.status),
+                shared_with,
+            });
+        }
+        // Stable order the holder can predict, and one that puts the rows they
+        // are most likely to be reconsidering — the faces shown to several
+        // communities — next to each other.
+        memberships.sort_by(|a, b| {
+            a.face_label
+                .cmp(&b.face_label)
+                .then_with(|| a.community_name.cmp(&b.community_name))
+        });
+        let personas = &mut self.content_panel.personas;
+        personas.membership_selected = personas
+            .membership_selected
+            .min(memberships.len().saturating_sub(1));
+        personas.memberships = memberships.into();
     }
 
     /// Stitch the verified agent name for each held VIC's issuer onto the VIC
@@ -1737,11 +1800,11 @@ mod tests {
         assert_eq!(task.remote_did, shorten_did(BOB_DID, 60));
     }
 
-    /// The VTA panel's Context Identities list carries the persona's verified
-    /// name beside its DID; the persona's own label is a separate line and is
-    /// left untouched.
+    /// The identity pane's Faces list carries the persona's verified name
+    /// beside its DID; the persona's own label is a separate line and is left
+    /// untouched.
     #[test]
-    fn context_did_row_carries_verified_agent_name() {
+    fn face_row_carries_verified_agent_name() {
         let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
         let mut config = config_with_membership(ALICE_DID, Some("Work me"), vtc_did, None);
         config.set_cached_agent_name(
@@ -1752,7 +1815,7 @@ mod tests {
 
         let mut page = MainPageState::default();
         page.sync_from_config(&config);
-        let row = &page.content_panel.vta.context_dids[0];
+        let row = &page.content_panel.personas.faces[0];
 
         assert_eq!(row.agent_name.as_deref(), Some("example.com/@alice"));
         assert_eq!(row.did, ALICE_DID);
@@ -1764,7 +1827,7 @@ mod tests {
     ///
     /// Nothing else did this: the list is rebuilt wholesale on every sync, and a
     /// stale index disables every list-scoped key (each is guarded on
-    /// `did_selected < did_count`) while drawing no cursor to show why — a
+    /// `face_selected < face count`) while drawing no cursor to show why — a
     /// keyboard that looks broken until the next restart resets the index to 0.
     #[test]
     fn syncing_clamps_a_stale_persona_selection() {
@@ -1773,12 +1836,12 @@ mod tests {
 
         let mut page = MainPageState::default();
         // What a deletion (or a smaller profile) leaves behind.
-        page.content_panel.vta.did_selected_index = 4;
+        page.content_panel.personas.face_selected = 4;
         page.sync_from_config(&config);
 
-        assert_eq!(page.content_panel.vta.context_dids.len(), 1);
+        assert_eq!(page.content_panel.personas.faces.len(), 1);
         assert_eq!(
-            page.content_panel.vta.did_selected_index, 0,
+            page.content_panel.personas.face_selected, 0,
             "the selection must land on a row that exists"
         );
     }
@@ -2063,9 +2126,9 @@ mod tests {
         assert!(page.content_panel.vta.vics[0].issuer_agent_name.is_none());
     }
 
-    /// A cached negative lookup leaves the Context Identities row on the DID.
+    /// A cached negative lookup leaves the face row on the DID.
     #[test]
-    fn context_did_row_ignores_a_cached_negative_lookup() {
+    fn face_row_ignores_a_cached_negative_lookup() {
         let vtc_did = "did:webvh:QmScidCommunityBBBBBBBBBBBBBBBBBB:example.com:community";
         let mut config = config_with_membership(ALICE_DID, None, vtc_did, None);
         config.set_cached_agent_name(ALICE_DID, None, chrono::Utc::now());
@@ -2073,7 +2136,7 @@ mod tests {
         let mut page = MainPageState::default();
         page.sync_from_config(&config);
 
-        assert!(page.content_panel.vta.context_dids[0].agent_name.is_none());
+        assert!(page.content_panel.personas.faces[0].agent_name.is_none());
     }
 
     // --- persona_in_scope (community-scoping filter, D10/R-C-6) ---

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -232,6 +232,7 @@ mod capability_actions;
 mod community_actions;
 mod create_persona;
 mod credential_actions;
+mod persona_actions;
 mod persona_binding_refresh;
 /// The DIDComm transport module, which now lives in `openvtc-core`.
 ///
@@ -1438,6 +1439,19 @@ impl StateHandler {
                         state.main_page.content_panel.vta.vic_refresh_queued = false;
                         spawn_vic_refresh(&dispatch_tx, &mut in_flight, &mut state, admin_vta.as_ref());
                     }
+                    // Same rule for the identity pane: a write that just landed
+                    // asked for the listing it invalidated, and could not start
+                    // it while its own outcome held the domain.
+                    if state.main_page.content_panel.personas.refresh_queued {
+                        state.main_page.content_panel.personas.refresh_queued = false;
+                        spawn_persona_effect(
+                            &dispatch_tx,
+                            &mut in_flight,
+                            &mut state,
+                            admin_vta.as_ref(),
+                            persona_actions::PersonaEffect::Read,
+                        );
+                    }
                 },
                 // D13 presence: another install using this account, or a
                 // report that we could not tell. The task never touches
@@ -2141,12 +2155,23 @@ impl StateHandler {
                             // No session or no messaging runtime: say so and
                             // disarm, rather than leaving the prompt hanging.
                             _ => {
-                                state.main_page.content_panel.vta.confirm_delete_did = None;
+                                state.main_page.content_panel.personas.confirm =
+                                    main_page::content::PersonaConfirm::None;
                                 state
                                     .main_page
                                     .log("Cannot remove an identity right now — no VTA session.");
                             }
                         }
+                    }
+                    Action::Persona(persona_action) => {
+                        // Serviced in State A as well: the attribute pool is
+                        // holder-scoped and the admin session that reads it
+                        // exists before any community does. The pane has no
+                        // faces or memberships to show yet, which is a true
+                        // answer rather than a missing one.
+                        let effect = persona_actions::apply(state, &persona_action);
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
+                        spawn_persona_effect(&dispatch_tx, &mut in_flight, state, av, effect);
                     }
                     Action::VicRefresh => {
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
@@ -2238,7 +2263,7 @@ impl StateHandler {
                     Action::CreatePersonaClose | Action::AgentNameManagerInput(..) |
                     Action::AgentNameManagerSelect(..) | Action::AgentNameManagerConfirmRemove |
                     Action::AgentNameManagerCancelRemove | Action::AgentNameManagerClose |
-                    Action::VicSelect(..) | Action::VicFocusToggle | Action::VicConfirmDelete(..) |
+                    Action::VicSelect(..) | Action::VicConfirmDelete(..) |
                     Action::VicCancelDelete | Action::VicConfirmPurge(..) | Action::VicCancelPurge |
                     Action::StartAddVic | Action::AddVicInput(..) | Action::AddVicPaste(..) |
                     Action::AddVicClose => {}
@@ -2313,6 +2338,17 @@ impl StateHandler {
                         state.main_page.content_panel.vta.vic_refresh_queued = false;
                         let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
                         spawn_vic_refresh(&dispatch_tx, &mut in_flight, state, av);
+                    }
+                    if state.main_page.content_panel.personas.refresh_queued {
+                        state.main_page.content_panel.personas.refresh_queued = false;
+                        let av = join_ctx.as_ref().and_then(|c| c.admin_vta.as_ref());
+                        spawn_persona_effect(
+                            &dispatch_tx,
+                            &mut in_flight,
+                            state,
+                            av,
+                            persona_actions::PersonaEffect::Read,
+                        );
                     }
                 }
                 Ok(interrupted) = interrupt_rx.recv() => {
@@ -2820,12 +2856,11 @@ fn begin_vic_refresh(
 /// Start a background VIC-list refresh, shared by both loops.
 ///
 /// The vault query is a trust task with a 30 s SDK timeout. It used to run
-/// inline in the action arm, which meant the `VicFocusToggle` queued behind it
-/// — a two-line in-memory change — could not be applied until the network
-/// answered: Tab into the Invitation Credentials list took as long as the round
-/// trip, with nothing on screen to say why. Here the loop only *starts* the
-/// query, so the focus change lands on the next frame and the list fills in
-/// when it arrives.
+/// inline in the action arm, which meant a key pressed behind it — a two-line
+/// in-memory change — could not be applied until the network answered: asking
+/// for the Invitation Credentials list took as long as the round trip, with
+/// nothing on screen to say why. Here the loop only *starts* the query, so the
+/// keypress lands on the next frame and the list fills in when it arrives.
 ///
 /// Guarding rules, in the order they apply:
 ///
@@ -2862,6 +2897,89 @@ fn spawn_vic_refresh(
     );
 }
 
+/// Start the identity pane's network work off the loop, shared by both loops.
+///
+/// Reads and writes share one domain, so the two cannot interleave and leave a
+/// listing that reflects neither.
+///
+/// A **read** rejected by the busy-guard is *deferred* rather than dropped: the
+/// in-flight call was issued before whatever prompted this one, so its answer is
+/// already stale, and silently discarding the new request would leave a
+/// just-saved attribute missing from the list until the operator refreshed by
+/// hand.
+///
+/// A **write** is not deferrable. Its arguments were resolved against the state
+/// as it was, so replaying it later could apply an edit to a row the operator
+/// has since moved off. It is refused instead — and the form it came from is
+/// handed back, because a submitted form is locked until an answer arrives and
+/// a request that never left has no answer coming.
+///
+/// Without an admin session there is nothing to ask: the pane says so rather
+/// than leaving a spinner running against a session that does not exist.
+fn spawn_persona_effect(
+    dispatch_tx: &tokio::sync::mpsc::UnboundedSender<background_dispatch::DispatchOutcome>,
+    in_flight: &mut background_dispatch::InFlight,
+    state: &mut State,
+    admin_vta: Option<&vta_sdk::client::VtaClient>,
+    effect: persona_actions::PersonaEffect,
+) {
+    use persona_actions::PersonaEffect;
+
+    let domain = background_dispatch::DispatchDomain::PersonaManage;
+    if matches!(effect, PersonaEffect::None) {
+        return;
+    }
+    let Some(admin_vta) = admin_vta else {
+        let reason =
+            "No VTA session — your identity is held by the agent, which cannot be reached \
+             right now."
+                .to_string();
+        let p = &mut state.main_page.content_panel.personas;
+        p.loading = false;
+        p.load_error = Some(reason.clone());
+        if matches!(effect, PersonaEffect::Job(_)) {
+            persona_actions::release_form(state, reason);
+        }
+        return;
+    };
+    if !in_flight.try_begin(domain) {
+        match effect {
+            PersonaEffect::Read => {
+                state.main_page.content_panel.personas.refresh_queued = true;
+            }
+            _ => persona_actions::release_form(
+                state,
+                background_dispatch::InFlight::busy_message(domain),
+            ),
+        }
+        return;
+    }
+
+    match effect {
+        PersonaEffect::None => unreachable!("returned above"),
+        PersonaEffect::Read => {
+            let job = persona_actions::PersonaReadJob {
+                admin_vta: admin_vta.clone(),
+                include_values: state.main_page.content_panel.personas.show_values,
+                targets: persona_actions::PersonaReadJob::targets(state),
+            };
+            state.main_page.content_panel.personas.loading = true;
+            background_dispatch::spawn_dispatch(dispatch_tx.clone(), domain, async move {
+                background_dispatch::DispatchOutcome::PersonaManage(job.run().await)
+            });
+        }
+        PersonaEffect::Job(job) => {
+            let job = persona_actions::PersonaJobRun {
+                admin_vta: admin_vta.clone(),
+                job,
+            };
+            background_dispatch::spawn_dispatch(dispatch_tx.clone(), domain, async move {
+                background_dispatch::DispatchOutcome::PersonaManage(job.run().await)
+            });
+        }
+    }
+}
+
 /// The typed name to claim, once it is non-empty and the overlay is idle.
 fn agent_name_to_claim(state: &mut State) -> Option<(String, String)> {
     use main_page::content::AgentNameManagerPhase;
@@ -2887,8 +3005,8 @@ fn open_agent_name_overlay(state: &mut State, index: usize) -> Option<String> {
     let Some(persona) = state
         .main_page
         .content_panel
-        .vta
-        .context_dids
+        .personas
+        .faces
         .get(index)
         .cloned()
     else {
@@ -2936,12 +3054,12 @@ fn prepare_delete_context_did(
     didcomm_service: &openvtc_core::didcomm::Messaging,
     index: usize,
 ) -> Option<relationship_actions::DidDeleteJob> {
-    state.main_page.content_panel.vta.confirm_delete_did = None;
+    state.main_page.content_panel.personas.confirm = main_page::content::PersonaConfirm::None;
     let did = state
         .main_page
         .content_panel
-        .vta
-        .context_dids
+        .personas
+        .faces
         .get(index)
         .map(|d| d.did.clone())?;
 
@@ -3131,24 +3249,18 @@ fn handle_nav_action(state: &mut State, action: &Action) -> bool {
             state.main_page.switcher = None;
         }
         Action::DidSelect(i) => {
-            state.main_page.content_panel.vta.did_selected_index = *i;
+            state.main_page.content_panel.personas.face_selected = *i;
         }
         Action::DidConfirmDelete(i) => {
-            state.main_page.content_panel.vta.confirm_delete_did = Some(*i);
+            state.main_page.content_panel.personas.confirm =
+                main_page::content::PersonaConfirm::DeleteFace(*i);
         }
         Action::DidCancelDelete => {
-            state.main_page.content_panel.vta.confirm_delete_did = None;
+            state.main_page.content_panel.personas.confirm =
+                main_page::content::PersonaConfirm::None;
         }
         Action::VicSelect(i) => {
             state.main_page.content_panel.vta.vic_selected_index = *i;
-        }
-        Action::VicFocusToggle => {
-            use main_page::content::VtaFocus;
-            let vta = &mut state.main_page.content_panel.vta;
-            vta.focus = match vta.focus {
-                VtaFocus::Dids => VtaFocus::Vics,
-                VtaFocus::Vics => VtaFocus::Dids,
-            };
         }
         Action::VicConfirmDelete(i) => {
             state.main_page.content_panel.vta.confirm_delete_vic = Some(*i);
@@ -3873,10 +3985,13 @@ mod tests {
                 },
             },
             Case {
-                name: "DidConfirmDelete arms the VTA DID confirmation (degraded mode used to drop this)",
+                name: "DidConfirmDelete arms the face confirmation (degraded mode used to drop this)",
                 action: Action::DidConfirmDelete(1),
                 assert_fn: |s| {
-                    assert_eq!(s.main_page.content_panel.vta.confirm_delete_did, Some(1))
+                    assert_eq!(
+                        s.main_page.content_panel.personas.confirm,
+                        main_page::content::PersonaConfirm::DeleteFace(1)
+                    )
                 },
             },
         ];

--- a/openvtc/src/state_handler/persona_actions.rs
+++ b/openvtc/src/state_handler/persona_actions.rs
@@ -180,7 +180,8 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
                 .iter()
                 .any(|profile| profile.referenced.contains(&attr.attribute_id));
             p.confirm = PersonaConfirm::DeleteAttribute {
-                index: *index,
+                attribute_id: attr.attribute_id.clone(),
+                name: attr.display_name().to_string(),
                 cascade,
             };
             PersonaEffect::None
@@ -219,7 +220,8 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
                 .values()
                 .any(|b| b.profile_id.as_deref() == Some(profile.profile_id.as_str()));
             p.confirm = PersonaConfirm::DeleteProfile {
-                index: *index,
+                profile_id: profile.profile_id.clone(),
+                name: profile.display_name().to_string(),
                 unbind,
             };
             PersonaEffect::None
@@ -246,7 +248,15 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
             PersonaEffect::None
         }
         PersonaAction::UnbindArm(index) => {
-            state.main_page.content_panel.personas.confirm = PersonaConfirm::Unbind(*index);
+            let p = &mut state.main_page.content_panel.personas;
+            let Some(m) = p.memberships.get(*index) else {
+                return PersonaEffect::None;
+            };
+            p.confirm = PersonaConfirm::Unbind {
+                context_id: m.sub_context_id.clone(),
+                persona_did: m.persona_did.clone(),
+                community: m.community_name.clone(),
+            };
             PersonaEffect::None
         }
 
@@ -360,6 +370,10 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
 }
 
 /// Answer the armed question.
+///
+/// Every arm acts on what the question named, not on where it sat: a listing
+/// that arrived while the prompt was on screen cannot redirect the answer onto
+/// a row the operator never selected.
 fn confirm_yes(state: &mut State) -> PersonaEffect {
     let p = &mut state.main_page.content_panel.personas;
     let confirm = std::mem::replace(&mut p.confirm, PersonaConfirm::None);
@@ -367,35 +381,27 @@ fn confirm_yes(state: &mut State) -> PersonaEffect {
         // A face deletion is not answered here — the pane arms the question and
         // the existing identity-deletion path answers it. See the key handler.
         PersonaConfirm::None | PersonaConfirm::DeleteFace(_) => PersonaEffect::None,
-        PersonaConfirm::DeleteAttribute { index, cascade } => {
-            let Some(attr) = p.attributes.get(index) else {
-                return PersonaEffect::None;
-            };
-            PersonaEffect::Job(PersonaJob::AttributeDelete {
-                attribute_id: attr.attribute_id.clone(),
-                cascade,
-            })
-        }
-        PersonaConfirm::DeleteProfile { index, unbind } => {
-            let Some(profile) = p.profiles.get(index) else {
-                return PersonaEffect::None;
-            };
-            PersonaEffect::Job(PersonaJob::ProfileDelete {
-                profile_id: profile.profile_id.clone(),
-                unbind,
-            })
-        }
-        PersonaConfirm::Unbind(index) => {
-            let Some(m) = p.memberships.get(index) else {
-                return PersonaEffect::None;
-            };
-            PersonaEffect::Job(PersonaJob::Bind {
-                context_id: m.sub_context_id.clone(),
-                persona_did: m.persona_did.clone(),
-                profile_id: None,
-                community: m.community_name.clone(),
-            })
-        }
+        PersonaConfirm::DeleteAttribute {
+            attribute_id,
+            cascade,
+            ..
+        } => PersonaEffect::Job(PersonaJob::AttributeDelete {
+            attribute_id,
+            cascade,
+        }),
+        PersonaConfirm::DeleteProfile {
+            profile_id, unbind, ..
+        } => PersonaEffect::Job(PersonaJob::ProfileDelete { profile_id, unbind }),
+        PersonaConfirm::Unbind {
+            context_id,
+            persona_did,
+            community,
+        } => PersonaEffect::Job(PersonaJob::Bind {
+            context_id,
+            persona_did,
+            profile_id: None,
+            community,
+        }),
     }
 }
 
@@ -913,7 +919,8 @@ mod tests {
         assert_eq!(
             personas(&state).confirm,
             PersonaConfirm::DeleteAttribute {
-                index: 0,
+                attribute_id: "01A".into(),
+                name: "email.work".into(),
                 cascade: true
             }
         );
@@ -922,7 +929,8 @@ mod tests {
         assert_eq!(
             personas(&state).confirm,
             PersonaConfirm::DeleteAttribute {
-                index: 1,
+                attribute_id: "01B".into(),
+                name: "email.work".into(),
                 cascade: false
             },
             "an unreferenced attribute needs no cascade"
@@ -962,7 +970,8 @@ mod tests {
         assert_eq!(
             personas(&state).confirm,
             PersonaConfirm::DeleteProfile {
-                index: 0,
+                profile_id: "01P".into(),
+                name: "(unnamed profile)".into(),
                 unbind: true
             }
         );
@@ -970,10 +979,49 @@ mod tests {
         assert_eq!(
             personas(&state).confirm,
             PersonaConfirm::DeleteProfile {
-                index: 1,
+                profile_id: "01Q".into(),
+                name: "(unnamed profile)".into(),
                 unbind: false
             }
         );
+    }
+
+    /// A listing that lands while a question is on screen cannot redirect the
+    /// answer.
+    ///
+    /// The prompt is armed against the attribute the operator selected, and a
+    /// refresh (or another surface's write) can reorder the pool underneath it
+    /// before they press `y`. An index into the old listing would then name a
+    /// different attribute in the new one — deleting something they never
+    /// selected while showing them the name of something else.
+    #[test]
+    fn an_armed_delete_survives_the_list_moving_underneath_it() {
+        let mut state = state_with(PersonasState {
+            attributes: vec![attribute("01A"), attribute("01B")].into(),
+            ..PersonasState::default()
+        });
+
+        apply(&mut state, &PersonaAction::AttributeDeleteArm(0));
+
+        // A read lands, and the pool comes back in a different order.
+        PersonaOutcome::Read {
+            attributes: Ok(vec![attribute("01B"), attribute("01A")]),
+            profiles: Ok(Vec::new()),
+            disclosures: Ok(Vec::new()),
+            bindings: HashMap::new(),
+            include_values: false,
+        }
+        .apply(&mut state);
+
+        match apply(&mut state, &PersonaAction::ConfirmYes) {
+            PersonaEffect::Job(PersonaJob::AttributeDelete { attribute_id, .. }) => {
+                assert_eq!(
+                    attribute_id, "01A",
+                    "the armed attribute is the one deleted"
+                )
+            }
+            _ => panic!("expected a delete"),
+        }
     }
 
     /// A credential-backed attribute does not open an editor. The refusal is
@@ -1321,7 +1369,8 @@ mod tests {
         let mut state = state_with(PersonasState {
             tab: PersonaTab::Attributes,
             confirm: PersonaConfirm::DeleteAttribute {
-                index: 0,
+                attribute_id: "01A".into(),
+                name: "email.work".into(),
                 cascade: false,
             },
             ..PersonasState::default()

--- a/openvtc/src/state_handler/persona_actions.rs
+++ b/openvtc/src/state_handler/persona_actions.rs
@@ -37,8 +37,8 @@ use vta_sdk::client::VtaClient;
 
 use crate::state_handler::actions::PersonaAction;
 use crate::state_handler::main_page::content::{
-    AttributeField, AttributeForm, BindPicker, PersonaConfirm, PersonaMembership, PersonaMode,
-    PersonaTab, ProfileForm, ProfileFormFocus, VALUE_TYPES,
+    AttributeField, AttributeForm, BindPicker, PersonaConfirm, PersonaMode, PersonaTab,
+    ProfileForm, ProfileFormFocus, VALUE_TYPES,
 };
 use crate::state_handler::persona_binding_refresh::{self, BindingTarget};
 use crate::state_handler::state::State;
@@ -240,7 +240,10 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
                 .and_then(|id| p.profiles.iter().position(|x| x.profile_id == id))
                 .map_or(0, |i| i + 1);
             p.mode = PersonaMode::Bind(BindPicker {
-                membership: *index,
+                context_id: membership.sub_context_id.clone(),
+                persona_did: membership.persona_did.clone(),
+                community: membership.community_name.clone(),
+                face_label: membership.face_label.clone(),
                 cursor,
                 working: false,
                 error: None,
@@ -415,14 +418,6 @@ fn form_submit(state: &mut State) -> PersonaEffect {
         .iter()
         .cloned()
         .collect();
-    let memberships: Vec<PersonaMembership> = state
-        .main_page
-        .content_panel
-        .personas
-        .memberships
-        .iter()
-        .cloned()
-        .collect();
     let p = &mut state.main_page.content_panel.personas;
 
     match &mut p.mode {
@@ -472,9 +467,6 @@ fn form_submit(state: &mut State) -> PersonaEffect {
             })
         }
         PersonaMode::Bind(picker) => {
-            let Some(m) = memberships.get(picker.membership) else {
-                return PersonaEffect::None;
-            };
             // Row 0 is "nothing"; the rest index the profile list.
             let profile_id = picker
                 .cursor
@@ -484,10 +476,10 @@ fn form_submit(state: &mut State) -> PersonaEffect {
             picker.error = None;
             picker.working = true;
             PersonaEffect::Job(PersonaJob::Bind {
-                context_id: m.sub_context_id.clone(),
-                persona_did: m.persona_did.clone(),
+                context_id: picker.context_id.clone(),
+                persona_did: picker.persona_did.clone(),
                 profile_id,
-                community: m.community_name.clone(),
+                community: picker.community.clone(),
             })
         }
     }
@@ -871,7 +863,7 @@ impl PersonaOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state_handler::main_page::content::PersonasState;
+    use crate::state_handler::main_page::content::{PersonaMembership, PersonasState};
     use openvtc_core::persona::binding::BindingSummary;
     use openvtc_core::persona::pool::ProvenanceKind;
 
@@ -1285,7 +1277,15 @@ mod tests {
 
         match &personas(&state).mode {
             // Row 0 is "nothing", so the second profile is row 2.
-            PersonaMode::Bind(picker) => assert_eq!(picker.cursor, 2),
+            PersonaMode::Bind(picker) => {
+                assert_eq!(picker.cursor, 2);
+                // Named, not indexed: the membership list is rebuilt from
+                // `Config` on every sync, and an inbound message is enough to
+                // reorder it while the picker is open. An index would then send
+                // the holder's identity to a community they were not looking at.
+                assert_eq!(picker.context_id, "ctx");
+                assert_eq!(picker.persona_did, "did:webvh:example.com:alice");
+            }
             _ => panic!("the picker must be open"),
         }
     }

--- a/openvtc/src/state_handler/persona_actions.rs
+++ b/openvtc/src/state_handler/persona_actions.rs
@@ -10,8 +10,9 @@
 //!
 //! # One domain for the whole pane
 //!
-//! Reads and writes share [`DispatchDomain::PersonaManage`], so a listing
-//! cannot overtake the write that invalidated it. A write asks for a re-read by
+//! Reads and writes share one dispatch domain
+//! ([`DispatchDomain::PersonaManage`](crate::state_handler::background_dispatch::DispatchDomain::PersonaManage)),
+//! so a listing cannot overtake the write that invalidated it. A write asks for a re-read by
 //! setting `refresh_queued` rather than starting one, because its own outcome
 //! is still holding the domain — the same shape the VIC manager uses.
 //!

--- a/openvtc/src/state_handler/persona_actions.rs
+++ b/openvtc/src/state_handler/persona_actions.rs
@@ -1,0 +1,1353 @@
+//! Identity-pane business logic: what each key does to the pane's state, and
+//! which of them need the agent.
+//!
+//! Split the way the architecture asks for it. [`apply`] is pure — it takes
+//! `&mut State` and an action, mutates the pane, and *names* any network work
+//! as a [`PersonaEffect`] rather than doing it. The loop spawns that off-thread
+//! and folds the result back in through [`PersonaOutcome::apply`], on the loop
+//! thread, so the single-mutator invariant holds and every decision this module
+//! makes is testable without a `VtaClient`.
+//!
+//! # One domain for the whole pane
+//!
+//! Reads and writes share [`DispatchDomain::PersonaManage`], so a listing
+//! cannot overtake the write that invalidated it. A write asks for a re-read by
+//! setting `refresh_queued` rather than starting one, because its own outcome
+//! is still holding the domain — the same shape the VIC manager uses.
+//!
+//! # Questions are asked once, and correctly
+//!
+//! Deleting an attribute a profile references is refused by the VTA unless the
+//! caller cascades; deleting a profile a face presents is refused unless the
+//! caller unbinds. Neither refusal is *discovered* here. The profile listing
+//! already says which attributes are referenced and the binding map already
+//! says which profiles are presented, so the prompt names the real consequence
+//! the first time it is put. Asking "delete this?", being refused, and then
+//! asking "delete it and edit three profiles?" trains a holder to answer the
+//! second question with the first one's reasoning.
+
+use std::collections::HashMap;
+
+use openvtc_core::persona::{
+    binding, disclosure,
+    pool::{self, AttributeDraft, PoolAttribute},
+    profile::{self, ProfileDetail, ProfileSummary},
+};
+use vta_sdk::client::VtaClient;
+
+use crate::state_handler::actions::PersonaAction;
+use crate::state_handler::main_page::content::{
+    AttributeField, AttributeForm, BindPicker, PersonaConfirm, PersonaMembership, PersonaMode,
+    PersonaTab, ProfileForm, ProfileFormFocus, VALUE_TYPES,
+};
+use crate::state_handler::persona_binding_refresh::{self, BindingTarget};
+use crate::state_handler::state::State;
+
+/// What an action needs beyond the state change [`apply`] already made.
+pub(crate) enum PersonaEffect {
+    /// Nothing — a pure view change.
+    None,
+    /// Re-read the agent-served tabs.
+    Read,
+    /// One round-trip, already resolved to its arguments on the loop thread.
+    Job(PersonaJob),
+}
+
+/// A single persona round-trip.
+pub(crate) enum PersonaJob {
+    AttributePut(AttributeDraft),
+    AttributeDelete {
+        attribute_id: String,
+        cascade: bool,
+    },
+    ProfilePut {
+        profile_id: Option<String>,
+        name: String,
+        live_refs: Vec<String>,
+        other_entries: Vec<vta_sdk::protocols::persona::ProfileEntry>,
+        expected_version: Option<u64>,
+    },
+    ProfileDelete {
+        profile_id: String,
+        unbind: bool,
+    },
+    /// Read one profile — to show what it presents, or to fill the editor.
+    ProfileGet {
+        profile_id: String,
+        /// `true` fills the editor: it needs the entries, not the values, so it
+        /// does not ask the VTA to resolve them. A read that decrypts the pool
+        /// to populate a form the holder may cancel is a read that did not need
+        /// to happen.
+        edit: bool,
+    },
+    /// Decide what one face presents in one context.
+    Bind {
+        context_id: String,
+        persona_did: String,
+        profile_id: Option<String>,
+        community: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// The reducer
+// ---------------------------------------------------------------------------
+
+/// Apply one identity-pane action. Pure: mutates the pane and returns the
+/// network work the loop still owes.
+pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect {
+    match action {
+        PersonaAction::TabNext | PersonaAction::TabPrev => {
+            let p = &mut state.main_page.content_panel.personas;
+            p.tab = match action {
+                PersonaAction::TabNext => p.tab.next(),
+                _ => p.tab.prev(),
+            };
+            // Leaving a tab drops what was armed or opened on it. A `y` is
+            // answered on the screen that asked, never two tabs later.
+            p.confirm = PersonaConfirm::None;
+            p.open_profile = None;
+            p.status_message = None;
+            // Read on arrival, once. The agent-served tabs are not polled: a
+            // pane nobody has opened should not be asking the agent about the
+            // holder's identity every few seconds.
+            if p.tab.needs_agent() && !p.loaded && !p.loading {
+                return PersonaEffect::Read;
+            }
+            PersonaEffect::None
+        }
+        PersonaAction::Select(index) => {
+            let p = &mut state.main_page.content_panel.personas;
+            match p.tab {
+                PersonaTab::Faces => p.face_selected = *index,
+                PersonaTab::Attributes => p.attribute_selected = *index,
+                PersonaTab::Profiles => p.profile_selected = *index,
+                PersonaTab::Communities => p.membership_selected = *index,
+                PersonaTab::Disclosures => p.disclosure_selected = *index,
+            }
+            PersonaEffect::None
+        }
+        PersonaAction::Refresh => PersonaEffect::Read,
+        PersonaAction::ToggleValues => {
+            let p = &mut state.main_page.content_panel.personas;
+            p.show_values = !p.show_values;
+            // A re-read, not a redraw: a listing fetched without values does
+            // not hold them. Flipping a display flag over data already in
+            // memory would mean the values had been read all along.
+            PersonaEffect::Read
+        }
+
+        // ── Attributes ───────────────────────────────────────────────────
+        PersonaAction::AttributeNew => {
+            let p = &mut state.main_page.content_panel.personas;
+            p.mode = PersonaMode::Attribute(AttributeForm::default());
+            PersonaEffect::None
+        }
+        PersonaAction::AttributeEdit(index) => {
+            let p = &mut state.main_page.content_panel.personas;
+            let Some(attr) = p.attributes.get(*index).cloned() else {
+                return PersonaEffect::None;
+            };
+            if !attr.provenance.is_editable_here() {
+                // Refused with the reason, not with a form that would fail on
+                // save. See `pool`'s module header.
+                if let pool::AttributeEdit::Refused(why) =
+                    pool::AttributeEdit::refusal(attr.provenance)
+                {
+                    p.status_message = Some(why);
+                }
+                return PersonaEffect::None;
+            }
+            p.mode = PersonaMode::Attribute(form_for(&attr));
+            // The editor was opened without a value in hand if the listing was
+            // fetched without one, and saving would then blank it. Fetch the
+            // values so the form starts from what is actually stored.
+            if !p.show_values {
+                p.show_values = true;
+                return PersonaEffect::Read;
+            }
+            PersonaEffect::None
+        }
+        PersonaAction::AttributeDeleteArm(index) => {
+            let p = &mut state.main_page.content_panel.personas;
+            let Some(attr) = p.attributes.get(*index) else {
+                return PersonaEffect::None;
+            };
+            // Referenced by a profile? Then the only delete that will succeed
+            // is the cascading one, and that is the question to put.
+            let cascade = p
+                .profiles
+                .iter()
+                .any(|profile| profile.referenced.contains(&attr.attribute_id));
+            p.confirm = PersonaConfirm::DeleteAttribute {
+                index: *index,
+                cascade,
+            };
+            PersonaEffect::None
+        }
+
+        // ── Profiles ─────────────────────────────────────────────────────
+        PersonaAction::ProfileOpen(index) | PersonaAction::ProfileEdit(index) => {
+            let edit = matches!(action, PersonaAction::ProfileEdit(_));
+            let p = &mut state.main_page.content_panel.personas;
+            let Some(profile) = p.profiles.get(*index) else {
+                return PersonaEffect::None;
+            };
+            PersonaEffect::Job(PersonaJob::ProfileGet {
+                profile_id: profile.profile_id.clone(),
+                edit,
+            })
+        }
+        PersonaAction::ProfileClose => {
+            state.main_page.content_panel.personas.open_profile = None;
+            PersonaEffect::None
+        }
+        PersonaAction::ProfileNew => {
+            state.main_page.content_panel.personas.mode =
+                PersonaMode::Profile(ProfileForm::default());
+            PersonaEffect::None
+        }
+        PersonaAction::ProfileDeleteArm(index) => {
+            let p = &mut state.main_page.content_panel.personas;
+            let Some(profile) = p.profiles.get(*index) else {
+                return PersonaEffect::None;
+            };
+            // Presented by a face somewhere? Deleting then leaves that face
+            // presenting nothing, which the prompt has to say.
+            let unbind = p
+                .bindings
+                .values()
+                .any(|b| b.profile_id.as_deref() == Some(profile.profile_id.as_str()));
+            p.confirm = PersonaConfirm::DeleteProfile {
+                index: *index,
+                unbind,
+            };
+            PersonaEffect::None
+        }
+
+        // ── Communities ──────────────────────────────────────────────────
+        PersonaAction::BindOpen(index) => {
+            let p = &mut state.main_page.content_panel.personas;
+            let Some(membership) = p.memberships.get(*index).cloned() else {
+                return PersonaEffect::None;
+            };
+            // Start on what is bound now, so ⏎ on an unchanged picker is a
+            // no-op rather than a silent unbind.
+            let current = p.binding_for(&membership).profile_id;
+            let cursor = current
+                .and_then(|id| p.profiles.iter().position(|x| x.profile_id == id))
+                .map_or(0, |i| i + 1);
+            p.mode = PersonaMode::Bind(BindPicker {
+                membership: *index,
+                cursor,
+                working: false,
+                error: None,
+            });
+            PersonaEffect::None
+        }
+        PersonaAction::UnbindArm(index) => {
+            state.main_page.content_panel.personas.confirm = PersonaConfirm::Unbind(*index);
+            PersonaEffect::None
+        }
+
+        // ── The confirmation slot ────────────────────────────────────────
+        PersonaAction::ConfirmNo => {
+            state.main_page.content_panel.personas.confirm = PersonaConfirm::None;
+            PersonaEffect::None
+        }
+        PersonaAction::ConfirmYes => confirm_yes(state),
+
+        // ── Forms ────────────────────────────────────────────────────────
+        PersonaAction::FormKey(key) => {
+            use tui_input::backend::crossterm::EventHandler;
+            let p = &mut state.main_page.content_panel.personas;
+            let event = crossterm::event::Event::Key(*key);
+            match &mut p.mode {
+                PersonaMode::Attribute(form) => {
+                    match form.field {
+                        AttributeField::ClaimType => form.claim_type.handle_event(&event),
+                        AttributeField::Label => form.label.handle_event(&event),
+                        AttributeField::Value => form.value.handle_event(&event),
+                        // The type is a choice, not a text field: ←/→ move it
+                        // and a keystroke here is not an edit.
+                        AttributeField::ValueType => None,
+                    };
+                }
+                PersonaMode::Profile(form) => {
+                    if form.focus == ProfileFormFocus::Name {
+                        form.name.handle_event(&event);
+                    }
+                }
+                PersonaMode::Bind(_) | PersonaMode::View => {}
+            }
+            PersonaEffect::None
+        }
+        PersonaAction::FormField(forwards) => {
+            let p = &mut state.main_page.content_panel.personas;
+            match &mut p.mode {
+                PersonaMode::Attribute(form) => {
+                    form.field = if *forwards {
+                        form.field.next()
+                    } else {
+                        form.field.prev()
+                    };
+                }
+                PersonaMode::Profile(form) => {
+                    form.focus = match form.focus {
+                        ProfileFormFocus::Name => ProfileFormFocus::Entries,
+                        ProfileFormFocus::Entries => ProfileFormFocus::Name,
+                    };
+                }
+                PersonaMode::Bind(_) | PersonaMode::View => {}
+            }
+            PersonaEffect::None
+        }
+        PersonaAction::FormCycle(forwards) => {
+            let attribute_count = state.main_page.content_panel.personas.attributes.len();
+            let option_count = state.main_page.content_panel.personas.profiles.len() + 1;
+            let p = &mut state.main_page.content_panel.personas;
+            match &mut p.mode {
+                PersonaMode::Attribute(form) => {
+                    if form.field == AttributeField::ValueType {
+                        let n = VALUE_TYPES.len();
+                        form.value_type = if *forwards {
+                            (form.value_type + 1) % n
+                        } else {
+                            (form.value_type + n - 1) % n
+                        };
+                    }
+                }
+                PersonaMode::Profile(form) => {
+                    form.cursor = step(form.cursor, attribute_count, *forwards);
+                }
+                PersonaMode::Bind(picker) => {
+                    picker.cursor = step(picker.cursor, option_count, *forwards);
+                }
+                PersonaMode::View => {}
+            }
+            PersonaEffect::None
+        }
+        PersonaAction::FormToggleEntry => {
+            let attribute_id = {
+                let p = &state.main_page.content_panel.personas;
+                match &p.mode {
+                    PersonaMode::Profile(form) => p
+                        .attributes
+                        .get(form.cursor)
+                        .map(|a| a.attribute_id.clone()),
+                    _ => None,
+                }
+            };
+            let p = &mut state.main_page.content_panel.personas;
+            if let (PersonaMode::Profile(form), Some(id)) = (&mut p.mode, attribute_id) {
+                match form.ticked.iter().position(|x| *x == id) {
+                    Some(i) => {
+                        form.ticked.remove(i);
+                    }
+                    // Appended, so tick order is presentation order — the
+                    // profile shows its claims in the order they were chosen.
+                    None => form.ticked.push(id),
+                }
+            }
+            PersonaEffect::None
+        }
+        PersonaAction::FormCancel => {
+            state.main_page.content_panel.personas.mode = PersonaMode::View;
+            PersonaEffect::None
+        }
+        PersonaAction::FormSubmit => form_submit(state),
+    }
+}
+
+/// Answer the armed question.
+fn confirm_yes(state: &mut State) -> PersonaEffect {
+    let p = &mut state.main_page.content_panel.personas;
+    let confirm = std::mem::replace(&mut p.confirm, PersonaConfirm::None);
+    match confirm {
+        // A face deletion is not answered here — the pane arms the question and
+        // the existing identity-deletion path answers it. See the key handler.
+        PersonaConfirm::None | PersonaConfirm::DeleteFace(_) => PersonaEffect::None,
+        PersonaConfirm::DeleteAttribute { index, cascade } => {
+            let Some(attr) = p.attributes.get(index) else {
+                return PersonaEffect::None;
+            };
+            PersonaEffect::Job(PersonaJob::AttributeDelete {
+                attribute_id: attr.attribute_id.clone(),
+                cascade,
+            })
+        }
+        PersonaConfirm::DeleteProfile { index, unbind } => {
+            let Some(profile) = p.profiles.get(index) else {
+                return PersonaEffect::None;
+            };
+            PersonaEffect::Job(PersonaJob::ProfileDelete {
+                profile_id: profile.profile_id.clone(),
+                unbind,
+            })
+        }
+        PersonaConfirm::Unbind(index) => {
+            let Some(m) = p.memberships.get(index) else {
+                return PersonaEffect::None;
+            };
+            PersonaEffect::Job(PersonaJob::Bind {
+                context_id: m.sub_context_id.clone(),
+                persona_did: m.persona_did.clone(),
+                profile_id: None,
+                community: m.community_name.clone(),
+            })
+        }
+    }
+}
+
+/// Validate and submit whichever form is open.
+fn form_submit(state: &mut State) -> PersonaEffect {
+    let profiles: Vec<ProfileSummary> = state
+        .main_page
+        .content_panel
+        .personas
+        .profiles
+        .iter()
+        .cloned()
+        .collect();
+    let memberships: Vec<PersonaMembership> = state
+        .main_page
+        .content_panel
+        .personas
+        .memberships
+        .iter()
+        .cloned()
+        .collect();
+    let p = &mut state.main_page.content_panel.personas;
+
+    match &mut p.mode {
+        PersonaMode::View => PersonaEffect::None,
+        PersonaMode::Attribute(form) => {
+            let claim_type = form.claim_type.value().trim().to_string();
+            if claim_type.is_empty() {
+                // Named rather than generic: the type is the one field with no
+                // sensible default, because it is what a verifier matches on.
+                form.error = Some("A type is required — e.g. email.work.".to_string());
+                return PersonaEffect::None;
+            }
+            let value_type = pool::value_type_from_str(VALUE_TYPES[form.value_type]);
+            let value = match pool::parse_typed_value(form.value.value(), value_type) {
+                Ok(value) => value,
+                Err(why) => {
+                    form.error = Some(why);
+                    return PersonaEffect::None;
+                }
+            };
+            let label = form.label.value().trim();
+            form.error = None;
+            form.working = true;
+            PersonaEffect::Job(PersonaJob::AttributePut(AttributeDraft {
+                attribute_id: form.attribute_id.clone(),
+                expected_version: form.expected_version,
+                claim_type,
+                label: (!label.is_empty()).then(|| label.to_string()),
+                value,
+                value_type,
+            }))
+        }
+        PersonaMode::Profile(form) => {
+            let name = form.name.value().trim().to_string();
+            if name.is_empty() {
+                form.error = Some("A name is required — \"Work\", \"Gaming\".".to_string());
+                return PersonaEffect::None;
+            }
+            form.error = None;
+            form.working = true;
+            PersonaEffect::Job(PersonaJob::ProfilePut {
+                profile_id: form.profile_id.clone(),
+                name,
+                live_refs: form.ticked.clone(),
+                other_entries: form.preserved.clone(),
+                expected_version: form.expected_version,
+            })
+        }
+        PersonaMode::Bind(picker) => {
+            let Some(m) = memberships.get(picker.membership) else {
+                return PersonaEffect::None;
+            };
+            // Row 0 is "nothing"; the rest index the profile list.
+            let profile_id = picker
+                .cursor
+                .checked_sub(1)
+                .and_then(|i| profiles.get(i))
+                .map(|profile| profile.profile_id.clone());
+            picker.error = None;
+            picker.working = true;
+            PersonaEffect::Job(PersonaJob::Bind {
+                context_id: m.sub_context_id.clone(),
+                persona_did: m.persona_did.clone(),
+                profile_id,
+                community: m.community_name.clone(),
+            })
+        }
+    }
+}
+
+/// Give an open form back to the operator after a request that never left.
+///
+/// A form marked `working` is waiting on an answer, and if the request was
+/// never sent there is no answer coming: the form would stay locked, showing
+/// "Saving…" over an edit nobody is saving, until the pane was closed. Both
+/// callers are the paths where the loop declines to spawn — no admin session,
+/// and the domain already busy.
+pub(crate) fn release_form(state: &mut State, reason: String) {
+    let p = &mut state.main_page.content_panel.personas;
+    match &mut p.mode {
+        PersonaMode::Attribute(form) => {
+            form.working = false;
+            form.error = Some(reason);
+        }
+        PersonaMode::Profile(form) => {
+            form.working = false;
+            form.error = Some(reason);
+        }
+        PersonaMode::Bind(picker) => {
+            picker.working = false;
+            picker.error = Some(reason);
+        }
+        PersonaMode::View => p.status_message = Some(reason),
+    }
+}
+
+/// Prefill the editor from an existing attribute.
+fn form_for(attr: &PoolAttribute) -> AttributeForm {
+    AttributeForm {
+        attribute_id: Some(attr.attribute_id.clone()),
+        expected_version: Some(attr.version),
+        claim_type: tui_input::Input::new(attr.claim_type.clone()),
+        label: tui_input::Input::new(attr.label.clone().unwrap_or_default()),
+        value_type: VALUE_TYPES
+            .iter()
+            .position(|t| *t == attr.value_type)
+            .unwrap_or(0),
+        value: tui_input::Input::new(match &attr.value {
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+            None => String::new(),
+        }),
+        field: AttributeField::default(),
+        error: None,
+        working: false,
+    }
+}
+
+/// Move a cursor one step, stopping at the ends rather than wrapping: a list
+/// that jumps from bottom to top under a held arrow key loses the operator's
+/// place.
+fn step(cursor: usize, len: usize, forwards: bool) -> usize {
+    if len == 0 {
+        return 0;
+    }
+    if forwards {
+        (cursor + 1).min(len - 1)
+    } else {
+        cursor.saturating_sub(1)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The jobs
+// ---------------------------------------------------------------------------
+
+/// How much of the disclosure history one read asks for.
+///
+/// The record is append-only and never trimmed, so "all of it" is a query that
+/// gets slower for the life of the account. A page of the newest releases is
+/// what the pane can show and what the holder opens it to see; the whole
+/// history is a `pnm persona disclosure history` question.
+pub(crate) const DISCLOSURE_PAGE: u64 = 100;
+
+/// One backgrounded read of everything the agent-served tabs show.
+pub(crate) struct PersonaReadJob {
+    pub(crate) admin_vta: VtaClient,
+    pub(crate) include_values: bool,
+    pub(crate) targets: Vec<BindingTarget>,
+}
+
+impl PersonaReadJob {
+    /// The targets a read should ask about: one per membership.
+    pub(crate) fn targets(state: &State) -> Vec<BindingTarget> {
+        state
+            .main_page
+            .content_panel
+            .personas
+            .memberships
+            .iter()
+            .filter(|m| !m.sub_context_id.is_empty() && !m.persona_did.is_empty())
+            .map(|m| (m.sub_context_id.clone(), m.persona_did.clone()))
+            .collect()
+    }
+
+    /// I/O only.
+    pub(crate) async fn run(self) -> PersonaOutcome {
+        let attributes = pool::list(&self.admin_vta, self.include_values)
+            .await
+            .map_err(|e| format!("{e}"));
+        let profiles = profile::list(&self.admin_vta)
+            .await
+            .map_err(|e| format!("{e}"));
+        let disclosures = match std::num::NonZeroU64::new(DISCLOSURE_PAGE) {
+            Some(limit) => disclosure::history(&self.admin_vta, limit)
+                .await
+                .map_err(|e| format!("{e}")),
+            None => Ok(Vec::new()),
+        };
+        let bindings = persona_binding_refresh::resolve_batch(self.admin_vta, self.targets).await;
+        PersonaOutcome::Read {
+            attributes,
+            profiles,
+            disclosures,
+            bindings,
+            include_values: self.include_values,
+        }
+    }
+}
+
+/// One backgrounded write (or single-profile read).
+pub(crate) struct PersonaJobRun {
+    pub(crate) admin_vta: VtaClient,
+    pub(crate) job: PersonaJob,
+}
+
+impl PersonaJobRun {
+    /// I/O only.
+    pub(crate) async fn run(self) -> PersonaOutcome {
+        let client = self.admin_vta;
+        match self.job {
+            PersonaJob::AttributePut(draft) => PersonaOutcome::Written {
+                verb: "Saved attribute",
+                error: pool::put(&client, draft)
+                    .await
+                    .err()
+                    .map(|e| format!("{e}")),
+            },
+            PersonaJob::AttributeDelete {
+                attribute_id,
+                cascade,
+            } => PersonaOutcome::Written {
+                verb: "Deleted attribute",
+                error: pool::delete(&client, &attribute_id, cascade)
+                    .await
+                    .err()
+                    .map(|e| format!("{e}")),
+            },
+            PersonaJob::ProfilePut {
+                profile_id,
+                name,
+                live_refs,
+                other_entries,
+                expected_version,
+            } => PersonaOutcome::Written {
+                verb: "Saved profile",
+                error: profile::put(
+                    &client,
+                    profile_id.as_deref(),
+                    &name,
+                    &live_refs,
+                    &other_entries,
+                    expected_version,
+                )
+                .await
+                .err()
+                .map(|e| format!("{e}")),
+            },
+            PersonaJob::ProfileDelete { profile_id, unbind } => PersonaOutcome::Written {
+                verb: "Deleted profile",
+                error: profile::delete(&client, &profile_id, unbind)
+                    .await
+                    .err()
+                    .map(|e| format!("{e}")),
+            },
+            PersonaJob::ProfileGet { profile_id, edit } => PersonaOutcome::ProfileRead {
+                edit,
+                result: profile::get(&client, &profile_id, !edit)
+                    .await
+                    .map_err(|e| format!("{e}")),
+            },
+            PersonaJob::Bind {
+                context_id,
+                persona_did,
+                profile_id,
+                community,
+            } => PersonaOutcome::Bound {
+                community,
+                cleared: profile_id.is_none(),
+                error: binding::set(&client, &context_id, &persona_did, profile_id.as_deref())
+                    .await
+                    .err()
+                    .map(|e| format!("{e}")),
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The outcomes
+// ---------------------------------------------------------------------------
+
+/// What a persona job produced. Data only; applied on the loop thread.
+pub(crate) enum PersonaOutcome {
+    Read {
+        attributes: Result<Vec<PoolAttribute>, String>,
+        profiles: Result<Vec<ProfileSummary>, String>,
+        disclosures: Result<Vec<disclosure::DisclosureRow>, String>,
+        bindings: HashMap<BindingTarget, openvtc_core::persona::binding::BindingSummary>,
+        include_values: bool,
+    },
+    Written {
+        verb: &'static str,
+        error: Option<String>,
+    },
+    ProfileRead {
+        edit: bool,
+        result: Result<ProfileDetail, String>,
+    },
+    Bound {
+        community: String,
+        cleared: bool,
+        error: Option<String>,
+    },
+}
+
+impl PersonaOutcome {
+    /// Fold the result into the pane, on the loop thread.
+    pub(crate) fn apply(self, state: &mut State) {
+        let p = &mut state.main_page.content_panel.personas;
+        p.loading = false;
+
+        match self {
+            PersonaOutcome::Read {
+                attributes,
+                profiles,
+                disclosures,
+                bindings,
+                include_values,
+            } => {
+                // A listing for a filter the operator has since flipped is
+                // dropped: they pressed `v` while it was in flight, so it
+                // answers the old question and a fresh job is already queued.
+                if include_values != p.show_values {
+                    return;
+                }
+                // The first failure is the one shown, and it is shown *instead*
+                // of an empty list — the whole reason `load_error` exists.
+                p.load_error = attributes
+                    .as_ref()
+                    .err()
+                    .or(profiles.as_ref().err())
+                    .or(disclosures.as_ref().err())
+                    .cloned();
+                if let Ok(list) = attributes {
+                    p.attribute_selected = p.attribute_selected.min(list.len().saturating_sub(1));
+                    p.attributes = list.into();
+                }
+                if let Ok(list) = profiles {
+                    p.profile_selected = p.profile_selected.min(list.len().saturating_sub(1));
+                    p.profiles = list.into();
+                }
+                if let Ok(list) = disclosures {
+                    p.disclosure_selected = p.disclosure_selected.min(list.len().saturating_sub(1));
+                    p.disclosures = list.into();
+                }
+                // Merged, not replaced: a read only carries the targets it was
+                // given, and replacing would blank every row it did not cover —
+                // which reads on screen as those faces having stopped
+                // presenting anything.
+                p.bindings.extend(bindings);
+                if p.load_error.is_none() {
+                    p.loaded = true;
+                }
+            }
+
+            PersonaOutcome::Written { verb, error } => {
+                // The store is authoritative and has just been invalidated, so
+                // ask for a re-read either way. A failed write is exactly when
+                // a stale list misleads most: its state is now unknown.
+                p.refresh_queued = true;
+                match error {
+                    None => {
+                        p.mode = PersonaMode::View;
+                        p.status_message = Some(format!("{verb}."));
+                        state.main_page.log(format!("{verb}."));
+                    }
+                    Some(e) => {
+                        // Into the form when one is open, so the holder keeps
+                        // what they typed and can fix it.
+                        match &mut p.mode {
+                            PersonaMode::Attribute(form) => {
+                                form.working = false;
+                                form.error = Some(e.clone());
+                            }
+                            PersonaMode::Profile(form) => {
+                                form.working = false;
+                                form.error = Some(e.clone());
+                            }
+                            _ => p.status_message = Some(e.clone()),
+                        }
+                        state
+                            .main_page
+                            .log_error(format!("{verb} failed"), e.as_str());
+                    }
+                }
+            }
+
+            PersonaOutcome::ProfileRead { edit, result } => match result {
+                Ok(detail) => {
+                    if edit {
+                        if detail.is_editable_here() {
+                            p.mode = PersonaMode::Profile(ProfileForm {
+                                profile_id: Some(detail.summary.profile_id.clone()),
+                                expected_version: Some(detail.summary.version),
+                                name: tui_input::Input::new(detail.summary.name.clone()),
+                                ticked: detail.live_refs.clone(),
+                                cursor: 0,
+                                focus: ProfileFormFocus::Name,
+                                preserved: detail.other_entries.clone(),
+                                error: None,
+                                working: false,
+                            });
+                        } else {
+                            // Refused rather than opened: saving could not
+                            // round-trip an entry this build cannot read, and a
+                            // save that silently drops one is invisible.
+                            p.status_message = Some(detail.refusal());
+                        }
+                    } else {
+                        p.open_profile = Some(detail);
+                    }
+                }
+                Err(e) => {
+                    p.status_message = Some(e.clone());
+                    state
+                        .main_page
+                        .log_error("Reading the profile failed", e.as_str());
+                }
+            },
+
+            PersonaOutcome::Bound {
+                community,
+                cleared,
+                error,
+            } => {
+                p.refresh_queued = true;
+                match error {
+                    None => {
+                        p.mode = PersonaMode::View;
+                        let msg = if cleared {
+                            format!("{community} is now shown nothing.")
+                        } else {
+                            format!("Updated what {community} is shown.")
+                        };
+                        p.status_message = Some(msg.clone());
+                        state.main_page.log(msg);
+                    }
+                    Some(e) => {
+                        if let PersonaMode::Bind(picker) = &mut p.mode {
+                            picker.working = false;
+                            picker.error = Some(e.clone());
+                        } else {
+                            p.status_message = Some(e.clone());
+                        }
+                        state
+                            .main_page
+                            .log_error("Changing what a face presents failed", e.as_str());
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::main_page::content::PersonasState;
+    use openvtc_core::persona::binding::BindingSummary;
+    use openvtc_core::persona::pool::ProvenanceKind;
+
+    fn attribute(id: &str) -> PoolAttribute {
+        PoolAttribute {
+            attribute_id: id.to_string(),
+            claim_type: "email.work".to_string(),
+            value_type: "string".to_string(),
+            version: 4,
+            ..PoolAttribute::default()
+        }
+    }
+
+    fn state_with(personas: PersonasState) -> State {
+        let mut state = State::default();
+        state.main_page.content_panel.personas = personas;
+        state
+    }
+
+    fn personas(state: &State) -> &PersonasState {
+        &state.main_page.content_panel.personas
+    }
+
+    /// Deleting an attribute a profile uses asks the cascading question *first*.
+    ///
+    /// The listing already says which attributes are referenced, so there is no
+    /// reason to put a question the VTA is going to refuse and then put a
+    /// different one — a holder who has already answered "yes, delete it"
+    /// answers the follow-up with the first question's reasoning.
+    #[test]
+    fn a_referenced_attribute_arms_the_cascading_question_directly() {
+        let mut state = state_with(PersonasState {
+            attributes: vec![attribute("01A"), attribute("01B")].into(),
+            profiles: vec![ProfileSummary {
+                profile_id: "01P".into(),
+                name: "Work".into(),
+                referenced: vec!["01A".into()],
+                ..ProfileSummary::default()
+            }]
+            .into(),
+            ..PersonasState::default()
+        });
+
+        apply(&mut state, &PersonaAction::AttributeDeleteArm(0));
+        assert_eq!(
+            personas(&state).confirm,
+            PersonaConfirm::DeleteAttribute {
+                index: 0,
+                cascade: true
+            }
+        );
+
+        apply(&mut state, &PersonaAction::AttributeDeleteArm(1));
+        assert_eq!(
+            personas(&state).confirm,
+            PersonaConfirm::DeleteAttribute {
+                index: 1,
+                cascade: false
+            },
+            "an unreferenced attribute needs no cascade"
+        );
+    }
+
+    /// Same rule one layer up: deleting a profile a face presents asks the
+    /// unbinding question, because that is what will actually happen.
+    #[test]
+    fn a_presented_profile_arms_the_unbinding_question() {
+        let mut bindings = HashMap::new();
+        bindings.insert(
+            ("ctx".to_string(), "did:webvh:example.com:alice".to_string()),
+            BindingSummary {
+                bound: true,
+                profile_id: Some("01P".into()),
+                ..BindingSummary::default()
+            },
+        );
+        let mut state = state_with(PersonasState {
+            profiles: vec![
+                ProfileSummary {
+                    profile_id: "01P".into(),
+                    ..ProfileSummary::default()
+                },
+                ProfileSummary {
+                    profile_id: "01Q".into(),
+                    ..ProfileSummary::default()
+                },
+            ]
+            .into(),
+            bindings,
+            ..PersonasState::default()
+        });
+
+        apply(&mut state, &PersonaAction::ProfileDeleteArm(0));
+        assert_eq!(
+            personas(&state).confirm,
+            PersonaConfirm::DeleteProfile {
+                index: 0,
+                unbind: true
+            }
+        );
+        apply(&mut state, &PersonaAction::ProfileDeleteArm(1));
+        assert_eq!(
+            personas(&state).confirm,
+            PersonaConfirm::DeleteProfile {
+                index: 1,
+                unbind: false
+            }
+        );
+    }
+
+    /// A credential-backed attribute does not open an editor. The refusal is
+    /// the point: retyping its value would manufacture an attested claim out of
+    /// a typed string.
+    #[test]
+    fn a_credential_backed_attribute_refuses_the_editor() {
+        let mut attr = attribute("01A");
+        attr.provenance = ProvenanceKind::CredentialBacked;
+        let mut state = state_with(PersonasState {
+            attributes: vec![attr].into(),
+            show_values: true,
+            ..PersonasState::default()
+        });
+
+        apply(&mut state, &PersonaAction::AttributeEdit(0));
+
+        assert!(matches!(personas(&state).mode, PersonaMode::View));
+        assert!(
+            personas(&state)
+                .status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("comes from a credential")),
+            "the refusal has to say why"
+        );
+    }
+
+    /// Opening the editor when the listing was fetched without values re-reads
+    /// with them. Without this the form would open empty and save a blank over
+    /// a value the holder never saw.
+    #[test]
+    fn editing_without_values_in_hand_asks_for_them() {
+        let mut state = state_with(PersonasState {
+            attributes: vec![attribute("01A")].into(),
+            show_values: false,
+            ..PersonasState::default()
+        });
+
+        let effect = apply(&mut state, &PersonaAction::AttributeEdit(0));
+
+        assert!(matches!(effect, PersonaEffect::Read));
+        assert!(personas(&state).show_values);
+        assert!(matches!(personas(&state).mode, PersonaMode::Attribute(_)));
+    }
+
+    /// Toggling values is a re-read, not a redraw — a listing fetched without
+    /// values does not hold them.
+    #[test]
+    fn toggling_values_re_reads() {
+        let mut state = State::default();
+        let effect = apply(&mut state, &PersonaAction::ToggleValues);
+        assert!(matches!(effect, PersonaEffect::Read));
+        assert!(personas(&state).show_values);
+    }
+
+    /// A read that answers a question the operator has already changed is
+    /// dropped rather than flashed — the same rule the VIC listing follows.
+    #[test]
+    fn a_superseded_read_is_discarded() {
+        let mut state = state_with(PersonasState {
+            attributes: vec![attribute("01A")].into(),
+            show_values: true,
+            ..PersonasState::default()
+        });
+
+        PersonaOutcome::Read {
+            attributes: Ok(vec![attribute("01B"), attribute("01C")]),
+            profiles: Ok(Vec::new()),
+            disclosures: Ok(Vec::new()),
+            bindings: HashMap::new(),
+            include_values: false,
+        }
+        .apply(&mut state);
+
+        assert_eq!(
+            personas(&state).attributes.len(),
+            1,
+            "the superseded listing must not apply"
+        );
+    }
+
+    /// A failed read keeps the previous list and records why — it must never
+    /// leave the pane claiming the holder has no attributes.
+    #[test]
+    fn a_failed_read_keeps_the_list_and_says_why() {
+        let mut state = state_with(PersonasState {
+            attributes: vec![attribute("01A")].into(),
+            loaded: true,
+            ..PersonasState::default()
+        });
+
+        PersonaOutcome::Read {
+            attributes: Err("connection refused".to_string()),
+            profiles: Ok(Vec::new()),
+            disclosures: Ok(Vec::new()),
+            bindings: HashMap::new(),
+            include_values: false,
+        }
+        .apply(&mut state);
+
+        assert_eq!(personas(&state).attributes.len(), 1);
+        assert_eq!(
+            personas(&state).load_error.as_deref(),
+            Some("connection refused")
+        );
+    }
+
+    /// A write asks for a re-read whether it succeeded or failed. After a
+    /// failure the store's state is unknown, which is when a stale list is most
+    /// misleading.
+    #[test]
+    fn every_write_asks_for_a_re_read() {
+        for error in [None, Some("refused".to_string())] {
+            let mut state = State::default();
+            PersonaOutcome::Written {
+                verb: "Saved attribute",
+                error,
+            }
+            .apply(&mut state);
+            assert!(personas(&state).refresh_queued);
+        }
+    }
+
+    /// A request the loop declines to send hands the form back.
+    ///
+    /// The form is marked `working` the moment it is submitted, and that flag
+    /// is what locks the keyboard. If the loop then declines to spawn — no
+    /// admin session, or the domain already busy — nothing is coming back to
+    /// clear it, and the form sits on "Saving…" over an edit nobody is saving.
+    #[test]
+    fn a_request_that_never_left_unlocks_the_form() {
+        let mut state = state_with(PersonasState {
+            mode: PersonaMode::Attribute(AttributeForm {
+                working: true,
+                ..AttributeForm::default()
+            }),
+            ..PersonasState::default()
+        });
+
+        release_form(&mut state, "no session".to_string());
+
+        match &personas(&state).mode {
+            PersonaMode::Attribute(form) => {
+                assert!(!form.working);
+                assert_eq!(form.error.as_deref(), Some("no session"));
+            }
+            _ => panic!("the form must stay open"),
+        }
+    }
+
+    /// The picker is the same: it locks itself on submit and has to be given
+    /// back if the write never went.
+    #[test]
+    fn a_request_that_never_left_unlocks_the_picker() {
+        let mut state = state_with(PersonasState {
+            mode: PersonaMode::Bind(BindPicker {
+                working: true,
+                ..BindPicker::default()
+            }),
+            ..PersonasState::default()
+        });
+
+        release_form(&mut state, "busy".to_string());
+
+        match &personas(&state).mode {
+            PersonaMode::Bind(picker) => {
+                assert!(!picker.working);
+                assert_eq!(picker.error.as_deref(), Some("busy"));
+            }
+            _ => panic!("the picker must stay open"),
+        }
+    }
+
+    /// A failed save keeps the form open with the reason on it, so the holder
+    /// does not lose what they typed.
+    #[test]
+    fn a_failed_save_keeps_the_form_and_its_contents() {
+        let mut state = state_with(PersonasState {
+            mode: PersonaMode::Attribute(AttributeForm {
+                claim_type: tui_input::Input::new("email.work".into()),
+                working: true,
+                ..AttributeForm::default()
+            }),
+            ..PersonasState::default()
+        });
+
+        PersonaOutcome::Written {
+            verb: "Saved attribute",
+            error: Some("version conflict".to_string()),
+        }
+        .apply(&mut state);
+
+        match &personas(&state).mode {
+            PersonaMode::Attribute(form) => {
+                assert_eq!(form.claim_type.value(), "email.work");
+                assert!(!form.working, "the form has to become editable again");
+                assert_eq!(form.error.as_deref(), Some("version conflict"));
+            }
+            _ => panic!("the form must stay open"),
+        }
+    }
+
+    /// An empty type is refused before the round-trip, because it is the one
+    /// field with no sensible default: it is what a verifier matches on.
+    #[test]
+    fn a_typeless_attribute_is_refused_locally() {
+        let mut state = state_with(PersonasState {
+            mode: PersonaMode::Attribute(AttributeForm::default()),
+            ..PersonasState::default()
+        });
+
+        let effect = apply(&mut state, &PersonaAction::FormSubmit);
+
+        assert!(matches!(effect, PersonaEffect::None));
+        match &personas(&state).mode {
+            PersonaMode::Attribute(form) => {
+                assert!(form.error.as_deref().is_some_and(|e| e.contains("type")));
+                assert!(!form.working, "nothing was sent, so nothing is in flight");
+            }
+            _ => panic!("the form must stay open"),
+        }
+    }
+
+    /// The picker opens on what is bound now, so pressing ⏎ without moving
+    /// leaves the binding alone instead of silently clearing it.
+    #[test]
+    fn the_picker_opens_on_the_current_binding() {
+        let membership = PersonaMembership {
+            community_name: "Acme".into(),
+            sub_context_id: "ctx".into(),
+            persona_did: "did:webvh:example.com:alice".into(),
+            ..PersonaMembership::default()
+        };
+        let mut bindings = HashMap::new();
+        bindings.insert(
+            ("ctx".to_string(), membership.persona_did.clone()),
+            BindingSummary {
+                bound: true,
+                profile_id: Some("01Q".into()),
+                ..BindingSummary::default()
+            },
+        );
+        let mut state = state_with(PersonasState {
+            memberships: vec![membership].into(),
+            profiles: vec![
+                ProfileSummary {
+                    profile_id: "01P".into(),
+                    ..ProfileSummary::default()
+                },
+                ProfileSummary {
+                    profile_id: "01Q".into(),
+                    ..ProfileSummary::default()
+                },
+            ]
+            .into(),
+            bindings,
+            ..PersonasState::default()
+        });
+
+        apply(&mut state, &PersonaAction::BindOpen(0));
+
+        match &personas(&state).mode {
+            // Row 0 is "nothing", so the second profile is row 2.
+            PersonaMode::Bind(picker) => assert_eq!(picker.cursor, 2),
+            _ => panic!("the picker must be open"),
+        }
+    }
+
+    /// An unbound face opens the picker on "nothing", which is where it
+    /// already is.
+    #[test]
+    fn an_unbound_face_opens_the_picker_on_nothing() {
+        let mut state = state_with(PersonasState {
+            memberships: vec![PersonaMembership::default()].into(),
+            ..PersonasState::default()
+        });
+        apply(&mut state, &PersonaAction::BindOpen(0));
+        match &personas(&state).mode {
+            PersonaMode::Bind(picker) => assert_eq!(picker.cursor, 0),
+            _ => panic!("the picker must be open"),
+        }
+    }
+
+    /// Ticking appends, so the order the holder chose is the order the profile
+    /// presents.
+    #[test]
+    fn ticking_preserves_the_order_entries_were_chosen_in() {
+        let mut state = state_with(PersonasState {
+            attributes: vec![attribute("01A"), attribute("01B"), attribute("01C")].into(),
+            mode: PersonaMode::Profile(ProfileForm {
+                focus: ProfileFormFocus::Entries,
+                ..ProfileForm::default()
+            }),
+            ..PersonasState::default()
+        });
+
+        apply(&mut state, &PersonaAction::FormCycle(true)); // → 01B
+        apply(&mut state, &PersonaAction::FormToggleEntry);
+        apply(&mut state, &PersonaAction::FormCycle(false)); // → 01A
+        apply(&mut state, &PersonaAction::FormToggleEntry);
+
+        match &personas(&state).mode {
+            PersonaMode::Profile(form) => {
+                assert_eq!(form.ticked, vec!["01B".to_string(), "01A".to_string()])
+            }
+            _ => panic!("the form must be open"),
+        }
+
+        // And ticking again removes it.
+        apply(&mut state, &PersonaAction::FormToggleEntry);
+        match &personas(&state).mode {
+            PersonaMode::Profile(form) => assert_eq!(form.ticked, vec!["01B".to_string()]),
+            _ => panic!("the form must be open"),
+        }
+    }
+
+    /// Editing a profile this build cannot fully read is refused rather than
+    /// opened. A save from that form could not round-trip the entry it could
+    /// not parse, and dropping it would be invisible.
+    #[test]
+    fn a_profile_with_unreadable_entries_refuses_the_editor() {
+        let mut state = State::default();
+        PersonaOutcome::ProfileRead {
+            edit: true,
+            result: Ok(ProfileDetail {
+                unreadable_entries: 1,
+                ..ProfileDetail::default()
+            }),
+        }
+        .apply(&mut state);
+
+        assert!(matches!(personas(&state).mode, PersonaMode::View));
+        assert!(
+            personas(&state)
+                .status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("cannot read"))
+        );
+    }
+
+    /// Moving tabs drops what was armed or opened on the one being left: a `y`
+    /// belongs to the screen that asked the question.
+    #[test]
+    fn changing_tab_disarms_the_confirmation() {
+        let mut state = state_with(PersonasState {
+            tab: PersonaTab::Attributes,
+            confirm: PersonaConfirm::DeleteAttribute {
+                index: 0,
+                cascade: false,
+            },
+            ..PersonasState::default()
+        });
+
+        apply(&mut state, &PersonaAction::TabNext);
+
+        assert_eq!(personas(&state).tab, PersonaTab::Profiles);
+        assert_eq!(personas(&state).confirm, PersonaConfirm::None);
+    }
+
+    /// The agent-served tabs read on first arrival and not again — the pane is
+    /// not a poller.
+    #[test]
+    fn an_agent_tab_reads_once_on_arrival() {
+        let mut state = State::default();
+        // Faces → Attributes: needs the agent, nothing loaded yet.
+        assert!(matches!(
+            apply(&mut state, &PersonaAction::TabNext),
+            PersonaEffect::Read
+        ));
+
+        state.main_page.content_panel.personas.loaded = true;
+        assert!(matches!(
+            apply(&mut state, &PersonaAction::TabNext),
+            PersonaEffect::None
+        ));
+    }
+}

--- a/openvtc/src/state_handler/persona_binding_refresh.rs
+++ b/openvtc/src/state_handler/persona_binding_refresh.rs
@@ -21,7 +21,7 @@
 
 use std::collections::HashMap;
 
-use openvtc_core::persona_binding::{self, BindingSummary};
+use openvtc_core::persona::binding::{self, BindingSummary};
 use vta_sdk::client::VtaClient;
 
 /// A `(sub_context_id, persona_did)` pair to ask about.
@@ -39,7 +39,7 @@ pub async fn resolve_batch(
 ) -> HashMap<BindingTarget, BindingSummary> {
     let mut out = HashMap::with_capacity(targets.len());
     for (context_id, persona_did) in targets {
-        let summary = persona_binding::get_or_unknown(&client, &context_id, &persona_did).await;
+        let summary = binding::get_or_unknown(&client, &context_id, &persona_did).await;
         out.insert((context_id, persona_did), summary);
     }
     out

--- a/openvtc/src/state_handler/runtime_actions.rs
+++ b/openvtc/src/state_handler/runtime_actions.rs
@@ -825,6 +825,18 @@ pub(crate) async fn handle_action(ctx: &mut ActionCtx<'_>, action: Action) -> Ha
                 );
             }
         }
+        Action::Persona(persona_action) => {
+            // The pane's own reducer decides what changed and what it still
+            // owes the agent; the loop only spawns what it names.
+            let effect = persona_actions::apply(ctx.state, &persona_action);
+            spawn_persona_effect(
+                ctx.dispatch_tx,
+                ctx.in_flight,
+                ctx.state,
+                ctx.admin_vta,
+                effect,
+            );
+        }
         Action::VicRefresh => {
             // Off the loop: this is Tab into the VIC list, and the
             // focus change queued behind it must not wait on a vault
@@ -1124,7 +1136,6 @@ pub(crate) async fn handle_action(ctx: &mut ActionCtx<'_>, action: Action) -> Ha
         | Action::AgentNameManagerCancelRemove
         | Action::AgentNameManagerClose
         | Action::VicSelect(..)
-        | Action::VicFocusToggle
         | Action::VicConfirmDelete(..)
         | Action::VicCancelDelete
         | Action::VicConfirmPurge(..)
@@ -1246,7 +1257,7 @@ mod tests {
         }
 
         fn with_persona(&mut self) {
-            self.state.main_page.content_panel.vta.context_dids = vec![ManagedDid {
+            self.state.main_page.content_panel.personas.faces = vec![ManagedDid {
                 did: "did:webvh:QmScidPersona:example.com:alice".into(),
                 agent_name: None,
                 label: "Alice".into(),

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -25,12 +25,23 @@ impl Panel for CommunitiesPanel {
         state: &ContentPanelState,
         _connection: &ConnectionState,
     ) -> Vec<Line<'static>> {
-        render(&state.communities)
+        render(&state.communities, &state.personas.bindings)
     }
 }
 
 /// Render the communities panel content.
-pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
+///
+/// `bindings` is the persona pane's map, read here rather than copied: this
+/// panel and the persona pane render the same fact — what a face presents in a
+/// community — and two copies of it would drift the moment one was refreshed
+/// and the other was not.
+pub fn render(
+    state: &CommunitiesState,
+    bindings: &std::collections::HashMap<
+        (String, String),
+        openvtc_core::persona::binding::BindingSummary,
+    >,
+) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from("")];
 
     if let Some(msg) = &state.status_message {
@@ -125,8 +136,7 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
         }
         if !c.sub_context_id.is_empty() && !c.persona_did.is_empty() {
             let key = (c.sub_context_id.clone(), c.persona_did.clone());
-            let summary = state
-                .bindings
+            let summary = bindings
                 .get(&key)
                 .cloned()
                 .unwrap_or_else(openvtc_core::persona::binding::BindingSummary::unknown);
@@ -516,6 +526,13 @@ mod key_hint_tests {
         }
     }
 
+    /// Render with no binding answers in hand — every row reads
+    /// "presents: unknown", which is the honest state before the agent has been
+    /// asked and the one these tests are not about.
+    fn render_for_test(state: &CommunitiesState) -> Vec<Line<'static>> {
+        render(state, &std::collections::HashMap::new())
+    }
+
     fn state_with(
         community: Option<CommunitySummary>,
         c: Option<PersonhoodChallengeView>,
@@ -568,7 +585,7 @@ mod key_hint_tests {
     /// — and on its own line rather than buried in a sentence.
     #[test]
     fn a_live_challenge_shows_its_match_code() {
-        let rendered: Vec<String> = render(&state_with(
+        let rendered: Vec<String> = render_for_test(&state_with(
             Some(row(true, false, false)),
             Some(challenge(5)),
         ))
@@ -587,7 +604,7 @@ mod key_hint_tests {
     /// cannot tell "it lapsed" from "it never arrived".
     #[test]
     fn an_expired_challenge_says_so_rather_than_vanishing() {
-        let rendered: Vec<String> = render(&state_with(
+        let rendered: Vec<String> = render_for_test(&state_with(
             Some(row(true, false, false)),
             Some(challenge(-1)),
         ))

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -129,7 +129,7 @@ pub fn render(state: &CommunitiesState) -> Vec<Line<'static>> {
                 .bindings
                 .get(&key)
                 .cloned()
-                .unwrap_or_else(openvtc_core::persona_binding::BindingSummary::unknown);
+                .unwrap_or_else(openvtc_core::persona::binding::BindingSummary::unknown);
             detail.push_str(&format!("  ·  {}", summary.describe()));
         }
         if c.archived {

--- a/openvtc/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc/src/ui/pages/main/components/content_panel.rs
@@ -82,6 +82,7 @@ impl ContentPanelState {
             MainMenu::Credentials => Some(Box::new(CredentialsPanel)),
             MainMenu::Settings => Some(Box::new(SettingsPanel)),
             MainMenu::Vta => Some(Box::new(VtaPanel)),
+            MainMenu::Personas => Some(Box::new(super::personas_panel::PersonasPanel)),
             _ => None,
         };
 
@@ -108,23 +109,6 @@ impl ContentPanelState {
                         Line::from(""),
                         Line::from("Press <Enter> to quit the application")
                             .fg(COLOR_WARNING_ACCESSIBLE_RED),
-                    ]
-                }
-                MainMenu::CreatePersona => {
-                    vec![
-                        Line::from(""),
-                        Line::from("Create a new persona DID").bold(),
-                        Line::from(""),
-                        Line::from(
-                            "Mint a fresh did:webvh identity you can present when joining a \
-                             community.",
-                        ),
-                        Line::from(
-                            "Hand its DID to a community to receive an invitation (VIC) bound \
-                             to it.",
-                        ),
-                        Line::from(""),
-                        Line::from("Press <Enter> to create a persona DID").fg(COLOR_SOFT_PURPLE),
                     ]
                 }
                 // Covered by the Panel trait above; included for exhaustiveness.

--- a/openvtc/src/ui/pages/main/components/mod.rs
+++ b/openvtc/src/ui/pages/main/components/mod.rs
@@ -9,6 +9,7 @@ pub mod inbox_panel;
 pub mod logs_panel;
 pub mod menu_panel;
 pub mod panel;
+pub mod personas_panel;
 pub mod relationships_panel;
 pub mod settings_panel;
 pub mod status;

--- a/openvtc/src/ui/pages/main/components/personas_panel.rs
+++ b/openvtc/src/ui/pages/main/components/personas_panel.rs
@@ -1,0 +1,1341 @@
+//! The identity pane — every surface for the holder's own identity, in one
+//! place.
+//!
+//! Four tabs, in the order the concepts build on each other: the **faces** a
+//! holder presents (persona DIDs), the **attributes** they hold about
+//! themselves, the **profiles** that project a subset of those attributes, and
+//! the **communities** each face is shown to. Tab one comes from `Config`; the
+//! other three come from the agent.
+//!
+//! # What this pane will not draw
+//!
+//! A value the holder never asked to see. The attribute list is fetched without
+//! values by default and `v` re-reads *with* them — an opt-in that costs a
+//! round-trip rather than a display flag over data already in memory, because a
+//! listing that holds values has already read the holder's identity whether or
+//! not the panel chose to paint it.
+//!
+//! A number it does not have. "We could not ask the agent" and "you hold
+//! nothing" are one pixel apart and one of them is a confident wrong answer
+//! about the holder's own data, so every agent-served tab draws the failure
+//! rather than an empty list.
+
+use super::panel::Panel;
+use crate::colors::{
+    COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+    COLOR_WARNING_ACCESSIBLE_RED,
+};
+use crate::state_handler::{
+    main_page::content::{
+        AttributeField, AttributeForm, BindPicker, PersonaConfirm, PersonaMode, PersonaTab,
+        PersonasState, ProfileForm, ProfileFormFocus, VALUE_TYPES,
+    },
+    state::ConnectionState,
+};
+use openvtc_core::display::display_identifier;
+use ratatui::{
+    style::{Style, Stylize},
+    text::{Line, Span},
+};
+
+/// Width for identifiers on a row. Long enough to be checkable, short enough
+/// that the label beside it survives on an 80-column terminal.
+const ID_WIDTH: usize = 46;
+
+/// Width for the DID inside a destructive confirmation, where both ends of the
+/// identifier have to stay readable.
+const CONFIRM_DID_WIDTH: usize = 48;
+
+/// The identity pane.
+pub struct PersonasPanel;
+
+impl Panel for PersonasPanel {
+    fn render(
+        &self,
+        state: &crate::state_handler::main_page::content::ContentPanelState,
+        _connection: &ConnectionState,
+    ) -> Vec<Line<'static>> {
+        render(&state.personas)
+    }
+}
+
+/// Render the pane. A form or picker owns the whole panel while it is open —
+/// the lists behind it are not interactive then, and drawing them would invite
+/// keys that go nowhere.
+pub fn render(state: &PersonasState) -> Vec<Line<'static>> {
+    match &state.mode {
+        PersonaMode::Attribute(form) => render_attribute_form(form),
+        PersonaMode::Profile(form) => render_profile_form(state, form),
+        PersonaMode::Bind(picker) => render_bind_picker(state, picker),
+        PersonaMode::View => render_tabs(state),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The tabbed view
+// ---------------------------------------------------------------------------
+
+fn render_tabs(state: &PersonasState) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+
+    if let Some(msg) = &state.status_message {
+        super::status::push_status(&mut lines, msg, "");
+        lines.push(Line::from(""));
+    }
+
+    // Tab strip.
+    let mut spans = Vec::new();
+    for (i, tab) in PersonaTab::all().into_iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" | ", Style::new().fg(COLOR_DARK_GRAY)));
+        }
+        let style = if state.tab == tab {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_DARK_GRAY)
+        };
+        spans.push(Span::styled(format!(" {} ", tab.label()), style));
+    }
+    lines.push(Line::from(spans));
+    lines.push(Line::from(""));
+
+    match state.tab {
+        PersonaTab::Faces => render_faces(state, &mut lines),
+        PersonaTab::Attributes => render_attributes(state, &mut lines),
+        PersonaTab::Profiles => render_profiles(state, &mut lines),
+        PersonaTab::Communities => render_communities(state, &mut lines),
+        PersonaTab::Disclosures => render_disclosures(state, &mut lines),
+    }
+
+    // The confirmation prompt replaces the key hints while it is armed: a
+    // destructive question and a menu of other things to press do not belong on
+    // screen together.
+    lines.push(Line::from(""));
+    match confirm_prompt(state) {
+        Some(prompt) => lines.push(Line::from(prompt).fg(COLOR_ORANGE).bold()),
+        None => lines.push(Line::from(hints(state)).fg(COLOR_DARK_GRAY)),
+    }
+    lines
+}
+
+/// The question to put, worded so a `y` cannot be given to the wrong one.
+fn confirm_prompt(state: &PersonasState) -> Option<String> {
+    match &state.confirm {
+        PersonaConfirm::None => None,
+        PersonaConfirm::DeleteFace(i) => {
+            let face = state.faces.get(*i)?;
+            // Keep *both* the name and the DID. The row the operator selected
+            // shows the name, so a DID-only prompt names something they never
+            // saw; but a destructive confirm must stay unambiguous, so the DID
+            // is not dropped either — it is centre-truncated to keep the line
+            // readable while both ends stay checkable.
+            let did = openvtc_core::display::truncate_did_centered(&face.did, CONFIRM_DID_WIDTH);
+            let name = match face
+                .label
+                .is_empty()
+                .then_some(face.agent_name.as_deref())
+                .flatten()
+                .or_else(|| (!face.label.is_empty()).then_some(face.label.as_str()))
+            {
+                Some(name) => format!("{name} ({did})"),
+                None => did.into_owned(),
+            };
+            Some(format!("Remove {name}?   y: confirm    n: cancel"))
+        }
+        PersonaConfirm::DeleteAttribute { index, cascade } => {
+            let attr = state.attributes.get(*index)?;
+            if *cascade {
+                // The escalated ask, and it names the consequence the first one
+                // did not have: profiles that show this value stop showing it.
+                Some(format!(
+                    "\"{}\" is used by one or more profiles. Delete it AND remove it from them?   \
+                     y: confirm    n: cancel",
+                    attr.display_name()
+                ))
+            } else {
+                Some(format!(
+                    "Delete \"{}\" from your pool?   y: confirm    n: cancel",
+                    attr.display_name()
+                ))
+            }
+        }
+        PersonaConfirm::DeleteProfile { index, unbind } => {
+            let profile = state.profiles.get(*index)?;
+            if *unbind {
+                Some(format!(
+                    "A face still presents \"{}\". Delete it and leave that face presenting \
+                     nothing?   y: confirm    n: cancel",
+                    profile.display_name()
+                ))
+            } else {
+                Some(format!(
+                    "Delete the profile \"{}\"?   y: confirm    n: cancel",
+                    profile.display_name()
+                ))
+            }
+        }
+        PersonaConfirm::Unbind(index) => {
+            let m = state.memberships.get(*index)?;
+            Some(format!(
+                "Stop presenting anything to {}?   y: confirm    n: cancel",
+                m.community_name
+            ))
+        }
+    }
+}
+
+fn hints(state: &PersonasState) -> &'static str {
+    match state.tab {
+        PersonaTab::Faces => {
+            "↑/↓ select   n: new face   g: agent names   d: remove orphan   ⇥/⇧⇥: tab"
+        }
+        PersonaTab::Attributes => {
+            "↑/↓ select   n: new   e: edit   d: delete   v: values   r: refresh   ⇥/⇧⇥: tab"
+        }
+        PersonaTab::Profiles => {
+            "↑/↓ select   ⏎: what it shows   n: new   e: edit   d: delete   r: refresh   ⇥/⇧⇥: tab"
+        }
+        PersonaTab::Communities => {
+            "↑/↓ select   b: choose what this face shows   u: show nothing   r: refresh   ⇥/⇧⇥: tab"
+        }
+        PersonaTab::Disclosures => "↑/↓ select   r: refresh   ⇥/⇧⇥: tab",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Faces
+// ---------------------------------------------------------------------------
+
+fn render_faces(state: &PersonasState, lines: &mut Vec<Line<'static>>) {
+    if state.faces.is_empty() {
+        lines.push(Line::from(" You have no persona DIDs yet.").fg(COLOR_DARK_GRAY));
+        lines.push(Line::from(""));
+        lines.push(
+            Line::from(
+                " A face is a did:webvh you present to a community. Mint one with `n`, hand its \
+                 DID to a community, and they can issue an invitation bound to it.",
+            )
+            .fg(COLOR_DARK_GRAY),
+        );
+        return;
+    }
+
+    lines.push(
+        Line::from(format!(
+            " {} face{}",
+            state.faces.len(),
+            if state.faces.len() == 1 { "" } else { "s" }
+        ))
+        .fg(COLOR_TEXT_DEFAULT),
+    );
+    lines.push(Line::from(""));
+
+    for (i, face) in state.faces.iter().enumerate() {
+        let is_selected = i == state.face_selected;
+        // An orphan is a face no community sees. Usually the residue of a join
+        // that failed, and worth spotting: it costs keys and a mediator
+        // registration while presenting nothing to anybody.
+        let orphan = face.bound_communities == 0;
+        let prefix = if is_selected { "▸ " } else { "  " };
+        let marker_style = if orphan {
+            Style::new().fg(COLOR_ORANGE)
+        } else {
+            Style::new().fg(COLOR_SUCCESS)
+        };
+        let row_style = if is_selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(prefix, marker_style),
+            Span::styled(if orphan { "○ " } else { "● " }, marker_style),
+            Span::styled(
+                display_identifier(face.agent_name.as_deref(), &face.did, ID_WIDTH).into_owned(),
+                row_style,
+            ),
+        ]));
+
+        let name = if face.label.is_empty() {
+            "unnamed face".to_string()
+        } else {
+            face.label.clone()
+        };
+        let seen_by = if orphan {
+            "orphan — no community".to_string()
+        } else {
+            format!(
+                "seen by {} communit{}",
+                face.bound_communities,
+                if face.bound_communities == 1 {
+                    "y"
+                } else {
+                    "ies"
+                }
+            )
+        };
+        let active = if face.is_active { "  ·  active" } else { "" };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("      {name}{active}  ·  "),
+                Style::new().fg(COLOR_DARK_GRAY),
+            ),
+            Span::styled(
+                seen_by,
+                if orphan {
+                    Style::new().fg(COLOR_ORANGE)
+                } else {
+                    Style::new().fg(COLOR_DARK_GRAY)
+                },
+            ),
+        ]));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Attributes
+// ---------------------------------------------------------------------------
+
+fn render_attributes(state: &PersonasState, lines: &mut Vec<Line<'static>>) {
+    if push_agent_state(state, lines, "attributes") {
+        return;
+    }
+
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!(
+                " {} attribute{} in your pool",
+                state.attributes.len(),
+                if state.attributes.len() == 1 { "" } else { "s" }
+            ),
+            Style::new().fg(COLOR_TEXT_DEFAULT),
+        ),
+        Span::styled(
+            if state.show_values {
+                "        values shown — v to hide"
+            } else {
+                "        values hidden — v to show"
+            },
+            if state.show_values {
+                Style::new().fg(COLOR_ORANGE)
+            } else {
+                Style::new().fg(COLOR_DARK_GRAY)
+            },
+        ),
+    ]));
+    lines.push(Line::from(""));
+
+    if state.attributes.is_empty() {
+        lines.push(
+            Line::from(
+                " Nothing in the pool yet. `n` adds a fact about yourself — a name, an email, a \
+                 date of birth — that profiles can then draw on.",
+            )
+            .fg(COLOR_DARK_GRAY),
+        );
+        return;
+    }
+
+    for (i, attr) in state.attributes.iter().enumerate() {
+        let is_selected = i == state.attribute_selected;
+        let row_style = if is_selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if is_selected { "▸ " } else { "  " }, row_style),
+            Span::styled(
+                format!("{:<28}", truncate(attr.display_name(), 27)),
+                row_style,
+            ),
+            Span::styled(
+                format!("{:<20}", truncate(&attr.claim_type, 19)),
+                Style::new().fg(COLOR_SOFT_PURPLE),
+            ),
+            Span::styled(
+                attr.provenance.label().to_string(),
+                // A credential-backed value is the one a holder must not expect
+                // to edit here, so its provenance is the part of the row that
+                // stands out rather than a footnote after they have tried.
+                if attr.provenance.is_editable_here() {
+                    Style::new().fg(COLOR_DARK_GRAY)
+                } else {
+                    Style::new().fg(COLOR_ORANGE)
+                },
+            ),
+        ]));
+        lines.push(Line::from(Span::styled(
+            format!(
+                "      {}",
+                truncate(&attr.display_value(state.show_values), 70)
+            ),
+            if attr.stale {
+                Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED)
+            } else {
+                Style::new().fg(COLOR_DARK_GRAY)
+            },
+        )));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Profiles
+// ---------------------------------------------------------------------------
+
+fn render_profiles(state: &PersonasState, lines: &mut Vec<Line<'static>>) {
+    if let Some(detail) = &state.open_profile {
+        lines.push(
+            Line::from(format!(" {}", detail.summary.display_name()))
+                .fg(COLOR_SUCCESS)
+                .bold(),
+        );
+        lines.push(Line::from(""));
+        if !detail.is_editable_here() {
+            super::status::push_status(lines, &detail.refusal(), " ");
+            lines.push(Line::from(""));
+        }
+        if detail.resolved.is_empty() {
+            lines.push(
+                Line::from(" This profile presents nothing — it has no entries.")
+                    .fg(COLOR_DARK_GRAY),
+            );
+        } else {
+            lines.push(
+                Line::from(format!(
+                    " Presents {} claim{}:",
+                    detail.resolved.len(),
+                    if detail.resolved.len() == 1 { "" } else { "s" }
+                ))
+                .fg(COLOR_TEXT_DEFAULT),
+            );
+            lines.push(Line::from(""));
+            for claim in &detail.resolved {
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("   {:<22}", truncate(&claim.claim_type, 21)),
+                        Style::new().fg(COLOR_SOFT_PURPLE),
+                    ),
+                    Span::styled(
+                        truncate(&claim.display_value(), 44),
+                        Style::new().fg(COLOR_TEXT_DEFAULT),
+                    ),
+                ]));
+                // An inline value lives only in this profile: it is not in the
+                // pool, so correcting it in the pool will not correct it here.
+                // Saying so on the row is the only place a holder finds out.
+                let origin = match claim.attribute_id {
+                    Some(_) => claim.provenance.label().to_string(),
+                    None => format!("{} · only in this profile", claim.provenance.label()),
+                };
+                lines.push(Line::from(Span::styled(
+                    format!("   {origin}"),
+                    Style::new().fg(COLOR_DARK_GRAY),
+                )));
+            }
+        }
+        lines.push(Line::from(""));
+        lines.push(Line::from(" ⏎/Esc: back   e: edit").fg(COLOR_DARK_GRAY));
+        return;
+    }
+
+    if push_agent_state(state, lines, "profiles") {
+        return;
+    }
+
+    lines.push(
+        Line::from(format!(
+            " {} profile{}",
+            state.profiles.len(),
+            if state.profiles.len() == 1 { "" } else { "s" }
+        ))
+        .fg(COLOR_TEXT_DEFAULT),
+    );
+    lines.push(Line::from(""));
+
+    if state.profiles.is_empty() {
+        lines.push(
+            Line::from(
+                " No profiles yet. A profile is a named subset of your pool — \"Work\", \
+                 \"Gaming\" — and it is what a face presents to a community.",
+            )
+            .fg(COLOR_DARK_GRAY),
+        );
+        return;
+    }
+
+    for (i, profile) in state.profiles.iter().enumerate() {
+        let is_selected = i == state.profile_selected;
+        let row_style = if is_selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if is_selected { "▸ " } else { "  " }, row_style),
+            Span::styled(
+                format!("{:<28}", truncate(profile.display_name(), 27)),
+                row_style,
+            ),
+            Span::styled(
+                format!(
+                    "{} entr{}",
+                    profile.entry_count,
+                    if profile.entry_count == 1 { "y" } else { "ies" }
+                ),
+                Style::new().fg(COLOR_DARK_GRAY),
+            ),
+        ]));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Communities
+// ---------------------------------------------------------------------------
+
+fn render_communities(state: &PersonasState, lines: &mut Vec<Line<'static>>) {
+    if state.memberships.is_empty() {
+        lines.push(Line::from(" You are not a member of any community yet.").fg(COLOR_DARK_GRAY));
+        return;
+    }
+
+    lines.push(
+        Line::from(format!(
+            " {} membership{}",
+            state.memberships.len(),
+            if state.memberships.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        ))
+        .fg(COLOR_TEXT_DEFAULT),
+    );
+    lines.push(Line::from(""));
+
+    for (i, m) in state.memberships.iter().enumerate() {
+        let is_selected = i == state.membership_selected;
+        let row_style = if is_selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if is_selected { "▸ " } else { "  " }, row_style),
+            Span::styled(truncate(&m.community_name, 30), row_style),
+            Span::styled(
+                format!("  as {}", truncate(&m.face_label, 24)),
+                Style::new().fg(COLOR_SOFT_PURPLE),
+            ),
+        ]));
+
+        // What that face tells them. `unknown` is drawn, never omitted: an
+        // omitted row is indistinguishable from a face bound to nothing, and
+        // "we have not asked" is not "you are sharing nothing".
+        let detail = format!(
+            "      {}  ·  {}",
+            m.status_label,
+            state.binding_for(m).describe()
+        );
+        lines.push(Line::from(Span::styled(
+            detail,
+            if is_selected {
+                Style::new().fg(COLOR_SOFT_PURPLE)
+            } else {
+                Style::new().fg(COLOR_DARK_GRAY)
+            },
+        )));
+
+        // The linkage line. Two communities shown one face can compare notes
+        // and find the same person behind both, and that is the consequence a
+        // holder cannot see by looking at either row on its own.
+        if m.shared_with > 0 {
+            lines.push(
+                Line::from(format!(
+                    "      ⚠ this face is also shown to {} other communit{}",
+                    m.shared_with,
+                    if m.shared_with == 1 { "y" } else { "ies" }
+                ))
+                .fg(COLOR_ORANGE),
+            );
+        }
+    }
+
+    lines.push(Line::from(""));
+    // The honest limit of this tab. A membership is held by a credential issued
+    // to one persona DID, so which face a community sees is fixed at the join —
+    // `b` changes what that face says, never who it is.
+    lines.push(
+        Line::from(
+            " `b` changes what a face presents here. To show a community a *different* face, join \
+             it again with that face — the membership credential is bound to the persona that \
+             joined.",
+        )
+        .fg(COLOR_DARK_GRAY),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Disclosures
+// ---------------------------------------------------------------------------
+
+fn render_disclosures(state: &PersonasState, lines: &mut Vec<Line<'static>>) {
+    if push_agent_state(state, lines, "disclosures") {
+        return;
+    }
+
+    lines.push(
+        Line::from(format!(
+            " {} disclosure{}, newest first",
+            state.disclosures.len(),
+            if state.disclosures.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        ))
+        .fg(COLOR_TEXT_DEFAULT),
+    );
+    lines.push(Line::from(""));
+
+    if state.disclosures.is_empty() {
+        lines.push(
+            Line::from(
+                " Nothing has been disclosed from this agent yet. A release happens when a \
+                 verifier asks and you approve it — this is the record of those, and it is \
+                 read-only.",
+            )
+            .fg(COLOR_DARK_GRAY),
+        );
+        return;
+    }
+
+    for (i, row) in state.disclosures.iter().enumerate() {
+        let is_selected = i == state.disclosure_selected;
+        let row_style = if is_selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if is_selected { "▸ " } else { "  " }, row_style),
+            Span::styled(
+                format!("{:<22}", truncate(&row.disclosed_at, 21)),
+                row_style,
+            ),
+            Span::styled(
+                truncate(&row.verifier_did, 44),
+                Style::new().fg(COLOR_SOFT_PURPLE),
+            ),
+        ]));
+        lines.push(Line::from(Span::styled(
+            format!("      {}", truncate(&row.describe_claims(), 70)),
+            Style::new().fg(COLOR_DARK_GRAY),
+        )));
+        // A durable credential is the one kind of release that is still live —
+        // and still revocable — rather than a thing that happened once.
+        if let Some(id) = &row.durable_credential_id {
+            lines.push(
+                Line::from(format!(
+                    "      ● still live as a credential ({})",
+                    truncate(id, 40)
+                ))
+                .fg(COLOR_ORANGE),
+            );
+        }
+    }
+}
+
+/// Draw the "we are still asking" / "we could not ask" states shared by the
+/// agent-served tabs. Returns true when it drew one and the caller should stop.
+///
+/// The failure case is why this exists: an empty list and an unreachable agent
+/// render identically unless something says otherwise, and of the two, "you
+/// hold no attributes" is the confident wrong answer (VTI R6.4).
+fn push_agent_state(state: &PersonasState, lines: &mut Vec<Line<'static>>, noun: &str) -> bool {
+    if let Some(error) = &state.load_error {
+        lines.push(
+            Line::from(format!(" Could not read your {noun} from the agent."))
+                .fg(COLOR_WARNING_ACCESSIBLE_RED),
+        );
+        lines.push(Line::from(""));
+        super::status::push_status(lines, error, " ");
+        lines.push(Line::from(""));
+        lines.push(Line::from(" r: try again").fg(COLOR_DARK_GRAY));
+        return true;
+    }
+    if state.loading && !state.loaded {
+        lines.push(Line::from(format!(" Reading your {noun}…")).fg(COLOR_DARK_GRAY));
+        return true;
+    }
+    if !state.loaded {
+        lines.push(
+            Line::from(format!(
+                " Your {noun} have not been read yet.   r: read them"
+            ))
+            .fg(COLOR_DARK_GRAY),
+        );
+        return true;
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// The attribute editor
+// ---------------------------------------------------------------------------
+
+fn render_attribute_form(form: &AttributeForm) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+    lines.push(
+        Line::from(if form.attribute_id.is_some() {
+            " Edit attribute"
+        } else {
+            " New attribute"
+        })
+        .fg(COLOR_SUCCESS)
+        .bold(),
+    );
+    lines.push(Line::from(""));
+    lines.push(
+        Line::from(
+            " A fact about you, held once. Profiles reference it, so correcting it here corrects \
+             it everywhere it is presented.",
+        )
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines.push(Line::from(""));
+
+    field(
+        &mut lines,
+        "Type",
+        form.claim_type.value(),
+        form.field == AttributeField::ClaimType,
+    );
+    lines.push(Line::from("      e.g. name.legal, email.work, phone.mobile").fg(COLOR_DARK_GRAY));
+    field(
+        &mut lines,
+        "Label",
+        form.label.value(),
+        form.field == AttributeField::Label,
+    );
+    field(
+        &mut lines,
+        "Value type",
+        &format!(
+            "◂ {} ▸",
+            VALUE_TYPES[form.value_type.min(VALUE_TYPES.len() - 1)]
+        ),
+        form.field == AttributeField::ValueType,
+    );
+    field(
+        &mut lines,
+        "Value",
+        form.value.value(),
+        form.field == AttributeField::Value,
+    );
+
+    lines.push(Line::from(""));
+    if let Some(error) = &form.error {
+        super::status::push_status(&mut lines, error, " ");
+        lines.push(Line::from(""));
+    }
+    lines.push(
+        Line::from(if form.working {
+            " Saving…"
+        } else {
+            " ⇥: next field   ←/→: value type   ⏎: save   Esc: cancel"
+        })
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines
+}
+
+// ---------------------------------------------------------------------------
+// The profile editor
+// ---------------------------------------------------------------------------
+
+fn render_profile_form(state: &PersonasState, form: &ProfileForm) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+    lines.push(
+        Line::from(if form.profile_id.is_some() {
+            " Edit profile"
+        } else {
+            " New profile"
+        })
+        .fg(COLOR_SUCCESS)
+        .bold(),
+    );
+    lines.push(Line::from(""));
+
+    field(
+        &mut lines,
+        "Name",
+        form.name.value(),
+        form.focus == ProfileFormFocus::Name,
+    );
+    lines.push(Line::from(""));
+
+    let list_style = if form.focus == ProfileFormFocus::Entries {
+        Style::new().fg(COLOR_SUCCESS).bold()
+    } else {
+        Style::new().fg(COLOR_DARK_GRAY)
+    };
+    lines.push(Line::from(Span::styled(
+        format!(" Shows these facts ({} ticked)", form.ticked.len()),
+        list_style,
+    )));
+    lines.push(Line::from(""));
+
+    if state.attributes.is_empty() {
+        lines.push(
+            Line::from("   Your pool is empty — add an attribute first.").fg(COLOR_DARK_GRAY),
+        );
+    } else {
+        for (i, attr) in state.attributes.iter().enumerate() {
+            let ticked = form.ticked.contains(&attr.attribute_id);
+            let is_cursor = form.focus == ProfileFormFocus::Entries && i == form.cursor;
+            let row_style = if is_cursor {
+                Style::new().fg(COLOR_SUCCESS).bold()
+            } else if ticked {
+                Style::new().fg(COLOR_TEXT_DEFAULT)
+            } else {
+                Style::new().fg(COLOR_DARK_GRAY)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(if is_cursor { " ▸ " } else { "   " }, row_style),
+                Span::styled(if ticked { "[x] " } else { "[ ] " }, row_style),
+                Span::styled(
+                    format!("{:<28}", truncate(attr.display_name(), 27)),
+                    row_style,
+                ),
+                Span::styled(
+                    truncate(&attr.claim_type, 24),
+                    Style::new().fg(COLOR_SOFT_PURPLE),
+                ),
+            ]));
+        }
+    }
+
+    // The entries this editor does not own, counted so a holder can see that
+    // saving will not lose them.
+    if !form.preserved.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(
+            Line::from(format!(
+                "   + {} pinned/overridden/inline entr{} kept as-is (edit with `pnm`)",
+                form.preserved.len(),
+                if form.preserved.len() == 1 {
+                    "y"
+                } else {
+                    "ies"
+                }
+            ))
+            .fg(COLOR_DARK_GRAY),
+        );
+    }
+
+    lines.push(Line::from(""));
+    if let Some(error) = &form.error {
+        super::status::push_status(&mut lines, error, " ");
+        lines.push(Line::from(""));
+    }
+    lines.push(
+        Line::from(if form.working {
+            " Saving…"
+        } else {
+            " ⇥: name/list   ↑/↓: move   Space: tick   ⏎: save   Esc: cancel"
+        })
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines
+}
+
+// ---------------------------------------------------------------------------
+// The bind picker
+// ---------------------------------------------------------------------------
+
+fn render_bind_picker(state: &PersonasState, picker: &BindPicker) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+    let Some(m) = state.memberships.get(picker.membership) else {
+        return lines;
+    };
+
+    lines.push(
+        Line::from(format!(
+            " What should {} present to {}?",
+            m.face_label, m.community_name
+        ))
+        .fg(COLOR_SUCCESS)
+        .bold(),
+    );
+    lines.push(Line::from(""));
+    lines.push(
+        Line::from(
+            " The values are copied into the community's context when you choose. It receives \
+             what the profile resolves to — never a reference back to your pool, and nothing \
+             about your other faces.",
+        )
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines.push(Line::from(""));
+
+    // Row 0 is always "nothing", because a face that deliberately presents
+    // nothing is a real choice and not the absence of one.
+    for (i, label) in bind_options(state).into_iter().enumerate() {
+        let is_cursor = i == picker.cursor;
+        let style = if is_cursor {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if is_cursor { " ▸ " } else { "   " }, style),
+            Span::styled(label, style),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+    if let Some(error) = &picker.error {
+        super::status::push_status(&mut lines, error, " ");
+        lines.push(Line::from(""));
+    }
+    lines.push(
+        Line::from(if picker.working {
+            " Applying…"
+        } else {
+            " ↑/↓: move   ⏎: apply   Esc: cancel"
+        })
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines
+}
+
+/// The picker's rows: "nothing", then every profile. Derived rather than stored
+/// so a profile added or renamed between opening the picker and reading it
+/// cannot show a stale name.
+pub fn bind_options(state: &PersonasState) -> Vec<String> {
+    let mut options = vec!["Nothing — present no identity here".to_string()];
+    options.extend(state.profiles.iter().map(|p| {
+        format!(
+            "{}  ({} entr{})",
+            p.display_name(),
+            p.entry_count,
+            if p.entry_count == 1 { "y" } else { "ies" }
+        )
+    }));
+    options
+}
+
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
+
+/// One labelled form field, with the focused one marked.
+fn field(lines: &mut Vec<Line<'static>>, label: &str, value: &str, focused: bool) {
+    let style = if focused {
+        Style::new().fg(COLOR_SUCCESS).bold()
+    } else {
+        Style::new().fg(COLOR_TEXT_DEFAULT)
+    };
+    lines.push(Line::from(vec![
+        Span::styled(if focused { " ▸ " } else { "   " }, style),
+        Span::styled(format!("{label:<12}"), Style::new().fg(COLOR_DARK_GRAY)),
+        Span::styled(value.to_string(), style),
+        Span::styled(if focused { "▏" } else { "" }, style),
+    ]));
+}
+
+/// Truncate for a fixed-width column, with an ellipsis so a cut is visible.
+fn truncate(text: &str, max: usize) -> String {
+    openvtc_core::display::truncate_chars(text, max).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::main_page::content::{ManagedDid, PersonaMembership};
+    use openvtc_core::persona::binding::BindingSummary;
+    use openvtc_core::persona::pool::PoolAttribute;
+
+    fn text(lines: &[Line<'static>]) -> String {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn loaded(state: &mut PersonasState) {
+        state.loaded = true;
+        state.loading = false;
+    }
+
+    /// The distinction the whole pane is built around: an agent that could not
+    /// be asked must never render as an empty pool. One of those sentences is a
+    /// confident claim about the holder's own data, and it would be wrong.
+    #[test]
+    fn an_unreachable_agent_never_reads_as_an_empty_pool() {
+        let mut state = PersonasState {
+            tab: PersonaTab::Attributes,
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+        let empty = text(&render(&state));
+        assert!(empty.contains("Nothing in the pool yet"), "{empty}");
+
+        state.load_error = Some("connection refused".to_string());
+        let failed = text(&render(&state));
+        assert!(
+            failed.contains("Could not read your attributes"),
+            "{failed}"
+        );
+        assert!(
+            failed.contains("connection refused"),
+            "the reason has to reach the operator: {failed}"
+        );
+        assert!(
+            !failed.contains("Nothing in the pool yet"),
+            "a failed read must not claim the pool is empty: {failed}"
+        );
+    }
+
+    /// Values are hidden until asked for, and the row says which state it is in
+    /// — otherwise "(hidden)" and "no value" are the same pixels.
+    #[test]
+    fn values_are_hidden_until_asked_for() {
+        let attr = PoolAttribute {
+            attribute_id: "01A".into(),
+            claim_type: "email.work".into(),
+            label: Some("Work email".into()),
+            ..PoolAttribute::default()
+        };
+        let mut state = PersonasState {
+            tab: PersonaTab::Attributes,
+            attributes: vec![attr].into(),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let hidden = text(&render(&state));
+        assert!(hidden.contains("values hidden"), "{hidden}");
+        assert!(hidden.contains("(hidden)"), "{hidden}");
+
+        state.show_values = true;
+        let shown = text(&render(&state));
+        assert!(shown.contains("values shown"), "{shown}");
+        assert!(
+            shown.contains("(no value)"),
+            "a listing that asked and got nothing says so: {shown}"
+        );
+    }
+
+    /// A face shown to more than one community carries the linkage warning.
+    /// Nothing else on screen lets a holder work that out from a single row.
+    #[test]
+    fn a_reused_face_is_flagged_as_linkable() {
+        let mut state = PersonasState {
+            tab: PersonaTab::Communities,
+            memberships: vec![
+                PersonaMembership {
+                    community_name: "Acme".into(),
+                    face_label: "Work me".into(),
+                    status_label: "Member".into(),
+                    shared_with: 1,
+                    ..PersonaMembership::default()
+                },
+                PersonaMembership {
+                    community_name: "Chess Club".into(),
+                    face_label: "Gaming me".into(),
+                    status_label: "Member".into(),
+                    shared_with: 0,
+                    ..PersonaMembership::default()
+                },
+            ]
+            .into(),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let out = text(&render(&state));
+        assert!(out.contains("also shown to 1 other community"), "{out}");
+        assert_eq!(
+            out.matches("also shown to").count(),
+            1,
+            "the face used once must not be flagged: {out}"
+        );
+    }
+
+    /// "We have not asked" and "presents nothing" are different sentences on a
+    /// membership row, for the same reason they are different in
+    /// `BindingSummary`.
+    #[test]
+    fn an_unasked_binding_reads_as_unknown_not_as_nothing() {
+        let membership = PersonaMembership {
+            community_name: "Acme".into(),
+            sub_context_id: "ctx".into(),
+            persona_did: "did:webvh:example.com:alice".into(),
+            face_label: "Work me".into(),
+            status_label: "Member".into(),
+            shared_with: 0,
+        };
+        let mut state = PersonasState {
+            tab: PersonaTab::Communities,
+            memberships: vec![membership.clone()].into(),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+        assert!(text(&render(&state)).contains("presents: unknown"));
+
+        state.bindings.insert(
+            ("ctx".to_string(), membership.persona_did.clone()),
+            BindingSummary::default(),
+        );
+        assert!(text(&render(&state)).contains("presents: nothing"));
+    }
+
+    /// The two delete questions are worded differently, and the cascading one
+    /// names the consequence the plain one does not have. Which is asked is
+    /// decided before the prompt appears — see `persona_actions`.
+    #[test]
+    fn a_cascading_delete_asks_a_visibly_different_question() {
+        let attr = PoolAttribute {
+            attribute_id: "01A".into(),
+            label: Some("Work email".into()),
+            ..PoolAttribute::default()
+        };
+        let mut state = PersonasState {
+            tab: PersonaTab::Attributes,
+            attributes: vec![attr].into(),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        state.confirm = PersonaConfirm::DeleteAttribute {
+            index: 0,
+            cascade: false,
+        };
+        let plain = text(&render(&state));
+        assert!(
+            plain.contains("Delete \"Work email\" from your pool?"),
+            "{plain}"
+        );
+        assert!(!plain.contains("profiles"), "{plain}");
+
+        state.confirm = PersonaConfirm::DeleteAttribute {
+            index: 0,
+            cascade: true,
+        };
+        let escalated = text(&render(&state));
+        assert!(
+            escalated.contains("used by one or more profiles"),
+            "{escalated}"
+        );
+    }
+
+    /// An armed confirmation replaces the key hints: a destructive question and
+    /// a menu of other keys do not belong on screen together.
+    #[test]
+    fn a_confirmation_replaces_the_key_hints() {
+        let mut state = PersonasState {
+            tab: PersonaTab::Faces,
+            faces: vec![ManagedDid {
+                did: "did:webvh:example.com:alice".into(),
+                label: "Work me".into(),
+                ..ManagedDid::default()
+            }]
+            .into(),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+        assert!(text(&render(&state)).contains("n: new face"));
+
+        state.confirm = PersonaConfirm::DeleteFace(0);
+        let armed = text(&render(&state));
+        assert!(armed.contains("Remove Work me"), "{armed}");
+        assert!(!armed.contains("n: new face"), "{armed}");
+    }
+
+    /// The destructive confirm names what the operator selected *and* keeps the
+    /// DID, so it is both recognisable and unambiguous. Moved here with the
+    /// list it prompts over.
+    #[test]
+    fn the_face_prompt_keeps_both_the_name_and_the_did() {
+        const DID: &str = "did:webvh:QmScidAliceAAAAAAAAAAAAAAAAAAAAAA:example.com:alice";
+        let mut state = PersonasState {
+            tab: PersonaTab::Faces,
+            faces: vec![ManagedDid {
+                did: DID.into(),
+                agent_name: Some("example.com/@alice".into()),
+                label: String::new(),
+                bound_communities: 0,
+                is_active: false,
+            }]
+            .into(),
+            confirm: PersonaConfirm::DeleteFace(0),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let out = text(&render(&state));
+        let prompt = out
+            .lines()
+            .find(|l| l.starts_with("Remove "))
+            .expect("confirm prompt rendered");
+        assert!(prompt.contains("example.com/@alice"), "{prompt}");
+        // The DID is centre-truncated, so both ends must still be checkable.
+        assert!(prompt.contains("did:webvh:QmScidAlice"), "{prompt}");
+        assert!(prompt.contains("example.com:alice"), "{prompt}");
+        assert!(prompt.contains("y: confirm"), "{prompt}");
+    }
+
+    /// With no name at all the prompt falls back to the DID alone — never to an
+    /// empty parenthetical or a nameless "this identity".
+    #[test]
+    fn the_face_prompt_without_a_name_shows_the_did() {
+        const DID: &str = "did:webvh:QmScidAliceAAAAAAAAAAAAAAAAAAAAAA:example.com:alice";
+        let mut state = PersonasState {
+            tab: PersonaTab::Faces,
+            faces: vec![ManagedDid {
+                did: DID.into(),
+                ..ManagedDid::default()
+            }]
+            .into(),
+            confirm: PersonaConfirm::DeleteFace(0),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let out = text(&render(&state));
+        let prompt = out
+            .lines()
+            .find(|l| l.starts_with("Remove "))
+            .expect("confirm prompt rendered");
+        assert!(prompt.contains("did:webvh:QmScidAlice"), "{prompt}");
+        assert!(prompt.contains("example.com:alice"), "{prompt}");
+        assert!(
+            !prompt.contains('('),
+            "no empty name parenthetical: {prompt}"
+        );
+    }
+
+    /// The picker always offers "nothing" first, and it is worded as a choice
+    /// rather than as an empty row.
+    #[test]
+    fn the_bind_picker_offers_nothing_as_a_first_class_choice() {
+        let state = PersonasState::default();
+        let options = bind_options(&state);
+        assert_eq!(options.len(), 1);
+        assert!(options[0].starts_with("Nothing"));
+    }
+
+    /// The disclosure history is read-only and says so, and an empty one says
+    /// what a release even is — the tab is where a holder goes to ask "what
+    /// does anyone already know", and an unexplained blank answers nothing.
+    #[test]
+    fn an_empty_history_explains_itself_rather_than_going_blank() {
+        let mut state = PersonasState {
+            tab: PersonaTab::Disclosures,
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let out = text(&render(&state));
+        assert!(out.contains("Nothing has been disclosed"), "{out}");
+        assert!(out.contains("read-only"), "{out}");
+        // No verbs beyond navigation and refresh: this pane cannot disclose.
+        assert!(!out.contains("n: new"), "{out}");
+    }
+
+    /// Every claim carries the rung it went out at, and a release that is still
+    /// live as a credential is marked as such — it is the one kind that can
+    /// still be revoked rather than only regretted.
+    #[test]
+    fn a_disclosure_row_shows_its_rungs_and_flags_a_live_credential() {
+        use openvtc_core::persona::disclosure::{DisclosedClaim, DisclosureRow};
+        let mut state = PersonasState {
+            tab: PersonaTab::Disclosures,
+            disclosures: vec![
+                DisclosureRow {
+                    verifier_did: "did:webvh:example.com:acme".into(),
+                    disclosed_at: "2026-09-06T10:00:00Z".into(),
+                    claims: vec![
+                        DisclosedClaim {
+                            claim_type: "email.work".into(),
+                            rung: "whole".into(),
+                        },
+                        DisclosedClaim {
+                            claim_type: "age.over18".into(),
+                            rung: "predicate".into(),
+                        },
+                    ],
+                    durable_credential_id: Some("urn:cred:1".into()),
+                    ..DisclosureRow::default()
+                },
+                DisclosureRow {
+                    verifier_did: "did:webvh:example.com:chess".into(),
+                    disclosed_at: "2026-09-05T10:00:00Z".into(),
+                    ..DisclosureRow::default()
+                },
+            ]
+            .into(),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let out = text(&render(&state));
+        assert!(out.contains("email.work (whole)"), "{out}");
+        assert!(out.contains("age.over18 (predicate)"), "{out}");
+        assert_eq!(
+            out.matches("still live as a credential").count(),
+            1,
+            "only the durable one is flagged: {out}"
+        );
+    }
+
+    /// A resolved claim with no pool attribute behind it is marked, because
+    /// correcting the pool will not correct it.
+    #[test]
+    fn an_inline_claim_says_it_lives_only_in_the_profile() {
+        use openvtc_core::persona::profile::{ProfileDetail, ProfileSummary, ResolvedClaim};
+        let mut state = PersonasState {
+            tab: PersonaTab::Profiles,
+            open_profile: Some(ProfileDetail {
+                summary: ProfileSummary {
+                    profile_id: "01P".into(),
+                    name: "Work".into(),
+                    ..ProfileSummary::default()
+                },
+                resolved: vec![
+                    ResolvedClaim {
+                        claim_type: "email.work".into(),
+                        value: Some(serde_json::json!("a@b.c")),
+                        attribute_id: Some("01A".into()),
+                        ..ResolvedClaim::default()
+                    },
+                    ResolvedClaim {
+                        claim_type: "nickname".into(),
+                        value: Some(serde_json::json!("Ace")),
+                        attribute_id: None,
+                        ..ResolvedClaim::default()
+                    },
+                ],
+                ..ProfileDetail::default()
+            }),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let out = text(&render(&state));
+        assert_eq!(
+            out.matches("only in this profile").count(),
+            1,
+            "exactly the inline claim is marked: {out}"
+        );
+    }
+}

--- a/openvtc/src/ui/pages/main/components/personas_panel.rs
+++ b/openvtc/src/ui/pages/main/components/personas_panel.rs
@@ -847,14 +847,10 @@ fn render_profile_form(state: &PersonasState, form: &ProfileForm) -> Vec<Line<'s
 
 fn render_bind_picker(state: &PersonasState, picker: &BindPicker) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from("")];
-    let Some(m) = state.memberships.get(picker.membership) else {
-        return lines;
-    };
-
     lines.push(
         Line::from(format!(
             " What should {} present to {}?",
-            m.face_label, m.community_name
+            picker.face_label, picker.community
         ))
         .fg(COLOR_SUCCESS)
         .bold(),

--- a/openvtc/src/ui/pages/main/components/personas_panel.rs
+++ b/openvtc/src/ui/pages/main/components/personas_panel.rs
@@ -142,45 +142,35 @@ fn confirm_prompt(state: &PersonasState) -> Option<String> {
             };
             Some(format!("Remove {name}?   y: confirm    n: cancel"))
         }
-        PersonaConfirm::DeleteAttribute { index, cascade } => {
-            let attr = state.attributes.get(*index)?;
+        PersonaConfirm::DeleteAttribute { name, cascade, .. } => {
             if *cascade {
-                // The escalated ask, and it names the consequence the first one
-                // did not have: profiles that show this value stop showing it.
+                // The cascading question names the consequence the plain one
+                // does not have: profiles that show this value stop showing it.
                 Some(format!(
-                    "\"{}\" is used by one or more profiles. Delete it AND remove it from them?   \
-                     y: confirm    n: cancel",
-                    attr.display_name()
+                    "\"{name}\" is used by one or more profiles. Delete it AND remove it from \
+                     them?   y: confirm    n: cancel"
                 ))
             } else {
                 Some(format!(
-                    "Delete \"{}\" from your pool?   y: confirm    n: cancel",
-                    attr.display_name()
+                    "Delete \"{name}\" from your pool?   y: confirm    n: cancel"
                 ))
             }
         }
-        PersonaConfirm::DeleteProfile { index, unbind } => {
-            let profile = state.profiles.get(*index)?;
+        PersonaConfirm::DeleteProfile { name, unbind, .. } => {
             if *unbind {
                 Some(format!(
-                    "A face still presents \"{}\". Delete it and leave that face presenting \
-                     nothing?   y: confirm    n: cancel",
-                    profile.display_name()
+                    "A face still presents \"{name}\". Delete it and leave that face presenting \
+                     nothing?   y: confirm    n: cancel"
                 ))
             } else {
                 Some(format!(
-                    "Delete the profile \"{}\"?   y: confirm    n: cancel",
-                    profile.display_name()
+                    "Delete the profile \"{name}\"?   y: confirm    n: cancel"
                 ))
             }
         }
-        PersonaConfirm::Unbind(index) => {
-            let m = state.memberships.get(*index)?;
-            Some(format!(
-                "Stop presenting anything to {}?   y: confirm    n: cancel",
-                m.community_name
-            ))
-        }
+        PersonaConfirm::Unbind { community, .. } => Some(format!(
+            "Stop presenting anything to {community}?   y: confirm    n: cancel"
+        )),
     }
 }
 
@@ -1117,7 +1107,8 @@ mod tests {
         loaded(&mut state);
 
         state.confirm = PersonaConfirm::DeleteAttribute {
-            index: 0,
+            attribute_id: "01A".into(),
+            name: "Work email".into(),
             cascade: false,
         };
         let plain = text(&render(&state));
@@ -1128,7 +1119,8 @@ mod tests {
         assert!(!plain.contains("profiles"), "{plain}");
 
         state.confirm = PersonaConfirm::DeleteAttribute {
-            index: 0,
+            attribute_id: "01A".into(),
+            name: "Work email".into(),
             cascade: true,
         };
         let escalated = text(&render(&state));

--- a/openvtc/src/ui/pages/main/components/vta_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vta_panel.rs
@@ -4,7 +4,7 @@ use crate::colors::{
     COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
 };
 use crate::state_handler::{
-    main_page::content::{ContentPanelState, VicLifecycle, VtaFocus, VtaState, VtaTransport},
+    main_page::content::{ContentPanelState, VicLifecycle, VtaState, VtaTransport},
     state::ConnectionState,
 };
 use openvtc_core::display::{display_identifier, truncate_did_centered};
@@ -162,8 +162,8 @@ pub fn render(state: &VtaState, panel_focused: bool) -> Vec<Line<'static>> {
 
     // Active DIDs — the persona plus one relationship pseudonym (R-DID) per
     // relationship. Suppressed when it holds nothing but the persona: that row
-    // duplicates the one already marked `active` in Context Identities below,
-    // and a section that restates the row under it is noise, not structure.
+    // duplicates the "Persona:" row above it, and a section that restates the
+    // row above it is noise, not structure.
     let active_dids_worth_showing = state
         .active_dids
         .iter()
@@ -196,144 +196,20 @@ pub fn render(state: &VtaState, panel_focused: bool) -> Vec<Line<'static>> {
         }
     }
 
-    // Context identities — every persona DID in this context, with its binding.
-    // Orphans (no community) are flagged so they can be spotted and removed.
-    if !state.context_dids.is_empty() {
-        // Same focus affordance the VIC section carries. Without it this list
-        // showed a `▸` selection cursor and a key-hint row with no indication
-        // that it was the focused list — the two lists looked equally live.
-        let focused = panel_focused && state.focus == VtaFocus::Dids;
-        lines.push(Line::from(""));
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!(" Context Identities ({})", state.context_dids.len()),
-                if focused {
-                    Style::new().fg(COLOR_SUCCESS).bold()
-                } else {
-                    Style::new().fg(COLOR_DARK_GRAY).bold()
-                },
-            ),
-            Span::styled(
-                focus_hint(focused, panel_focused),
-                Style::new().fg(COLOR_DARK_GRAY),
-            ),
-        ]));
-        lines.push(Line::from(""));
-
-        for (i, d) in state.context_dids.iter().enumerate() {
-            // Only the focused list shows a selection cursor, so `↑/↓` never
-            // appears to be driving two lists at once (matches the VIC rows).
-            let is_selected = focused && i == state.did_selected_index;
-            let orphan = d.bound_communities == 0;
-            let prefix = if is_selected { "▸ " } else { "  " };
-            let marker = if orphan { "○ " } else { "● " };
-            let marker_style = if orphan {
-                Style::new().fg(COLOR_ORANGE)
-            } else {
-                Style::new().fg(COLOR_SUCCESS)
-            };
-            let did_style = if is_selected {
-                Style::new().fg(COLOR_SUCCESS).bold()
-            } else {
-                Style::new().fg(COLOR_TEXT_DEFAULT)
-            };
-            lines.push(Line::from(vec![
-                Span::styled(prefix, marker_style),
-                Span::styled(marker, marker_style),
-                Span::styled(
-                    display_identifier(d.agent_name.as_deref(), &d.did, ID_WIDTH).into_owned(),
-                    did_style,
-                ),
-            ]));
-
-            let name = if d.label.is_empty() {
-                "persona".to_string()
-            } else {
-                d.label.clone()
-            };
-            let active = if d.is_active { "  ·  active" } else { "" };
-            let binding = if orphan {
-                "orphan — no community".to_string()
-            } else {
-                format!(
-                    "{} communit{}",
-                    d.bound_communities,
-                    if d.bound_communities == 1 { "y" } else { "ies" }
-                )
-            };
-            let binding_style = if orphan {
-                Style::new().fg(COLOR_ORANGE)
-            } else {
-                Style::new().fg(COLOR_DARK_GRAY)
-            };
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("      {name}{active}  ·  "),
-                    Style::new().fg(COLOR_DARK_GRAY),
-                ),
-                Span::styled(binding, binding_style),
-            ]));
-        }
-
-        // Confirmation prompt (a delete is armed) or, when focused, the
-        // navigation/remove hint. The spacer goes with them — an unfocused list
-        // ends at its last row rather than trailing a blank.
-        if state.confirm_delete_did.is_some() || focused {
-            lines.push(Line::from(""));
-        }
-        if let Some(idx) = state.confirm_delete_did {
-            // Keep *both* the name and the DID. The row the operator selected
-            // shows the name, so a DID-only prompt names something they never
-            // saw; but a destructive confirm must stay unambiguous, so the DID
-            // is not dropped either — it is centre-truncated to keep the line
-            // readable while both ends stay checkable.
-            let target = match state.context_dids.get(idx) {
-                Some(d) => {
-                    let did = truncate_did_centered(&d.did, CONFIRM_DID_WIDTH);
-                    match d.agent_name.as_deref() {
-                        Some(name) => format!("{name} ({did})"),
-                        None => did.into_owned(),
-                    }
-                }
-                None => "this identity".to_string(),
-            };
-            lines.push(
-                Line::from(format!("Remove {target}?   y: confirm    n: cancel"))
-                    .fg(COLOR_ORANGE)
-                    .bold(),
-            );
-        } else if focused {
-            // Same verb order as the VIC hints: navigation, then create, then
-            // the rest, each `key: verb` with the same separator.
-            lines.push(
-                Line::from("↑/↓ select   n: new persona   g: agent names   d: remove orphan")
-                    .fg(COLOR_DARK_GRAY),
-            );
-        }
-    } else {
-        // No personas yet: still surface how to mint one.
-        lines.push(Line::from(""));
-        lines.push(
-            Line::from("No persona DIDs yet.   n: create a new persona DID").fg(COLOR_DARK_GRAY),
-        );
-    }
-
     render_vics(state, panel_focused, &mut lines);
 
     lines
 }
 
-/// The focus affordance for one of the two manageable lists.
+/// The focus affordance for the invitation-credential list.
 ///
-/// Three states, not two: the list has the keyboard, the *other* list has it
-/// (Tab switches between them), or the content panel is not focused at all — in
-/// which case Tab does not reach these lists and the operator needs the panel
-/// first. Collapsing the last two into "\[Tab\] focus" pointed at the wrong key.
-fn focus_hint(focused: bool, panel_focused: bool) -> &'static str {
-    match (focused, panel_focused) {
-        (true, _) => "   ◀ focus",
-        (false, true) => "   [Tab] focus",
-        (false, false) => "   [→] focus the panel",
+/// Two states now that it is the panel's only list: it has the keyboard, or the
+/// content panel does not and the operator needs the panel first. The third
+/// state — "the *other* list has it" — went with the persona list.
+fn focus_hint(focused: bool) -> &'static str {
+    match focused {
+        true => "   ◀ focus",
+        false => "   [→] focus the panel",
     }
 }
 
@@ -475,7 +351,9 @@ fn render_transports(state: &VtaState, lines: &mut Vec<Line<'static>>) {
 /// Render the "Invitation Credentials" (VIC) manager section: the held VICs with
 /// their lifecycle state, the confirm gates, and the focus-aware key hints.
 fn render_vics(state: &VtaState, panel_focused: bool, lines: &mut Vec<Line<'static>>) {
-    let focused = panel_focused && state.focus == VtaFocus::Vics;
+    // The only list on this panel, so it has the keyboard whenever the panel
+    // does — there is no longer a second list to Tab between.
+    let focused = panel_focused;
     let header_style = if focused {
         Style::new().fg(COLOR_SUCCESS).bold()
     } else {
@@ -488,10 +366,7 @@ fn render_vics(state: &VtaState, panel_focused: bool, lines: &mut Vec<Line<'stat
             format!(" Invitation Credentials ({})", state.vics.len()),
             header_style,
         ),
-        Span::styled(
-            focus_hint(focused, panel_focused),
-            Style::new().fg(COLOR_DARK_GRAY),
-        ),
+        Span::styled(focus_hint(focused), Style::new().fg(COLOR_DARK_GRAY)),
         // The vault query runs off the loop now, so the list can be visibly
         // mid-load. Saying so is the difference between "you hold no VICs" and
         // "we haven't heard back yet" — the panel used to render both as the
@@ -606,7 +481,7 @@ fn render_vics(state: &VtaState, panel_focused: bool, lines: &mut Vec<Line<'stat
 mod tests {
     use super::*;
     use crate::state_handler::main_page::content::{
-        ActiveDid, AdvertisedTransports, ManagedDid, VicSummary, VtaTransports,
+        ActiveDid, AdvertisedTransports, VicSummary, VtaTransports,
     };
 
     const PERSONA_DID: &str = "did:webvh:QmScidAliceAAAAAAAAAAAAAAAAAAAA:example.com:alice";
@@ -625,16 +500,6 @@ mod tests {
             .collect()
     }
 
-    fn managed_did(agent_name: Option<&str>) -> ManagedDid {
-        ManagedDid {
-            did: PERSONA_DID.to_string(),
-            agent_name: agent_name.map(str::to_owned),
-            label: "Work me".to_string(),
-            bound_communities: 0,
-            is_active: false,
-        }
-    }
-
     fn vic(issuer_agent_name: Option<&str>) -> VicSummary {
         VicSummary {
             id: "urn:vic:1".to_string(),
@@ -646,9 +511,8 @@ mod tests {
         }
     }
 
-    fn state_with(dids: Vec<ManagedDid>, vics: Vec<VicSummary>) -> VtaState {
+    fn state_with(vics: Vec<VicSummary>) -> VtaState {
         VtaState {
-            context_dids: dids.into(),
             vics: vics.into(),
             ..VtaState::default()
         }
@@ -919,7 +783,7 @@ mod tests {
     // --- section suppression ------------------------------------------------
 
     /// "Active DIDs" holding nothing but the persona restates the row already
-    /// marked `active` in Context Identities, so it is suppressed.
+    /// already named on the "Persona:" row above, so it is suppressed.
     #[test]
     fn active_dids_is_hidden_when_it_only_restates_the_persona() {
         let mut state = vta_managed(None);
@@ -957,60 +821,39 @@ mod tests {
 
     // --- focus cues ---------------------------------------------------------
 
-    /// Both manageable lists carry the same focus affordance, and only the
-    /// focused one shows a selection cursor and its key hints.
+    /// The invitation-credential list carries the panel's focus affordance and
+    /// shows its cursor and hints only when the content panel has the keyboard.
+    ///
+    /// It used to have to say which of *two* lists was focused; the persona
+    /// list has moved to the identity pane, so the remaining question is just
+    /// whether this panel is the focused one.
     #[test]
-    fn only_the_focused_identity_list_shows_a_cursor_and_hints() {
-        let mut state = state_with(vec![managed_did(None)], vec![vic(None)]);
+    fn the_vic_list_shows_a_cursor_and_hints_only_when_the_panel_is_focused() {
+        let state = state_with(vec![vic(None)]);
 
-        state.focus = VtaFocus::Dids;
         let focused = joined(&render(&state, true));
-        assert!(
-            focused.contains("Context Identities (1)   ◀ focus"),
-            "{focused}"
-        );
+        assert!(focused.contains("◀ focus"), "{focused}");
         assert!(
             focused.contains("▸ "),
             "cursor shown when focused: {focused}"
         );
-        assert!(focused.contains("n: new persona"), "{focused}");
 
-        state.focus = VtaFocus::Vics;
-        let unfocused = joined(&render(&state, true));
+        let unfocused = joined(&render(&state, false));
         assert!(
-            unfocused.contains("Context Identities (1)   [Tab] focus"),
-            "{unfocused}"
+            !unfocused.contains("◀ focus"),
+            "the list does not have the keyboard when the panel does not: {unfocused}"
         );
-        assert!(
-            !unfocused.contains("n: new persona"),
-            "hints belong to the focused list: {unfocused}"
-        );
+        assert!(unfocused.contains("[→] focus the panel"), "{unfocused}");
     }
 
-    /// With the content panel itself unfocused, neither list may claim the
-    /// keyboard. Both lists used to draw their affordance from `state.focus`
-    /// alone, so a panel whose keys are all discarded still announced "◀ focus"
-    /// and advertised `g` / `n` / `d` — the shortest path to "I pressed the key
-    /// and nothing happened".
+    /// The persona list, and the `n` / `g` / `d` verbs that acted on it, are
+    /// gone from this panel — they live on the identity pane, and a panel that
+    /// still advertised them would be advertising keys it no longer handles.
     #[test]
-    fn an_unfocused_panel_points_at_the_panel_not_the_lists() {
-        let mut state = state_with(vec![managed_did(None)], vec![vic(None)]);
-        state.focus = VtaFocus::Dids;
-
-        let out = joined(&render(&state, false));
-        assert!(
-            !out.contains("◀ focus"),
-            "no list has the keyboard when the panel does not: {out}"
-        );
-        assert!(
-            !out.contains("[Tab] focus"),
-            "Tab is not the key that helps here: {out}"
-        );
-        assert!(out.contains("[→] focus the panel"), "{out}");
-        assert!(
-            !out.contains("n: new persona"),
-            "hints belong to a list the keyboard can reach: {out}"
-        );
+    fn the_persona_list_is_no_longer_on_this_panel() {
+        let out = joined(&render(&state_with(vec![vic(None)]), true));
+        assert!(!out.contains("Context Identities"), "{out}");
+        assert!(!out.contains("n: new persona"), "{out}");
     }
 
     /// An in-flight vault query is visible. "No invitation credentials" is a
@@ -1018,7 +861,7 @@ mod tests {
     /// before this the load was inline, so the panel simply froze instead.
     #[test]
     fn a_loading_vic_list_says_so_instead_of_claiming_none() {
-        let mut state = state_with(vec![managed_did(None)], vec![]);
+        let mut state = state_with(vec![]);
         state.vic_loading = true;
 
         let out = joined(&render(&state, true));
@@ -1038,7 +881,7 @@ mod tests {
     #[test]
     fn vic_row_shows_the_issuers_verified_agent_name() {
         let out = text(&render(
-            &state_with(vec![], vec![vic(Some("example.com/@acme"))]),
+            &state_with(vec![vic(Some("example.com/@acme"))]),
             true,
         ));
         assert!(
@@ -1054,51 +897,10 @@ mod tests {
     /// A cached negative lookup arrives as `None`, so the row keeps the DID.
     #[test]
     fn vic_row_without_a_name_keeps_the_issuer_did() {
-        let out = text(&render(&state_with(vec![], vec![vic(None)]), true));
+        let out = text(&render(&state_with(vec![vic(None)]), true));
         assert!(
             out.iter().any(|l| l.contains(VTC_DID)),
             "issuer DID is shown: {out:?}"
-        );
-    }
-
-    // --- delete-confirm prompt (KEEP-BOTH) ----------------------------------
-
-    /// The destructive confirm names what the operator selected *and* keeps the
-    /// DID, so it is both recognisable and unambiguous.
-    #[test]
-    fn delete_confirm_keeps_both_the_name_and_the_did() {
-        let mut state = state_with(vec![managed_did(Some("example.com/@alice"))], vec![]);
-        state.confirm_delete_did = Some(0);
-        let out = text(&render(&state, true));
-
-        let prompt = out
-            .iter()
-            .find(|l| l.starts_with("Remove "))
-            .expect("confirm prompt rendered");
-        assert!(prompt.contains("example.com/@alice"), "{prompt}");
-        // The DID is centre-truncated, so both ends must still be checkable.
-        assert!(prompt.contains("did:webvh:QmScidAlice"), "{prompt}");
-        assert!(prompt.contains("example.com:alice"), "{prompt}");
-        assert!(prompt.contains("y: confirm"), "{prompt}");
-    }
-
-    /// With no verified name (uncached or a cached negative) the prompt falls
-    /// back to the DID alone — never to an empty or name-less "this identity".
-    #[test]
-    fn delete_confirm_without_a_name_shows_the_did() {
-        let mut state = state_with(vec![managed_did(None)], vec![]);
-        state.confirm_delete_did = Some(0);
-        let out = text(&render(&state, true));
-
-        let prompt = out
-            .iter()
-            .find(|l| l.starts_with("Remove "))
-            .expect("confirm prompt rendered");
-        assert!(prompt.contains("did:webvh:QmScidAlice"), "{prompt}");
-        assert!(prompt.contains("example.com:alice"), "{prompt}");
-        assert!(
-            !prompt.contains('('),
-            "no empty name parenthetical: {prompt}"
         );
     }
 }

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -176,9 +176,6 @@ impl Component for MainPage {
             KeyCode::Enter => {
                 if self.props.main_page.menu_panel.selected_menu == MainMenu::Quit {
                     let _ = self.action_tx.send(Action::Exit);
-                } else if self.props.main_page.menu_panel.selected_menu == MainMenu::CreatePersona {
-                    // Action item, not a panel: open the overlay (like Quit→Exit).
-                    let _ = self.action_tx.send(Action::StartCreatePersona);
                 } else if self.props.main_page.menu_panel.selected {
                     let _ = self
                         .action_tx
@@ -355,21 +352,23 @@ impl MainPage {
             MainMenu::Logs => self.handle_logs_key(key),
             MainMenu::Help => self.handle_help_key(key),
             MainMenu::Communities => self.handle_communities_key(key),
+            MainMenu::Personas => self.handle_personas_key(key),
             MainMenu::Vta => self.handle_vta_key(key),
             _ => false,
         }
     }
 
-    /// VTA Service / DID-manager keys: ↑/↓ move the Context-Identities
-    /// selection, `d`/Del removes the selected **orphan** (unbound) DID after a
-    /// y/n confirmation. Returns true if consumed.
+    /// VTA Service keys. The panel's one manageable list is the invitation
+    /// credentials: ↑/↓ move the selection, `a` imports, `i` flips the archived
+    /// filter, `r`/`u`/`d`/`p` drive the lifecycle. Returns true if consumed.
+    ///
+    /// The persona DID list that used to share this panel — and the `n`, `g`
+    /// and `d` verbs that acted on it — moved to the identity pane, which is
+    /// where the rest of a persona's management already lives.
     fn handle_vta_key(&mut self, key: KeyEvent) -> bool {
-        use crate::state_handler::main_page::content::{VicLifecycle, VtaFocus};
+        use crate::state_handler::main_page::content::VicLifecycle;
 
         let vta = &self.props.main_page.content_panel.vta;
-        let did_count = vta.context_dids.len();
-        let did_selected = vta.did_selected_index;
-        let focus = vta.focus;
         let vic_count = vta.vics.len();
         let vic_selected = vta.vic_selected_index;
         let vic_lifecycle = vta.vics.get(vic_selected).map(|v| v.lifecycle);
@@ -391,142 +390,291 @@ impl MainPage {
             let _ = self.action_tx.send(act);
             return true;
         }
-        // DID deletion confirmation: only y/Enter confirms; anything else cancels.
-        if let Some(idx) = vta.confirm_delete_did {
-            match key.code {
-                KeyCode::Char('y') | KeyCode::Enter => {
-                    let _ = self.action_tx.send(Action::DeleteDid(idx));
-                }
-                _ => {
-                    let _ = self.action_tx.send(Action::DidCancelDelete);
-                }
-            }
-            return true;
-        }
 
-        // Keys that apply regardless of which list has focus.
         match key.code {
+            // The list is read on demand rather than polled, and this is the
+            // key that asks. It was Tab because Tab moved focus onto the list
+            // and the load rode along; with one list left, the load is the
+            // whole of what the key does.
             KeyCode::Tab => {
-                // Focus moves first, then the VIC list is loaded on demand (no
-                // polling). Order matters: the handler services actions in
-                // sequence, so sending the load first put a vault round-trip in
-                // front of a pure in-memory focus change. The load is off the
-                // loop now, but the focus change still goes first — it is what
-                // the operator pressed the key for.
-                let _ = self.action_tx.send(Action::VicFocusToggle);
-                if focus == VtaFocus::Dids {
-                    let _ = self.action_tx.send(Action::VicRefresh);
-                }
-                return true;
-            }
-            KeyCode::Char('n') => {
-                // Mint a new standalone persona DID (also on the top-level menu).
-                let _ = self.action_tx.send(Action::StartCreatePersona);
-                return true;
+                let _ = self.action_tx.send(Action::VicRefresh);
+                true
             }
             KeyCode::Char('a') => {
                 let _ = self.action_tx.send(Action::StartAddVic);
-                return true;
+                true
             }
             KeyCode::Char('i') => {
                 let _ = self.action_tx.send(Action::VicToggleInactive);
-                return true;
-            }
-            // Manage the selected persona's agent names (claim / park / remove).
-            // Deliberately focus-independent, alongside `n` and `a`: while this
-            // sat in the DID-list arm, pressing it with the VIC list focused was
-            // swallowed with no message and no state change — indistinguishable
-            // from a dead keyboard, and the reported symptom that sent someone
-            // restarting the app. The selection it acts on is the DID list's,
-            // which Tab does not move.
-            KeyCode::Char('g') => {
-                let _ = self
-                    .action_tx
-                    .send(Action::StartAgentNameManager(did_selected));
-                return true;
+                true
             }
             KeyCode::Esc => {
                 let _ = self
                     .action_tx
                     .send(Action::MainPanelSwitch(MainPanel::MainMenu));
+                true
+            }
+            KeyCode::Up if vic_count > 0 => {
+                let _ = self
+                    .action_tx
+                    .send(Action::VicSelect(vic_selected.saturating_sub(1)));
+                true
+            }
+            KeyCode::Down if vic_count > 0 => {
+                let _ = self
+                    .action_tx
+                    .send(Action::VicSelect((vic_selected + 1).min(vic_count - 1)));
+                true
+            }
+            // r: archive an active VIC (reversible, so no confirm).
+            KeyCode::Char('r') if vic_lifecycle == Some(VicLifecycle::Active) => {
+                let _ = self.action_tx.send(Action::VicArchive(vic_selected));
+                true
+            }
+            // u: unarchive an archived VIC, or restore a soft-deleted one.
+            KeyCode::Char('u') => {
+                match vic_lifecycle {
+                    Some(VicLifecycle::Archived) => {
+                        let _ = self.action_tx.send(Action::VicUnarchive(vic_selected));
+                    }
+                    Some(VicLifecycle::Deleted) => {
+                        let _ = self.action_tx.send(Action::VicRestore(vic_selected));
+                    }
+                    _ => {}
+                }
+                true
+            }
+            // d: soft-delete (not already deleted).
+            KeyCode::Char('d') | KeyCode::Delete
+                if vic_selected < vic_count && vic_lifecycle != Some(VicLifecycle::Deleted) =>
+            {
+                let _ = self.action_tx.send(Action::VicConfirmDelete(vic_selected));
+                true
+            }
+            // p: irreversible purge.
+            KeyCode::Char('p') if vic_selected < vic_count => {
+                let _ = self.action_tx.send(Action::VicConfirmPurge(vic_selected));
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Identity-pane keys.
+    ///
+    /// Three layers, in this order, and the order is what keeps them legible:
+    /// an open form or picker owns every key; then an armed confirmation owns
+    /// `y`/`n`; then the active tab's own verbs apply. Anything reaching layer
+    /// three has already been shown to be unambiguous.
+    fn handle_personas_key(&mut self, key: KeyEvent) -> bool {
+        use crate::state_handler::actions::PersonaAction as PA;
+        use crate::state_handler::main_page::content::{
+            PersonaConfirm, PersonaMode, PersonaTab, ProfileFormFocus,
+        };
+
+        let personas = &self.props.main_page.content_panel.personas;
+        let send = |action: PA| {
+            let _ = self.action_tx.send(Action::Persona(action));
+            true
+        };
+
+        // ── An open form or picker owns the keyboard ──────────────────────
+        match &personas.mode {
+            PersonaMode::Attribute(form) => {
+                // A write is in flight: swallow input rather than editing a
+                // form whose result is already on the wire.
+                if form.working {
+                    return true;
+                }
+                return match key.code {
+                    KeyCode::Esc => send(PA::FormCancel),
+                    KeyCode::Enter => send(PA::FormSubmit),
+                    KeyCode::Tab | KeyCode::Down => send(PA::FormField(true)),
+                    KeyCode::BackTab | KeyCode::Up => send(PA::FormField(false)),
+                    KeyCode::Right => send(PA::FormCycle(true)),
+                    KeyCode::Left => send(PA::FormCycle(false)),
+                    _ => send(PA::FormKey(key)),
+                };
+            }
+            PersonaMode::Profile(form) => {
+                if form.working {
+                    return true;
+                }
+                let on_entries = form.focus == ProfileFormFocus::Entries;
+                return match key.code {
+                    KeyCode::Esc => send(PA::FormCancel),
+                    KeyCode::Enter => send(PA::FormSubmit),
+                    KeyCode::Tab => send(PA::FormField(true)),
+                    KeyCode::BackTab => send(PA::FormField(false)),
+                    KeyCode::Down if on_entries => send(PA::FormCycle(true)),
+                    KeyCode::Up if on_entries => send(PA::FormCycle(false)),
+                    // Only a keystroke *on the list* ticks an entry. On the
+                    // name field a space is a space — a form that swallowed it
+                    // would refuse to let a profile be called "Work laptop".
+                    KeyCode::Char(' ') if on_entries => send(PA::FormToggleEntry),
+                    _ => send(PA::FormKey(key)),
+                };
+            }
+            PersonaMode::Bind(picker) => {
+                if picker.working {
+                    return true;
+                }
+                return match key.code {
+                    KeyCode::Esc => send(PA::FormCancel),
+                    KeyCode::Enter => send(PA::FormSubmit),
+                    KeyCode::Down => send(PA::FormCycle(true)),
+                    KeyCode::Up => send(PA::FormCycle(false)),
+                    _ => true,
+                };
+            }
+            PersonaMode::View => {}
+        }
+
+        // ── An armed confirmation owns y/n ────────────────────────────────
+        //
+        // Removing a face goes through the existing identity-deletion path
+        // (`DeleteDid`), which does the VTA delete, the listener teardown and
+        // the local cleanup. The pane owns the *question*; it does not own a
+        // second implementation of the answer.
+        match personas.confirm {
+            PersonaConfirm::None => {}
+            PersonaConfirm::DeleteFace(i) => {
+                let act = match key.code {
+                    KeyCode::Char('y') | KeyCode::Enter => Action::DeleteDid(i),
+                    _ => Action::DidCancelDelete,
+                };
+                let _ = self.action_tx.send(act);
                 return true;
             }
+            _ => {
+                return match key.code {
+                    KeyCode::Char('y') | KeyCode::Enter => send(PA::ConfirmYes),
+                    _ => send(PA::ConfirmNo),
+                };
+            }
+        }
+
+        // ── Tab navigation and the pane-wide verbs ────────────────────────
+        match key.code {
+            KeyCode::Tab | KeyCode::Right => return send(PA::TabNext),
+            KeyCode::BackTab | KeyCode::Left => return send(PA::TabPrev),
+            KeyCode::Esc => {
+                // Esc backs out of the opened profile first, so it is not also
+                // the key that leaves the panel while a detail view is up.
+                if personas.open_profile.is_some() {
+                    return send(PA::ProfileClose);
+                }
+                let _ = self
+                    .action_tx
+                    .send(Action::MainPanelSwitch(MainPanel::MainMenu));
+                return true;
+            }
+            KeyCode::Char('r') if personas.tab.needs_agent() => return send(PA::Refresh),
             _ => {}
         }
 
-        // List-scoped keys act on whichever list has focus.
-        match focus {
-            VtaFocus::Dids => match key.code {
-                KeyCode::Up if did_count > 0 => {
-                    let _ = self
-                        .action_tx
-                        .send(Action::DidSelect(did_selected.saturating_sub(1)));
-                    true
-                }
-                KeyCode::Down if did_count > 0 => {
-                    let _ = self
-                        .action_tx
-                        .send(Action::DidSelect((did_selected + 1).min(did_count - 1)));
-                    true
-                }
-                KeyCode::Char('d') | KeyCode::Delete if did_selected < did_count => {
-                    // Only orphan (unbound) personas are removable.
-                    if vta
-                        .context_dids
-                        .get(did_selected)
-                        .is_some_and(|d| d.bound_communities == 0)
-                    {
-                        let _ = self.action_tx.send(Action::DidConfirmDelete(did_selected));
+        match personas.tab {
+            PersonaTab::Faces => {
+                let count = personas.faces.len();
+                let selected = personas.face_selected;
+                match key.code {
+                    KeyCode::Up if count > 0 => {
+                        let _ = self
+                            .action_tx
+                            .send(Action::DidSelect(selected.saturating_sub(1)));
+                        true
                     }
-                    true
-                }
-                _ => false,
-            },
-            VtaFocus::Vics => match key.code {
-                KeyCode::Up if vic_count > 0 => {
-                    let _ = self
-                        .action_tx
-                        .send(Action::VicSelect(vic_selected.saturating_sub(1)));
-                    true
-                }
-                KeyCode::Down if vic_count > 0 => {
-                    let _ = self
-                        .action_tx
-                        .send(Action::VicSelect((vic_selected + 1).min(vic_count - 1)));
-                    true
-                }
-                // r: archive an active VIC (reversible, so no confirm).
-                KeyCode::Char('r') if vic_lifecycle == Some(VicLifecycle::Active) => {
-                    let _ = self.action_tx.send(Action::VicArchive(vic_selected));
-                    true
-                }
-                // u: unarchive an archived VIC, or restore a soft-deleted one.
-                KeyCode::Char('u') => {
-                    match vic_lifecycle {
-                        Some(VicLifecycle::Archived) => {
-                            let _ = self.action_tx.send(Action::VicUnarchive(vic_selected));
-                        }
-                        Some(VicLifecycle::Deleted) => {
-                            let _ = self.action_tx.send(Action::VicRestore(vic_selected));
-                        }
-                        _ => {}
+                    KeyCode::Down if count > 0 => {
+                        let _ = self
+                            .action_tx
+                            .send(Action::DidSelect((selected + 1).min(count - 1)));
+                        true
                     }
-                    true
+                    KeyCode::Char('n') => {
+                        let _ = self.action_tx.send(Action::StartCreatePersona);
+                        true
+                    }
+                    KeyCode::Char('g') => {
+                        let _ = self.action_tx.send(Action::StartAgentNameManager(selected));
+                        true
+                    }
+                    // Only an orphan is removable: a face a community still
+                    // presents cannot be deleted without leaving that community
+                    // first, and the deletion path refuses it anyway. Refusing
+                    // to *arm* it keeps the prompt from appearing over a
+                    // question that has already been answered no.
+                    KeyCode::Char('d') | KeyCode::Delete if selected < count => {
+                        if personas
+                            .faces
+                            .get(selected)
+                            .is_some_and(|f| f.bound_communities == 0)
+                        {
+                            let _ = self.action_tx.send(Action::DidConfirmDelete(selected));
+                        }
+                        true
+                    }
+                    _ => false,
                 }
-                // d: soft-delete (not already deleted).
-                KeyCode::Char('d') | KeyCode::Delete
-                    if vic_selected < vic_count && vic_lifecycle != Some(VicLifecycle::Deleted) =>
-                {
-                    let _ = self.action_tx.send(Action::VicConfirmDelete(vic_selected));
-                    true
+            }
+            PersonaTab::Attributes => {
+                let count = personas.attributes.len();
+                let selected = personas.attribute_selected;
+                match key.code {
+                    KeyCode::Up if count > 0 => send(PA::Select(selected.saturating_sub(1))),
+                    KeyCode::Down if count > 0 => send(PA::Select((selected + 1).min(count - 1))),
+                    KeyCode::Char('v') => send(PA::ToggleValues),
+                    KeyCode::Char('n') => send(PA::AttributeNew),
+                    KeyCode::Char('e') if selected < count => send(PA::AttributeEdit(selected)),
+                    KeyCode::Char('d') | KeyCode::Delete if selected < count => {
+                        send(PA::AttributeDeleteArm(selected))
+                    }
+                    _ => false,
                 }
-                // p: irreversible purge.
-                KeyCode::Char('p') if vic_selected < vic_count => {
-                    let _ = self.action_tx.send(Action::VicConfirmPurge(vic_selected));
-                    true
+            }
+            PersonaTab::Profiles => {
+                let count = personas.profiles.len();
+                let selected = personas.profile_selected;
+                // The opened detail view is a mode of this tab, not of the
+                // pane, so its keys live here.
+                if personas.open_profile.is_some() {
+                    return match key.code {
+                        KeyCode::Enter => send(PA::ProfileClose),
+                        KeyCode::Char('e') => send(PA::ProfileEdit(selected)),
+                        _ => false,
+                    };
                 }
-                _ => false,
-            },
+                match key.code {
+                    KeyCode::Up if count > 0 => send(PA::Select(selected.saturating_sub(1))),
+                    KeyCode::Down if count > 0 => send(PA::Select((selected + 1).min(count - 1))),
+                    KeyCode::Enter if selected < count => send(PA::ProfileOpen(selected)),
+                    KeyCode::Char('n') => send(PA::ProfileNew),
+                    KeyCode::Char('e') if selected < count => send(PA::ProfileEdit(selected)),
+                    KeyCode::Char('d') | KeyCode::Delete if selected < count => {
+                        send(PA::ProfileDeleteArm(selected))
+                    }
+                    _ => false,
+                }
+            }
+            PersonaTab::Disclosures => {
+                let count = personas.disclosures.len();
+                let selected = personas.disclosure_selected;
+                match key.code {
+                    KeyCode::Up if count > 0 => send(PA::Select(selected.saturating_sub(1))),
+                    KeyCode::Down if count > 0 => send(PA::Select((selected + 1).min(count - 1))),
+                    _ => false,
+                }
+            }
+            PersonaTab::Communities => {
+                let count = personas.memberships.len();
+                let selected = personas.membership_selected;
+                match key.code {
+                    KeyCode::Up if count > 0 => send(PA::Select(selected.saturating_sub(1))),
+                    KeyCode::Down if count > 0 => send(PA::Select((selected + 1).min(count - 1))),
+                    KeyCode::Char('b') if selected < count => send(PA::BindOpen(selected)),
+                    KeyCode::Char('u') if selected < count => send(PA::UnbindArm(selected)),
+                    _ => false,
+                }
+            }
         }
     }
 
@@ -2853,10 +3001,11 @@ mod key_handler_tests {
     //! `Action` and its sub-enums derive neither `PartialEq` nor `Debug`, so
     //! assertions pattern-match the expected variant rather than `assert_eq!`.
     use super::*;
+    use crate::state_handler::actions::PersonaAction;
     use crate::state_handler::main_page::content::{
         CommunitySummary, CommunitySwitcherState, CredentialTab, CredentialsMode, InboxConfirm,
-        RawCredential, RelationshipSummary, RelationshipsMode, SwitcherItem, TaskKind, TaskSummary,
-        VrcSummary,
+        ManagedDid, PersonaConfirm, PersonaMode, PersonaTab, RawCredential, RelationshipSummary,
+        RelationshipsMode, SwitcherItem, TaskKind, TaskSummary, VrcSummary,
     };
     use crossterm::event::KeyModifiers;
     use std::sync::Arc;
@@ -3240,12 +3389,38 @@ mod key_handler_tests {
         }
     }
 
-    // ----- VTA / DID manager -------------------------------------------------
+    // ----- Identity pane: faces ---------------------------------------------
 
+    fn face(did: &str, label: &str, bound: usize) -> ManagedDid {
+        ManagedDid {
+            did: did.to_string(),
+            agent_name: None,
+            label: label.to_string(),
+            bound_communities: bound,
+            is_active: false,
+        }
+    }
+
+    /// Two faces, the second one an orphan and selected.
+    fn faces_with_orphan_selected() -> impl Fn(&mut State) {
+        move |s: &mut State| {
+            let p = &mut s.main_page.content_panel.personas;
+            p.faces = vec![
+                face("did:webvh:example.com:alice", "Alice", 1),
+                face("did:webvh:example.com:bob", "Bob", 0),
+            ]
+            .into();
+            p.face_selected = 1;
+        }
+    }
+
+    /// Removing a face is armed here and answered by the existing
+    /// identity-deletion path — the pane owns the question, not a second
+    /// implementation of the answer.
     #[test]
-    fn vta_confirm_commits_and_cancels() {
-        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
-            s.main_page.content_panel.vta.confirm_delete_did = Some(1);
+    fn personas_face_confirm_commits_and_cancels() {
+        let (mut page, mut rx) = page_for(MainMenu::Personas, |s| {
+            s.main_page.content_panel.personas.confirm = PersonaConfirm::DeleteFace(1);
         });
         page.handle_key_event(press(KeyCode::Enter));
         match rx.try_recv() {
@@ -3253,8 +3428,8 @@ mod key_handler_tests {
             _ => panic!("expected DeleteDid(1)"),
         }
 
-        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
-            s.main_page.content_panel.vta.confirm_delete_did = Some(0);
+        let (mut page, mut rx) = page_for(MainMenu::Personas, |s| {
+            s.main_page.content_panel.personas.confirm = PersonaConfirm::DeleteFace(0);
         });
         page.handle_key_event(press(KeyCode::Esc));
         match rx.try_recv() {
@@ -3263,11 +3438,33 @@ mod key_handler_tests {
         }
     }
 
-    // ----- Create persona ----------------------------------------------------
+    /// Only an orphan arms: a face a community still presents cannot be
+    /// deleted without leaving that community, and the deletion path refuses
+    /// it. Arming anyway would put a question that has already been answered.
+    #[test]
+    fn personas_d_arms_only_on_an_orphan_face() {
+        let (mut page, mut rx) = page_for(MainMenu::Personas, faces_with_orphan_selected());
+        page.handle_key_event(press(KeyCode::Char('d')));
+        match rx.try_recv() {
+            Ok(Action::DidConfirmDelete(1)) => {}
+            _ => panic!("expected DidConfirmDelete(1)"),
+        }
+
+        let (mut page, mut rx) = page_for(MainMenu::Personas, |s| {
+            let p = &mut s.main_page.content_panel.personas;
+            p.faces = vec![face("did:webvh:example.com:alice", "Alice", 1)].into();
+            p.face_selected = 0;
+        });
+        page.handle_key_event(press(KeyCode::Char('d')));
+        assert!(
+            rx.try_recv().is_err(),
+            "a face a community presents must not arm a deletion"
+        );
+    }
 
     #[test]
-    fn vta_n_opens_create_persona() {
-        let (mut page, mut rx) = page_for(MainMenu::Vta, |_| {});
+    fn personas_n_opens_create_persona() {
+        let (mut page, mut rx) = page_for(MainMenu::Personas, |_| {});
         page.handle_key_event(press(KeyCode::Char('n')));
         match rx.try_recv() {
             Ok(Action::StartCreatePersona) => {}
@@ -3276,28 +3473,8 @@ mod key_handler_tests {
     }
 
     #[test]
-    fn vta_g_opens_agent_name_manager_for_selected_persona() {
-        use crate::state_handler::main_page::content::ManagedDid;
-        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
-            s.main_page.content_panel.vta.context_dids = vec![
-                ManagedDid {
-                    did: "did:webvh:example.com:alice".into(),
-                    agent_name: None,
-                    label: "Alice".into(),
-                    bound_communities: 1,
-                    is_active: true,
-                },
-                ManagedDid {
-                    did: "did:webvh:example.com:bob".into(),
-                    agent_name: None,
-                    label: "Bob".into(),
-                    bound_communities: 0,
-                    is_active: false,
-                },
-            ]
-            .into();
-            s.main_page.content_panel.vta.did_selected_index = 1;
-        });
+    fn personas_g_opens_agent_name_manager_for_the_selected_face() {
+        let (mut page, mut rx) = page_for(MainMenu::Personas, faces_with_orphan_selected());
         page.handle_key_event(press(KeyCode::Char('g')));
         match rx.try_recv() {
             Ok(Action::StartAgentNameManager(1)) => {}
@@ -3305,29 +3482,142 @@ mod key_handler_tests {
         }
     }
 
-    /// `g` works with either list focused. It used to live in the DID-list arm,
-    /// so pressing it after a Tab was swallowed silently — no action, no state
-    /// change, no message. The selection it acts on is the DID list's, which Tab
-    /// does not move, so the target is unambiguous either way.
+    // ----- Identity pane: tabs and their verbs -------------------------------
+
+    /// Tab moves between the pane's four tabs; the verbs that follow belong to
+    /// whichever one is showing.
     #[test]
-    fn vta_g_opens_agent_name_manager_from_the_vic_list_too() {
-        use crate::state_handler::main_page::content::{ManagedDid, VtaFocus};
-        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
-            s.main_page.content_panel.vta.context_dids = vec![ManagedDid {
-                did: "did:webvh:example.com:alice".into(),
-                agent_name: None,
-                label: "Alice".into(),
-                bound_communities: 1,
-                is_active: true,
-            }]
-            .into();
-            s.main_page.content_panel.vta.focus = VtaFocus::Vics;
-        });
-        page.handle_key_event(press(KeyCode::Char('g')));
-        match rx.try_recv() {
-            Ok(Action::StartAgentNameManager(0)) => {}
-            _ => panic!("expected StartAgentNameManager(0)"),
+    fn personas_tab_moves_between_tabs() {
+        let (mut page, mut rx) = page_for(MainMenu::Personas, |_| {});
+        page.handle_key_event(press(KeyCode::Tab));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::Persona(PersonaAction::TabNext))
+        ));
+
+        let (mut page, mut rx) = page_for(MainMenu::Personas, |_| {});
+        page.handle_key_event(press(KeyCode::BackTab));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::Persona(PersonaAction::TabPrev))
+        ));
+    }
+
+    /// The attribute verbs only fire on the Attributes tab, and only with a row
+    /// under the cursor.
+    #[test]
+    fn personas_attribute_keys_map_to_actions() {
+        use openvtc_core::persona::pool::PoolAttribute;
+        let open = || {
+            page_for(MainMenu::Personas, |s| {
+                let p = &mut s.main_page.content_panel.personas;
+                p.tab = PersonaTab::Attributes;
+                p.attributes = vec![PoolAttribute {
+                    attribute_id: "01A".into(),
+                    ..PoolAttribute::default()
+                }]
+                .into();
+            })
+        };
+
+        for (key, want) in [
+            (KeyCode::Char('n'), PersonaAction::AttributeNew),
+            (KeyCode::Char('e'), PersonaAction::AttributeEdit(0)),
+            (KeyCode::Char('d'), PersonaAction::AttributeDeleteArm(0)),
+            (KeyCode::Char('v'), PersonaAction::ToggleValues),
+            (KeyCode::Char('r'), PersonaAction::Refresh),
+        ] {
+            let (mut page, mut rx) = open();
+            page.handle_key_event(press(key));
+            match rx.try_recv() {
+                Ok(Action::Persona(got)) => assert_eq!(
+                    std::mem::discriminant(&got),
+                    std::mem::discriminant(&want),
+                    "{key:?}"
+                ),
+                _ => panic!("expected a persona action for {key:?}"),
+            }
         }
+    }
+
+    /// An armed confirmation owns `y`/`n` — every other pane verb is suppressed
+    /// while a destructive question is on screen.
+    #[test]
+    fn personas_confirmation_owns_the_keyboard() {
+        let armed = || {
+            page_for(MainMenu::Personas, |s| {
+                let p = &mut s.main_page.content_panel.personas;
+                p.tab = PersonaTab::Attributes;
+                p.confirm = PersonaConfirm::DeleteAttribute {
+                    index: 0,
+                    cascade: false,
+                };
+            })
+        };
+
+        let (mut page, mut rx) = armed();
+        page.handle_key_event(press(KeyCode::Char('y')));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::Persona(PersonaAction::ConfirmYes))
+        ));
+
+        // `n` would open the attribute editor if it reached the tab. It does
+        // not: while a question is armed it is the answer "no".
+        let (mut page, mut rx) = armed();
+        page.handle_key_event(press(KeyCode::Char('n')));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::Persona(PersonaAction::ConfirmNo))
+        ));
+    }
+
+    /// A space is a space on the name field, and a tick on the entry list. A
+    /// form that swallowed it everywhere could not name a profile "Work
+    /// laptop".
+    #[test]
+    fn personas_space_ticks_only_on_the_entry_list() {
+        use crate::state_handler::main_page::content::{ProfileForm, ProfileFormFocus};
+        let with_focus = |focus: ProfileFormFocus| {
+            page_for(MainMenu::Personas, move |s| {
+                s.main_page.content_panel.personas.mode = PersonaMode::Profile(ProfileForm {
+                    focus,
+                    ..ProfileForm::default()
+                });
+            })
+        };
+
+        let (mut page, mut rx) = with_focus(ProfileFormFocus::Entries);
+        page.handle_key_event(press(KeyCode::Char(' ')));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::Persona(PersonaAction::FormToggleEntry))
+        ));
+
+        let (mut page, mut rx) = with_focus(ProfileFormFocus::Name);
+        page.handle_key_event(press(KeyCode::Char(' ')));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(Action::Persona(PersonaAction::FormKey(_)))
+        ));
+    }
+
+    /// A form with a write in flight swallows input rather than editing a
+    /// request that is already on the wire.
+    #[test]
+    fn personas_a_working_form_swallows_input() {
+        use crate::state_handler::main_page::content::AttributeForm;
+        let (mut page, mut rx) = page_for(MainMenu::Personas, |s| {
+            s.main_page.content_panel.personas.mode = PersonaMode::Attribute(AttributeForm {
+                working: true,
+                ..AttributeForm::default()
+            });
+        });
+        page.handle_key_event(press(KeyCode::Char('x')));
+        assert!(
+            rx.try_recv().is_err(),
+            "no action while a save is in flight"
+        );
     }
 
     #[test]
@@ -3441,17 +3731,21 @@ mod key_handler_tests {
         );
     }
 
+    /// The menu's identity entry opens a panel like every other one.
+    ///
+    /// It used to be "Create Persona DID" — a menu item that fired an action
+    /// instead of switching panels, because minting was the only persona verb
+    /// the TUI had. Everything it stood for is now a key inside the pane.
     #[test]
-    fn menu_enter_on_create_persona_opens_overlay() {
-        // The top-level "Create Persona DID" item is an action, not a panel.
-        let (mut page, mut rx) = page_for(MainMenu::CreatePersona, |s| {
+    fn menu_enter_on_identity_switches_to_the_panel() {
+        let (mut page, mut rx) = page_for(MainMenu::Personas, |s| {
             s.main_page.menu_panel.selected = true;
             s.main_page.content_panel.selected = false;
         });
         page.handle_key_event(press(KeyCode::Enter));
         match rx.try_recv() {
-            Ok(Action::StartCreatePersona) => {}
-            _ => panic!("expected StartCreatePersona"),
+            Ok(Action::MainPanelSwitch(MainPanel::ContentPanel)) => {}
+            _ => panic!("expected a switch to the content panel"),
         }
     }
 
@@ -3460,7 +3754,7 @@ mod key_handler_tests {
         use crate::state_handler::main_page::content::CreatePersonaState;
         // The open overlay owns all input regardless of the focused panel.
         let open = || {
-            page_for(MainMenu::Vta, |s| {
+            page_for(MainMenu::Personas, |s| {
                 s.main_page.create_persona = Some(CreatePersonaState::default());
             })
         };
@@ -3491,7 +3785,7 @@ mod key_handler_tests {
     fn create_persona_done_phase_keys() {
         use crate::state_handler::main_page::content::{CreatePersonaPhase, CreatePersonaState};
         let done = || {
-            page_for(MainMenu::Vta, |s| {
+            page_for(MainMenu::Personas, |s| {
                 s.main_page.create_persona = Some(CreatePersonaState {
                     phase: CreatePersonaPhase::Done,
                     did: Some("did:webvh:example:alice".to_string()),
@@ -3520,7 +3814,7 @@ mod key_handler_tests {
     // ----- VIC manager -------------------------------------------------------
 
     use crate::state_handler::main_page::content::{
-        AddVicPhase, AddVicState, VicLifecycle, VicSummary, VtaFocus,
+        AddVicPhase, AddVicState, VicLifecycle, VicSummary,
     };
 
     fn vic(id: &str, lifecycle: VicLifecycle) -> VicSummary {
@@ -3534,11 +3828,10 @@ mod key_handler_tests {
         }
     }
 
-    /// Focus the VIC list with the given rows selected at index 0.
+    /// The VIC list with the given rows, selected at index 0.
     fn vta_vics(rows: Vec<VicSummary>) -> impl Fn(&mut State) {
         move |s: &mut State| {
             let vta = &mut s.main_page.content_panel.vta;
-            vta.focus = VtaFocus::Vics;
             vta.vics = rows.clone().into();
             vta.vic_selected_index = 0;
         }
@@ -3554,35 +3847,20 @@ mod key_handler_tests {
         }
     }
 
+    /// Tab asks for the invitation-credential listing.
+    ///
+    /// It used to *also* move focus, because the panel held two lists and the
+    /// load rode along with the focus change. With the persona list moved to
+    /// the identity pane there is one list left, and asking for it is the whole
+    /// of what the key does.
     #[test]
-    fn vta_tab_toggles_focus_before_refreshing() {
-        // From the default (Dids) focus, Tab switches lists *first*, then asks
-        // for the VIC listing. The reverse order (what this asserted before) put
-        // a credential-vault round-trip in front of the focus change in the
-        // handler's serial queue, so Tab visibly lagged by the length of a
-        // network call.
+    fn vta_tab_asks_for_the_vic_listing() {
         let (mut page, mut rx) = page_for(MainMenu::Vta, |_| {});
         page.handle_key_event(press(KeyCode::Tab));
         match rx.try_recv() {
-            Ok(Action::VicFocusToggle) => {}
-            _ => panic!("focus must move first, before any VIC listing"),
-        }
-        match rx.try_recv() {
             Ok(Action::VicRefresh) => {}
-            _ => panic!("expected VicRefresh second"),
+            _ => panic!("expected VicRefresh"),
         }
-    }
-
-    /// Tab back off the VIC list does not re-list: the listing is loaded on
-    /// demand when the list is entered, not on every focus change.
-    #[test]
-    fn vta_tab_off_the_vic_list_does_not_refresh() {
-        use crate::state_handler::main_page::content::VtaFocus;
-        let (mut page, mut rx) = page_for(MainMenu::Vta, |s| {
-            s.main_page.content_panel.vta.focus = VtaFocus::Vics;
-        });
-        page.handle_key_event(press(KeyCode::Tab));
-        assert!(matches!(rx.try_recv(), Ok(Action::VicFocusToggle)));
         assert!(rx.try_recv().is_err(), "no second action expected");
     }
 

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -3549,7 +3549,8 @@ mod key_handler_tests {
                 let p = &mut s.main_page.content_panel.personas;
                 p.tab = PersonaTab::Attributes;
                 p.confirm = PersonaConfirm::DeleteAttribute {
-                    index: 0,
+                    attribute_id: "01A".into(),
+                    name: "Work email".into(),
                     cascade: false,
                 };
             })

--- a/tasks/follow-ups.md
+++ b/tasks/follow-ups.md
@@ -24,6 +24,31 @@ single call site). Closes the last deferred item from the multi-community spec
 Deferred from the multi-community plan; never scoped. No config-model or UI
 support for rotating a persona's keys today.
 
+### [ ] Identity pane — the four `persona/*` verbs it does not offer
+The pane (`ui/pages/main/components/personas_panel.rs` + `state_handler/persona_actions.rs`)
+covers faces, the pool, profiles, bindings and the disclosure history. Four
+parts of the family are deliberately not on it, each for a reason worth keeping:
+
+- **Authoring a credential-backed or generated attribute.** Both are shown and
+  neither is editable. A credential-backed one names a `credentialId` and a
+  `claimPath`, so authoring one means a credential picker *and* a JSON-Pointer
+  picker into its subject; a generated one has no single value to edit. Until
+  those pickers exist, `pool::put` writes self-asserted attributes only and
+  `AttributeDraft` has no provenance field to pass anything else through.
+- **Pinned / override / inline profile entries.** Read, carried through a save
+  untouched, and left to `pnm persona profile`. Each is a divergence between
+  what a profile shows and what the pool holds, which is a decision worth naming
+  out loud rather than producing as a side effect of a checkbox.
+- **`disclosure/preview` + `present`.** Driven by a verifier's request, and
+  OpenVTC has nothing asking. A "disclose something now" button would be a
+  request with no requester — the shape the two-call gate exists to prevent.
+  The wallet (`vta-browser-plugin`) is where that belongs.
+- **`contact/*` and `correlation/analyze`.** Contacts are what *peers* disclosed
+  to the holder, which is a relationships question rather than an identity one.
+  Correlation analysis is the natural next thing to hang off an attribute row
+  (`persona_correlation_analyze` takes an `attributeId`) and is the cheapest of
+  the four to add: one call, one detail line, no new flow.
+
 ---
 
 ## Small / unscheduled


### PR DESCRIPTION
Persona management was in four places and mostly in none of them: minting a DID
was a menu item that fired an action, the list of personas was a section of the
VTA Service panel, what each face presents was one clause on a communities row,
and the three layers above those — the attribute pool, the profiles over it, and
the bindings deciding what a community is shown — were reachable only from
`pnm persona`.

**"My Identity"** replaces all of it. Five tabs, in the order the concepts build
on each other:

| Tab | Answers | Verbs |
|---|---|---|
| **Faces** | which identities do I have | `n` new · `g` agent names · `d` remove orphan |
| **Attributes** | what do I hold about myself | `n` · `e` · `d` · `v` values · `r` |
| **Profiles** | what do I choose to show | `⏎` what it presents · `n` · `e` · `d` · `r` |
| **Communities** | who sees which of it | `b` choose what this face shows · `u` show nothing |
| **Disclosures** | what has actually left | read-only |

Faces come from `Config` and draw with no session; the other four come from the
agent, over the `persona/*` Trust Tasks the SDK already exposes (no bump — 0.32.4
has the whole family).

## Per-community faces, and the honest limit

A membership row says which face a community sees, what that face presents, and
**whether the same face is shown elsewhere** — the linkage that lets two
communities compare notes and find one person behind both, and the one thing a
holder cannot work out from a single row.

`b` changes what a face presents there. Showing a community a *different* face
means joining again with it — the membership credential is bound to the persona
that joined — and the tab says so rather than offering a control that would fail.

## Four decisions worth reviewing as decisions

- **Values are opt-in and cost a round-trip.** The pool is listed without values;
  `v` re-reads *with* them. Not a display flag over data already in memory: a
  listing that holds values has read the holder's identity whether or not the
  panel painted it. Opening the editor on an attribute whose value is not in hand
  re-reads first, so a save cannot blank a value nobody saw.
- **"We could not ask" is never drawn as "you hold nothing."** Every agent-served
  tab renders the failure and its reason instead of an empty list (R6.4).
- **Destructive questions are asked once, correctly.** Deleting an attribute a
  profile references needs a cascade; deleting a profile a face presents needs an
  unbind. Both are knowable from data the pane already holds, so the first prompt
  names the real consequence instead of being refused and re-asked — being asked
  a second, larger question trains a holder to answer it with the first
  question's reasoning.
- **The editor authors what it can honestly author.** Self-asserted attributes and
  live profile references. A credential-backed attribute is shown and refused
  (retyping its value manufactures an attested claim from a typed string); an
  unrecognised provenance parses as credential-backed for the same reason. A
  profile's pinned/overridden/inline entries are read, written back untouched,
  and left to `pnm`; one this build cannot parse makes the profile read-only,
  because a save that cannot round-trip an entry cannot preserve it and the loss
  would be invisible.

## Two bugs found while reviewing my own diff

Both the same shape, both fixed in their own commits:

- A confirmation held an **index** into a list that every read rebuilds. A refresh
  landing while the prompt was on screen reordered the pool underneath it, so `y`
  deleted whatever now occupied that row while the prompt named what the operator
  had selected. `PersonaConfirm` now carries the id.
- The bind picker held an index into the membership list, which is rebuilt on
  every `Config` sync — an inbound message is enough. It now carries the
  `(context, persona)` pair it will write.

## Shape

`persona_actions::apply` is pure and returns a `PersonaEffect` naming the network
work; the loop spawns it and folds the result back on the loop thread, so the
single-mutator invariant holds and every decision is testable without a
`VtaClient`. Reads and writes share one `DispatchDomain`, so a listing cannot
overtake the write that invalidated it. A rejected read is deferred; a rejected
write is refused and **its form handed back**, because a submitted form is locked
until an answer arrives and a request that never left has none coming.

`openvtc_core::persona` gains `pool`, `profile` and `disclosure` beside the
existing `binding`, with the holder/context boundary in the module header: the
holder pushes a materialised projection down, and nothing in `pool` or `profile`
can name a context.

## Also

The VTA Service panel is about the agent again — its identity list and the
`n`/`g`/`d` verbs moved, and with one list left `Tab` asks for the
invitation-credential listing rather than switching a focus with nowhere to go.

Deferred, with reasons, in `tasks/follow-ups.md`: authoring credential-backed or
generated attributes (needs a credential + JSON-Pointer picker), pinned/override/
inline entries, `disclosure/preview`+`present` (a request with no requester —
that belongs in the wallet), contacts, and correlation analysis (the cheapest of
the five to add next).

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new reqwest::Client::new() / bare fetch(); all clients have finite timeouts (R1.2)
      — every call goes through VtaClient::dispatch_trust_task (30 s SDK timeout)
- [x] No lock held across a network await (R1.3)
- [x] No local state committed before its remote effect (R2.1) — the pane holds
      no persisted state; view state changes only on the outcome
- [x] Every retry is bounded + backed off (R1.4) — no retries; the refresh flag
      is single-shot and cleared before it spawns
- [x] Accept/poll/listen loops survive transient errors (R1.5) — n/a
- [x] Acks/deletes happen only after durable handoff (R1.6) — n/a
- [x] New/changed wire types (R3.*) — none; existing camelCase responses parsed
      defensively, unparsable profile entries counted rather than dropped
- [x] Config absence = most restrictive (R5.*) — unknown provenance is not
      editable; a failed read never renders as an empty pool
- [x] Logs/status claim only what was verified (R6.*) — "presents: unknown" is
      distinct from "presents: nothing"; write failures carry their reason
- [x] "Process dies on the next line" answered (R2.1) — the VTA store is
      authoritative; nothing local to become inconsistent
- [x] Deviations flagged — none
```

`cargo test --workspace` green (419 in the binary, 499 in core), `cargo clippy
--workspace --all-targets` clean.
