### PR TITLE
feat(setup): ask for the grant the identity pane needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Setup now asks for the grant the identity pane needs.** The `pnm` command on
+  the setup screen ends `--admin-holder`, which grants the `persona-holder`
+  capability alongside OpenVTC's context-scoped admin entry.
+
+  Without it the pane's Attributes, Profiles and Disclosures tabs are refused on
+  every install — correctly. Those sit above every trust context, and OpenVTC's
+  credential is scoped to one, so reaching them used to require making OpenVTC
+  an administrator of *every* context on the agent. The capability grants
+  authority over your own identity without granting that
+  (verifiable-trust-infrastructure#1286).
+
+  On an install that already exists, the pane's refusal now carries the command
+  to fix it rather than only the agent's explanation of why it said no.
+
+
 - **One pane for your own identity — "My Identity" on the main menu.** Everything
   a holder can do with their persona now lives in one place, with five tabs in
   the order the concepts build on each other: **Faces** (the persona DIDs),

--- a/openvtc/src/ui/pages/main/components/personas_panel.rs
+++ b/openvtc/src/ui/pages/main/components/personas_panel.rs
@@ -652,6 +652,15 @@ fn push_agent_state(state: &PersonasState, lines: &mut Vec<Line<'static>>, noun:
         lines.push(Line::from(""));
         super::status::push_status(lines, error, " ");
         lines.push(Line::from(""));
+        // The one failure with a specific answer, so it gets one. Everything
+        // above this line is the agent's own words; this is what to do about
+        // them.
+        if needs_holder_grant(error) {
+            for line in HOLDER_GRANT_HINT {
+                lines.push(Line::from(*line).fg(COLOR_ORANGE));
+            }
+            lines.push(Line::from(""));
+        }
         lines.push(Line::from(" r: try again").fg(COLOR_DARK_GRAY));
         return true;
     }
@@ -669,6 +678,34 @@ fn push_agent_state(state: &PersonasState, lines: &mut Vec<Line<'static>>, noun:
         return true;
     }
     false
+}
+
+/// What to do about the one refusal that has a specific answer.
+///
+/// Kept as lines rather than a paragraph because the middle one is a command an
+/// operator has to read character by character.
+const HOLDER_GRANT_HINT: &[&str] = &[
+    " Your agent credential administers this context. The pool and the profiles",
+    " over it sit above every context, so reaching them is a separate grant:",
+    "",
+    "   pnm acl update --did <this install's DID> --capabilities persona-holder",
+    "",
+    " It adds authority over your own identity without giving this install any",
+    " authority over other contexts. `openvtc health` prints the DID.",
+];
+
+/// Whether a read failed because the caller lacks holder authority, as opposed
+/// to the agent being unreachable or the request being malformed.
+///
+/// Matched on the phrase both the current and the pre-capability VTA use, since
+/// an operator may be pointing at either: the older one refuses with "unscoped
+/// holder credential" and names no capability, because there was none to name.
+/// A false negative here costs a hint; a false positive would tell someone to
+/// run a grant that is not their problem, so the match is on the specific
+/// phrase rather than on "forbidden".
+fn needs_holder_grant(error: &str) -> bool {
+    let e = error.to_ascii_lowercase();
+    e.contains("holder credential") || e.contains("persona-holder")
 }
 
 // ---------------------------------------------------------------------------
@@ -989,6 +1026,45 @@ mod tests {
             !failed.contains("Nothing in the pool yet"),
             "a failed read must not claim the pool is empty: {failed}"
         );
+    }
+
+    /// The refusal a context-scoped credential earns says what to do about it.
+    ///
+    /// This is the failure every install hits before the grant exists, so the
+    /// agent's own words — accurate but abstract — are not enough on their own:
+    /// the operator needs the command.
+    #[test]
+    fn the_holder_refusal_carries_the_grant_command() {
+        let mut state = PersonasState {
+            tab: PersonaTab::Attributes,
+            load_error: Some(
+                "this task reads or writes the holder's attribute pool … it requires an unscoped \
+                 holder credential"
+                    .to_string(),
+            ),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let out = text(&render(&state));
+        assert!(out.contains("persona-holder"), "{out}");
+        assert!(out.contains("pnm acl update"), "{out}");
+    }
+
+    /// And an unrelated failure does not: telling someone to run a grant when
+    /// their agent is simply unreachable sends them to fix the wrong thing.
+    #[test]
+    fn an_unrelated_failure_carries_no_grant_command() {
+        let mut state = PersonasState {
+            tab: PersonaTab::Attributes,
+            load_error: Some("connection refused".to_string()),
+            ..PersonasState::default()
+        };
+        loaded(&mut state);
+
+        let out = text(&render(&state));
+        assert!(out.contains("connection refused"));
+        assert!(!out.contains("pnm acl update"), "{out}");
     }
 
     /// Values are hidden until asked for, and the row says which state it is in

--- a/openvtc/src/ui/pages/setup_flow/vta_acl_instructions.rs
+++ b/openvtc/src/ui/pages/setup_flow/vta_acl_instructions.rs
@@ -246,8 +246,20 @@ fn build_pnm_command(state: &SetupState, typed_ctx: &str) -> String {
     } else {
         trimmed
     };
+    // `--admin-holder` grants the `persona-holder` capability alongside the
+    // context-scoped admin entry. Without it OpenVTC can administer its own
+    // context and nothing of the holder's: the attribute pool and the profiles
+    // over it sit *above* every context, so the identity pane's Attributes,
+    // Profiles and Disclosures tabs are refused — correctly — by a gate a
+    // context-scoped credential cannot satisfy.
+    //
+    // It is not a way around that boundary; it is the grant the boundary was
+    // always waiting for. The entry stays scoped to this one context and gains
+    // authority over the holder's own identity, which is exactly what a client
+    // that *is* the holder should have and an integration should not.
     format!(
-        "pnm contexts create --id {display_ctx} --name \"OpenVTC\" \\\n  --admin-did {setup_did} --admin-expires 1h",
+        "pnm contexts create --id {display_ctx} --name \"OpenVTC\" \\\n  \
+         --admin-did {setup_did} --admin-expires 1h --admin-holder",
     )
 }
 
@@ -264,4 +276,71 @@ fn render_input(input: &Input, frame: &mut Frame, area: Rect) {
     );
     let x = input.visual_cursor().max(scroll) - scroll;
     frame.set_cursor_position((area.x + x as u16, area.y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The command is pasted, character for character, into another terminal.
+    /// It has to be one clean line-continued command — a stray run of spaces
+    /// from a mangled string literal is invisible in review and survives all
+    /// the way to the operator's shell.
+    #[test]
+    fn the_pnm_command_is_clean_and_carries_the_holder_grant() {
+        let state = SetupState::default();
+        let cmd = build_pnm_command(&state, "openvtc");
+
+        assert!(
+            cmd.starts_with("pnm contexts create --id openvtc "),
+            "{cmd}"
+        );
+        assert!(
+            cmd.contains("--admin-holder"),
+            "without it the identity pane is refused the pool: {cmd}"
+        );
+        // The second line is indented by two spaces on purpose; what must not
+        // appear is a run of spaces *within* a line, which is what a collapsed
+        // string-literal continuation leaves behind.
+        for line in cmd.lines() {
+            assert!(
+                !line.trim_start().contains("  "),
+                "a run of spaces inside a line means the continuation collapsed: {cmd:?}"
+            );
+        }
+        assert_eq!(cmd.lines().count(), 2, "one continued command: {cmd:?}");
+    }
+
+    /// The setup DID the operator is authorising is the one in the command.
+    #[test]
+    fn the_setup_did_reaches_the_command() {
+        let mut state = SetupState::default();
+        let key =
+            vta_sdk::provision_client::EphemeralSetupKey::generate().expect("generate a setup key");
+        let did = key.did.clone();
+        state.vta.setup_key = Some(std::sync::Arc::new(key));
+
+        assert!(
+            build_pnm_command(&state, "openvtc").contains(&format!("--admin-did {did}")),
+            "the command must authorise the key this page is showing"
+        );
+    }
+
+    /// The typed context id is what ends up in the command. The page lets the
+    /// operator choose one, and a command that named the default anyway would
+    /// grant admin over a context they are not creating.
+    #[test]
+    fn the_typed_context_id_reaches_the_command() {
+        let cmd = build_pnm_command(&SetupState::default(), "  my-ctx  ");
+        assert!(cmd.contains("--id my-ctx "), "{cmd}");
+        assert!(!cmd.contains("--id openvtc"), "{cmd}");
+    }
+
+    /// An empty input falls back to the default rather than emitting `--id `
+    /// with nothing after it.
+    #[test]
+    fn an_empty_context_id_falls_back_to_the_default() {
+        let cmd = build_pnm_command(&SetupState::default(), "   ");
+        assert!(cmd.contains("--id openvtc "), "{cmd}");
+    }
 }


### PR DESCRIPTION
Splits the functional half out of #278, so it isn't waiting on a vocabulary
decision. **No naming changes here** — this is the reason most of the pane
shipped in #277 cannot work.

## The problem

Setup provisions a **context-scoped** admin — `pnm contexts create --admin-did`
writes `allowed_contexts: ["openvtc"]` — while the attribute pool, the profiles
over it and the disclosure history are gated on an **unscoped** holder
credential, because they sit above every trust context.

So Attributes, Profiles and Disclosures are refused on every install today.
Correctly: the gate is the boundary working. But the only way to satisfy it was
to make OpenVTC an administrator of *every* context on the agent — a real
escalation for a community client, and not something to document as the happy
path.

## The fix

Upstream, **verifiable-trust-infrastructure#1286** adds
`Capability::PersonaHolder`: granted by name, conferred only by a super admin,
and additive — it grants authority over the holder's own identity *without*
granting authority over other contexts.

Here:

- the setup screen's command ends `--admin-holder`;
- for installs that already exist, the pane's refusal carries the command rather
  than only the agent's (accurate, abstract) explanation. It matches the phrase
  both the current and the pre-capability VTA use, so either agent produces the
  hint — and matches that phrase rather than "forbidden", because a false
  positive sends someone to fix something that is not their problem;
- the command is now **tested**. It is pasted character for character into
  another terminal, and a mangled string literal — a run of spaces where a line
  continuation collapsed — is invisible in review and survives to the operator's
  shell. One had already got in while writing this.

## Merge order

Harmless before #1286: `--admin-holder` is refused by an older VTA with a clear
error, and the pane behaves exactly as it does today. Useful after it.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new clients/timeouts (R1.2) — no new network calls
- [x] No lock held across a network await (R1.3)
- [x] No local state before its remote effect (R2.1)
- [x] Retries bounded (R1.4) — none added
- [x] Loops survive transient errors (R1.5) — n/a
- [x] Acks after durable handoff (R1.6) — n/a
- [x] Wire types (R3.*) — none changed
- [x] Config absence = most restrictive (R5.*) — unchanged; the hint is display
- [x] Logs/status claim only what was verified (R6.*) — the hint is shown only
      for the refusal it actually addresses
- [x] "Process dies on the next line" (R2.1) — n/a, no new mutation
- [x] Deviations — none
```

`cargo test --workspace` green (425 in the binary), clippy clean.