### PR TITLE
chore(deps): take the vta-sdk 0.34 line the VTA and VTC deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,18 +100,18 @@ dependencies = [
 
 [[package]]
 name = "affinidi-crypto"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5420ba310200f4caaa72efb95898a1202636ee40c3baeb6555be88a7dde423"
+checksum = "5b1ad69d57c11963b06e015366e0d628dad720123516bd2dc7bf6d4adc6bf2e9"
 dependencies = [
- "aes 0.8.4",
+ "aes 0.9.3",
  "affinidi-encoding",
  "base58",
  "base64 0.23.1",
- "cbc",
+ "cbc 0.2.1",
  "ed25519-dalek 3.0.0",
  "getrandom 0.2.17",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "k256 0.14.0",
  "multibase",
  "p256 0.14.0",
@@ -121,7 +121,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.20",
  "x25519-dalek 3.0.0",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-data-integrity"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "837d0913b02cccd98439abed758329bb568f5bea1edab9e719525a65ef80552b"
+checksum = "b8fb570864d6902ae4eab7e9fa440b7fd510950819058f8592a01cafc02276a5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -145,7 +145,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tracing",
  "zeroize",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.34"
+version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d96b5e9a4f92941ae4262a1d15729e234c49e598bd32598df8bf3db4d160b64"
+checksum = "15d261ce9e5886c890492a1ed7ae6f0b286f8c8c2c711af96eb1bdf1eee9efa6"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
@@ -237,15 +237,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-web"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48bff79fe41fa2bd3e50b9ac14cdc660a83f61ebbb7fd321517b478781dd3046"
+checksum = "1d8fc4d44f666b034f50cd753afc1bdfef6d7801cccc35672518ab2e2fda007c"
 dependencies = [
  "affinidi-did-common",
  "percent-encoding",
  "reqwest",
  "serde_json",
  "thiserror 2.0.20",
+ "tokio",
  "tracing",
 ]
 
@@ -264,23 +265,23 @@ dependencies = [
 
 [[package]]
 name = "affinidi-mdoc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69ac8bedce32dcf6798e480166e3601b73b0408e2d51ae40964d09de3457ebc"
+checksum = "f5f7477efe2234b653a5c44f3c204b84053d13296dae2b47c1da8d6ca8484ee2"
 dependencies = [
- "aes-gcm 0.10.3",
+ "aes-gcm 0.11.1",
  "ciborium",
  "ciborium-io",
  "coset",
  "hex",
- "hkdf 0.12.4",
- "hmac 0.12.1",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "p256 0.14.0",
  "rand 0.9.5",
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "time",
  "tracing",
@@ -360,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.20.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0090bf4aaf7ac6febbf1c294bfc4d6e7eb2def11e610d6fb816048f39adc2189"
+checksum = "be1185f26910648388327dea8997e3e62531b50c9a0dd9cd750a32c46d0f7c0f"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -391,8 +392,8 @@ dependencies = [
  "hostname",
  "http",
  "humantime",
- "itertools 0.14.0",
- "jsonwebtoken 10.4.0",
+ "itertools 0.15.0",
+ "jsonwebtoken 11.0.0",
  "metrics",
  "metrics-exporter-prometheus",
  "num-format",
@@ -413,7 +414,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tower",
- "tower-http 0.7.0",
+ "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
  "trust-tasks-rs",
@@ -423,20 +424,20 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-common"
-version = "0.15.35"
+version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2972b94ba1f4236c8739ad5660ec1ffe92e0b6a55c64b4ed13ad0c029cf4f283"
+checksum = "f7a8d75667f60abd3a3cf57cada307744333187032cee74235daeff93f8471a0"
 dependencies = [
- "aes-gcm 0.10.3",
+ "aes-gcm 0.11.1",
  "ahash",
- "argon2 0.5.3",
+ "argon2 0.6.0",
  "async-trait",
  "axum",
  "base64 0.23.1",
  "futures-util",
  "hex",
- "hkdf 0.12.4",
- "hmac 0.12.1",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "humantime",
  "metrics",
  "num-format",
@@ -446,7 +447,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sha256",
  "thiserror 2.0.20",
  "tokio",
@@ -460,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator-config"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3929d4772d53742c4da737f3973df3b314a746bc3718337427d9fd76fa9d84"
+checksum = "fd0812369e1827f0478b70cbb5be0ae293e47d7e7143c8c76b54d35c82c2c127"
 dependencies = [
  "affinidi-messaging-mediator-common",
  "serde",
@@ -473,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f32712a19146d4a5353a98a60b676b572976a85abf318a412863389cc8f064"
+checksum = "b579af2fee18048f092391f3c73e1b6a7be44fed38ed2bf79e03b58b9cafc84b"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -510,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3858685de0deba7be2b6b7481c2eb0823b7b64dbe6852b474fed4c23360a019f"
+checksum = "07c5f50dfcde03a3b9ee6d7d4282e6fcf18700fc67e6324fca551d7583bb20dd"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -520,9 +521,8 @@ dependencies = [
  "affinidi-messaging-mediator-common",
  "affinidi-messaging-sdk",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.10.0",
+ "affinidi-tdk",
  "async-trait",
- "jsonwebtoken 10.4.0",
  "ring",
  "rustls",
  "serde_json",
@@ -597,13 +597,13 @@ dependencies = [
 
 [[package]]
 name = "affinidi-rdf-encoding"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb75e7ca98d464c1f461ca8c8258ae8fc22dfef9fe9b72aa6a56d8659d28f8f"
+checksum = "b6d1204d600710d19ba262a0202fb26e3ed107db45f3cb6a5286d8e35b7f2260"
 dependencies = [
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tracing",
 ]
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-secrets-resolver"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a913e027583fb282b22370a35562221240ee4923d1d1b0900b84512bf2961c"
+checksum = "ff9c7363b25897b1b7080caab1ab36f95a833d84aca905b5b6d6e3a3a2b384bb"
 dependencies = [
  "affinidi-crypto",
  "affinidi-encoding",
@@ -648,7 +648,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -688,34 +688,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715c365fa19276fb50332e10b922822b25d52d6119721f28abb6cac02029a365"
-dependencies = [
- "affinidi-crypto",
- "affinidi-data-integrity",
- "affinidi-did-authentication",
- "affinidi-did-common",
- "affinidi-did-resolver-cache-sdk",
- "affinidi-meeting-place",
- "affinidi-messaging-didcomm",
- "affinidi-messaging-sdk",
- "affinidi-secrets-resolver",
- "affinidi-tdk-common",
- "clap",
- "rustls",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "affinidi-tdk"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abceec2e934dfffbc31924d970d650c972660125cd26fe7ecd14e4552713f43f"
+checksum = "796229a5640d2c8e1ae81242ff86a1147994210542e3d1cdd59ec1df12bce3ea"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -767,24 +742,24 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tsp"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e905b7f05d5af040cdabc6afef3bf28c14abd59a3ae05cfc31bc2f662b6c8c6"
+checksum = "0987c24a0fd0ea62705f94a3a7886566e3a0fe281212a632415db32408d1ae77"
 dependencies = [
  "affinidi-cesr",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-encoding",
- "blake2 0.10.6",
- "chacha20poly1305 0.10.1",
+ "blake2 0.11.0",
+ "chacha20poly1305 0.11.0",
  "ed25519-dalek 3.0.0",
  "hex",
- "hkdf 0.12.4",
+ "hkdf 0.13.0",
  "rand 0.10.2",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
  "url",
@@ -1132,7 +1107,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1158,9 +1133,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1169,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -1359,8 +1334,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08e33815c87d8cadcddb1e74ac307368a3751fbe40c961538afa21a1899f21c"
 dependencies = [
  "base64 0.21.7",
- "pastey",
+ "pastey 0.1.1",
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1502,6 +1497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1670,15 +1674,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.4.4"
+name = "cbc"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1825,6 +1847,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,7 +1888,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1980,6 +2013,12 @@ checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -2014,6 +2053,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core-models"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3344d349528f449816cfa85e558c439bdca5a6d8a738cfb21e69f0b2b1952f"
+dependencies = [
+ "hax-lib",
+ "pastey 0.2.3",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
 name = "coset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,6 +2101,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crabgrind"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7459e07732f6de74001fcf73a3fdfbb0f368e4fd8e2392f4a2206a065e6e95"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2105,18 +2172,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2124,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2143,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crossterm"
@@ -2342,16 +2409,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
@@ -2376,19 +2433,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
@@ -2397,7 +2441,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2413,24 +2457,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core 0.24.1",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2470,7 +2503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2500,8 +2533,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "aes 0.8.4",
- "block-padding",
- "cbc",
+ "block-padding 0.3.3",
+ "cbc 0.1.2",
  "dbus",
  "fastrand",
  "hkdf 0.12.4",
@@ -2589,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
@@ -2698,7 +2731,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2729,8 +2762,8 @@ dependencies = [
 
 [[package]]
 name = "did-git-sign"
-version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=d2c091d795168357d8bf3d1c4fffce645f2415de#d2c091d795168357d8bf3d1c4fffce645f2415de"
+version = "0.4.7"
+source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=584f57be6b41407e2da639de3f1db2904dec3633#584f57be6b41407e2da639de3f1db2904dec3633"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -2759,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "did-scid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f36397874c3c2b88ba76e39e2e4599bf8a71ca36b9ce0b92b79a84f17d27ff"
+checksum = "73c7754d192a630118d5fa3353f1cce5c291187762b0e493f397d3e0328b407d"
 dependencies = [
  "affinidi-did-common",
  "didwebvh-rs",
@@ -2773,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "didwebvh-rs"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b131547e3380c910c2cdc078299bd07ec510d6aa5c074f83bdbf3852c77ba8c0"
+checksum = "87a6d8803724264019c1b1dda174b4f666b833e9ac05acd45e87e9fecef2c67b"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
@@ -2862,7 +2895,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2898,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "dtg-credentials"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ca14987f0a6499c50b482764224686a204f74ba12d6713de90fde5f3d980a3"
+checksum = "3f292eb5ba50d7f69dd9671e87b4d6ceddbeb973cbf0c05715220bee8446ff90"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -2959,7 +2992,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der 0.8.1",
+ "der 0.8.2",
  "digest 0.11.3",
  "elliptic-curve 0.14.1",
  "rfc6979 0.6.0",
@@ -3111,11 +3144,17 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "2a7a45518d2863d18aa47f4a0cf9faec2aa4304cc09df5e41299f276b3ad135e"
 dependencies = [
  "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
 ]
 
 [[package]]
@@ -3214,6 +3253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "finl_unicode"
@@ -3304,9 +3354,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fjall"
-version = "3.1.9"
+version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5427b70d8592043024955a4a40b5cf44af323fdad7c1f62848a01ec7806709e"
+checksum = "cd201c93927cdf4712e8f7d4c9c8d34d68c7534380c05d4a58864a309f91c33f"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -3490,7 +3540,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3625,6 +3675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "globset"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,7 +3749,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -3761,6 +3817,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "hax-lib"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a33cb227f97ee5c419064c31d7c55a7d895f28d8019ccdadc311cc036500c4"
+dependencies = [
+ "hax-lib-macros",
+ "num-bigint 0.4.8",
+ "num-traits",
+]
+
+[[package]]
+name = "hax-lib-macros"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28da835a5f153e9f3d0cc1f42ee605a1cfa9093c93348193793d60a1b0908b51"
+dependencies = [
+ "hax-lib-macros-types",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "hax-lib-macros-types"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed327e9a28d6ee018a4a9ba842d4ee27e378c8a591d2beb6f42f32b24a02fcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,9 +3885,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -3804,9 +3897,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+checksum = "db3fef046dca3ca91ee1408a8c1b80ab777e80a4d308d1bf4e7adb3fcb047e08"
 dependencies = [
  "arrayvec",
 ]
@@ -3872,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "hpke"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5130e119706b4d8c2180da6126f7e60b6c38c2d340d539219f57051f0a7af7"
+checksum = "a5324110b02044183df000f0bd7d2d7e61f1000631508627e77f63983b6fdffb"
 dependencies = [
  "aead 0.6.1",
  "chacha20poly1305 0.11.0",
@@ -3890,6 +3983,75 @@ dependencies = [
  "turboshake",
  "x-wing",
  "x25519-dalek 3.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812de62ab573b876c6c40d7553bae9402ae3bad95b64af06f964388eecb9b7b1"
+dependencies = [
+ "hpke-rs-crypto",
+ "hpke-rs-libcrux",
+ "hpke-rs-rust-crypto",
+ "libcrux-sha3",
+ "log",
+ "serde",
+ "subtle",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c461da2e0c9c93d875b597f0c78214fb0d2d5c57834b2ef2a2fa057fa20e24"
+dependencies = [
+ "rand 0.10.2",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-libcrux"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c1ace95ef11fbbd84527eada5fc1304f66720fc4c008db30d888d62d3c52613"
+dependencies = [
+ "hpke-rs-crypto",
+ "libcrux-aead",
+ "libcrux-ecdh",
+ "libcrux-hkdf",
+ "libcrux-kem",
+ "libcrux-traits",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+ "zeroize",
+]
+
+[[package]]
+name = "hpke-rs-rust-crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a606ac19851da841862ef5f39d26d6227bfcfb4047417801a66c1f6e6652d71"
+dependencies = [
+ "aes-gcm 0.10.3",
+ "chacha20poly1305 0.10.1",
+ "hkdf 0.13.0",
+ "hpke-rs-crypto",
+ "k256 0.13.4",
+ "ml-kem",
+ "p256 0.13.2",
+ "p384 0.13.1",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "subtle",
+ "x-wing",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -4202,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -4227,7 +4389,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -4237,6 +4399,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding 0.4.2",
  "hybrid-array",
 ]
 
@@ -4250,7 +4413,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4264,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4297,6 +4460,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -4421,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4459,27 +4631,29 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.47.0"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
 dependencies = [
  "ahash",
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex 0.18.0",
+ "fancy-regex 0.19.1",
  "fraction",
  "getrandom 0.3.4",
  "idna",
  "itoa",
- "jsonschema-regex 0.47.0",
+ "jsonschema-regex 0.49.9",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
- "referencing 0.47.0",
+ "referencing 0.49.9",
  "regex",
  "serde",
  "serde_json",
+ "strum",
  "unicode-general-category",
  "uuid-simd",
 ]
@@ -4495,11 +4669,25 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.47.0"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -4512,11 +4700,9 @@ dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
- "pem",
  "serde",
  "serde_json",
  "signature 2.2.0",
- "simple_asn1",
  "zeroize",
 ]
 
@@ -4655,12 +4841,241 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libcrux-aead"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22acbe68be84b7b41aaba6e39b87036fc4324dee628d94773750bf3d7e906d69"
+dependencies = [
+ "libcrux-aes",
+ "libcrux-chacha20poly1305",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-aes"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cc95b11dbc797b1e169467b1fc4205c4e6ee2ce516a035ad7342ce5f6ae971"
+dependencies = [
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-chacha20poly1305"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537e6eee5cdc9a980014d058784b0be09614f0596df789b114f7833aa9f35d75"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-poly1305",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-curve25519"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f3cfd5e31cb9745e290ee061222c380ec42884654b09fc7d12a5b0ed63e028"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-secrets",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-ecdh"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a227590b89ff55ce7cd97b5a7468c82d231db8f3b890bb4d4fb6d271e7524d7"
+dependencies = [
+ "libcrux-curve25519",
+ "libcrux-p256",
+ "rand 0.10.2",
+ "tls_codec",
+]
+
+[[package]]
+name = "libcrux-hacl-rs"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66106db376ae249af86911aee048cf73ea1f394d6653026fc988dd22cf2a4ace"
+dependencies = [
+ "libcrux-macros",
+]
+
+[[package]]
+name = "libcrux-hkdf"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc94e651dca4d47edbcdd88bb2428ce16a2bd86b7a4e7170da87b505478f9839"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-hmac",
+ "libcrux-secrets",
+]
+
+[[package]]
+name = "libcrux-hmac"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500ad9b32c715161b594172ca1fb11503a1c033b393ff4c0c33505ce51c1943c"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-sha2",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-intrinsics"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a0c574d4eb81d0814bc2b91e4a433d7e0b35851b1d62eb5dd95c064f1f76d0"
+dependencies = [
+ "core-models",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-kem"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "541a7377fb35060892e0620982e224e47419f10da8c212453bf642dafe529691"
+dependencies = [
+ "libcrux-curve25519",
+ "libcrux-ecdh",
+ "libcrux-ml-kem",
+ "libcrux-p256",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "libcrux-macros"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6aa2dcd5be681662001b81d493f1569c6d49a32361f470b0c955465cd0338"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "libcrux-ml-kem"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8160f7d64fd2716b4fd05cc886a042f8dcda18d9206c0d506e2c67bdf97daa"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.10.2",
+ "tls_codec",
+]
+
+[[package]]
+name = "libcrux-p256"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3400732702d578be622257b98cec85e9b0cd34a67f1f06d3ebe9ae34963cdf02"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-secrets",
+ "libcrux-sha2",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-platform"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9e21d7ed31a92ac539bd69a8c970b183ee883872d2d19ce27036e24cb8ecc4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libcrux-poly1305"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a9144949845813a0b8787d08cbba47baabe59c83f3043e558e6e92385c40cc"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+]
+
+[[package]]
+name = "libcrux-secrets"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79054fc9037cb70d6a546cf094cea7d7df06af5e49d230ba24103d27ccc886f1"
+dependencies = [
+ "crabgrind",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-sha2"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e46e1be0b77098cc6ce82137864936ecad3a1b9fd4303dd51202ca140dd1e"
+dependencies = [
+ "libcrux-hacl-rs",
+ "libcrux-macros",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-sha3"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c09f5c39afae0528e1f70a3c1e3c6ee649ec1f19dda26fc9b6ea91108fb879ef"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-traits"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa7a21e8c2e8baa8b40f0b176740f2ca4baadd79d1b00e48d6b1e363c42085a"
+dependencies = [
+ "libcrux-secrets",
+ "rand 0.10.2",
+]
+
+[[package]]
 name = "libdbus-sys"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -4671,12 +5086,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "line-clipping"
@@ -4755,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d317b4b9eb398e6acce275758ec6125535505e7a146fb1a9b8bda2451b0ff4c"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -4770,9 +5191,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
-version = "3.1.9"
+version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c4da84fa3a8638fb26d4432bfeb69a1b560905ee2980134d8993e2cfa0dbf3"
+checksum = "5498808f4d41cf785079d3ef3f28716f1b4364af1b512f3097bfb651bded1b3e"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -4888,7 +5309,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -4956,14 +5377,30 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -5043,6 +5480,34 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
 ]
+
+[[package]]
+name = "multiversion"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edb7f0ff51249dfda9ab96b5823695e15a052dc15074c9dbf3d118afaf2c201"
+dependencies = [
+ "multiversion-macros",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "target-features",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
 
 [[package]]
 name = "nix"
@@ -5428,6 +5893,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openmls"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b08d90fc020cb5354d5f08ca17711b84c82e2bcc7331753fd94f000d99a8c8"
+dependencies = [
+ "log",
+ "openmls_serialization_helpers",
+ "openmls_traits",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.20",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "openmls_basic_credential"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd3f0c3422e7c7a8496f042b547b0c28d0793f8ba97feb401966e58196a1e40"
+dependencies = [
+ "ed25519-dalek 2.2.0",
+ "ml-dsa",
+ "openmls_traits",
+ "p256 0.13.2",
+ "p384 0.13.1",
+ "rand_core 0.6.4",
+ "serde",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "openmls_memory_storage"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce927945a16eaa19302ed5ccef052f01ba68f2ba7ae67e4ac4ff2fc661445364"
+dependencies = [
+ "log",
+ "openmls_traits",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "openmls_rust_crypto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36bf3fe824ead6e81d22f49a9cd7feffca3494979fac14c1248e19516e3625f1"
+dependencies = [
+ "aes-gcm 0.10.3",
+ "chacha20poly1305 0.10.1",
+ "ed25519-dalek 2.2.0",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "hpke-rs",
+ "hpke-rs-crypto",
+ "hpke-rs-rust-crypto",
+ "ml-dsa",
+ "openmls_memory_storage",
+ "openmls_traits",
+ "p256 0.13.2",
+ "p384 0.13.1",
+ "rand_chacha 0.3.1",
+ "rand_core 0.10.1",
+ "rand_core 0.6.4",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tls_codec",
+]
+
+[[package]]
+name = "openmls_serialization_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2cf2193541e83ce1a89aaa44c2fd4783abd54853823075a32b60ef032284c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "openmls_traits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac13edad8698eb1917cbc1dab99591fa1594d84320904fe3fc5121854f95831c"
+dependencies = [
+ "serde",
+ "tls_codec",
+]
+
+[[package]]
 name = "openpgp-card"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5520,7 +6081,7 @@ version = "0.3.1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
- "affinidi-tdk 0.10.0",
+ "affinidi-tdk",
  "anyhow",
  "apple-native-keyring-store",
  "arboard",
@@ -5583,7 +6144,7 @@ dependencies = [
  "affinidi-messaging-delivery",
  "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
- "affinidi-tdk 0.10.0",
+ "affinidi-tdk",
  "agent-names",
  "anyhow",
  "arbitrary",
@@ -5848,6 +6409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pcsc"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5902,9 +6469,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -5912,9 +6479,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
+checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5922,9 +6489,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
+checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
 dependencies = [
  "pest",
  "pest_meta",
@@ -5935,9 +6502,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
+checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
 dependencies = [
  "pest",
 ]
@@ -5950,7 +6517,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
 ]
 
 [[package]]
@@ -5966,7 +6533,7 @@ dependencies = [
  "argon2 0.5.3",
  "base64 0.22.1",
  "bitfields",
- "block-padding",
+ "block-padding 0.3.3",
  "blowfish",
  "buffer-redux",
  "byteorder",
@@ -6157,7 +6724,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.1",
+ "der 0.8.2",
  "spki 0.8.0",
 ]
 
@@ -6260,9 +6827,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -6304,6 +6871,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "primefield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6337,6 +6914,28 @@ dependencies = [
  "primefield",
  "serdect 0.4.3",
  "wnaf",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6531,6 +7130,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6713,9 +7322,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37a4ca5c6ca42aa3e6df2fd32b987a65d32a4c2159a6f3fe0fd1df306a2658f"
+checksum = "2acbc41a996f7652b2ddd9dfd98cc4ff602cfd742ae35382f07f608405ab50ed"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -6780,7 +7389,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -6802,9 +7411,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.47.0"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -6848,51 +7457,18 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regorus"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419a0413adeece71e4d4a64fb75adc359cb807496f0dfd10f429517be908b807"
+checksum = "94d90cbdbc4d2900378cf7dbb0c8df85a28e6de07fad75c60cd4d73283eded23"
 dependencies = [
  "anyhow",
  "chrono",
  "chrono-tz",
  "data-encoding",
  "globset",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "ipnet",
- "jsonschema 0.46.10",
- "lazy_static",
- "lru",
- "msvc_spectre_libs",
- "num-bigint 0.4.8",
- "num-traits",
- "parking_lot",
- "postcard",
- "rand 0.10.2",
- "regex",
- "semver",
- "serde",
- "serde_json",
- "serde_yaml",
- "spin 0.10.1",
- "thiserror 2.0.20",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "regorus"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc4dc91481b1d4001ba7f2e81f7faf674142e0ac36d37d79e5f02764d06571e"
-dependencies = [
- "anyhow",
- "chrono",
- "chrono-tz",
- "data-encoding",
- "globset",
- "indexmap 2.14.0",
- "ipnet",
- "jsonschema 0.47.0",
+ "jsonschema 0.49.9",
  "lazy_static",
  "lru",
  "msvc_spectre_libs",
@@ -6905,11 +7481,12 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml",
  "spin 0.12.3",
  "thiserror 2.0.20",
  "url",
  "uuid",
+ "vstd",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -7070,9 +7647,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7239,7 +7816,7 @@ checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct 1.0.0",
  "ctutils",
- "der 0.8.1",
+ "der 0.8.2",
  "hybrid-array",
  "subtle",
  "zeroize",
@@ -7348,7 +7925,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7419,16 +7996,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+checksum = "935177bb8c0cd8ca1a4e6d1a2ac8988bea69cab4f9d3a31311e012ad27868ea4"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -7440,27 +8017,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+checksum = "1d607aa01a3cb0ad757d6fd216136910db3c97b102fe686585689615a02dbcdc"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7637,6 +8201,12 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -7746,9 +8316,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "snafu"
@@ -7792,12 +8362,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
-
-[[package]]
-name = "spin"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
@@ -7828,7 +8392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.1",
+ "der 0.8.2",
 ]
 
 [[package]]
@@ -7909,9 +8473,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7985,6 +8549,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-features"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "tempfile"
@@ -8112,7 +8682,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -8192,9 +8762,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8204,6 +8774,29 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18cc98286004cea38f717e2b03d990fc774fbfd38a82720de40e5c94365067c8"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674f41dd95f76cdeb005c83f9444e20cf43daebef37cde9e49a9ca6f4e87b423"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "tokio"
@@ -8230,14 +8823,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -8299,11 +8892,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -8373,7 +8966,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -8404,9 +8997,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+checksum = "08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
@@ -8538,9 +9131,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.17.3"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b98bc63ee0c95b3d0778aa03264da922cb23cd098326fb7406c8b1bd0fa5550"
+checksum = "04a992eca852980b874479e39811c64184694268eb09e676c0e29296cf875d3f"
 dependencies = [
  "chrono",
  "serde",
@@ -8552,9 +9145,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.17.3"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20a9db1b7be64041806c7b17e8be51c9c26122dacd9c5cbd132c5a742e8f0ab"
+checksum = "67928dcdbcdf8e2034baa1cb2925933e08a2fa7c8313d55b8892fe909761e78a"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -8568,9 +9161,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.17.3"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b54beded7933b21154eb0d1bcde15bcb42f57d75ae0b92599b1d37caf7167a"
+checksum = "413c109aeb9d110f2b5bfa1c452df4f53d16dc3113b3ea61c9fd8b76fc7aee94"
 dependencies = [
  "axum",
  "chrono",
@@ -8587,9 +9180,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.17.3"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3ac0e9fd0d5d9c0f2cd8166d8df64b4e3b869b074a08d42950d89f670fea939"
+checksum = "c5211f57e53d2fb47fd4f989dd02a5038930180b4342da71626dc3fb685402a5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -8604,9 +9197,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.17.3"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d841bf16638473fed22f94ce446cadcc932afc60ca3f623eef184d546d945b"
+checksum = "fe43bd5d03b468c49ffa6c75d53afca9fe27cb70b35384941db3a8c42c1da4b8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8708,6 +9301,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "ulid"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947dde63b6d514cc5e044edad4e0ca7261afd1099d16c83d942cb2b2f348689c"
+dependencies = [
+ "rand 0.10.2",
+ "serde",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8778,12 +9382,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8838,7 +9436,7 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.2",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -8919,9 +9517,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "verus_builtin"
+version = "0.0.0-2026-08-09-0044"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f2985ebd252c492375e32f2bfcff6e6a04523009a0d624785d3468f3729158"
+
+[[package]]
+name = "verus_builtin_macros"
+version = "0.0.0-2026-08-23-0033"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f5b1ed2151955cfe25ebfc1382ab422ae004e5cda6c502871425cc9e2ad5f3"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+ "verus_prettyplease",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_prettyplease"
+version = "0.0.0-2026-08-09-0044"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fc115de5fb3806bc362060bb683024660ed2bc13c1183d1f01d464e4537139"
+dependencies = [
+ "proc-macro2",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_state_machines_macros"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f77ff8d121edb1bf2651335769a80a2f611da8573c3b498434a66b3162805f"
+dependencies = [
+ "indexmap 2.14.2",
+ "proc-macro2",
+ "quote",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_syn"
+version = "0.0.0-2026-08-02-0125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17237ea6d267e457d53ce36f55b315fc9edd26eb88c765dd95e035c0b415869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "vgi-core"
-version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=d2c091d795168357d8bf3d1c4fffce645f2415de#d2c091d795168357d8bf3d1c4fffce645f2415de"
+version = "0.4.7"
+source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=584f57be6b41407e2da639de3f1db2904dec3633#584f57be6b41407e2da639de3f1db2904dec3633"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -8938,10 +9590,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
-name = "vta-audit"
-version = "0.3.1"
+name = "vstd"
+version = "0.0.0-2026-08-23-0033"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dfc15f430f88946d9d5e51c399466d5fd167a5e98b08492cc5a36103a68ac0"
+checksum = "93b32ef60c0a4ce7d85691135c15fada7ab84b2c1471322d320fba313190e2e9"
+dependencies = [
+ "verus_builtin",
+ "verus_builtin_macros",
+ "verus_state_machines_macros",
+]
+
+[[package]]
+name = "vta-audit"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b85c6b716c51485907bd1c2c48def63897c9a4681919054d180111f3c45ad9"
 dependencies = [
  "async-trait",
  "tracing",
@@ -8952,13 +9615,13 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ebe2bf5befdaa6dc6508aa0c91f8fe3b4b9f454c0f8771f780870b0b1abd6a"
+checksum = "ae3c9b816c41fb13180126aa62ad2241c19e64ed114882ef70c3e44ddf544740"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "hex",
  "rand 0.10.2",
@@ -8980,9 +9643,9 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0579191869b5151e84d35dd1d88e0d5202887685400806be9db8f08b4cb19a"
+checksum = "697dc43008a4838716942244167708e555fb328935d56fe2790fa675f08a3b93"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9001,15 +9664,16 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "vta-sdk",
+ "vtc-client",
  "vti-common",
  "x25519-dalek 3.0.0",
 ]
 
 [[package]]
 name = "vta-config"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f7460d682620da4bc1e266670273c39431eed305c4aac072091b1571aa91fd"
+checksum = "5d73206973663ba51124613c6c69613e630899edff205a5a846531f311ddb8ec"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9024,14 +9688,14 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d443fc7cbfff9ceef6b170231268884d2861c812a3c7d35c7a2351ab8bdbeee"
+checksum = "36ff38a96115d7ad01018d0d7e586aa2d3fca950622936c509501503dbe80e7d"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
- "affinidi-tdk 0.10.0",
- "base64 0.22.1",
+ "affinidi-tdk",
+ "base64 0.23.1",
  "bip39",
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9058,22 +9722,41 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa351226581a21904769b8a5afda65eae669ab8da5b52dcae2e94b3718196f2"
+checksum = "6caa9b60da8192db125a00bb90ffa6b1c6be1ff42af08265505432bba644bb44"
 dependencies = [
  "vti-common",
 ]
 
 [[package]]
-name = "vta-policy"
-version = "0.3.1"
+name = "vta-persona"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b360c5d30623464a511a9e5b81ae37abc1819bd96f60b15f8737aa87b458c8c"
+checksum = "7dffc559ec67e6aa46e8abde41d20723679cb0b71c57ae4151cc659eb95a8d79"
+dependencies = [
+ "chrono",
+ "hmac 0.13.0",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "subtle",
+ "tokio",
+ "tracing",
+ "ulid",
+ "vta-keyspaces",
+ "vti-common",
+]
+
+[[package]]
+name = "vta-policy"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f4bdc5b03d46692840c543c7bd6f46200576d8e39b53a04d74c05ea92cc9f4"
 dependencies = [
  "hex",
  "multibase",
- "regorus 0.10.1",
+ "regorus",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
@@ -9087,9 +9770,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.32.4"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b124bc8519ad8894325a0ce1a6349c352f79eba1b996164d84a512e6b24f8f72"
+checksum = "e8afb6ae8320688356666abaafbcead756e5de6b728e5658a5337b9d013547f2"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9102,7 +9785,7 @@ dependencies = [
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.11.0",
+ "affinidi-tdk",
  "affinidi-vc",
  "agent-names",
  "apple-native-keyring-store",
@@ -9138,9 +9821,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.23.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa89d1f331e7fa24fc8c643a971641e791032f6d7daa37fd94f0a05b7b54e9b"
+checksum = "27f1cc9599c01d4b2224a2857c6285f4ceef577cfa6369b7bdca8330dab2b439"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9156,7 +9839,7 @@ dependencies = [
  "affinidi-sd-jwt-vc",
  "affinidi-secrets-resolver",
  "affinidi-status-list",
- "affinidi-tdk 0.11.0",
+ "affinidi-tdk",
  "affinidi-tdk-common",
  "argon2 0.6.0",
  "async-trait",
@@ -9170,6 +9853,7 @@ dependencies = [
  "dialoguer",
  "didwebvh-rs",
  "dirs",
+ "dtg-credentials",
  "ed25519-dalek 3.0.0",
  "fjall",
  "futures-util",
@@ -9182,7 +9866,7 @@ dependencies = [
  "multibase",
  "p256 0.14.0",
  "rand 0.10.2",
- "regorus 0.11.0",
+ "regorus",
  "reqwest",
  "serde",
  "serde_ignored",
@@ -9196,7 +9880,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tower",
- "tower-http 0.7.0",
+ "tower-http 0.7.1",
  "tower_governor",
  "tracing",
  "tracing-subscriber",
@@ -9215,6 +9899,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
+ "vta-persona",
  "vta-policy",
  "vta-sdk",
  "vta-support",
@@ -9222,6 +9907,8 @@ dependencies = [
  "vta-vault",
  "vta-webvh",
  "vti-common",
+ "vti-rooms",
+ "vti-rooms-dtg",
  "vti-secrets",
  "vti-webauthn",
  "webauthn-rs",
@@ -9232,9 +9919,9 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa10c2dfbcdcb98f6d109e2b4c45963387f568d575f699f20f806f352be7e43a"
+checksum = "eed63e6c96ee8c88efe58f5b1ee7299e36e0d9f0a06b651dd0e230d18b86c79d"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9253,9 +9940,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sweepers"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba96705f6033cc969144f4bb2846cde9106aaa16820203f35f8ad2a93acf3005"
+checksum = "f903daaa27f0cb88c8f0c7ba4c4f1e0bc7c692a5bc5cc83c8955f2c34dd29d18"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9268,9 +9955,9 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06628eaaf5a7af3e5bab76016e37aa1de46bb6b5ed412b1f2aebb1216f29a5a3"
+checksum = "cbbb46c63ad98fe0781099ad430ffba092b51fe1d035867075b20913574ab33d"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9300,11 +9987,11 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e61c8c6b6b3f2d96cdae050ce6422198d45cfd5b8ef9fa2ef80f47c2c4f8cfe"
+checksum = "f4b39907f5aad946ab83758f3d7daecc46000a98fe2adf8e1018e58eeac6483c"
 dependencies = [
- "affinidi-tdk 0.10.0",
+ "affinidi-tdk",
  "chrono",
  "reqwest",
  "serde",
@@ -9318,17 +10005,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "vti-common"
-version = "0.16.2"
+name = "vtc-client"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2145c8913e002c56cc25d5b993407e4f74e1cbe8e0f20d74e52a781f73526afb"
+checksum = "0be2ed238b23af7ef840209a1e12370da08b1e78cf4d1cfa9ddcb59d0bb7f35e"
+dependencies = [
+ "chrono",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "trust-tasks-rs",
+ "vta-sdk",
+ "vti-rooms",
+]
+
+[[package]]
+name = "vti-common"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98c45c6d11902ae931cba5214314d599c544a51a3c4b1dc9169dd1e1670a36d"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-delivery",
  "affinidi-secrets-resolver",
- "affinidi-tdk 0.11.0",
+ "affinidi-tdk",
  "async-trait",
  "axum",
  "axum-extra",
@@ -9362,27 +10065,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "vti-secrets"
-version = "0.3.1"
+name = "vti-rooms"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4038c534f077f7553ca0e27f16c49887fb6a3eba8bf80348b01f8b504202ee41"
+checksum = "398b577ead63f1d32bd1fbd1580d69404fdec36c80ff1f92498d76f856bf30c4"
+dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "chacha20poly1305 0.10.1",
+ "chrono",
+ "getrandom 0.4.3",
+ "openmls",
+ "openmls_basic_credential",
+ "openmls_rust_crypto",
+ "openmls_traits",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tls_codec",
+ "vti-common",
+]
+
+[[package]]
+name = "vti-rooms-dtg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33607ac06a06e934c91050b21422b9cb80585aa6947e77ce9ec87ee4a2389190"
+dependencies = [
+ "affinidi-data-integrity",
+ "affinidi-secrets-resolver",
+ "async-trait",
+ "base64 0.23.1",
+ "chrono",
+ "dtg-credentials",
+ "serde_json",
+ "tracing",
+ "vti-common",
+ "vti-rooms",
+]
+
+[[package]]
+name = "vti-secrets"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e8b56ba76536a1fe79d8273740b894f261f6886e2faea215cfee83c216f268"
 dependencies = [
  "hex",
  "serde",
  "tokio",
  "tracing",
  "vti-common",
+ "zeroize",
 ]
 
 [[package]]
 name = "vti-webauthn"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a328d542c58d76057e71da029cd606533df2e57218d73e07e10c01fc2f9e5173"
+checksum = "0fd90a117f0599d443b9eff0f790fd0990162f003a10ebfead1ab8275f51c011"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
- "base64 0.22.1",
+ "base64 0.23.1",
  "multibase",
  "p256 0.14.0",
  "serde",
@@ -9439,9 +10183,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9452,9 +10196,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9462,9 +10206,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9472,22 +10216,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -9574,9 +10318,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10159,6 +10903,7 @@ dependencies = [
  "sha3 0.12.0",
  "shake",
  "x25519-dalek 3.0.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -10241,6 +10986,19 @@ name = "xxhash-rust"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918"
+dependencies = [
+ "indexmap 2.14.2",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "yoke"
@@ -10356,7 +11114,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "did-git-sign"
 version = "0.4.7"
-source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=584f57be6b41407e2da639de3f1db2904dec3633#584f57be6b41407e2da639de3f1db2904dec3633"
+source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=5111dc177d25d68088a4d6ba991210e262498950#5111dc177d25d68088a4d6ba991210e262498950"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -9573,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "vgi-core"
 version = "0.4.7"
-source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=584f57be6b41407e2da639de3f1db2904dec3633#584f57be6b41407e2da639de3f1db2904dec3633"
+source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?rev=5111dc177d25d68088a4d6ba991210e262498950#5111dc177d25d68088a4d6ba991210e262498950"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,23 +21,25 @@ openvtc-core = { version = "0.3", path = "openvtc-core", default-features = fals
 
 # Decentralized Trust Graph Credentials.
 #
-# 0.2 tracks DTG Core Credentials spec v1.0 Working Draft 01. Unlike
-# `trust-tasks-rs`, this one is safe to move ahead of the VTA/VTC (still on
-# 0.1.3): nothing in the vta-sdk graph depends on it, so there is no second
-# copy and no type that has to unify across the sdk boundary — openvtc and
-# openvtc-core are its only consumers.
+# Nothing in the vta-sdk graph depends on it, so there is no second copy and no
+# type that has to unify across the sdk boundary — openvtc and openvtc-core are
+# its only consumers. That is why this line was allowed to lead the VTA/VTC for
+# several releases while they sat on 0.1.3; as of this refresh it no longer
+# does, because VTI main is on 0.6 as well and the two agree again.
 #
-# It is also wire-compatible with a 0.1.3 peer for the credentials we
-# actually exchange. The major's breaking changes are `new_vwc()`'s new
-# required `task_context` argument and strict `WitnessCredential`
-# deserialization; we call neither and handle no VWCs. The new `taskContext`
-# field is `skip_serializing_if = "Option::is_none"` with `default`, so
-# credentials we issue serialize to the same JCS bytes as before (a 0.1.3
-# VTC still verifies our proofs) and 0.1.3-issued VRC/VMC/VICs still parse.
+# The one thing that always has to be checked when this moves is the *wire*,
+# not the types: a peer on an older line still has to verify the credentials we
+# issue and we still have to parse theirs. The additions across 0.2–0.6 are all
+# `skip_serializing_if = "Option::is_none"` with `default`, so a credential we
+# issue serialises to the same JCS bytes as before and older-issued VRC/VMC/VICs
+# still parse.
 #
-# The crate's documented VWC `digest` divergence from WD-01 does not reach
-# us either — `digest_multibase()` / `verify_digest()` have no call sites here.
-dtg-credentials = "0.5"
+# The breaking changes on the way here are `new_vwc()`'s required `task_context`
+# argument, strict `WitnessCredential` deserialization, and the VWC `digest`
+# divergence from WD-01 — none of which reach us: we call neither constructor,
+# handle no VWCs, and `digest_multibase()` / `verify_digest()` have no call
+# sites here.
+dtg-credentials = "0.6"
 
 aes-gcm = "0.11"
 # The one direct requirement in this workspace that was behind its latest
@@ -53,9 +55,10 @@ aes-gcm = "0.11"
 # `affinidi-messaging-sdk`, and no line we control moves it. The bump puts us on
 # the same copy as `vta-service` rather than on the older one.
 argon2 = "0.6"
-# 0.8.5 is `vta-sdk` 0.27's and `vta-service` 0.19's own requirement — the floor
-# is set by the graph, and this line only records it.
-affinidi-tdk = "0.10"
+# The floor is set by the graph, not chosen here: `vta-sdk` 0.34 and
+# `vta-service` 0.24 both declare `^0.12`, and `affinidi-messaging-test-mediator`
+# 0.5 does too. This line only records it.
+affinidi-tdk = "0.12"
 affinidi-data-integrity = "0.7"
 # The delivery layer (D1). Replaced `affinidi-messaging-didcomm-service`, the
 # type-routed framework both VTI services had already cut over from (#189).
@@ -78,36 +81,25 @@ affinidi-messaging-delivery = "0.1.14"
 # 0.1.5 the enum is exhaustively matched already and that arm is an
 # unreachable pattern, which `-D warnings` rejects.
 affinidi-messaging-core = "0.1.6"
-# Floor is 0.19.10 (affinidi-tdk-rs #718): the release where a closed websocket
-# says why it closed. The transport matched the close frame as `Message::Close(_)`
-# and discarded it — `debug!("WebSocket connection closed by server")` — so a
-# refused duplicate arrived here as a socket that simply vanished, and the loop
-# reconnected into a duel. The mediator's `Close` now carries a reason, each with
-# its own problem-report code, and the sdk surfaces the close code and reason at
-# WARN. `duplicate-channel` is preserved verbatim for the genuinely-replaced
-# case, so the matches on it below are unaffected. Filed from this side as
-# `OpenVTC/verifiable-trust-infrastructure#1028`; the eviction *policy* is
-# deliberately unchanged, because displacement is what triggers the mediator's
-# stored-mail redelivery for clients that do not pull explicitly.
+# This crate carries `trust-tasks-rs` types in its own API (`MediatorAcl` reaches
+# `atm.trust_tasks().account_update`), so its line is not independent of the one
+# below: a copy left on an older trust-tasks is a *second* semver-incompatible
+# `trust-tasks-rs` whose types do not unify. 0.22 is the line built on
+# trust-tasks 0.18, and it is also what `vta-sdk` 0.34 and
+# `affinidi-messaging-test-mediator` 0.5 declare — so it is the graph's floor
+# whether or not this line states it.
 #
-# 0.19.9 (#717) is the release that moves the messaging crates from
-# `trust-tasks-rs` 0.9 to 0.11. That is not a courtesy bump — this workspace is
-# on 0.11, `affinidi-messaging-sdk` carries `trust-tasks-rs` types in its own
-# API (`MediatorAcl` reaches `atm.trust_tasks().account_update`), and a copy
-# left on 0.9 is a *second* semver-incompatible `trust-tasks-rs` whose types do
-# not unify. Same class of failure as the `vta-sdk` note below.
-#
-# 0.19.8 (#716) is the fix underneath it, and the one this repo chased for weeks:
-# `_refresh_authentication` discarded `force_refresh`, so the websocket
-# transport's proactive refresh at 80% of token life rebuilt the socket *without*
-# refreshing and re-armed at 80% of the time remaining — a geometric cascade of
-# reconnects per token rather than one clean cycle. See `#231`–`#234`, where the
-# symptom was two listeners flapping about every 15 minutes.
-#
-# Earlier floors are below this one by construction: 0.19.4 (#694) was the
+# Older floors are below this one by construction and kept in git history rather
+# than as a wall of satisfied constraints. Each named a defect this repo had no
+# lever over: 0.19.10 (affinidi-tdk-rs #718) surfaced the websocket close code
+# and reason instead of discarding the frame, so a mediator refusing a duplicate
+# channel stopped looking like a socket that merely vanished; 0.19.8 (#716) was
+# the `force_refresh` drop that made the proactive token refresh rebuild the
+# socket *without* refreshing and re-arm at 80% of the time remaining — the
+# geometric reconnect cascade behind `#231`–`#234`; and 0.19.4 (#694) was the
 # `live_stream_next*` read guard that blocked `stop_websocket` for the remainder
-# of a 10s poll window, so quitting the TUI mid-window paid it.
-affinidi-messaging-sdk = "0.21"
+# of a 10s poll window.
+affinidi-messaging-sdk = "0.22"
 # `StreamExt::next` on the `BoxStream` returned by `MessagingService::subscribe`.
 futures-util = "0.3"
 # Agent names (DID shortcuts). `agent-names` carries the parse /
@@ -136,6 +128,14 @@ chrono = "0.4"
 clap = { version = "4.6", features = ["derive"] }
 console = "0.16"
 crossterm = { version = "0.29", features = ["event-stream"] }
+# Held at 6 deliberately, not merely unrefreshed. `vta-sdk` and `did-git-sign`
+# both declare `^6`, and this is the only line that could split them — the graph
+# currently holds exactly one `dirs` and moving to 7 alone would make it two,
+# for a release whose sole breaking change is `preference_dir` resolving to
+# `RoamingAppData` rather than `LocalAppData` on Windows. We call `home_dir` and
+# `config_dir`, neither of which moved, so a second copy would buy nothing and
+# risk this workspace and the sdk disagreeing about where a path is. It follows
+# the stack up when the stack goes.
 dirs = "6.0"
 dialoguer = { version = "0.12", features = ["password"] }
 didwebvh-rs = "0.6"
@@ -189,140 +189,112 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # our copy has to be the same crate version vta-sdk resolves, or the two are
 # distinct types that do not unify.
 #
-# Moved 0.9 → 0.11 when vta-sdk went to 0.27, as it moved 0.6 → 0.9 when vta-sdk
-# went to 0.25 and 0.4 → 0.6 when vta-sdk went to 0.23.3. This is a *follow*, not
-# a lead: holding an older line here
-# stops matching the stack and starts splitting the type — on the 0.4 → 0.6 move
-# a `cargo update` alone put 0.4.1 and 0.6.5 in the same binary, which is the
-# exact failure the paragraph above exists to prevent. `cargo tree -d` is the
-# check: two `trust-tasks-rs` rows means this pin has drifted from vta-sdk's
-# again, whichever direction it drifted.
+# Moved 0.17 → 0.18 when vta-sdk went to 0.34, as it moved 0.11 → 0.17 for 0.31,
+# 0.9 → 0.11 for 0.27, 0.6 → 0.9 for 0.25 and 0.4 → 0.6 for 0.23.3. This is a
+# *follow*, not a lead: holding an older line here stops matching the stack and
+# starts splitting the type — on the 0.4 → 0.6 move a `cargo update` alone put
+# 0.4.1 and 0.6.5 in the same binary, which is the exact failure the paragraph
+# above exists to prevent. `cargo tree -d` is the check: two `trust-tasks-rs`
+# rows means this pin has drifted from vta-sdk's again, whichever direction it
+# drifted.
 #
-# `trust-tasks-capability-client` moves with it (0.8 → 0.9) for the same reason
-# — it re-exports the same `TrustTask`. Its own leading component moves one step
-# per two of this crate's because it tracks its API, not the framework's;
-# upstream releases the six siblings as one event for exactly this reason
-# (trust-tasks-tf #250, where a sibling left behind produced
-# `expected TrustTask<Value>, found a different TrustTask<Value>`).
+# The patch is named because vta-sdk 0.34 declares `^0.18.3`, not a bare `^0.18`
+# — a floor below what the sdk itself requires is a floor that does nothing.
+# 0.18.5 is the release VTI main pins across the whole stack, so that is the
+# line the services actually build against.
+#
+# `trust-tasks-capability-client` moves with it for the same reason — it
+# re-exports the same `TrustTask`. Upstream releases the six siblings as one
+# event for exactly this reason (trust-tasks-tf #250, where a sibling left
+# behind produced `expected TrustTask<Value>, found a different
+# TrustTask<Value>`), and on this line the two crates share a version number.
 #
 # Note the check has to include the **dev** graph. On the 0.6 → 0.9 move the
 # shipped graph was clean while `cargo tree -d -e normal,build,dev` still showed
 # two, because `openvtc-core` dev-depends on `vta-service` for `MockVta` and
-# that pin was a line behind. See its note in `openvtc-core/Cargo.toml`. The
-# 0.9 → 0.11 move needed a third crate to follow as well: the messaging stack
-# carries `trust-tasks-rs` types in its own API, so `affinidi-messaging-sdk` has
-# a floor of 0.19.9 above for the same reason (affinidi-tdk-rs #717).
-trust-tasks-rs = "0.17"
-trust-tasks-capability-client = "0.17"
+# that pin was a line behind. See its note in `openvtc-core/Cargo.toml`. Since
+# the 0.9 → 0.11 move a third and fourth crate have had to follow as well: the
+# messaging stack carries `trust-tasks-rs` types in its own API, so
+# `affinidi-messaging-sdk` (above) and the `affinidi-messaging-test-mediator`
+# dev-dependency both have to sit on the line built against it.
+trust-tasks-rs = "0.18.5"
+trust-tasks-capability-client = "0.18.5"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-# The 0.27 line — the one `vta-service` 0.19 is built on, and the one that
-# declares `trust-tasks-rs ^0.11`. As always this pin *follows* the VTA rather
-# than leading it; see the `trust-tasks-rs` note above for why the two versions
-# cannot be chosen independently.
+# The 0.34 line — the one `vta-service` 0.24 is built on, the one VTI main
+# deploys, and the one that declares `trust-tasks-rs ^0.18.3`. As always this pin
+# *follows* the VTA rather than leading it; see the `trust-tasks-rs` note above
+# for why the two versions cannot be chosen independently.
 #
-# 0.25 → 0.27 crossed two minors and broke nothing here — the workspace compiled
-# and tested clean with no source change. What it buys is a live defect fix that
-# reaches this repo silently:
+# What 0.33 and 0.34 change for this repo is the *shape* of the wire types
+# rather than any behaviour of its own. VTI #1270/#1271 made the growth-prone
+# request/response bodies `#[non_exhaustive]` — `AclEntry` and `AppStateWrite`
+# among them — so a struct literal outside the sdk no longer compiles and the
+# constructor is the only way in. That is a deliberate constraint rather than an
+# inconvenience: on `AclEntry`, an absent `allowed_keys` and a present-but-empty
+# one are OPPOSITE grants (absent reaches every key the entry's scopes reach,
+# empty reaches none), and a literal is exactly how a member added later gets
+# defaulted to the wrong one of the two.
 #
-# 0.27.0 (VTI #1033) repairs the Trust-Task response decode. VTI #1000 folded
-# Trust-Task payloads to lowerCamelCase per SPEC §4.10 but excluded
-# `client/types.rs` on a stale path assumption, so the agent moved to `basePath`
-# while the client went on demanding `base_path` — eleven required fields with no
-# `default`, across `contexts` create/get/update/list and `keys`
-# sign/rename/revoke/export-secret, failing hard on every transport. Our two
-# `list_contexts()` call sites (`state_handler/mod.rs`, `context_probe.rs`) both
-# sit behind `let Ok(..)`/`match`, so against a post-#1000 agent this degraded
-# quietly rather than erroring: the sub-context probe simply saw nothing. The fix
-# is intake aliases, not a rename, so 0.27 also still decodes an older agent's
-# snake_case — safe against a VTA on either side of the fold.
+# VTI #1280 then replaced `create_acl`'s positional argument list with
+# `CreateAclParams`, so an entry can be created already narrowed instead of
+# being narrowed by a second call. The window that closes is real: between the
+# grant and the narrowing the entry holds everything its role implies, and a
+# subject that authenticates inside it is authorized by what it found there.
 #
-# 0.26.0 (VTI #1012) adds `VtaClient::idempotent`, which holds one
-# `idempotencyKey` across every attempt of an operation so a retried
-# `create_key` is deduplicated at the VTA instead of taking effect twice. Not
-# adopted here yet — our retry owner is `vta_retry()` — but it is the seam that
-# eventually replaces it, and the SDK is now the layer that retries.
-#
-# 0.26 is not itself a viable floor: it declares `trust-tasks-rs ^0.9`, so a
-# checkout resolving back to it while this workspace is on 0.11 would put two
-# `trust-tasks-rs` in the binary — the same trap 0.24 (`^0.6`) posed against 0.9
-# and 0.23.0 (`^0.4`) posed against 0.6.
+# 0.34 also adds `room_present` / `room_open` (VTI #1285), the member half of
+# the rooms oracle. Nothing here calls them yet.
 #
 # Older floor notes are gone with their lines and kept in git history rather than
 # as a wall of satisfied constraints. Each recorded a defect this repo had no
-# lever over: 0.23's `CreateDidWebvhRequest.add_tsp_service` (VTI #959, the field
-# that lets a minted persona advertise `#tsp` at all — see
-# `setup_sequence/vta.rs`), 0.25's `CreateKeyRequest.internal` (VTI #995), and
-# the 0.21.x line's `provision/integration/0.2` casing (VTI #917) and `null`
-# `CreateKeyBody` members (VTI #919).
+# lever over: 0.32's Trust-Task dispatch identity (VTI #1184/#1192 — both DIDComm
+# and TSP transports built every client with `identity: None`, so a dispatched
+# task carried no issuer, no recipient and no proof) and its
+# `provision/integration` 0.3 cut (VTI #1200/#1202, which killed setup's last
+# step on every fresh install); 0.31's mandatory `ClientIdentity`; 0.27's
+# Trust-Task response decode (VTI #1033, `basePath` vs `base_path`); 0.25's
+# `CreateKeyRequest.internal` (VTI #995); 0.23's
+# `CreateDidWebvhRequest.add_tsp_service` (VTI #959, the field that lets a minted
+# persona advertise `#tsp` at all); and the 0.21.x line's
+# `provision/integration/0.2` casing (VTI #917) and `null` `CreateKeyBody`
+# members (VTI #919).
 #
 # The graph holds exactly one `vta-sdk` and one `trust-tasks-rs`, and keeping it
-# that way took a release in another repo: `did-git-sign` 0.4.5 required
-# `vta-sdk ^0.25`, so until VGI published 0.4.6 on 0.27 this workspace carried
-# 0.25.1 beside 0.27.0. That is the third consecutive cycle it has done so — see
-# the floor note on `did-git-sign` in `openvtc/Cargo.toml`, which is where the
-# obligation is written down.
+# that way is the whole cost of this pin. `vta-sdk` is a 0.x crate, so `"0.32"`
+# *excludes* 0.34: every consumer edge that declares its own requirement has to
+# move in the same change, or the workspace carries two sdks. That is not merely
+# untidy — `vti-common` re-exports `vta_sdk::acl::{ActScope, ApproveScope,
+# ContextDirection}` as its own public API, so the two copies carry types that
+# cannot unify, and in practice the build fails outright rather than mis-typing.
 #
-# 0.31 → 0.32 is the fifth. Two upstream edges declare `vta-sdk` and both had to
-# move first, because `"0.31"` on a 0.x crate excludes 0.32: `did-git-sign`
-# (VGI #33, whose head this workspace already patches to) and `vta-service`,
-# which `openvtc-core` dev-depends on for `MockVta` — 0.22 is built on 0.31, so
-# the dev graph would have split even with the shipped one clean. Both are moved
-# in this change. `trql-client`, the third git-pinned edge, does **not** depend
-# on `vta-sdk` at all, so trust-registry stays where it is.
+# There are two such edges, and both move here:
 #
-# What 0.32 buys, all of it reaching this repo through calls it already makes:
+# - `vta-service`, which `openvtc-core` dev-depends on for `MockVta` (0.24 is
+#   the line built on 0.34). Dev-only, which is exactly why it gets forgotten —
+#   the *shipped* graph looks clean while the harness tests this client against
+#   a server it is no longer paired with.
+# - `did-git-sign`, which is the standing obligation. It has now blocked this
+#   line **six** consecutive times (0.23, 0.25, 0.27, 0.31, 0.32, 0.34), so read
+#   it as a recurring cost to budget for rather than as an incident. Read the
+#   `[patch.crates-io]` block at the bottom of this file for how the edge is
+#   carried this cycle, and the floor note in `openvtc/Cargo.toml` for where the
+#   obligation is written down.
 #
-# VTI #1184 + #1192 are one defect in two halves. `didcomm_transport` and
-# `tsp_transport` built every client with `identity: None`, so a dispatched
-# Trust Task carried no `issuer`, no `recipient` and no proof — which the VTA's
-# dispatch spine refuses as `malformedRequest` over DIDComm and, because the TSP
-# paths back-fill those two members, as `proofRequired` over TSP. Same bug, two
-# names, depending on transport. #1192 then stopped `address_trust_task`
-# rewriting `issuer`/`recipient` *after* signing, which had been turning a valid
-# proof into `proofInvalid` at the far end. Every Trust Task this repo dispatches
-# — agent names, devices, keys, join — goes through those transports.
+# `trql-client`, the third git-pinned edge in this ecosystem, does **not**
+# depend on `vta-sdk` at all, so the trust registry needs no release for an sdk
+# bump.
 #
-# VTI #1193 lifts Trust-Task signing off `did:key`. The signer derived the
-# verification method as `<did>#<multibase>`, which only a `did:key` has, so a
-# provisioned `did:webvh` integration could not sign any of the 210
-# proof-requiring tasks. `ClientIdentity` gains `verification_method` for the
-# methods that must name one; the two sites here that built it by hand now use
-# `ClientIdentity::did_key`, which is the constructor for the one method whose
-# key *is* its identifier.
-#
-# VTI #1191 adds `device_heartbeat_named`, which is what lets this install
-# correct its own `displayName` — set once at registration and, until now,
-# unchangeable. Taken here; used in the follow-up.
-#
-# **The floor names the patch.** 0.32.0 cannot link this repo to a VTA at all.
-# VTI #1147 cut `provision/integration` to 0.3 and removed 0.2 outright, moved
-# the server and the REST runner, and left the TSP runner on 0.2 and both
-# DIDComm runners on 0.1 — so setup's last step died with `unsupportedType`
-# against a healthy VTA. The setup wizard prefers TSP, and the failure lands
-# *after* auth as a `PostAuthFailure`, which the runner treats as terminal — so
-# it never falls back to the REST leg that would have worked. Every fresh
-# install hit it. VTI #1200 routes all four dispatch sites through
-# `ProvisionSpecVersion::CURRENT` and guards it server-side; 0.32.1 is that fix.
-#
-# `"0.32"` would admit 0.32.0 and resolve to it on any machine with a stale
-# index — the same shape as the `did-git-sign` `"0.4.3"` floor that quietly
-# admitted 0.4.5 and let a duplicate `vta-sdk` into the graph unnoticed. A floor
-# that exists to exclude a specific broken release has to name it.
-#
-# 0.32.2 is the *reply* half of that same 0.3 cut (VTI #1202). #1200 moved the
-# dispatch sites; `result_uri_for` kept a hand-written table that tested only
-# for 0.2 and fell through to 0.1, so a provisioning reply went out as a 0.3
-# body labelled `provision/integration/0.1#response` — a message that cannot
-# satisfy the schema it names. This client does not *see* it, because it derives
-# the reply type it waits for with the same function and so agrees with the
-# server, wrongly, in both directions; it takes an independent client (the
-# browser wallet, reading the URI from the registry bindings) to notice. Which
-# is the reason to take it here anyway: a wire label this repo agrees with only
-# by sharing the bug is not a contract, and the next conformance witness or
-# non-Rust peer on the other end of a provisioning run is what collects on it.
-vta-sdk = { version = "0.32.4", features = [
+# **The floor names the patch, never a bare minor**, wherever a specific release
+# is what makes the line viable — a caret that admits a broken or duplicate-
+# reintroducing release lets a clean checkout resolve straight back onto it. On
+# the 0.32 line that was 0.32.1/0.32.2 (VTI #1200/#1202: `provision/integration`
+# had been cut to 0.3 while three of the four dispatch runners still sent 0.2 or
+# 0.1, so setup's last step died with `unsupportedType` against a healthy VTA,
+# and the reply came back labelled with a schema it could not satisfy). On this
+# line 0.34.0 is the first release of its minor and there is no such release to
+# exclude, so the patch is named only to record what was verified.
+vta-sdk = { version = "0.34.0", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses
@@ -348,6 +320,13 @@ reqwest = { version = "0.13", features = ["json"] }
 # declare `x25519-dalek ^2`, and we hand our `StaticSecret` straight to pgp's
 # `ecdh::SecretKey::Curve25519Legacy` — a 3.x secret is a different type there
 # and would not compile. 3.0 also moves to curve25519-dalek 5 / rand_core 0.10.
+#
+# The graph does hold a 3.x copy as well, and that is fine because it is bounded
+# and no type crosses: 3.0.0 is reached only through the vta-sdk crypto stack
+# (and, in the dev graph, `vti-rooms`' MLS chain), while 2.0.1 is the one our
+# `StaticSecret` is handed to. `cargo tree -i x25519-dalek@2.0.1` is where that
+# is checked. It collapses when `pgp` releases on 3.x; 0.20.0 is still its
+# latest and still declares `^2`.
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 zeroize = "1.8"
 
@@ -361,32 +340,41 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 
-# `did-git-sign` 0.4.6 — the latest published release — requires `vta-sdk ^0.27`,
-# and that one edge re-splits `vta-sdk`, `affinidi-tdk`, `affinidi-messaging-sdk`
-# and `trust-tasks-rs` into two copies each against this workspace's 0.31. It does
-# not merely fail to unify types: `vta-keys` 0.2.9 does not compile against
-# `vti-common` 0.15, so the whole workspace fails to build.
+# `did-git-sign` 0.4.6 — still the latest *published* release — requires
+# `vta-sdk ^0.27`, and that one edge re-splits `vta-sdk`, `affinidi-tdk`,
+# `affinidi-messaging-sdk` and `trust-tasks-rs` into two copies each against this
+# workspace's 0.34. It does not merely fail to unify types: an older `vta-keys`
+# does not compile against the current `vti-common`, so the whole workspace fails
+# to build.
 #
-# OpenVTC/verifiable-git-infrastructure#33 is the release that ends it — the VGI
-# workspace onto vta-sdk 0.32 and TDK 0.10, no source change, green on its own
+# OpenVTC/verifiable-git-infrastructure#37 is the change that ends it — the VGI
+# workspace onto vta-sdk 0.34 and TDK 0.12, no source change, green on its own
 # pipeline. Its head is a better dependency than the stale published crate, so
 # this workspace takes it directly rather than waiting on the publish: the
 # requirement in `openvtc/Cargo.toml` still names `0.4.6` (the version VGI carries
 # at that rev), and this patch is what decides where that 0.4.6 comes from.
 #
-# The rev moved with the vta-sdk 0.32 bump. That is the whole reason this block
-# is cheap: a published `did-git-sign` would have made 0.32 wait on a full VGI
-# release cycle, as 0.23, 0.25 and 0.27 each did.
+# The rev moves with every vta-sdk minor. That is the whole reason this block is
+# cheap: a published `did-git-sign` would have made 0.32 and 0.34 each wait on a
+# full VGI release cycle, as 0.23, 0.25 and 0.27 each did.
 #
 # Pinned by `rev`, never by `branch` — a further push to that PR must not silently
 # change what this builds against. VGI's own manifest pins `trql-client` the same
 # way, and both git sources are allow-listed in `deny.toml`.
 #
-# **Delete this whole block the moment VGI publishes 0.4.7 on vta-sdk 0.31**, and
-# raise the floor in `openvtc/Cargo.toml` to name that release. `publish = false`
-# here, so a git source costs this workspace nothing on its own release path — but
-# it is still a dependency on an unmerged branch, which is a thing to unwind
-# rather than to keep.
+# **Delete this whole block the moment VGI publishes 0.4.7**, and raise the floor
+# in `openvtc/Cargo.toml` to name that release. `publish = false` here, so a git
+# source costs this workspace nothing on its own release path — but it is still a
+# dependency on an unmerged branch, which is a thing to unwind rather than to
+# keep. The unwind is three deep and all three are still open:
+#
+#   1. affinidi/affinidi-trust-registry-rs#128 merges and publishes
+#      `trql-client` 0.15 (on trust-tasks 0.18, so it also clears the duplicate
+#      that pin currently leaves in VGI's own tree)
+#   2. VGI swaps its `trql-client` git pin back to `"0.15"` — `cargo publish`
+#      rejects git dependencies, so 0.4.7 *cannot* be released while it stands —
+#      then tags, which fires `publish.yml`
+#   3. OpenVTC deletes this block and floors `did-git-sign` at `"0.4.7"`
 [patch.crates-io]
-did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "d2c091d795168357d8bf3d1c4fffce645f2415de" }
-vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "d2c091d795168357d8bf3d1c4fffce645f2415de" }
+did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "584f57be6b41407e2da639de3f1db2904dec3633" }
+vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "584f57be6b41407e2da639de3f1db2904dec3633" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,24 +349,26 @@ strip = "symbols"
 #
 # OpenVTC/verifiable-git-infrastructure#37 is the change that ends it — the VGI
 # workspace onto vta-sdk 0.34 and TDK 0.12, no source change, green on its own
-# pipeline. Its head is a better dependency than the stale published crate, so
-# this workspace takes it directly rather than waiting on the publish: the
-# requirement in `openvtc/Cargo.toml` still names `0.4.6` (the version VGI carries
-# at that rev), and this patch is what decides where that 0.4.6 comes from.
+# pipeline. It is **merged**, and the rev below is VGI's `main` at that merge, so
+# this is a pin to a released-in-git tree rather than to a branch that could be
+# deleted under it. What it is not is a *published* release: the requirement in
+# `openvtc/Cargo.toml` still names `0.4.6` (the version VGI carries at that rev),
+# and this patch is what decides where that 0.4.6 comes from.
 #
 # The rev moves with every vta-sdk minor. That is the whole reason this block is
 # cheap: a published `did-git-sign` would have made 0.32 and 0.34 each wait on a
 # full VGI release cycle, as 0.23, 0.25 and 0.27 each did.
 #
-# Pinned by `rev`, never by `branch` — a further push to that PR must not silently
-# change what this builds against. VGI's own manifest pins `trql-client` the same
-# way, and both git sources are allow-listed in `deny.toml`.
+# Pinned by `rev`, never by `branch` — a later commit on VGI main must not
+# silently change what this builds against. VGI's own manifest pins `trql-client`
+# the same way, and both git sources are allow-listed in `deny.toml`.
 #
 # **Delete this whole block the moment VGI publishes 0.4.7**, and raise the floor
 # in `openvtc/Cargo.toml` to name that release. `publish = false` here, so a git
-# source costs this workspace nothing on its own release path — but it is still a
-# dependency on an unmerged branch, which is a thing to unwind rather than to
-# keep. The unwind is three deep and all three are still open:
+# source costs this workspace nothing on its own release path — but a git source
+# is still a thing to unwind rather than to keep. Merging #37 discharged the
+# first obligation (VGI main now builds on 0.34) and none of the publish chain,
+# which is three deep and all three still open:
 #
 #   1. affinidi/affinidi-trust-registry-rs#128 merges and publishes
 #      `trql-client` 0.15 (on trust-tasks 0.18, so it also clears the duplicate
@@ -376,5 +378,5 @@ strip = "symbols"
 #      then tags, which fires `publish.yml`
 #   3. OpenVTC deletes this block and floors `did-git-sign` at `"0.4.7"`
 [patch.crates-io]
-did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "584f57be6b41407e2da639de3f1db2904dec3633" }
-vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "584f57be6b41407e2da639de3f1db2904dec3633" }
+did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "5111dc177d25d68088a4d6ba991210e262498950" }
+vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "5111dc177d25d68088a4d6ba991210e262498950" }

--- a/deny.toml
+++ b/deny.toml
@@ -26,17 +26,24 @@ ignore = [
     # unlock and SSH key parsing — so the residual exposure is limited.
     # Re-evaluate when the `rsa` crate ships a constant-time implementation.
     "RUSTSEC-2023-0071",
-    # RUSTSEC-2025-0134: rustls-pemfile is unmaintained. Pulled via both
-    # reqwest 0.11 (1.x) and tonic (2.x) inside the affinidi messaging
-    # stack. No security impact identified — purely a maintenance
-    # advisory. Will fall off when the upstream chains migrate to
-    # rustls-pki-types/rustls-types.
-    "RUSTSEC-2025-0134",
     # RUSTSEC-2024-0436: paste is unmaintained. Build-time proc-macro
     # pulled transitively via vta-service/vti-common (utoipa-axum). No
     # runtime code; falls off when utoipa migrates off paste.
     "RUSTSEC-2024-0436",
+    # RUSTSEC-2026-0173: proc-macro-error2 is unmaintained. Same shape as
+    # the `paste` entry above and narrower in reach: a build-time
+    # proc-macro with no runtime code, and it enters only through the
+    # **dev** graph — vta-service 0.24 -> vti-rooms -> openmls_rust_crypto
+    # -> hpke-rs -> libcrux-sha3 -> hax-lib. Nothing the shipped binary
+    # links reaches it. It arrived with the vta-sdk 0.34 refresh, which is
+    # when vta-service grew the rooms crates; it falls off when hax-lib
+    # migrates off the macro.
+    "RUSTSEC-2026-0173",
 ]
+# Removed with the vta-sdk 0.34 refresh: RUSTSEC-2025-0134 (rustls-pemfile
+# unmaintained) no longer matches anything in the graph, and cargo-deny warns
+# about an ignore that never fires — an ignore list that keeps entries after
+# their crate is gone stops being a record of accepted risk.
 
 [licenses]
 version = 2

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -97,18 +97,30 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # embedded in the test process with the JWT keys, DID document, ACL
 # defaults, and local-DID whitelisting set up. Replaces the hand-rolled
 # harness that did the same dance manually.
-affinidi-messaging-test-mediator = "0.4"
+#
+# Track this with `affinidi-messaging-sdk`, for the same reason `vta-service`
+# below tracks `vta-sdk`: 0.5 is the line built on messaging-sdk 0.22 / TDK 0.12
+# / trust-tasks 0.18, and the 0.4 line declares `^0.21.0` / `^0.11` / `^0.17`.
+# Leaving it behind puts a second copy of each in the **dev** graph — including
+# `trust-tasks-rs`, whose types the messaging sdk carries in its own API.
+affinidi-messaging-test-mediator = "0.5.2"
 # In-process MockVta for the bootstrap e2e (VTI#406/#427 test-support seams).
 # `vta-service` is the VTA server crate; it carries the credential-vault
 # lifecycle tasks (receive/query/archive/delete/restore/purge) + the
 # `MockVta::start_provisionable` seams used by the e2e tests. Track this with
-# the vta-sdk major: 0.19 is the line built against vta-sdk 0.27, as 0.17 was
-# against 0.25, 0.15 against 0.23, 0.14 against 0.21 and 0.13 against 0.20. An
-# older line pulls an older sdk into the test build and the two disagree about
-# the wire types the e2e tests assert on.
+# the vta-sdk major: 0.24 is the line built against vta-sdk 0.34, as 0.23 was
+# against 0.32, 0.19 against 0.27, 0.17 against 0.25, 0.15 against 0.23 and 0.14
+# against 0.21. An older line pulls an older sdk into the test build and the two
+# disagree about the wire types the e2e tests assert on.
 #
-# 0.19 also carries `trust-tasks-rs ^0.11`, which is what keeps the **dev** graph
-# from growing the second `trust-tasks-rs` the root manifest's note warns about.
+# 0.24 also carries `trust-tasks-rs ^0.18.3` and `affinidi-tdk ^0.12`, which is
+# what keeps the **dev** graph from growing the second copy of each that the
+# root manifest's notes warn about.
+#
+# Its `affinidi-messaging-sdk` edge is still on `^0.21` upstream, one line
+# behind the runtime graph — but it sits behind the non-default `tsp` feature,
+# which the feature list below does not enable, so it pulls nothing in. If
+# `tsp` is ever added here, check `cargo tree -d` before assuming it is free.
 #
 # Moving to 0.15 is what collapsed the *second* vta-sdk this workspace grew when
 # the runtime dependency went to 0.23 (#213): 0.14.37 asks for `vta-sdk ^0.21`,
@@ -118,7 +130,7 @@ affinidi-messaging-test-mediator = "0.4"
 # ApproveScope, ContextDirection}` as its own public API, so a graph holding two
 # sdks has two distinct `ApproveScope` types that do not unify. VTI republished
 # this crate for exactly this reason (see its Cargo.toml note on `publish`).
-vta-service = { version = "0.23", default-features = false, features = ["test-support", "rest", "didcomm"] }
+vta-service = { version = "0.24", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc-core/src/persona/claim_types.rs
+++ b/openvtc-core/src/persona/claim_types.rs
@@ -34,11 +34,17 @@
 //!   behind you without being worth withholding from every listing.
 //! - **`sensitivity: high`** means the value is *withheld from a listing that
 //!   did not explicitly ask for sensitive values*. That is the half that is not
-//!   cosmetic, it is a read-path control, and **it does not exist**:
-//!   `persona_attribute_list` takes `include_values` and nothing finer, so a
-//!   listing this pane asks for values in is sent every card number the holder
-//!   holds. [`Sensitivity`] is carried here so a caller can read it, and
-//!   nothing in this crate can act on it.
+//!   cosmetic — it is a read-path control. It now **exists on the wire**:
+//!   vta-sdk 0.34 gave `persona_attribute_list` an `include_sensitive`
+//!   argument, where before it took `include_values` and nothing finer. What
+//!   does not exist yet is a client that can *use* it, because this pane has
+//!   one escalation and the control needs two: `show_values` both asks for
+//!   values and reveals masked ones whole, so asking for a listing without
+//!   sensitive values would make a card number come back as "(no value)" under
+//!   a reveal — indistinguishable from holding nothing. Honouring it means the
+//!   reveal fetching that one value on its own. Until then [`Sensitivity`] is
+//!   still carried here only so a caller can read it, and `pool::list` passes
+//!   `include_values` through to both arguments.
 //!
 //! So the mask is what makes a missing control visible, not a substitute for
 //! it. A `high` type is masked *because its style says so*, not because

--- a/openvtc-core/src/persona/pool.rs
+++ b/openvtc-core/src/persona/pool.rs
@@ -318,7 +318,21 @@ pub async fn list(
     include_values: bool,
 ) -> Result<Vec<PoolAttribute>, OpenVTCError> {
     let value = client
-        .persona_attribute_list(None, include_values, None, None, None)
+        // `include_sensitive` is vta-sdk 0.34's second escalation, and it is
+        // passed `include_values` rather than a constant on purpose. In this
+        // client the two questions have one answer: the only caller is the
+        // identity pane's `show_values` toggle, which is the holder saying
+        // "show me what I hold" — and when it is on, the pane reveals masked
+        // values whole from what this call returned. Passing `false` here would
+        // not narrow that read, it would make every `sensitivity: high`
+        // attribute come back valueless and render as "(no value)" under the
+        // reveal — which is a *wrong answer* about what the holder holds, and
+        // one glance away from "nothing is stored". Honouring the escalation
+        // properly means the `s` reveal fetching that one value on its own, so
+        // the default read stops carrying every card number into this process
+        // while the reveal stays truthful. That is a pane change, not a
+        // dependency bump.
+        .persona_attribute_list(None, include_values, include_values, None, None, None)
         .await
         .map_err(|e| OpenVTCError::Vta(format!("persona attribute list failed: {e}")))?;
 

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -34,8 +34,9 @@ anyhow.workspace = true
 # consumer of the published crate.
 #
 # Floor is 0.4.6, but 0.4.6 is NOT where this resolves from: the `did-git-sign`
-# entry under `[patch.crates-io]` in the root manifest redirects it to VGI#37's
-# head, the unpublished commit that takes VGI to vta-sdk 0.34. The published
+# entry under `[patch.crates-io]` in the root manifest redirects it to VGI main
+# at the #37 merge — merged, but not published — which takes VGI to vta-sdk
+# 0.34. The published
 # 0.4.6 requires `^0.27`, which against this workspace's 0.34 does not merely
 # split the graph — an older `vta-keys` will not compile against the current
 # `vti-common`, so the build fails outright. Read the patch block for the full

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -34,19 +34,20 @@ anyhow.workspace = true
 # consumer of the published crate.
 #
 # Floor is 0.4.6, but 0.4.6 is NOT where this resolves from: the `did-git-sign`
-# entry under `[patch.crates-io]` in the root manifest redirects it to VGI#33's
-# head, the unpublished commit that takes VGI to vta-sdk 0.31. The published
-# 0.4.6 requires `^0.27`, which against this workspace's 0.31 does not merely
-# split the graph — `vta-keys` 0.2.9 will not compile against `vti-common` 0.15,
-# so the build fails outright. Read the patch block for the full rationale and
-# for what to delete once 0.4.7 exists; this line then names 0.4.7.
+# entry under `[patch.crates-io]` in the root manifest redirects it to VGI#37's
+# head, the unpublished commit that takes VGI to vta-sdk 0.34. The published
+# 0.4.6 requires `^0.27`, which against this workspace's 0.34 does not merely
+# split the graph — an older `vta-keys` will not compile against the current
+# `vti-common`, so the build fails outright. Read the patch block for the full
+# rationale and for what to delete once 0.4.7 exists; this line then names 0.4.7.
 #
 # That patch is what the standing obligation now looks like when it is not yet
-# discharged. It is the fourth consecutive cycle — 0.4.3 was the first release on
-# vta-sdk 0.23, 0.4.5 the first on 0.25, 0.4.6 the first on 0.27 — so read the
-# rule rather than the version: when the workspace's vta-sdk minor moves, VGI has
-# to move with it, and until it publishes, the graph carries two sdks unless
-# something says otherwise.
+# discharged. It is the sixth consecutive cycle — 0.4.3 was the first release on
+# vta-sdk 0.23, 0.4.5 the first on 0.25, 0.4.6 the first on 0.27, and 0.31, 0.32
+# and 0.34 have each been carried by a rev-pin because 0.4.7 still cannot be
+# published — so read the rule rather than the version: when the workspace's
+# vta-sdk minor moves, VGI has to move with it, and until it publishes, the graph
+# carries two sdks unless something says otherwise.
 #
 # The floor must name the exact release, never a lower caret. `"0.4.3"` admitted
 # 0.4.5, which requires `vta-sdk ^0.25` — so while this workspace was already on


### PR DESCRIPTION
Refreshes the dependency graph onto what `verifiable-trust-infrastructure` main actually builds against, rather than onto what is newest on crates.io.

| crate | from | to | why |
|---|---|---|---|
| `vta-sdk` | 0.32.4 | 0.34.0 | the line vta-service 0.24 is built on and VTI main deploys |
| `trust-tasks-rs` / `-capability-client` | 0.17 | 0.18.5 | vta-sdk 0.34 declares `^0.18.3`; 0.18.5 is VTI's pin |
| `affinidi-tdk` | 0.10 | 0.12 | declared by vta-sdk 0.34, vta-service 0.24 and test-mediator 0.5 |
| `affinidi-messaging-sdk` | 0.21 | 0.22 | the line built on trust-tasks 0.18 |
| `dtg-credentials` | 0.5 | 0.6 | VTI is on 0.6, so the two agree again |
| `vta-service` (dev) | 0.23 | 0.24 | MockVta — the harness has to be paired with the sdk it tests |
| `affinidi-messaging-test-mediator` (dev) | 0.4 | 0.5.2 | 0.4 pins sdk `^0.21` / TDK `^0.11` / trust-tasks `^0.17` |

These are not independent choices. `TrustTask` crosses the vta-sdk boundary in both directions, `vti-common` re-exports `vta_sdk::acl` as its own public API, and the messaging stack carries trust-tasks types in *its* API — so a crate left a line behind is a second, semver-incompatible copy whose types do not unify. The graph now holds exactly one `vta-sdk`, one `trust-tasks-rs`, one `affinidi-tdk` and one `affinidi-messaging-sdk` across `normal,build,dev`.

## The one source change

vta-sdk 0.34 gave `persona_attribute_list` an `include_sensitive` argument, and `pool::list` passes `include_values` through to it. That preserves this client's behaviour exactly, and it is deliberate rather than expedient: the identity pane has one escalation (`show_values`) and this control needs two. `show_values` both asks the agent for values *and* reveals masked ones whole, so passing `false` would not narrow the read — it would make every `sensitivity: high` attribute come back valueless and render as `(no value)` under a reveal, which is a wrong answer about what the holder holds and one glance from "nothing is stored". `masked_is_not_the_same_state_as_absent` is the test that names that hazard.

What this does close is a documentation defect. `claim_types`'s module header stated as fact that the sensitivity half of the registry "does not exist" because the task took `include_values` and nothing finer. It exists now; the header says so, and says what a client needs before it can use it — the `s` reveal fetching that one value on its own.

## Deliberate holds

- `dirs` stays at 6 against a published 7. vta-sdk and did-git-sign both declare `^6` and this is the only line that could split them; 7's sole breaking change is `preference_dir` on Windows, and we call `home_dir` and `config_dir`.
- `rand` 0.8 and `x25519-dalek` 2 stay where their existing notes put them: pgp 0.20 is still the latest release and still declares both.

## did-git-sign, for the sixth cycle running

The published 0.4.6 requires `vta-sdk ^0.27`, which against 0.34 does not merely split the graph — it fails to build. VGI cannot cut 0.4.7 while its `trql-client` git pin stands, so the `[patch.crates-io]` rev moves to the head of OpenVTC/verifiable-git-infrastructure#37 (VGI onto vta-sdk 0.34 / TDK 0.12, no source change, green on its own pipeline). The three-deep unwind back to a published 0.4.7 is unchanged and now written out in the patch block.

## cargo-deny

Adds RUSTSEC-2026-0173 (`proc-macro-error2` unmaintained) — a build-time proc-macro reaching only the **dev** graph, via vta-service 0.24's new `vti-rooms -> openmls -> hpke-rs -> libcrux -> hax-lib` chain. Removes RUSTSEC-2025-0134, which no longer matches anything and which cargo-deny warns about for that reason.

## Gate

`cargo fmt --all`; `cargo clippy --workspace --all-targets -- -D warnings`; `RUSTDOCFLAGS="-D warnings" cargo doc`; `cargo deny check` (all four sections); `cargo test --workspace`; and `cargo test --workspace -- --include-ignored` so the MockVta e2es actually run against vta-service 0.24. Default and `--no-default-features` both check.

**Merge order:** OpenVTC/verifiable-git-infrastructure#37 does not need to merge first — the patch pins its head by `rev` — but it should merge, or this pin points at a branch that could be deleted.
