### PR TITLE
refactor(persona): the copy outside the pane speaks the vocabulary too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **The join flow and communities panel speak the persona vocabulary too.** The
+  pane was brought over in #280; this is the copy outside it —
+  *"Who should this community know you as?"*, *"Already known to:"*, and the
+  reuse warning in the sentence the table asks every surface to share:
+  *"the same person to anyone who sees both."*
+
+  `profile` elsewhere in the TUI is left alone on purpose: setup, backup and
+  `--profile` mean the **config profile**, a different thing that predates the
+  persona family and has its own meaning to operators.
+
+
+### Changed
+
 - **The identity pane speaks the words a person would use.** Following
   `design-docs/persona-vocabulary.md`, which fixes one vocabulary across the
   console, `pnm`, the mobile agent and this TUI: an *attribute* is a **fact**,

--- a/openvtc/src/ui/pages/join_flow/identity_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/identity_choice.rs
@@ -87,7 +87,7 @@ impl IdentityChoice {
             Block::bordered()
                 .fg(COLOR_BORDER)
                 .padding(Padding::proportional(1))
-                .title(" Choose an identity for this community "),
+                .title(" Who should this community know you as? "),
             middle,
         );
         let inner = middle.inner(Margin::new(3, 2));
@@ -98,14 +98,14 @@ impl IdentityChoice {
             let label = opt.map(|o| o.label.as_str()).unwrap_or("this persona");
             let mut lines = vec![
                 Line::styled(
-                    "Reuse an existing identity?",
+                    "Use a persona this community can already be linked to?",
                     Style::new().fg(COLOR_ORANGE).bold(),
                 ),
                 Line::default(),
                 Line::styled(
                     format!(
-                        "Presenting \"{label}\" to this community links you across every \
-                         community that uses it."
+                        "Being known here as \"{label}\" makes you the same person to \
+                         anyone who sees both this community and the others using it."
                     ),
                     Style::new().fg(COLOR_TEXT_DEFAULT),
                 ),
@@ -113,13 +113,13 @@ impl IdentityChoice {
             if let Some(opt) = opt {
                 if opt.linked_communities.is_empty() {
                     lines.push(Line::styled(
-                        "It is not yet presented to any other community.",
+                        "No other community knows you by it yet.",
                         Style::new().fg(COLOR_DARK_GRAY),
                     ));
                 } else {
                     lines.push(Line::default());
                     lines.push(Line::styled(
-                        "Already presented to:",
+                        "Already known to:",
                         Style::new().fg(COLOR_DARK_GRAY),
                     ));
                     for c in &opt.linked_communities {
@@ -148,7 +148,7 @@ impl IdentityChoice {
         // Otherwise the body is the selectable list: each persona, then "mint new".
         let mut lines = vec![
             Line::styled(
-                "Select the identity to present to this community:",
+                "Choose the persona this community will know you as:",
                 Style::new().fg(COLOR_BORDER).bold(),
             ),
             Line::default(),
@@ -174,7 +174,7 @@ impl IdentityChoice {
                 format!("    {}", opt.did)
             } else {
                 format!(
-                    "    {}  ·  used by {} communit{}",
+                    "    {}  ·  known to {} communit{}",
                     opt.did,
                     opt.linked_communities.len(),
                     if opt.linked_communities.len() == 1 {
@@ -195,11 +195,11 @@ impl IdentityChoice {
             Style::new().fg(COLOR_SOFT_PURPLE)
         };
         lines.push(Line::from(Span::styled(
-            format!("{marker}✦ Create a new identity for this community"),
+            format!("{marker}✦ Be someone new to this community"),
             style,
         )));
         lines.push(Line::styled(
-            "    A fresh did:webvh, unlinked from your other communities",
+            "    A fresh did:webvh — nothing links it to your other communities",
             Style::new().fg(COLOR_DARK_GRAY),
         ));
         lines.push(Line::default());

--- a/openvtc/src/ui/pages/join_flow/invitation_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/invitation_choice.rs
@@ -144,7 +144,7 @@ impl InvitationChoice {
             {
                 lines.push(Line::styled(
                     format!(
-                        "    Issued to {} — presented via a linkage proof",
+                        "    Issued to {} — shown with a proof that links the two",
                         shorten_did(subject, 40)
                     ),
                     Style::new().fg(COLOR_ORANGE),

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -388,7 +388,7 @@ fn render_empty(mut lines: Vec<Line<'static>>) -> Vec<Line<'static>> {
             .fg(COLOR_TEXT_DEFAULT),
     );
     lines.push(
-        Line::from("Find a Verifiable Trust Community and present an identity to join it.")
+        Line::from("Find a Verifiable Trust Community and choose who it will know you as.")
             .fg(COLOR_TEXT_DEFAULT),
     );
     lines.push(Line::from(""));


### PR DESCRIPTION
Third of three PRs bringing the persona vocabulary into sync across the stack:

- verifiable-trust-infrastructure#1291 — `pnm persona …`
- vta-browser-plugin#183 — the console's persona pane (which was also *stale*)
- **this one** — the OpenVTC copy outside the identity pane

#280 brought the pane over and left the rest for "when next touched".

## What changed

The join flow's identity choice — *"Who should this community know you as?"*,
*"Choose the persona this community will know you as"*, *"Already known to:"*,
*"Be someone new to this community"* — the invitation list, and the communities
panel's empty state.

**The reuse warning is the one that matters.** It is the last thing a person
reads before linking themselves across two communities, and it now carries the
table's sentence verbatim:

> Being known here as "Work me" makes you the same person to anyone who sees
> both this community and the others using it.

The point of a fixed phrase is that meeting it twice teaches it. A paraphrase in
one surface spends the recognition and gives nothing back.

## What I deliberately left alone

**`profile` in setup, backup and `--profile`.** That is the *config profile* — a
local installation profile that predates the persona family, has its own meaning
to operators, and appears in a flag they type. It is exactly the collision the
vocabulary doc cites when it declines to use "profile" for a face; renaming it
here would manufacture the confusion the table exists to prevent.

## Pre-merge checklist (vti-stack-development-guide §9)

```
- [x] No new clients/timeouts (R1.2) — copy only
- [x] No lock held across a network await (R1.3)
- [x] No local state before its remote effect (R2.1)
- [x] Retries bounded (R1.4) — none added
- [x] Loops survive transient errors (R1.5) — n/a
- [x] Acks after durable handoff (R1.6) — n/a
- [x] Wire types (R3.*) — none changed
- [x] Config absence = most restrictive (R5.*) — unchanged
- [x] Logs/status claim only what was verified (R6.*) — the linkage warning
      keeps its exact claim, in the shared wording
- [x] "Process dies on the next line" (R2.1) — n/a
- [x] Deviations — none
```

`cargo test --workspace` green (426 in the binary); clippy `-D warnings` clean.