### PR TITLE
feat(persona): worlds, families, and the claim-type table the agent serves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9197,9 +9197,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.18.6"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe43bd5d03b468c49ffa6c75d53afca9fe27cb70b35384941db3a8c42c1da4b8"
+checksum = "e3b18725200227aa173e4c7b6b89450bf6d42ab4add65caf510464378f196356"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9770,9 +9770,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8afb6ae8320688356666abaafbcead756e5de6b728e5658a5337b9d013547f2"
+checksum = "2d0282804d77ca99e9911f4a8a070e94e63f2cdad57fbdcd1bb9065b9b5194d4"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9771,8 +9771,7 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0282804d77ca99e9911f4a8a070e94e63f2cdad57fbdcd1bb9065b9b5194d4"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=129597aa86a0ebf5681b5d5485cb353f544e7bcc#129597aa86a0ebf5681b5d5485cb353f544e7bcc"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,9 +292,12 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # had been cut to 0.3 while three of the four dispatch runners still sent 0.2 or
 # 0.1, so setup's last step died with `unsupportedType` against a healthy VTA,
 # and the reply came back labelled with a schema it could not satisfy). On this
-# line 0.34.0 is the first release of its minor and there is no such release to
-# exclude, so the patch is named only to record what was verified.
-vta-sdk = { version = "0.34.0", features = [
+# line the patch names 0.34.1, and it is a floor rather than a record: 0.34.0
+# has neither `persona/facet/*` nor `persona/claim-types/list`, and the identity
+# pane now calls both. On 0.34.0 the pane compiles and then cannot find the
+# constants; naming the patch is what turns that into a resolver error at the
+# point where it can be read.
+vta-sdk = { version = "0.34.1", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,3 +383,26 @@ strip = "symbols"
 [patch.crates-io]
 did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "5111dc177d25d68088a4d6ba991210e262498950" }
 vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", rev = "5111dc177d25d68088a4d6ba991210e262498950" }
+# `vta-sdk` ahead of its last release, for `persona/facet/*` only.
+#
+# **Temporary, and this note is the owner.** The released 0.34.1 carries
+# `persona/claim-types/list` (VTI #1315) but not the facet tasks: #1338 landed
+# after that release was cut, so the three `TASK_PERSONA_FACET_*` constants
+# exist on `main` and nowhere on crates.io. Worlds are the holder-facing half of
+# that task family, and a client cannot address a Trust Task whose Type URI it
+# has no way to name.
+#
+# A rev, not a branch: this pin *follows* the VTA rather than leading it, and a
+# branch would let it drift under a routine refresh onto something nobody here
+# read. It is #1338's own merge commit rather than the head of `main`: at that
+# point `vta-sdk` is still the 0.34.1 that was released, so the patch adds three
+# Type URI constants and moves nothing else. Later revs carry the rooms and
+# `present/0.2` work, which pulls the whole TDK line forward — a real bump, and
+# not one that belongs in a change about worlds.
+#
+# **Delete this entry as soon as a `vta-sdk` release carries #1338**, and move
+# the requirement above to name that patch. Two entries in this block already
+# carry an unwind obligation and the `did-git-sign` note above is what one looks
+# like after six cycles of not being unwound; a third is where "temporary" stops
+# being true by itself.
+vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "129597aa86a0ebf5681b5d5485cb353f544e7bcc" }

--- a/deny.toml
+++ b/deny.toml
@@ -104,8 +104,14 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Both entries are rev-pinned git sources standing in for a release that has not
-# happened yet, and both are meant to be deleted rather than lived with.
+# Every entry is a rev-pinned git source standing in for a release that has not
+# happened yet, and every one is meant to be deleted rather than lived with.
+#
+# This list is the second half of each `[patch.crates-io]` entry in the root
+# `Cargo.toml`. A patch added there and not here fails `cargo deny check
+# sources` rather than quietly resolving to a source nobody reviewed, which is
+# what `unknown-git = "deny"` is for — so the two are edited together or the
+# build says so.
 #
 # * `verifiable-git-infrastructure` — `did-git-sign`'s published 0.4.6 requires
 #   `vta-sdk ^0.27`, which does not build against this workspace's 0.31. The
@@ -116,7 +122,15 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 #   dependency until the trust-registry release pipeline publishes a version
 #   built on the current trust-tasks line. It reaches this workspace only
 #   through VGI, whose own manifest pins the same rev.
+# * `verifiable-trust-infrastructure` — `vta-sdk` ahead of its last release, for
+#   `persona/facet/*` and nothing else. VTI #1338 landed after 0.34.1 was cut,
+#   so the three `TASK_PERSONA_FACET_*` constants the identity pane addresses
+#   worlds through exist on `main` and nowhere on crates.io. The pin is #1338's
+#   own merge commit rather than the head of `main`, so it adds those constants
+#   and moves nothing else. **Delete this entry and the patch together the
+#   moment a `vta-sdk` release carries #1338.**
 allow-git = [
     "https://github.com/OpenVTC/verifiable-git-infrastructure",
     "https://github.com/affinidi/affinidi-trust-registry-rs",
+    "https://github.com/OpenVTC/verifiable-trust-infrastructure",
 ]

--- a/openvtc-core/src/persona/claim_types.rs
+++ b/openvtc-core/src/persona/claim_types.rs
@@ -419,9 +419,13 @@ impl Registry {
     /// Parse a served response.
     ///
     /// Read member by member and defensively: a missing ordering leaves the
-    /// axis empty, which [`Axis::rank`] reads as "everything is most
-    /// protective" — degraded, but degraded towards showing less.
-    fn from_wire(value: &Value) -> Self {
+    /// axis unable to place either token, which [`Axis::stricter`] resolves to
+    /// the floor — degraded, but degraded towards showing less.
+    ///
+    /// `pub(crate)` for [`family`](crate::persona::family)'s tests, which need
+    /// a table declaring a root this build has no words for and cannot get one
+    /// from the compiled copy by construction.
+    pub(crate) fn from_wire(value: &Value) -> Self {
         let entries = value
             .get("entries")
             .and_then(Value::as_array)

--- a/openvtc-core/src/persona/claim_types.rs
+++ b/openvtc-core/src/persona/claim_types.rs
@@ -1,19 +1,38 @@
-//! What a claim type says about showing its own value — a **vendored copy** of
-//! the masking half of the persona claim-type registry.
+//! What a claim type says about showing its own value — **read from the agent**,
+//! with a compiled copy kept only for an agent too old to serve one.
 //!
-//! Source of truth:
-//! `dtgwg-trust-tasks-tf/specs/persona/_shared/0.1/claim-types.json`, with the
-//! reasoning beside it in `CLAIM-TYPES.md`. This module carries two of that
-//! file's four per-type members — `sensitivity` and `mask` — because those are
-//! the two a pane needs to decide how to paint a row. `release` and `oidc` are
-//! deliberately absent: nothing here releases anything, and a copy of a table
-//! nobody reads is a copy that goes stale unnoticed.
+//! Source of truth on the wire: `persona/claim-types/list/1.0`, served since
+//! VTI #1315. The reasoning behind the table itself lives beside it in
+//! `dtgwg-trust-tasks-tf/specs/persona/_shared/0.1/CLAIM-TYPES.md`.
 //!
-//! It is vendored because **the agent does not serve this table.** There is no
-//! `persona/claim-types/list` task — the registry's own §6 lists adding one as
-//! an open question — so a client that wants a default has to ship it. Re-sync
-//! by hand against the file named above when the registry moves; the whole of
-//! the copy is the private `TABLE` in this file plus [`UNREGISTERED`].
+//! # Why this stopped being vendored
+//!
+//! This module used to carry a copy of the registry, and the copy was
+//! *correct*. That was never the problem. The problem is that a copy of a table
+//! two other repositories own costs a re-sync against each of them on every
+//! change — which is the argument for the registry existing at all, applied one
+//! layer down — and, since VTI #1327, that a **deployment may declare its own
+//! claim types**. An agent serving an extension token is invisible to a client
+//! that ships its own table, and the divergence is silent: the token resolves
+//! from the compiled copy exactly as it would have with no configuration at
+//! all, so the operator's intended tightening is quietly not in force and the
+//! screen looks completely normal.
+//!
+//! That is the shape of the `employer` / `profile.*` masking divergence this
+//! module was carrying: our copy matched spec 0.1 exactly, and 0.1 simply has
+//! no entry for either.
+//!
+//! # The compiled copy that remains
+//!
+//! [`Registry::vendored`] is spec 0.1, and it is reached in exactly one case:
+//! the agent answered `persona/claim-types/list` with
+//! `VtaError::UnsupportedTaskType`, meaning it is older than this client. Every
+//! other failure — the network, the ACL, a malformed body — is returned as an
+//! error, because a fallback that also covers "we could not ask" is a fallback
+//! that hides an outage behind a plausible screen. [`Registry::is_fallback`]
+//! says which one the caller got, and the pane says so too: a masking decision
+//! taken from a table the holder's own agent did not supply is worth one line
+//! of screen.
 //!
 //! # This is not a security control, and it must not be described as one
 //!
@@ -25,46 +44,75 @@
 //!
 //! # Masking is the half of the registry this client can honour
 //!
-//! The registry's §3.3 makes `mask` and `sensitivity` two decisions, not one,
-//! and they land in two different places:
+//! §3.3 makes `mask` and `sensitivity` two decisions, not one, and they land in
+//! two different places:
 //!
 //! - **`mask`** is a rendering. Any type whose style is not `none` is shown
 //!   reduced, whatever its sensitivity — which is why `email.work` is masked
-//!   here despite being `normal`. An address is worth hiding from the person
-//!   behind you without being worth withholding from every listing.
+//!   despite being `normal`. An address is worth hiding from the person behind
+//!   you without being worth withholding from every listing.
 //! - **`sensitivity: high`** means the value is *withheld from a listing that
-//!   did not explicitly ask for sensitive values*. That is the half that is not
-//!   cosmetic — it is a read-path control. It now **exists on the wire**:
-//!   vta-sdk 0.34 gave `persona_attribute_list` an `include_sensitive`
-//!   argument, where before it took `include_values` and nothing finer. What
-//!   does not exist yet is a client that can *use* it, because this pane has
-//!   one escalation and the control needs two: `show_values` both asks for
-//!   values and reveals masked ones whole, so asking for a listing without
-//!   sensitive values would make a card number come back as "(no value)" under
-//!   a reveal — indistinguishable from holding nothing. Honouring it means the
-//!   reveal fetching that one value on its own. Until then [`Sensitivity`] is
-//!   still carried here only so a caller can read it, and `pool::list` passes
-//!   `include_values` through to both arguments.
+//!   did not explicitly ask for sensitive values* — a read-path control, not a
+//!   cosmetic one. It exists on the wire (`persona_attribute_list`'s
+//!   `include_sensitive`), and this pane still has one escalation where the
+//!   control needs two. See `pool::list`.
 //!
-//! So the mask is what makes a missing control visible, not a substitute for
-//! it. A `high` type is masked *because its style says so*, not because
-//! anything here withheld it.
+//! `release` is carried but not acted on: nothing in this client releases
+//! anything. It is read so that a caller can *say* what a type would require,
+//! which is the half a holder can act on.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+use vta_sdk::client::VtaClient;
+use vta_sdk::error::VtaError;
+use vta_sdk::trust_tasks;
+
+use crate::errors::OpenVTCError;
+
+/// Round-trip budget for the registry read, in seconds.
+///
+/// The same 30s every other persona task gets (VTI R1.2 — an outbound call
+/// without a finite timeout turns a hung service into a hung command). This one
+/// is a pure local-store read at the agent, so the budget is generous rather
+/// than tuned.
+const REGISTRY_TIMEOUT: u64 = 30;
+
+/// The namespace the registry leaves open, and never resolves through a family.
+const EXTENSION_PREFIX: &str = "x:";
+
+/// The reverse-DNS `ext` key the agent reports its own configuration under.
+/// Kept in lockstep with `vta-service`'s `handle_claim_types_list` and with the
+/// console's `EXT_KEY_CLAIM_TYPES`.
+const EXT_KEY_CLAIM_TYPES: &str = "org.openvtc.claim-types";
 
 /// How carefully a value is shown **to its own holder**.
 ///
-/// Not linkability, and not what it takes to release the value — the registry's
-/// §3 keeps those three apart because a mechanism that reads one as a proxy for
-/// another hides the wrong things and warns about the wrong things. A payment
-/// card is highly sensitive and barely linkable; a nickname can be the reverse.
+/// Not linkability, and not what it takes to release the value — §3 keeps those
+/// three apart because a mechanism that reads one as a proxy for another hides
+/// the wrong things and warns about the wrong things. A payment card is highly
+/// sensitive and barely linkable; a nickname can be the reverse.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Sensitivity {
     /// Nothing beyond whatever [`MaskStyle`] the type carries.
     #[default]
     Normal,
     /// Additionally withheld from a listing that did not ask for sensitive
-    /// values — a read-path control this client cannot exercise. See the module
-    /// header.
+    /// values. See the module header.
     High,
+}
+
+impl Sensitivity {
+    /// Read a served token. An unrecognised one is treated as
+    /// [`High`](Sensitivity::High), the protective answer: a client that reads
+    /// an unknown sensitivity as `normal` has quietly widened a listing the
+    /// maintainer narrowed.
+    fn from_wire(token: &str) -> Self {
+        match token {
+            "normal" => Self::Normal,
+            _ => Self::High,
+        }
+    }
 }
 
 /// How a value is reduced when it is shown masked. The styles, and their
@@ -98,6 +146,28 @@ const BULLET: char = '•';
 const FULL_MASK_WIDTH: usize = 8;
 
 impl MaskStyle {
+    /// Read a served token.
+    ///
+    /// An unrecognised style becomes [`Full`](MaskStyle::Full), which the
+    /// schema states as a MUST: a maintainer may serve a style this build has
+    /// never heard of, and the only safe reading of "I do not know how to
+    /// reduce this" is "do not show it". Reading it as `none` would show in the
+    /// clear precisely the values a maintainer had just decided to reduce.
+    ///
+    /// Note that this collapses *rendering* only. Strictness comparison uses
+    /// the served ordering and the token as written, so an unknown style the
+    /// agent ranks as looser than `full` still compares at its true position —
+    /// see [`Registry::resolve`].
+    fn from_wire(token: &str) -> Self {
+        match token {
+            "none" => Self::None,
+            "last2" => Self::Last2,
+            "last4" => Self::Last4,
+            "emailLocal" => Self::EmailLocal,
+            _ => Self::Full,
+        }
+    }
+
     /// Reduce `text` to the form this style shows.
     ///
     /// Every style falls back to [`Full`](MaskStyle::Full) rather than to the
@@ -141,11 +211,48 @@ impl MaskStyle {
     }
 }
 
-/// What one claim type says about showing its value.
+/// What it takes to let a value leave — `release` in the registry's words.
+///
+/// Carried, not enforced: nothing in this client releases anything. It is here
+/// so a pane can *say* which attributes the holder's agent will stop and ask
+/// about, which is a fact about the holder's own arrangement and one they can
+/// act on.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Release {
+    /// Approved once, before it goes.
+    #[default]
+    Consent,
+    /// Asked again, on the holder's own device, every single time.
+    StepUp,
+}
+
+impl Release {
+    /// Read a served token, defaulting to the protective answer for the same
+    /// reason [`Sensitivity::from_wire`] does.
+    fn from_wire(token: &str) -> Self {
+        match token {
+            "consent" => Self::Consent,
+            _ => Self::StepUp,
+        }
+    }
+
+    /// The words this requirement wears on screen
+    /// (`design-docs/persona-vocabulary.md`, *letting it leave*).
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Consent => "you approve it once, before it goes",
+            Self::StepUp => "your agent asks you again, every single time",
+        }
+    }
+}
+
+/// What one claim type says about showing and releasing its value.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ClaimTypeDefaults {
     pub sensitivity: Sensitivity,
     pub mask: MaskStyle,
+    pub release: Release,
 }
 
 impl ClaimTypeDefaults {
@@ -172,187 +279,480 @@ impl ClaimTypeDefaults {
     }
 }
 
-/// The floor: what a token resolves to when nothing more specific supplies an
-/// axis.
+/// One row of the served table, as written.
 ///
-/// The conservative answer, and the registry's §4 rule 4: a vocabulary nobody
-/// has reasoned about is exactly the one nothing is known about, and an unknown
-/// value rendered in the clear is a decision nobody made. `x:` tokens are
-/// unregistered by construction and land here too.
-pub const UNREGISTERED: ClaimTypeDefaults = ClaimTypeDefaults {
-    sensitivity: Sensitivity::High,
-    mask: MaskStyle::Full,
-};
-
-/// The vendored table, in `claim-types.json`'s order so the two diff against
-/// each other by eye.
-const TABLE: &[(&str, Sensitivity, MaskStyle)] = &[
-    // Family entries, matched as prefixes. Without them `payment.somethingNew`
-    // resolves to the floor, and a gated family becomes leavable by inventing a
-    // token. `name` is also an exact token: a pool that keeps one
-    // undifferentiated name is using it.
-    ("payment", Sensitivity::High, MaskStyle::Full),
-    ("gov", Sensitivity::High, MaskStyle::Full),
-    ("name", Sensitivity::Normal, MaskStyle::None),
-    ("name.legal", Sensitivity::Normal, MaskStyle::None),
-    ("name.given", Sensitivity::Normal, MaskStyle::None),
-    ("name.family", Sensitivity::Normal, MaskStyle::None),
-    ("name.display", Sensitivity::Normal, MaskStyle::None),
-    // A former name is the one a holder most often keeps in order to answer a
-    // question once and never show again.
-    ("name.previous", Sensitivity::High, MaskStyle::Full),
-    ("person.birthDate", Sensitivity::High, MaskStyle::Full),
-    ("person.pronouns", Sensitivity::Normal, MaskStyle::None),
-    ("person.locale", Sensitivity::Normal, MaskStyle::None),
-    ("email.personal", Sensitivity::Normal, MaskStyle::EmailLocal),
-    ("email.work", Sensitivity::Normal, MaskStyle::EmailLocal),
-    // High because a mobile number is both a strong join key and an
-    // authentication factor: its harm is account takeover, not embarrassment.
-    ("phone.mobile", Sensitivity::High, MaskStyle::Last2),
-    ("phone.landline", Sensitivity::High, MaskStyle::Last2),
-    ("address.postal", Sensitivity::High, MaskStyle::Full),
-    ("address.country", Sensitivity::Normal, MaskStyle::None),
-    ("gov.id.passport", Sensitivity::High, MaskStyle::Last4),
-    ("gov.id.driverLicence", Sensitivity::High, MaskStyle::Last4),
-    ("gov.id.national", Sensitivity::High, MaskStyle::Last4),
-    ("gov.taxId", Sensitivity::High, MaskStyle::Last4),
-    ("payment.card", Sensitivity::High, MaskStyle::Last4),
-    ("payment.cardExpiry", Sensitivity::High, MaskStyle::Full),
-    ("payment.iban", Sensitivity::High, MaskStyle::Last4),
-    ("payment.accountNumber", Sensitivity::High, MaskStyle::Last4),
-    ("account.handle", Sensitivity::Normal, MaskStyle::None),
-    ("url.homepage", Sensitivity::Normal, MaskStyle::None),
-    ("org.name", Sensitivity::Normal, MaskStyle::None),
-    ("org.role", Sensitivity::Normal, MaskStyle::None),
-];
-
-/// The namespace the registry leaves open, and never resolves through a family.
-const EXTENSION_PREFIX: &str = "x:";
-
-impl Sensitivity {
-    /// Position in `claim-types.json`'s `strictness` ordering, most protective
-    /// first.
-    fn strictness(self) -> u8 {
-        match self {
-            Self::High => 0,
-            Self::Normal => 1,
-        }
-    }
+/// The wire tokens are kept rather than parsed straight to enums, because
+/// strictness comparison happens against the agent's own ordering and a token
+/// this build does not recognise still has a true position in it.
+#[derive(Clone, Debug)]
+struct Entry {
+    claim_type: String,
+    sensitivity: String,
+    mask: String,
+    release: String,
 }
 
-impl MaskStyle {
-    /// Position in `claim-types.json`'s `strictness` ordering, most protective
-    /// first. `last2` outranks `last4` because it shows fewer characters.
-    fn strictness(self) -> u8 {
-        match self {
-            Self::Full => 0,
-            Self::Last2 => 1,
-            Self::Last4 => 2,
-            Self::EmailLocal => 3,
-            Self::None => 4,
-        }
-    }
-}
+/// One axis's ordering, most protective first.
+#[derive(Clone, Debug, Default)]
+struct Axis(Vec<String>);
 
-impl ClaimTypeDefaults {
-    /// The more protective of two answers, taken per axis.
+impl Axis {
+    /// Position of a token in this ordering, if it places it at all.
+    fn rank(&self, token: &str) -> Option<usize> {
+        self.0.iter().position(|t| t == token)
+    }
+
+    /// The more protective of a registered prefix's answer and the floor's.
     ///
-    /// Per axis rather than whole-record, because the axes are independent
-    /// (§3) and a record chosen as a unit would carry one axis's answer on the
-    /// strength of another's.
-    fn tightest(self, other: Self) -> Self {
+    /// Asymmetric on purpose — the two arguments are not interchangeable, and
+    /// naming them is what keeps the fallback honest. When the ordering does
+    /// not place **both** tokens it cannot say which is more protective, and
+    /// the answer is the floor: it is the one that shows less, and a tie-break
+    /// that reached for the prefix instead would let a family *loosen* the
+    /// floor on an ordering the agent never sent. That is precisely the
+    /// direction §4 says must never happen, and it is the direction that fails
+    /// quietly — an unregistered `name.somethingNew` inheriting `name`'s `none`
+    /// is a value shown in the clear that no table said to show.
+    fn stricter<'a>(&self, prefix: &'a str, floor: &'a str) -> &'a str {
+        match (self.rank(prefix), self.rank(floor)) {
+            (Some(p), Some(f)) if p <= f => prefix,
+            _ => floor,
+        }
+    }
+}
+
+/// One claim type this deployment declared and its agent would not apply.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnappliedClaimType {
+    /// The token as the operator's file spelled it.
+    pub claim_type: String,
+    /// The agent's reason, in its words.
+    pub reason: String,
+}
+
+/// What the agent could not apply from its own claim-type configuration.
+///
+/// **Why a client reads this at all.** A refused row is otherwise invisible:
+/// the token resolves from the core table exactly as it would with no file, so
+/// an operator's intended tightening is quietly not in force and the screen
+/// looks completely normal. The agent reports its refusals precisely so
+/// somebody can be told, and this is the half that tells them.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct UnappliedReport {
+    pub rejected: Vec<UnappliedClaimType>,
+    /// Set when the extension file itself could not be read — a different
+    /// sentence from a rejected row, because then *nothing* the deployment
+    /// declared is in force.
+    pub file_error: Option<String>,
+}
+
+impl UnappliedReport {
+    /// Whether there is anything here worth saying on screen.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rejected.is_empty() && self.file_error.is_none()
+    }
+}
+
+/// The claim-type registry this agent resolves against.
+///
+/// Held for the life of a session and keyed on
+/// [`registry_version`](Registry::registry_version); it is a constant for a
+/// given agent. It **must not** be carried across agents: two agents may
+/// declare different extension types, and a table from one applied to the other
+/// resolves tokens it has never heard of.
+#[derive(Clone, Debug)]
+pub struct Registry {
+    /// Version of the core registry the agent implements — the version of
+    /// `claim-types.json`, not of the task.
+    pub registry_version: String,
+    /// True when this is [`Registry::vendored`] rather than the agent's answer.
+    pub is_fallback: bool,
+    /// What the deployment declared and the agent refused.
+    pub unapplied: UnappliedReport,
+    entries: Vec<Entry>,
+    unregistered: Entry,
+    sensitivity_order: Axis,
+    mask_order: Axis,
+    release_order: Axis,
+}
+
+impl Default for Registry {
+    /// The compiled copy. A [`Registry`] is only ever *default* before the
+    /// first read has come back, and drawing from spec 0.1 in that window is
+    /// the same answer this client gave for its whole life until now.
+    fn default() -> Self {
+        Self::vendored()
+    }
+}
+
+impl Registry {
+    /// Read the agent's claim-type registry.
+    ///
+    /// Returns [`vendored`](Registry::vendored) — flagged
+    /// [`is_fallback`](Registry::is_fallback) — only when the agent says it
+    /// does not serve the task, which means it predates VTI #1315. Every other
+    /// failure is an error: a fallback that also covered "we could not ask"
+    /// would draw a plausible screen over an outage, and the holder would have
+    /// no way to tell a masking decision their agent made from one this binary
+    /// invented (VTI R6.4).
+    pub async fn fetch(client: &VtaClient) -> Result<Self, OpenVTCError> {
+        // The payload is empty by schema, and the agent gates the task as
+        // reachable by any authenticated caller precisely so the holder's own
+        // tooling — which has no trust context to name — can read it.
+        match client
+            .dispatch_trust_task(
+                trust_tasks::TASK_PERSONA_CLAIM_TYPES_LIST_1_0,
+                serde_json::json!({}),
+                REGISTRY_TIMEOUT,
+            )
+            .await
+        {
+            Ok(value) => Ok(Self::from_wire(&value)),
+            Err(VtaError::UnsupportedTaskType { .. }) => Ok(Self::vendored()),
+            Err(e) => Err(OpenVTCError::Vta(format!(
+                "persona claim-types list failed: {e}"
+            ))),
+        }
+    }
+
+    /// Parse a served response.
+    ///
+    /// Read member by member and defensively: a missing ordering leaves the
+    /// axis empty, which [`Axis::rank`] reads as "everything is most
+    /// protective" — degraded, but degraded towards showing less.
+    fn from_wire(value: &Value) -> Self {
+        let entries = value
+            .get("entries")
+            .and_then(Value::as_array)
+            .map(|rows| rows.iter().filter_map(Entry::from_wire).collect())
+            .unwrap_or_default();
+
+        let unregistered = value
+            .get("unregistered")
+            .map_or_else(Entry::conservative_floor, Entry::floor_from_wire);
+
+        let axis = |name: &str| {
+            Axis(
+                value
+                    .get("strictness")
+                    .and_then(|s| s.get(name))
+                    .and_then(Value::as_array)
+                    .map(|xs| {
+                        xs.iter()
+                            .filter_map(Value::as_str)
+                            .map(str::to_string)
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+            )
+        };
+
         Self {
-            sensitivity: if self.sensitivity.strictness() <= other.sensitivity.strictness() {
-                self.sensitivity
-            } else {
-                other.sensitivity
-            },
-            mask: if self.mask.strictness() <= other.mask.strictness() {
-                self.mask
-            } else {
-                other.mask
-            },
+            registry_version: value
+                .get("registryVersion")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string(),
+            is_fallback: false,
+            unapplied: unapplied_from_ext(value),
+            entries,
+            unregistered,
+            sensitivity_order: axis("sensitivity"),
+            mask_order: axis("mask"),
+            release_order: axis("release"),
+        }
+    }
+
+    /// Resolve a claim type to how its value is shown — §4, minus the rule this
+    /// client cannot reach.
+    ///
+    /// 1. Rule 1 — a holder's explicit override — is **not implemented, because
+    ///    there is nowhere to store one.** `persona/attribute/put` has no
+    ///    `sensitivity` or `mask` member, so the choice the rule resolves first
+    ///    cannot currently be made. When it can, it belongs above everything
+    ///    here.
+    /// 2. Rule 4 is taken first among the rest: `x:` is unregistered *by
+    ///    construction*, so it borrows neither an entry nor a family however
+    ///    much of a registered token it happens to spell.
+    /// 3. An exact entry is used **as written**, and is not compared against
+    ///    anything: it is a decision someone made about that token.
+    /// 4. Otherwise the longest registered *proper* prefix, on dot boundaries,
+    ///    is taken together with the floor and the more protective of the two
+    ///    wins on each axis. A family entry can therefore only ever tighten —
+    ///    `name` as a prefix does not make an unregistered `name.somethingNew`
+    ///    visible, while `payment.giftCard` still inherits `payment`'s gating.
+    /// 5. Otherwise the floor.
+    ///
+    /// Rule 4's tightening direction is the one that fails quietly. Without it
+    /// `payment.giftCard` resolves to a floor whose `release` is weaker than
+    /// every registered member of the family it plainly belongs to, and a gated
+    /// family becomes leavable by inventing a token.
+    #[must_use]
+    pub fn resolve(&self, claim_type: &str) -> ClaimTypeDefaults {
+        let floor = &self.unregistered;
+
+        if claim_type.starts_with(EXTENSION_PREFIX) {
+            return floor.defaults();
+        }
+
+        if let Some(exact) = self.exact(claim_type) {
+            return exact.defaults();
+        }
+
+        let Some(prefix) = self.longest_registered_prefix(claim_type) else {
+            return floor.defaults();
+        };
+
+        ClaimTypeDefaults {
+            sensitivity: Sensitivity::from_wire(
+                self.sensitivity_order
+                    .stricter(&prefix.sensitivity, &floor.sensitivity),
+            ),
+            mask: MaskStyle::from_wire(self.mask_order.stricter(&prefix.mask, &floor.mask)),
+            release: Release::from_wire(
+                self.release_order.stricter(&prefix.release, &floor.release),
+            ),
+        }
+    }
+
+    /// Whether the registry **declares** this token, or a family it belongs to.
+    ///
+    /// The same walk [`resolve`](Registry::resolve) performs, asked as a
+    /// question: the floor and a declared entry are different kinds of answer,
+    /// and a pane that groups by family needs to tell them apart. An `x:` token
+    /// is never registered, per §4's last rule.
+    #[must_use]
+    pub fn is_registered(&self, claim_type: &str) -> bool {
+        !claim_type.starts_with(EXTENSION_PREFIX)
+            && (self.exact(claim_type).is_some()
+                || self.longest_registered_prefix(claim_type).is_some())
+    }
+
+    /// The first segment of every registered token — the roots a pane may group
+    /// by.
+    ///
+    /// Read from the table rather than from a compiled list, so a family the
+    /// agent knows and this build does not still groups.
+    #[must_use]
+    pub fn registered_roots(&self) -> BTreeSet<String> {
+        self.entries
+            .iter()
+            .filter_map(|e| e.claim_type.split('.').next())
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn exact(&self, claim_type: &str) -> Option<&Entry> {
+        self.entries.iter().find(|e| e.claim_type == claim_type)
+    }
+
+    /// The longest registered ancestor of a token, on `.` boundaries.
+    ///
+    /// Boundaries matter, and it is a *proper* prefix: `paymentx.foo` is not in
+    /// the `payment` family, and a plain `starts_with` would put it there.
+    fn longest_registered_prefix(&self, claim_type: &str) -> Option<&Entry> {
+        let mut cut = claim_type.len();
+        while let Some(dot) = claim_type[..cut].rfind('.') {
+            if let Some(entry) = self.exact(&claim_type[..dot]) {
+                return Some(entry);
+            }
+            cut = dot;
+        }
+        None
+    }
+
+    /// Spec 0.1, compiled in — the answer for an agent that predates
+    /// `persona/claim-types/list`, and nothing else. See the module header.
+    #[must_use]
+    pub fn vendored() -> Self {
+        // `claim-types.json`'s order, so the two diff against each other by eye.
+        const TABLE: &[(&str, &str, &str, &str)] = &[
+            // Family entries, matched as prefixes. Without them
+            // `payment.somethingNew` resolves to the floor, and a gated family
+            // becomes leavable by inventing a token. `name` is also an exact
+            // token: a pool that keeps one undifferentiated name is using it.
+            ("payment", "high", "full", "stepUp"),
+            ("gov", "high", "full", "stepUp"),
+            ("name", "normal", "none", "consent"),
+            ("name.legal", "normal", "none", "consent"),
+            ("name.given", "normal", "none", "consent"),
+            ("name.family", "normal", "none", "consent"),
+            ("name.display", "normal", "none", "consent"),
+            // A former name is the one a holder most often keeps in order to
+            // answer a question once and never show again.
+            ("name.previous", "high", "full", "consent"),
+            ("person.birthDate", "high", "full", "consent"),
+            ("person.pronouns", "normal", "none", "consent"),
+            ("person.locale", "normal", "none", "consent"),
+            ("email.personal", "normal", "emailLocal", "consent"),
+            ("email.work", "normal", "emailLocal", "consent"),
+            // High because a mobile number is both a strong join key and an
+            // authentication factor: its harm is account takeover, not
+            // embarrassment.
+            ("phone.mobile", "high", "last2", "consent"),
+            ("phone.landline", "high", "last2", "consent"),
+            ("address.postal", "high", "full", "consent"),
+            ("address.country", "normal", "none", "consent"),
+            ("gov.id.passport", "high", "last4", "stepUp"),
+            ("gov.id.driverLicence", "high", "last4", "stepUp"),
+            ("gov.id.national", "high", "last4", "stepUp"),
+            ("gov.taxId", "high", "last4", "stepUp"),
+            ("payment.card", "high", "last4", "stepUp"),
+            ("payment.cardExpiry", "high", "full", "stepUp"),
+            ("payment.iban", "high", "last4", "stepUp"),
+            ("payment.accountNumber", "high", "last4", "stepUp"),
+            ("account.handle", "normal", "none", "consent"),
+            ("url.homepage", "normal", "none", "consent"),
+            ("org.name", "normal", "none", "consent"),
+            ("org.role", "normal", "none", "consent"),
+        ];
+
+        let order = |xs: &[&str]| Axis(xs.iter().map(|s| (*s).to_string()).collect());
+
+        Self {
+            registry_version: "0.1".to_string(),
+            is_fallback: true,
+            unapplied: UnappliedReport::default(),
+            entries: TABLE
+                .iter()
+                .map(|(claim_type, sensitivity, mask, release)| Entry {
+                    claim_type: (*claim_type).to_string(),
+                    sensitivity: (*sensitivity).to_string(),
+                    mask: (*mask).to_string(),
+                    release: (*release).to_string(),
+                })
+                .collect(),
+            unregistered: Entry::conservative_floor(),
+            sensitivity_order: order(&["high", "normal"]),
+            mask_order: order(&["full", "last2", "last4", "emailLocal", "none"]),
+            release_order: order(&["stepUp", "consent"]),
         }
     }
 }
 
-/// Resolve a claim type to how its value is shown — the registry's §4, minus
-/// the rule this client cannot reach.
-///
-/// 1. Rule 1 — a holder's explicit override — is **not implemented, because
-///    there is nowhere to store one.** `persona/attribute/put` has no
-///    `sensitivity` or `mask` member and the SDK's attribute carries neither,
-///    so the choice the rule resolves first cannot currently be made. When it
-///    can, it belongs above everything here.
-/// 2. An exact entry is used **as written**, and is not compared against
-///    anything: it is a decision someone made about that token.
-/// 3. Otherwise the longest registered *prefix* is taken together with
-///    [`UNREGISTERED`], and the more protective of the two wins on each axis.
-///    A family entry can therefore only ever tighten — `name` as a prefix does
-///    not make an unregistered `name.somethingNew` visible.
-/// 4. Otherwise the floor.
-///
-/// Rule 3 is what stops a gated family being left by inventing a token:
-/// without it `payment.giftCard` would resolve to the floor, whose `release`
-/// is `consent` — weaker than every registered member of the family it plainly
-/// belongs to.
-#[must_use]
-pub fn resolve(claim_type: &str) -> ClaimTypeDefaults {
-    if let Some(exact) = entry(claim_type) {
-        return exact;
-    }
-    // The open namespace is unregistered by construction, so it never inherits
-    // a family's answer: `x:payment.card` is a token this registry has never
-    // seen that happens to read like one it has.
-    if claim_type.starts_with(EXTENSION_PREFIX) {
-        return UNREGISTERED;
-    }
-    longest_registered_prefix(claim_type)
-        .map_or(UNREGISTERED, |family| family.tightest(UNREGISTERED))
-}
-
-fn entry(claim_type: &str) -> Option<ClaimTypeDefaults> {
-    TABLE
-        .iter()
-        .find(|(token, _, _)| *token == claim_type)
-        .map(|(_, sensitivity, mask)| ClaimTypeDefaults {
-            sensitivity: *sensitivity,
-            mask: *mask,
+impl Entry {
+    fn from_wire(value: &Value) -> Option<Self> {
+        Some(Self {
+            claim_type: value.get("type").and_then(Value::as_str)?.to_string(),
+            sensitivity: read_token(value, "sensitivity", "high"),
+            mask: read_token(value, "mask", "full"),
+            release: read_token(value, "release", "stepUp"),
         })
+    }
+
+    /// The served floor, which carries no `type` of its own.
+    fn floor_from_wire(value: &Value) -> Self {
+        Self {
+            claim_type: String::new(),
+            sensitivity: read_token(value, "sensitivity", "high"),
+            mask: read_token(value, "mask", "full"),
+            release: read_token(value, "release", "stepUp"),
+        }
+    }
+
+    /// The floor when the agent supplied none: the conservative answer, and
+    /// §4's rule 4. A vocabulary nobody has reasoned about is exactly the one
+    /// nothing is known about, and an unknown value rendered in the clear is a
+    /// decision nobody made.
+    fn conservative_floor() -> Self {
+        Self {
+            claim_type: String::new(),
+            sensitivity: "high".to_string(),
+            mask: "full".to_string(),
+            release: "consent".to_string(),
+        }
+    }
+
+    fn defaults(&self) -> ClaimTypeDefaults {
+        ClaimTypeDefaults {
+            sensitivity: Sensitivity::from_wire(&self.sensitivity),
+            mask: MaskStyle::from_wire(&self.mask),
+            release: Release::from_wire(&self.release),
+        }
+    }
 }
 
-/// The longest registered ancestor of a token, on `.` boundaries.
+/// One axis token off a served object, defaulting to the protective answer when
+/// the member is missing or is not a string.
+fn read_token(value: &Value, member: &str, fallback: &str) -> String {
+    value
+        .get(member)
+        .and_then(Value::as_str)
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+/// Read the agent's own refusals out of the response's `ext`.
 ///
-/// Boundaries matter: `paymentx.foo` is not in the `payment` family, and a
-/// plain `starts_with` would put it there.
-fn longest_registered_prefix(claim_type: &str) -> Option<ClaimTypeDefaults> {
-    let mut cut = claim_type.len();
-    while let Some(dot) = claim_type[..cut].rfind('.') {
-        if let Some(found) = entry(&claim_type[..dot]) {
-            return Some(found);
-        }
-        cut = dot;
+/// Member by member and defensively, because `ext` is a vendor-namespaced
+/// object the schema does not constrain, so nothing upstream has checked its
+/// shape. A malformed report is dropped rather than rendered: a banner built
+/// from a missing field is a second fault reported as the first.
+fn unapplied_from_ext(value: &Value) -> UnappliedReport {
+    let Some(report) = value.get("ext").and_then(|e| e.get(EXT_KEY_CLAIM_TYPES)) else {
+        return UnappliedReport::default();
+    };
+
+    UnappliedReport {
+        rejected: report
+            .get("rejected")
+            .and_then(Value::as_array)
+            .map(|rows| {
+                rows.iter()
+                    .filter_map(|row| {
+                        Some(UnappliedClaimType {
+                            claim_type: row.get("type").and_then(Value::as_str)?.to_string(),
+                            reason: row
+                                .get("reason")
+                                .and_then(Value::as_str)
+                                .unwrap_or("no reason given")
+                                .to_string(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        file_error: report
+            .get("fileError")
+            .and_then(Value::as_str)
+            .map(str::to_string),
     }
-    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The registered types resolve to what the vendored table says, including
-    /// the two that are `high` without being `full` — the styles exist so a
-    /// holder can still recognise their own card and their own number.
+    /// Every resolution test below runs against the compiled copy, which is
+    /// spec 0.1 — the same table this module used to *be*. Keeping the
+    /// assertions is what says the fallback did not quietly change meaning when
+    /// it stopped being the only answer.
+    fn spec_0_1() -> Registry {
+        Registry::vendored()
+    }
+
+    /// The floor, asked for by resolving something nothing declares. Written as
+    /// a question rather than as a constant so the served and compiled tables
+    /// can both be checked against their own floor.
+    fn floor(registry: &Registry) -> ClaimTypeDefaults {
+        registry.resolve("nothing.registered.here")
+    }
+
+    /// The registered types resolve to what the table says, including the two
+    /// that are `high` without being `full` — the styles exist so a holder can
+    /// still recognise their own card and their own number.
     #[test]
     fn registered_types_resolve_to_their_entry() {
-        assert_eq!(resolve("name.legal").sensitivity, Sensitivity::Normal);
-        assert_eq!(resolve("phone.mobile").mask, MaskStyle::Last2);
-        assert!(resolve("gov.id.passport").masks_by_default());
-        assert!(!resolve("org.role").masks_by_default());
+        let r = spec_0_1();
+        assert_eq!(r.resolve("name.legal").sensitivity, Sensitivity::Normal);
+        assert_eq!(r.resolve("phone.mobile").mask, MaskStyle::Last2);
+        assert!(r.resolve("gov.id.passport").masks_by_default());
+        assert!(!r.resolve("org.role").masks_by_default());
         // An exact entry is used as written and is not compared against its
         // family: `payment.card` shows its last four even though the `payment`
         // family entry is `full`. Someone decided that about that token.
-        assert_eq!(resolve("payment.card").mask, MaskStyle::Last4);
+        assert_eq!(r.resolve("payment.card").mask, MaskStyle::Last4);
     }
 
     /// An unregistered token with no registered family gets the conservative
@@ -363,8 +763,9 @@ mod tests {
     /// clear would be a decision nobody made.
     #[test]
     fn an_unknown_type_masks_fully() {
+        let r = spec_0_1();
         for token in ["medical.condition", "", "somethingElse"] {
-            let resolved = resolve(token);
+            let resolved = r.resolve(token);
             assert_eq!(resolved.sensitivity, Sensitivity::High, "{token}");
             assert_eq!(resolved.mask, MaskStyle::Full, "{token}");
         }
@@ -378,8 +779,10 @@ mod tests {
     /// plainly belongs to.
     #[test]
     fn a_new_token_inherits_its_registered_family() {
-        assert_eq!(resolve("payment.giftCard"), resolve("payment"));
-        assert_eq!(resolve("gov.id.somethingNew").mask, MaskStyle::Full);
+        let r = spec_0_1();
+        assert_eq!(r.resolve("payment.giftCard"), r.resolve("payment"));
+        assert_eq!(r.resolve("gov.id.somethingNew").mask, MaskStyle::Full);
+        assert_eq!(r.resolve("payment.giftCard").release, Release::StepUp);
     }
 
     /// A family can only tighten. `name` is `normal`/`none`, and an unknown
@@ -387,27 +790,32 @@ mod tests {
     /// on the strength of its prefix.
     #[test]
     fn a_family_never_loosens_the_floor() {
-        assert_eq!(resolve("name.somethingNew"), UNREGISTERED);
+        let r = spec_0_1();
+        assert_eq!(r.resolve("name.somethingNew"), floor(&r));
         // …while the family token itself, being an exact entry, is used as
         // written.
-        assert_eq!(resolve("name").mask, MaskStyle::None);
+        assert_eq!(r.resolve("name").mask, MaskStyle::None);
     }
 
     /// A prefix is a prefix on `.` boundaries. `paymentx` is not in the
     /// `payment` family, and a plain `starts_with` would put it there.
     #[test]
     fn a_family_matches_on_segment_boundaries() {
-        assert_eq!(resolve("paymentx.token"), UNREGISTERED);
-        assert_eq!(resolve("governance.role"), UNREGISTERED);
+        let r = spec_0_1();
+        assert_eq!(r.resolve("paymentx.token"), floor(&r));
+        assert_eq!(r.resolve("governance.role"), floor(&r));
+        assert!(!r.is_registered("paymentx.token"));
     }
 
     /// The open namespace never inherits a family: `x:payment.card` is a token
     /// this registry has never seen that happens to read like one it has.
     #[test]
     fn an_extension_token_never_inherits() {
-        assert_eq!(resolve("x:employer.badge"), UNREGISTERED);
-        assert_eq!(resolve("x:payment.card"), UNREGISTERED);
-        assert_eq!(resolve("x:name.given"), UNREGISTERED);
+        let r = spec_0_1();
+        for token in ["x:employer.badge", "x:payment.card", "x:name.given"] {
+            assert_eq!(r.resolve(token), floor(&r), "{token}");
+            assert!(!r.is_registered(token), "{token}");
+        }
     }
 
     /// The style masks whatever the sensitivity says. `email.work` is `normal`
@@ -415,7 +823,7 @@ mod tests {
     /// the person behind you without being worth withholding from a listing.
     #[test]
     fn a_normal_type_is_masked_by_its_style() {
-        let email = resolve("email.work");
+        let email = spec_0_1().resolve("email.work");
         assert_eq!(email.sensitivity, Sensitivity::Normal);
         assert!(email.masks_by_default());
         assert_eq!(email.render("alice@example.com"), "a•••@example.com");
@@ -426,7 +834,7 @@ mod tests {
     /// reflex protects nothing.
     #[test]
     fn a_type_with_no_style_is_shown_whole() {
-        let name = resolve("name.given");
+        let name = spec_0_1().resolve("name.given");
         assert!(!name.masks_by_default());
         assert_eq!(name.render("Alice"), "Alice");
     }
@@ -476,5 +884,175 @@ mod tests {
     #[test]
     fn masking_counts_characters_not_bytes() {
         assert_eq!(MaskStyle::Last2.apply("naïve café"), "••••••••fé");
+    }
+
+    // ── the served table ────────────────────────────────────────────────
+
+    /// A minimal served response, with room for a caller to add rows.
+    fn served(entries: Value, extra: Option<(&str, Value)>) -> Registry {
+        let mut body = serde_json::json!({
+            "registryVersion": "0.2",
+            "entries": entries,
+            "unregistered": { "sensitivity": "high", "release": "consent", "mask": "full" },
+            "strictness": {
+                "sensitivity": ["high", "normal"],
+                "release": ["stepUp", "consent"],
+                "mask": ["full", "last2", "last4", "emailLocal", "none"]
+            }
+        });
+        if let Some((key, value)) = extra {
+            body[key] = value;
+        }
+        Registry::from_wire(&body)
+    }
+
+    /// A token the compiled copy has never heard of resolves from the agent's
+    /// table — which is the whole reason this stopped being vendored.
+    ///
+    /// `employer` and `profile.*` are the two that were actually diverging:
+    /// spec 0.1 declares neither, so a deployment that declared them got the
+    /// floor's full mask from a client that could not be told otherwise.
+    #[test]
+    fn a_deployment_type_resolves_from_the_served_table() {
+        let r = served(
+            serde_json::json!([
+                { "type": "employer", "sensitivity": "normal", "release": "consent", "mask": "none" },
+                { "type": "profile", "sensitivity": "normal", "release": "consent", "mask": "none" },
+            ]),
+            None,
+        );
+
+        assert!(!r.is_fallback);
+        assert_eq!(r.registry_version, "0.2");
+        assert!(!r.resolve("employer").masks_by_default());
+        assert!(r.is_registered("profile.github"));
+        // …and the compiled copy still gives the old, wrong-for-this-deployment
+        // answer, which is what the fallback flag exists to disclose.
+        assert!(spec_0_1().resolve("employer").masks_by_default());
+    }
+
+    /// Strictness comes from the agent, not from a constant here.
+    ///
+    /// A maintainer that serves a style this build has never heard of, and
+    /// ranks it looser than `full`, gets that ranking honoured in the
+    /// comparison — while the *rendering* still collapses to `full`, because
+    /// this build does not know how to reduce a value that way. Those are two
+    /// separate decisions and reading either off the other loses one of them.
+    #[test]
+    fn an_unknown_mask_style_ranks_where_the_agent_puts_it() {
+        let r = served(
+            serde_json::json!([
+                { "type": "vessel", "sensitivity": "normal", "release": "consent", "mask": "first3" },
+            ]),
+            Some((
+                "strictness",
+                serde_json::json!({
+                    "sensitivity": ["high", "normal"],
+                    "release": ["stepUp", "consent"],
+                    "mask": ["full", "first3", "none"]
+                }),
+            )),
+        );
+
+        // `first3` is looser than the floor's `full`, so the floor wins the
+        // comparison for an unregistered member of the family…
+        assert_eq!(r.resolve("vessel.somethingNew").mask, MaskStyle::Full);
+        // …while the exact entry is used as written, and an unrenderable style
+        // is drawn as `full` rather than shown in the clear.
+        assert_eq!(r.resolve("vessel").mask, MaskStyle::Full);
+    }
+
+    /// A response missing its orderings still resolves, and resolves towards
+    /// showing less: an axis nobody ordered ranks everything most protective.
+    #[test]
+    fn a_response_with_no_strictness_degrades_protectively() {
+        let r = Registry::from_wire(&serde_json::json!({
+            "registryVersion": "0.1",
+            "entries": [
+                { "type": "name", "sensitivity": "normal", "release": "consent", "mask": "none" }
+            ],
+            "unregistered": { "sensitivity": "high", "release": "consent", "mask": "full" }
+        }));
+
+        // The exact entry is used as written, and needs no ordering to be.
+        assert_eq!(r.resolve("name").mask, MaskStyle::None);
+        // …while the family cannot loosen the floor on an ordering that was
+        // never sent, so an unregistered member of it stays masked.
+        assert_eq!(r.resolve("name.somethingNew").mask, MaskStyle::Full);
+        assert_eq!(
+            r.resolve("name.somethingNew").sensitivity,
+            Sensitivity::High
+        );
+    }
+
+    /// The roots a pane groups by come from the served table, so a family the
+    /// agent knows and this build does not still groups.
+    #[test]
+    fn the_grouping_roots_come_from_the_table() {
+        let r = served(
+            serde_json::json!([
+                { "type": "name.given", "sensitivity": "normal", "release": "consent", "mask": "none" },
+                { "type": "vessel.hull", "sensitivity": "normal", "release": "consent", "mask": "none" },
+            ]),
+            None,
+        );
+        let roots = r.registered_roots();
+        assert!(roots.contains("name"));
+        assert!(roots.contains("vessel"));
+        assert_eq!(roots.len(), 2);
+    }
+
+    /// A refused row from the deployment's own file is read back, because it is
+    /// otherwise invisible: the token resolves exactly as it would with no file
+    /// at all, so the operator's intended tightening is silently not in force.
+    #[test]
+    fn the_agents_own_refusals_are_read_back() {
+        let r = served(
+            serde_json::json!([]),
+            Some((
+                "ext",
+                serde_json::json!({
+                    "org.openvtc.claim-types": {
+                        "rejected": [{ "type": "Employer", "reason": "type is not lowercase" }],
+                        "fileError": "claim-types.json: permission denied"
+                    }
+                }),
+            )),
+        );
+
+        assert!(!r.unapplied.is_empty());
+        assert_eq!(r.unapplied.rejected[0].claim_type, "Employer");
+        assert_eq!(r.unapplied.rejected[0].reason, "type is not lowercase");
+        assert_eq!(
+            r.unapplied.file_error.as_deref(),
+            Some("claim-types.json: permission denied")
+        );
+    }
+
+    /// A malformed `ext` is dropped rather than rendered: nothing upstream has
+    /// checked its shape, and a banner built from a missing field is a second
+    /// fault reported as the first.
+    #[test]
+    fn a_malformed_refusal_report_is_dropped() {
+        let r = served(
+            serde_json::json!([]),
+            Some((
+                "ext",
+                serde_json::json!({
+                    "org.openvtc.claim-types": { "rejected": [{ "reason": "no type member" }] }
+                }),
+            )),
+        );
+        assert!(r.unapplied.is_empty());
+    }
+
+    /// The compiled copy says so about itself. The pane reads this to disclose
+    /// that a masking decision came from a table the holder's agent did not
+    /// supply.
+    #[test]
+    fn the_compiled_copy_declares_itself() {
+        assert!(Registry::vendored().is_fallback);
+        assert!(Registry::default().is_fallback);
+        assert_eq!(Registry::vendored().registry_version, "0.1");
     }
 }

--- a/openvtc-core/src/persona/correlation.rs
+++ b/openvtc-core/src/persona/correlation.rs
@@ -1,0 +1,324 @@
+//! Links — where the holder's identities join up, and which of those joins
+//! cross a part of their life.
+//!
+//! `persona/correlation/analyze` on the wire; **link** on screen, per
+//! `design-docs/persona-vocabulary.md`. "Correlation" is never said to a
+//! person: the sentence they need is *same person to anyone who sees both*.
+//!
+//! # Two axes, and reading either off the other loses one
+//!
+//! - [`Finding::severity`] is **how strongly** a disclosure would link the
+//!   holder. It follows from provenance and proof rung and is true whatever the
+//!   holder meant: a credential shown whole carries the same signature to
+//!   everyone who sees it, and that is a fact about the value.
+//! - [`Finding::crosses_worlds`] is **whether the holder would mind**. A value
+//!   shared between two faces in the *same* world is linkage they arranged on
+//!   purpose — a work email in every work face — and a pane that alarmed on it
+//!   would teach people to dismiss the alarm. A value shared *across* worlds is
+//!   the finding worth raising.
+//!
+//! So the pane leads with the second and qualifies with the first. Neither is a
+//! restatement of the other, and a client that showed only `severity` would be
+//! loudest about exactly the arrangements a holder had deliberately made.
+//!
+//! # Absent is not false
+//!
+//! `crossesFacets` is **absent** when the agent does not implement worlds at
+//! all, which is a different answer from "this link stays inside one part of
+//! your life". [`Finding::crosses_worlds`] keeps that as an `Option` and the
+//! pane says nothing rather than guessing — a reassurance nobody computed is
+//! worse than silence.
+
+use serde_json::Value;
+use vta_sdk::client::VtaClient;
+use vta_sdk::error::VtaError;
+
+use crate::errors::OpenVTCError;
+
+/// How strongly a disclosure of this value would link the holder.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Severity {
+    /// Linkable, but not by a signature anyone else can match.
+    #[default]
+    Low,
+    /// The same to everyone who sees it.
+    High,
+}
+
+impl Severity {
+    fn from_wire(token: &str) -> Self {
+        match token {
+            "high" => Self::High,
+            _ => Self::Low,
+        }
+    }
+}
+
+/// What the holder can actually do about a link.
+///
+/// Kept as served rather than narrowed to the ones this build renders, because
+/// the list is the point: a holder told "this links your personas" with no
+/// action but to abandon the attribute has been given a warning rather than a
+/// choice, and the honest fix — a credential re-issued against the persona
+/// actually using it — stays invisible unless something names it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Remedy {
+    UseDifferentValue,
+    ReissueCredentialToThisDid,
+    CorrelateDeliberately,
+    ProceedAndRecord,
+}
+
+impl Remedy {
+    fn from_wire(token: &str) -> Option<Self> {
+        match token {
+            "useDifferentValue" => Some(Self::UseDifferentValue),
+            "reissueCredentialToThisDid" => Some(Self::ReissueCredentialToThisDid),
+            "correlateDeliberately" => Some(Self::CorrelateDeliberately),
+            "proceedAndRecord" => Some(Self::ProceedAndRecord),
+            // A remedy this build has never heard of. Dropped rather than
+            // rendered as its raw token: an action a holder cannot take from
+            // here, spelled in wire vocabulary, is not a choice.
+            _ => None,
+        }
+    }
+
+    /// What this remedy says to the holder, in the second person.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::UseDifferentValue => "hold a different value for one of them",
+            Self::ReissueCredentialToThisDid => {
+                "have the credential re-issued to the persona that uses it"
+            }
+            Self::CorrelateDeliberately => "decide the link is one you want",
+            Self::ProceedAndRecord => "go ahead, and have it written down",
+        }
+    }
+}
+
+/// One link the agent found.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Finding {
+    /// The attribute this is about, when the finding is about one.
+    pub attribute_id: Option<String>,
+    pub severity: Severity,
+    /// Plain-language cause, in the agent's words.
+    ///
+    /// Shown rather than summarised: a severity with no explanation is a
+    /// warning a holder learns to dismiss.
+    pub why: String,
+    pub remedies: Vec<Remedy>,
+    /// Whether this link spans two or more worlds.
+    ///
+    /// `None` means the agent does not implement worlds — **not** that the link
+    /// stays inside one. See the module header.
+    pub crosses_worlds: Option<bool>,
+    /// How many places this value appears in.
+    pub shared_with: usize,
+}
+
+impl Finding {
+    fn from_wire(value: &Value) -> Self {
+        Self {
+            attribute_id: value
+                .get("attributeId")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            severity: value
+                .get("severity")
+                .and_then(Value::as_str)
+                .map_or(Severity::Low, Severity::from_wire),
+            why: value
+                .get("why")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            remedies: value
+                .get("remedies")
+                .and_then(Value::as_array)
+                .map(|xs| {
+                    xs.iter()
+                        .filter_map(Value::as_str)
+                        .filter_map(Remedy::from_wire)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            crosses_worlds: value.get("crossesFacets").and_then(Value::as_bool),
+            shared_with: value
+                .get("sharedWith")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len),
+        }
+    }
+
+    /// Whether this is the finding worth raising: a link across parts of a life
+    /// the holder said belong apart.
+    #[must_use]
+    pub fn crosses_a_world(&self) -> bool {
+        self.crosses_worlds == Some(true)
+    }
+
+    /// The sentence this finding leads with.
+    ///
+    /// The cross-world case gets the vocabulary's own line, because it is the
+    /// one a holder has to be able to recognise on sight and the words are
+    /// fixed so they meet the same sentence on every surface.
+    #[must_use]
+    pub fn headline(&self) -> &'static str {
+        match (self.crosses_a_world(), self.severity) {
+            (true, _) => {
+                "These two worlds share a value — anyone who sees both knows they are \
+                          the same person."
+            }
+            (false, Severity::High) => {
+                "Provable — and the same signature to everyone who sees it, so it links."
+            }
+            (false, Severity::Low) => "Same person to anyone who sees both.",
+        }
+    }
+}
+
+/// Ask the agent where the holder's identities link up.
+///
+/// The whole pool, not one attribute: the pane draws a marker per row and a
+/// count above them, and asking per row would be one round-trip per attribute
+/// for an answer the agent computes across all of them anyway.
+///
+/// Returns an empty list — not an error — when the agent does not serve the
+/// task. Every other failure is returned: "we could not ask" and "nothing links"
+/// are one glance apart, and of the two, a clean bill of health nobody computed
+/// is the one that misleads (VTI R6.4).
+pub async fn analyze(client: &VtaClient) -> Result<Vec<Finding>, OpenVTCError> {
+    let value = match client.persona_correlation_analyze(None, None, None).await {
+        Ok(value) => value,
+        Err(VtaError::UnsupportedTaskType { .. }) => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(OpenVTCError::Vta(format!(
+                "persona correlation analyze failed: {e}"
+            )));
+        }
+    };
+
+    Ok(value
+        .get("findings")
+        .and_then(Value::as_array)
+        .map(|rows| rows.iter().map(Finding::from_wire).collect())
+        .unwrap_or_default())
+}
+
+/// The finding for one attribute, if the agent raised one.
+///
+/// The cross-world finding wins when an attribute has more than one, because it
+/// is the one the holder would act on: severity is true whatever they intended,
+/// and this is the axis that says whether they would mind.
+#[must_use]
+pub fn for_attribute<'a>(findings: &'a [Finding], attribute_id: &str) -> Option<&'a Finding> {
+    let mine = || {
+        findings
+            .iter()
+            .filter(|f| f.attribute_id.as_deref() == Some(attribute_id))
+    };
+    mine()
+        .find(|f| f.crosses_a_world())
+        .or_else(|| mine().next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn finding(attribute: &str, crosses: Option<bool>, severity: &str) -> Value {
+        let mut row = json!({
+            "attributeId": attribute,
+            "severity": severity,
+            "why": "the same mobile number is in two faces",
+            "remedies": ["useDifferentValue", "correlateDeliberately"],
+            "sharedWith": [{ "profileId": "01P" }, { "profileId": "02P" }],
+        });
+        if let Some(c) = crosses {
+            row["crossesFacets"] = json!(c);
+        }
+        row
+    }
+
+    fn parse(rows: Value) -> Vec<Finding> {
+        rows.as_array()
+            .unwrap()
+            .iter()
+            .map(Finding::from_wire)
+            .collect()
+    }
+
+    /// A finding is read whole, remedies included — the remedies are the
+    /// difference between a warning and a choice.
+    #[test]
+    fn a_finding_is_read_whole() {
+        let f = &parse(json!([finding("01A", Some(true), "high")]))[0];
+        assert_eq!(f.attribute_id.as_deref(), Some("01A"));
+        assert_eq!(f.severity, Severity::High);
+        assert_eq!(f.shared_with, 2);
+        assert_eq!(
+            f.remedies,
+            vec![Remedy::UseDifferentValue, Remedy::CorrelateDeliberately]
+        );
+        assert!(f.crosses_a_world());
+    }
+
+    /// An absent `crossesFacets` is not `false`.
+    ///
+    /// The agent does not implement worlds, which is a different answer from
+    /// "this link stays inside one part of your life" — and a reassurance
+    /// nobody computed is worse than silence.
+    #[test]
+    fn an_absent_answer_is_not_a_negative_one() {
+        let f = &parse(json!([finding("01A", None, "low")]))[0];
+        assert_eq!(f.crosses_worlds, None);
+        assert!(!f.crosses_a_world());
+
+        let explicit = &parse(json!([finding("01A", Some(false), "low")]))[0];
+        assert_eq!(explicit.crosses_worlds, Some(false));
+        assert!(!explicit.crosses_a_world());
+    }
+
+    /// Severity and crossing are two axes. A high-severity link *inside* one
+    /// world is a strong link the holder arranged on purpose, and it does not
+    /// get the cross-world sentence.
+    #[test]
+    fn the_two_axes_are_not_read_off_each_other() {
+        let inside = &parse(json!([finding("01A", Some(false), "high")]))[0];
+        let across = &parse(json!([finding("01A", Some(true), "low")]))[0];
+
+        assert!(!inside.crosses_a_world());
+        assert!(across.crosses_a_world());
+        assert!(inside.headline().contains("same signature"));
+        assert!(across.headline().contains("These two worlds"));
+    }
+
+    /// A remedy this build has never heard of is dropped, not printed in wire
+    /// vocabulary: an action the holder cannot take from here is not a choice.
+    #[test]
+    fn an_unknown_remedy_is_dropped() {
+        let mut row = finding("01A", Some(true), "low");
+        row["remedies"] = json!(["useDifferentValue", "summonALawyer"]);
+        let f = &parse(json!([row]))[0];
+        assert_eq!(f.remedies, vec![Remedy::UseDifferentValue]);
+    }
+
+    /// The cross-world finding wins when one attribute has several, because it
+    /// is the one the holder would act on.
+    #[test]
+    fn the_cross_world_finding_is_the_one_shown() {
+        let findings = parse(json!([
+            finding("01A", Some(false), "high"),
+            finding("01A", Some(true), "low"),
+            finding("02A", Some(false), "low"),
+        ]));
+
+        let chosen = for_attribute(&findings, "01A").expect("a finding for 01A");
+        assert!(chosen.crosses_a_world());
+        assert!(!for_attribute(&findings, "02A").unwrap().crosses_a_world());
+        assert!(for_attribute(&findings, "03A").is_none());
+    }
+}

--- a/openvtc-core/src/persona/facet.rs
+++ b/openvtc-core/src/persona/facet.rs
@@ -1,0 +1,584 @@
+//! Worlds — the parts of a life, and the faces that belong to them.
+//!
+//! `persona/facet/*` on the wire (VTI #1338); **world** on screen, per
+//! `design-docs/persona-vocabulary.md`. "Facet" is the analyst's word — nobody
+//! says "my work facet" to a friend — and "group" carries no model while
+//! colliding with grouping attributes by family.
+//!
+//! A world is *a part of your life, and the faces that belong to it*: Work,
+//! Home, Play. A face belongs to at most one world; an attribute may belong to
+//! several, because a mobile number is genuinely both work and home.
+//!
+//! # A world arranges, it does not contain
+//!
+//! Deleting a world deletes nothing else. The faces and attributes that
+//! belonged to it are untouched and simply belong to no world afterwards —
+//! which is why [`delete`] returns [`Deletion::released_faces`] rather than a
+//! bare acknowledgement: the count is what lets a caller say what the screen
+//! will look like, and "deleted" on its own invites the reading that the faces
+//! went with it.
+//!
+//! # `put` is a replace, and that is the trap
+//!
+//! `persona/facet/put` replaces the whole record. Omitting `faceIds` means *an
+//! empty list*, not "leave them as they were" — the spec is explicit, because a
+//! member whose absence meant "keep" would make it impossible to empty one. So
+//! every write from this module goes through [`FacetDraft`], which carries the
+//! full membership, and every caller that wants to change one thing has to
+//! start from what [`list`] returned. There is no partial update to reach for
+//! by accident.
+//!
+//! # Dangling members are kept, not tidied
+//!
+//! A world may name a face or an attribute that has since been deleted. The
+//! maintainer does not prune those and neither does this module: a dangling id
+//! is how a consumer can offer to tidy, and silently dropping it turns a
+//! deletion the holder may not have intended into one they cannot see. It
+//! shows up wherever a caller resolves [`Facet::face_ids`] against a face list
+//! and finds fewer faces than the world names.
+
+use serde_json::{Value, json};
+use vta_sdk::client::VtaClient;
+use vta_sdk::error::VtaError;
+use vta_sdk::trust_tasks;
+
+use crate::errors::OpenVTCError;
+
+/// Round-trip budget for a facet task, in seconds. The same 30s the rest of the
+/// persona surface gets — these are local-store operations at the agent (VTI
+/// R1.2: an outbound call with no finite timeout turns a hung service into a
+/// hung command).
+const FACET_TIMEOUT: u64 = 30;
+
+/// How many worlds one page asks for.
+///
+/// The schema caps a page at 250 and a holder will have a handful, so this is
+/// generous rather than tuned. [`list`] still follows `nextCursor` to the end:
+/// the schema is explicit that a short page does not mean the last one, and a
+/// pane that drew four of five worlds would be wrong in a way nothing on screen
+/// could reveal.
+const PAGE: u64 = 100;
+
+/// How many pages [`list`] will follow before giving up.
+///
+/// A bound, not an expectation (VTI R1.4 — a polling or paging loop is bounded).
+/// At [`PAGE`] a world each this is far past any real holder; what it actually
+/// refuses is a maintainer whose cursor never terminates, which would otherwise
+/// hang the pane forever on a read that looks like it is working.
+const MAX_PAGES: usize = 32;
+
+/// The colour a world wears.
+///
+/// A **name**, resolved by each consumer against its own palette — never a hex
+/// value. A literal cannot be legible in a terminal, in a light theme and in a
+/// dark one at once, so a stored `#8B0000` is a colour that is wrong somewhere
+/// and the holder has no way to know where. The eight members deliberately
+/// carry no status connotation: none is named for success, warning or danger,
+/// so a holder's decorative choice can never be mistaken for the pane saying
+/// something is wrong.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Colour {
+    #[default]
+    Slate,
+    Indigo,
+    Teal,
+    Moss,
+    Sand,
+    Clay,
+    Rose,
+    Plum,
+}
+
+impl Colour {
+    /// Every colour, in the order the spec lists them — which is the order a
+    /// picker offers them in.
+    #[must_use]
+    pub fn all() -> [Colour; 8] {
+        [
+            Colour::Slate,
+            Colour::Indigo,
+            Colour::Teal,
+            Colour::Moss,
+            Colour::Sand,
+            Colour::Clay,
+            Colour::Rose,
+            Colour::Plum,
+        ]
+    }
+
+    /// The wire token.
+    #[must_use]
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Colour::Slate => "slate",
+            Colour::Indigo => "indigo",
+            Colour::Teal => "teal",
+            Colour::Moss => "moss",
+            Colour::Sand => "sand",
+            Colour::Clay => "clay",
+            Colour::Rose => "rose",
+            Colour::Plum => "plum",
+        }
+    }
+
+    /// Read a served token.
+    ///
+    /// An unrecognised colour becomes [`Slate`](Colour::Slate) rather than an
+    /// error: a colour is decoration, and refusing to draw a whole world
+    /// because a later spec added a ninth name would lose the holder something
+    /// that matters over something that does not.
+    #[must_use]
+    pub fn from_wire(token: &str) -> Self {
+        Colour::all()
+            .into_iter()
+            .find(|c| c.as_wire() == token)
+            .unwrap_or(Colour::Slate)
+    }
+}
+
+/// One world, as the agent holds it.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Facet {
+    pub facet_id: String,
+    /// The holder's name for this part of their life.
+    ///
+    /// Never disclosed to a verifier — it is how the holder finds it again. The
+    /// agent stores it without interpreting it: it is not a scope, not a policy
+    /// input, and not a name a counterparty ever sees.
+    pub name: String,
+    pub colour: Colour,
+    /// One or two emoji, kept opaque.
+    ///
+    /// A mark rather than a field. A terminal that cannot render it shows the
+    /// name, which is why it is optional and carries no meaning of its own.
+    pub icon: Option<String>,
+    /// The faces belonging to this world, by `profile_id`.
+    pub face_ids: Vec<String>,
+    /// The attributes belonging to this world, by `attribute_id`.
+    ///
+    /// Carried whole so that a write can put it back untouched. This client
+    /// does not yet offer a way to change it — the console does — and a `put`
+    /// that dropped it would silently empty a membership the holder set
+    /// elsewhere.
+    pub attribute_ids: Vec<String>,
+    /// The store's write counter, for the conditional write that follows.
+    pub version: u64,
+    pub updated_at: String,
+}
+
+impl Facet {
+    fn from_wire(value: &Value) -> Self {
+        let ids = |member: &str| {
+            value
+                .get(member)
+                .and_then(Value::as_array)
+                .map(|xs| {
+                    xs.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        Self {
+            facet_id: value
+                .get("facetId")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            name: value
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            colour: value
+                .get("colour")
+                .and_then(Value::as_str)
+                .map_or(Colour::Slate, Colour::from_wire),
+            icon: value
+                .get("icon")
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            face_ids: ids("faceIds"),
+            attribute_ids: ids("attributeIds"),
+            version: value.get("version").and_then(Value::as_u64).unwrap_or(0),
+            updated_at: value
+                .get("updatedAt")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+        }
+    }
+
+    /// The name to show. Never empty, so a row cannot render as a blank line.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        match self.name.trim().is_empty() {
+            false => &self.name,
+            true => "(unnamed world)",
+        }
+    }
+
+    /// Whether this world names that face.
+    #[must_use]
+    pub fn holds_face(&self, profile_id: &str) -> bool {
+        self.face_ids.iter().any(|id| id == profile_id)
+    }
+
+    /// This world's membership as a draft that replaces it unchanged.
+    ///
+    /// The starting point for every edit, because `put` is a replace: a caller
+    /// that built a draft from scratch to rename a world would empty its
+    /// membership on the way past.
+    #[must_use]
+    pub fn to_draft(&self) -> FacetDraft {
+        FacetDraft {
+            facet_id: Some(self.facet_id.clone()),
+            name: self.name.clone(),
+            colour: self.colour,
+            icon: self.icon.clone(),
+            face_ids: self.face_ids.clone(),
+            attribute_ids: self.attribute_ids.clone(),
+            expected_version: Some(self.version),
+        }
+    }
+}
+
+/// A world about to be written.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FacetDraft {
+    /// Absent to create; present to replace.
+    pub facet_id: Option<String>,
+    pub name: String,
+    pub colour: Colour,
+    pub icon: Option<String>,
+    pub face_ids: Vec<String>,
+    pub attribute_ids: Vec<String>,
+    /// The version a prior read returned, making the write conditional.
+    ///
+    /// Supplied on every edit built by [`Facet::to_draft`], so a world someone
+    /// changed from `pnm` or the console between the read and the write is
+    /// refused rather than silently overwritten.
+    pub expected_version: Option<u64>,
+}
+
+impl FacetDraft {
+    /// A brand-new world with nothing in it yet.
+    #[must_use]
+    pub fn new(name: String, colour: Colour) -> Self {
+        Self {
+            name,
+            colour,
+            // Create-only. Without it a retry after a lost response would
+            // replace whatever the first attempt had created, and the holder
+            // would lose whatever they had put in it in between.
+            expected_version: Some(0),
+            ..Self::default()
+        }
+    }
+}
+
+/// What a write did.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FacetWrite {
+    pub facet_id: String,
+    pub version: u64,
+    /// True when the write created the world, false when it replaced one.
+    pub created: bool,
+}
+
+/// What a delete did.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Deletion {
+    /// False when there was nothing to delete — a successful no-op rather than
+    /// an error, so a retry after a lost response can reach the state it wanted.
+    pub existed: bool,
+    /// How many faces belong to no world as a result.
+    ///
+    /// Nothing was deleted and nothing changed about them. This is the count a
+    /// caller needs to finish the sentence honestly: "deleted" on its own reads
+    /// as though the faces went too.
+    pub released_faces: u64,
+}
+
+/// List the holder's worlds, following the cursor to the end.
+///
+/// Returns an empty list — not an error — when the agent does not serve
+/// `persona/facet/*`, which means it predates VTI #1338. A holder on such an
+/// agent has no worlds and cannot have any, and that is exactly what an empty
+/// list says; every other failure is returned, because "we could not ask" and
+/// "you have none" are one glance apart and one of them is a confident wrong
+/// answer about the holder's own arrangement (VTI R6.4).
+pub async fn list(client: &VtaClient) -> Result<Vec<Facet>, OpenVTCError> {
+    let mut facets: Vec<Facet> = Vec::new();
+    let mut cursor: Option<String> = None;
+
+    for _ in 0..MAX_PAGES {
+        let mut payload = json!({ "limit": PAGE });
+        if let Some(c) = &cursor {
+            payload["cursor"] = json!(c);
+        }
+
+        let value = match client
+            .dispatch_trust_task(
+                trust_tasks::TASK_PERSONA_FACET_LIST_1_0,
+                payload,
+                FACET_TIMEOUT,
+            )
+            .await
+        {
+            Ok(value) => value,
+            Err(VtaError::UnsupportedTaskType { .. }) => return Ok(Vec::new()),
+            Err(e) => return Err(OpenVTCError::Vta(format!("persona facet list failed: {e}"))),
+        };
+
+        facets.extend(
+            value
+                .get("facets")
+                .and_then(Value::as_array)
+                .map(|rows| rows.iter().map(Facet::from_wire))
+                .into_iter()
+                .flatten(),
+        );
+
+        // The absence of `nextCursor` is the *only* signal that a listing is
+        // complete. A short page is not one: the schema says a maintainer may
+        // return fewer than asked for reasons of its own.
+        cursor = value
+            .get("nextCursor")
+            .and_then(Value::as_str)
+            .filter(|c| !c.is_empty())
+            .map(str::to_string);
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    // Display order the holder can predict, which is the order they named them
+    // in — the store returns creation order and a name sort would reshuffle the
+    // whole screen the first time somebody renamed one.
+    Ok(facets)
+}
+
+/// Create or replace one world.
+///
+/// A replace in the full sense: the draft's membership is what the world will
+/// have afterwards. Build it with [`Facet::to_draft`] unless the world is new.
+pub async fn put(client: &VtaClient, draft: FacetDraft) -> Result<FacetWrite, OpenVTCError> {
+    let mut payload = json!({
+        "name": draft.name,
+        "colour": draft.colour.as_wire(),
+        "faceIds": draft.face_ids,
+        "attributeIds": draft.attribute_ids,
+    });
+    if let Some(id) = &draft.facet_id {
+        payload["facetId"] = json!(id);
+    }
+    if let Some(icon) = draft.icon.as_deref().filter(|s| !s.is_empty()) {
+        payload["icon"] = json!(icon);
+    }
+    if let Some(version) = draft.expected_version {
+        payload["expectedVersion"] = json!(version);
+    }
+
+    let value = client
+        .dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_FACET_PUT_1_0,
+            payload,
+            FACET_TIMEOUT,
+        )
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona facet write failed: {e}")))?;
+
+    Ok(FacetWrite {
+        facet_id: value
+            .get("facetId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        version: value.get("version").and_then(Value::as_u64).unwrap_or(0),
+        created: value
+            .get("created")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    })
+}
+
+/// Delete one world. The faces and attributes that belonged to it are
+/// untouched.
+pub async fn delete(
+    client: &VtaClient,
+    facet_id: &str,
+    expected_version: Option<u64>,
+) -> Result<Deletion, OpenVTCError> {
+    let mut payload = json!({ "facetId": facet_id });
+    if let Some(version) = expected_version {
+        payload["expectedVersion"] = json!(version);
+    }
+
+    let value = client
+        .dispatch_trust_task(
+            trust_tasks::TASK_PERSONA_FACET_DELETE_1_0,
+            payload,
+            FACET_TIMEOUT,
+        )
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona facet delete failed: {e}")))?;
+
+    Ok(Deletion {
+        existed: value
+            .get("existed")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        released_faces: value
+            .get("releasedFaces")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+    })
+}
+
+/// Move a face into a world, or out of every world.
+///
+/// Two writes at most, and they are not interchangeable: the face is removed
+/// from whichever world holds it *before* it is added to the new one, because a
+/// face belongs to at most one world and a maintainer refuses the second write
+/// with `faceAlreadyPlaced` if the first has not happened yet.
+///
+/// `into` of `None` is *take it out of every world*, which is a real state — the
+/// console calls it "belongs to no world" and says every face belonging
+/// somewhere is fine too.
+pub async fn place_face(
+    client: &VtaClient,
+    facets: &[Facet],
+    profile_id: &str,
+    into: Option<&str>,
+) -> Result<(), OpenVTCError> {
+    for facet in facets.iter().filter(|f| f.holds_face(profile_id)) {
+        if Some(facet.facet_id.as_str()) == into {
+            // Already where it is being asked to go. Writing anyway would burn
+            // a version and turn a no-op into a conflict for anyone else
+            // holding this world.
+            return Ok(());
+        }
+        let mut draft = facet.to_draft();
+        draft.face_ids.retain(|id| id != profile_id);
+        put(client, draft).await?;
+    }
+
+    let Some(target) = into else {
+        return Ok(());
+    };
+    let Some(facet) = facets.iter().find(|f| f.facet_id == target) else {
+        return Err(OpenVTCError::Vta(format!(
+            "no such world: {target}. It may have been deleted from another \
+             client since this list was read"
+        )));
+    };
+
+    let mut draft = facet.to_draft();
+    // The version this draft carries came from the read, and the removal above
+    // may have just moved it — but only on a *different* world, so this one is
+    // still at the version we saw. A conflict here is a genuine one.
+    draft.face_ids.push(profile_id.to_string());
+    put(client, draft).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wire(name: &str, faces: &[&str]) -> Value {
+        json!({
+            "facetId": "01FACET",
+            "name": name,
+            "colour": "moss",
+            "icon": "🏠",
+            "faceIds": faces,
+            "attributeIds": ["01ATTR"],
+            "version": 3,
+            "updatedAt": "2026-09-09T10:00:00Z",
+        })
+    }
+
+    /// A served world is read whole, membership included.
+    #[test]
+    fn a_world_is_read_whole() {
+        let facet = Facet::from_wire(&wire("Home", &["01FACE"]));
+        assert_eq!(facet.facet_id, "01FACET");
+        assert_eq!(facet.name, "Home");
+        assert_eq!(facet.colour, Colour::Moss);
+        assert_eq!(facet.icon.as_deref(), Some("🏠"));
+        assert_eq!(facet.face_ids, vec!["01FACE".to_string()]);
+        assert_eq!(facet.attribute_ids, vec!["01ATTR".to_string()]);
+        assert_eq!(facet.version, 3);
+    }
+
+    /// A colour this build has never heard of is decoration that failed to
+    /// arrive, not a reason to refuse the world it belongs to.
+    #[test]
+    fn an_unknown_colour_does_not_lose_the_world() {
+        let mut value = wire("Home", &[]);
+        value["colour"] = json!("chartreuse");
+        let facet = Facet::from_wire(&value);
+        assert_eq!(facet.colour, Colour::Slate);
+        assert_eq!(facet.name, "Home");
+    }
+
+    /// Every colour round-trips through its wire token, so a value read back is
+    /// the one written.
+    #[test]
+    fn every_colour_round_trips() {
+        for colour in Colour::all() {
+            assert_eq!(Colour::from_wire(colour.as_wire()), colour);
+        }
+    }
+
+    /// An edit starts from what was read, membership and version included.
+    ///
+    /// This is the guard against the trap in `put`: a draft built from scratch
+    /// to rename a world would send no `faceIds`, and the spec reads that as an
+    /// empty list rather than "leave them alone".
+    #[test]
+    fn an_edit_carries_the_whole_membership_forward() {
+        let facet = Facet::from_wire(&wire("Home", &["01FACE", "02FACE"]));
+        let mut draft = facet.to_draft();
+        draft.name = "Home life".to_string();
+
+        assert_eq!(
+            draft.face_ids,
+            vec!["01FACE".to_string(), "02FACE".to_string()]
+        );
+        assert_eq!(draft.attribute_ids, vec!["01ATTR".to_string()]);
+        assert_eq!(draft.expected_version, Some(3));
+        assert_eq!(draft.facet_id.as_deref(), Some("01FACET"));
+    }
+
+    /// A new world is create-only, so a retry after a lost response cannot
+    /// replace what the first attempt made.
+    #[test]
+    fn a_new_world_is_create_only() {
+        let draft = FacetDraft::new("Play".to_string(), Colour::Rose);
+        assert_eq!(draft.expected_version, Some(0));
+        assert!(draft.facet_id.is_none());
+        assert!(draft.face_ids.is_empty());
+    }
+
+    /// A world with no name still draws as a row rather than a blank line.
+    #[test]
+    fn an_unnamed_world_still_has_something_to_draw() {
+        let mut value = wire("", &[]);
+        value["name"] = json!("   ");
+        assert_eq!(Facet::from_wire(&value).display_name(), "(unnamed world)");
+    }
+
+    /// Membership is asked as a question, and a world that does not hold a face
+    /// says so.
+    #[test]
+    fn a_world_knows_which_faces_it_holds() {
+        let facet = Facet::from_wire(&wire("Home", &["01FACE"]));
+        assert!(facet.holds_face("01FACE"));
+        assert!(!facet.holds_face("02FACE"));
+    }
+}

--- a/openvtc-core/src/persona/family.rs
+++ b/openvtc-core/src/persona/family.rs
@@ -1,0 +1,277 @@
+//! Which family an attribute's claim type belongs to — the groups the pane
+//! lays the pool out in.
+//!
+//! # Why a family at all
+//!
+//! The attributes tab draws every attribute the holder keeps as one row in one
+//! list. At five rows that is a list; at thirty it is a wall, and a wall is
+//! where the answer to "what does this person actually keep about themselves"
+//! goes to hide. Grouping restores the shape of the pool at a glance — who you
+//! are, how to reach you, what is already public, what your agent gates — and
+//! costs nothing but a heading.
+//!
+//! # Only what the registry declares gets classified
+//!
+//! [`Family::of`] reads the *served* table's roots and refuses to invent
+//! anything beyond them. A token the registry has never declared resolves to
+//! [`Family::Unregistered`] — never to a family guessed from its spelling — for
+//! the same reason
+//! [`Registry::resolve`](crate::persona::claim_types::Registry::resolve) will
+//! not walk a prefix into a *looser* treatment: a local rule that groups
+//! `profile.github` under some invented "profile" family is a statement about a
+//! vocabulary nobody has agreed to.
+//!
+//! And a root the agent *does* declare but this build has no words for is
+//! [`Family::Declared`], not `Unregistered`. The distinction is the one an
+//! operator needs: telling them their own extension type is unknown to their
+//! own agent sends them to debug a file that is working.
+
+use crate::persona::claim_types::Registry;
+
+/// The namespace the registry leaves open. Unregistered by construction.
+const EXTENSION_PREFIX: &str = "x:";
+
+/// The groups the pool is laid out in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Family {
+    /// Names, and what is true of the holder as a person.
+    Identity,
+    /// An address someone can arrive at.
+    Contact,
+    /// Handles, pages and roles others can already see.
+    Public,
+    /// Types the registry marks `release: stepUp`.
+    Gated,
+    /// Declared by this agent, in a family this build has no words for.
+    Declared,
+    /// Declared by nobody.
+    Unregistered,
+}
+
+impl Family {
+    /// Top to bottom, the order the pane lays the groups out in.
+    ///
+    /// Roughly how closely a value identifies the person, so the list reads as
+    /// a gradient rather than an alphabet. [`Unregistered`](Family::Unregistered)
+    /// sits last because its size is a question rather than a fact about the
+    /// holder.
+    #[must_use]
+    pub fn all() -> [Family; 6] {
+        [
+            Family::Identity,
+            Family::Contact,
+            Family::Public,
+            Family::Gated,
+            Family::Declared,
+            Family::Unregistered,
+        ]
+    }
+
+    /// The roots this build has words for.
+    ///
+    /// Deliberately **not** a claim about what the agent serves: a maintainer
+    /// may declare a family this build has never heard of, and
+    /// [`Declared`](Family::Declared) is the honest answer for one.
+    #[must_use]
+    pub fn placed_roots() -> [&'static str; 10] {
+        [
+            "name", "person", "email", "phone", "address", "account", "url", "org", "payment",
+            "gov",
+        ]
+    }
+
+    /// The family of a claim type.
+    ///
+    /// Matched on the **root segment only**, and only when the registry
+    /// declares that root. `payment.giftCard` is [`Gated`](Family::Gated)
+    /// because `payment` is a declared family entry; `profile.github` is
+    /// [`Unregistered`](Family::Unregistered) when no `profile` entry exists.
+    ///
+    /// `x:` is tested first, so `x:name.legal` cannot borrow `name`'s group —
+    /// exactly as it cannot borrow `name`'s mask.
+    #[must_use]
+    pub fn of(claim_type: &str, registry: &Registry) -> Family {
+        if claim_type.starts_with(EXTENSION_PREFIX) {
+            return Family::Unregistered;
+        }
+        let root = claim_type.split('.').next().unwrap_or_default();
+        if !registry.registered_roots().contains(root) {
+            return Family::Unregistered;
+        }
+        match root {
+            "name" | "person" => Family::Identity,
+            "email" | "phone" | "address" => Family::Contact,
+            "account" | "url" | "org" => Family::Public,
+            "payment" | "gov" => Family::Gated,
+            _ => Family::Declared,
+        }
+    }
+
+    /// The group heading, in the words of `design-docs/persona-vocabulary.md`.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Family::Identity => "Who you are",
+            Family::Contact => "How to reach you",
+            Family::Public => "Where you already appear",
+            // Not "sensitive" and not "protected": the registry marks these
+            // `release: stepUp`, so the agent refuses a disclosure until the
+            // holder approves that particular one. That is an agent behaviour
+            // worth naming, and it is the only claim this label makes.
+            Family::Gated => "Your agent asks first",
+            Family::Declared => "Your agent's own",
+            Family::Unregistered => "Not in the registry",
+        }
+    }
+
+    /// One line under the heading, saying what the group *is*.
+    ///
+    /// Never what it protects: the mask defends a screen and a heading defends
+    /// nothing.
+    #[must_use]
+    pub fn note(self) -> &'static str {
+        match self {
+            Family::Identity => "names, and what is true of you as a person",
+            Family::Contact => "an address someone can arrive at",
+            Family::Public => "handles, pages and roles others can already see",
+            // The console says "a disclosure needs your approval each time"
+            // here, and that word is one `persona-vocabulary.md` retires — the
+            // agreed phrase for this journey is *letting it leave*. Same fact,
+            // in the words the table fixes; the banned-word test in
+            // `identity_panel` is what caught the borrowed string.
+            Family::Gated => {
+                "the registry gates these — your agent asks you again before one of them leaves"
+            }
+            // The third answer, and it arrived with deployment extension types
+            // (VTI #1327). Saying "not in the registry" would be false about
+            // the very rows an operator had just added, which is the one place
+            // they would go looking to check their work.
+            Family::Declared => {
+                "declared by this agent rather than by the shared registry — it decides how these \
+                 are treated"
+            }
+            Family::Unregistered => {
+                "your agent's claim-type table does not declare these, so they are treated as the \
+                 most private kind"
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec_0_1() -> Registry {
+        Registry::vendored()
+    }
+
+    /// Each placed root lands in the group this build has words for.
+    #[test]
+    fn a_registered_root_lands_in_its_group() {
+        let r = spec_0_1();
+        assert_eq!(Family::of("name.legal", &r), Family::Identity);
+        assert_eq!(Family::of("person.birthDate", &r), Family::Identity);
+        assert_eq!(Family::of("email.work", &r), Family::Contact);
+        assert_eq!(Family::of("phone.mobile", &r), Family::Contact);
+        assert_eq!(Family::of("address.postal", &r), Family::Contact);
+        assert_eq!(Family::of("account.handle", &r), Family::Public);
+        assert_eq!(Family::of("org.role", &r), Family::Public);
+        assert_eq!(Family::of("url.homepage", &r), Family::Public);
+        assert_eq!(Family::of("payment.card", &r), Family::Gated);
+        assert_eq!(Family::of("gov.id.passport", &r), Family::Gated);
+    }
+
+    /// A new token in a declared family groups with it, the same walk the mask
+    /// takes: `payment.giftCard` is gated because `payment` is declared.
+    #[test]
+    fn a_new_token_groups_with_its_declared_root() {
+        assert_eq!(Family::of("payment.giftCard", &spec_0_1()), Family::Gated);
+    }
+
+    /// A token nothing declares is unregistered, not guessed at from its
+    /// spelling. `profile` is the live example: spec 0.1 has no such entry, so
+    /// inventing a "profile" family here would put a heading on a vocabulary
+    /// nobody has agreed to.
+    #[test]
+    fn an_undeclared_root_is_never_guessed_at() {
+        let r = spec_0_1();
+        assert_eq!(Family::of("profile.github", &r), Family::Unregistered);
+        assert_eq!(Family::of("employer", &r), Family::Unregistered);
+        assert_eq!(Family::of("medical.condition", &r), Family::Unregistered);
+    }
+
+    /// The open namespace never borrows a group, exactly as it never borrows a
+    /// mask.
+    #[test]
+    fn an_extension_token_never_borrows_a_group() {
+        let r = spec_0_1();
+        assert_eq!(Family::of("x:name.legal", &r), Family::Unregistered);
+        assert_eq!(Family::of("x:payment.card", &r), Family::Unregistered);
+    }
+
+    /// A root the *agent* declares and this build has no words for is the
+    /// agent's own, not unregistered.
+    ///
+    /// The difference is the whole reason the two labels exist: telling an
+    /// operator their extension type is unknown to their own agent sends them
+    /// to debug a file that is working.
+    #[test]
+    fn a_root_only_the_agent_declares_is_its_own() {
+        let served = Registry::from_wire(&serde_json::json!({
+            "registryVersion": "0.1",
+            "entries": [
+                { "type": "name", "sensitivity": "normal", "release": "consent", "mask": "none" },
+                { "type": "profile", "sensitivity": "normal", "release": "consent", "mask": "none" },
+                { "type": "employer", "sensitivity": "normal", "release": "consent", "mask": "none" }
+            ],
+            "unregistered": { "sensitivity": "high", "release": "consent", "mask": "full" },
+            "strictness": {
+                "sensitivity": ["high", "normal"],
+                "release": ["stepUp", "consent"],
+                "mask": ["full", "last2", "last4", "emailLocal", "none"]
+            }
+        }));
+
+        assert_eq!(Family::of("profile.github", &served), Family::Declared);
+        assert_eq!(Family::of("employer", &served), Family::Declared);
+        // …and a root nobody declares is still unregistered against the same
+        // table, so `Declared` has not become a catch-all.
+        assert_eq!(
+            Family::of("medical.condition", &served),
+            Family::Unregistered
+        );
+        assert_eq!(Family::of("name.given", &served), Family::Identity);
+    }
+
+    /// Every root this build claims to have placed actually resolves to a group
+    /// other than the two "we have no words" answers. A root added to
+    /// [`Family::placed_roots`] and forgotten in [`Family::of`] would otherwise
+    /// read as unregistered while claiming to be placed.
+    #[test]
+    fn every_placed_root_is_actually_placed() {
+        let r = spec_0_1();
+        for root in Family::placed_roots() {
+            let family = Family::of(root, &r);
+            assert!(
+                !matches!(family, Family::Declared | Family::Unregistered),
+                "{root} claims to be placed but resolves to {family:?}"
+            );
+        }
+    }
+
+    /// Every family has a heading and a line, and no two share a heading — a
+    /// duplicate would merge two groups on screen while the code kept them
+    /// apart.
+    #[test]
+    fn every_family_has_its_own_words() {
+        let mut labels: Vec<&str> = Family::all().iter().map(|f| f.label()).collect();
+        labels.sort_unstable();
+        let count = labels.len();
+        labels.dedup();
+        assert_eq!(labels.len(), count, "two families share a heading");
+        for family in Family::all() {
+            assert!(!family.note().is_empty(), "{family:?} has no line");
+        }
+    }
+}

--- a/openvtc-core/src/persona/mod.rs
+++ b/openvtc-core/src/persona/mod.rs
@@ -47,6 +47,7 @@
 
 pub mod binding;
 pub mod claim_types;
+pub mod correlation;
 pub mod disclosure;
 pub mod facet;
 pub mod family;

--- a/openvtc-core/src/persona/mod.rs
+++ b/openvtc-core/src/persona/mod.rs
@@ -13,10 +13,11 @@
 //! ([`binding`]). Those live in the VTA, not in `Config`, and every function
 //! here is a round-trip to it.
 //!
-//! [`claim_types`] is the one exception and makes no round-trip at all: it is a
-//! vendored copy of the claim-type registry's masking table, carried here
-//! because the agent does not serve that table. Its header says what that is
-//! worth and what it is not.
+//! [`claim_types`] is the table the other three resolve against — how a value
+//! is shown, and what it takes to let it leave. It is **read from the agent**
+//! like everything else here (`persona/claim-types/list`, VTI #1315); the
+//! compiled copy it used to be survives only as the answer for an agent too old
+//! to serve one. Its header says what that is worth and what it is not.
 //!
 //! This crate holds the persona; the agent holds what the persona says. They join on
 //! the `(context_id, persona_did)` pair every community membership already

--- a/openvtc-core/src/persona/mod.rs
+++ b/openvtc-core/src/persona/mod.rs
@@ -48,6 +48,7 @@
 pub mod binding;
 pub mod claim_types;
 pub mod disclosure;
+pub mod facet;
 pub mod family;
 pub mod pool;
 pub mod profile;

--- a/openvtc-core/src/persona/mod.rs
+++ b/openvtc-core/src/persona/mod.rs
@@ -48,5 +48,6 @@
 pub mod binding;
 pub mod claim_types;
 pub mod disclosure;
+pub mod family;
 pub mod pool;
 pub mod profile;

--- a/openvtc-core/src/persona/pool.rs
+++ b/openvtc-core/src/persona/pool.rs
@@ -32,7 +32,7 @@ use vta_sdk::client::VtaClient;
 use vta_sdk::protocols::persona::{Provenance, ValueType};
 
 use crate::errors::OpenVTCError;
-use crate::persona::claim_types::{self, ClaimTypeDefaults};
+use crate::persona::claim_types::{ClaimTypeDefaults, Registry};
 
 /// Where an attribute's value came from, reduced to what a panel can act on.
 ///
@@ -180,8 +180,8 @@ impl PoolAttribute {
 
     /// What this attribute's claim type says about showing its value.
     #[must_use]
-    pub fn claim_defaults(&self) -> ClaimTypeDefaults {
-        claim_types::resolve(&self.claim_type)
+    pub fn claim_defaults(&self, registry: &Registry) -> ClaimTypeDefaults {
+        registry.resolve(&self.claim_type)
     }
 
     /// Whether [`display_value`](Self::display_value) is showing a reduced form
@@ -191,8 +191,8 @@ impl PoolAttribute {
     /// empty: `••••••••` and "(no value)" are one glance apart, and one of them
     /// is a wrong answer about what the holder holds.
     #[must_use]
-    pub fn is_masked(&self) -> bool {
-        !self.stale && self.value.is_some() && self.claim_defaults().masks_by_default()
+    pub fn is_masked(&self, registry: &Registry) -> bool {
+        !self.stale && self.value.is_some() && self.claim_defaults(registry).masks_by_default()
     }
 
     /// The value as one line, or the reason there is none — masked when its
@@ -204,8 +204,8 @@ impl PoolAttribute {
     /// have it and are not painting it* — which is why it is
     /// [`is_masked`](Self::is_masked) rather than a fourth string here.
     #[must_use]
-    pub fn display_value(&self, values_requested: bool) -> String {
-        self.value_line(values_requested, false)
+    pub fn display_value(&self, registry: &Registry, values_requested: bool) -> String {
+        self.value_line(registry, values_requested, false)
     }
 
     /// The same line with the mask lifted, for a holder who asked for this one
@@ -217,11 +217,11 @@ impl PoolAttribute {
     /// gets passed through, and the caller that ends up passing `true` is
     /// rarely the one that meant to.
     #[must_use]
-    pub fn revealed_value(&self, values_requested: bool) -> String {
-        self.value_line(values_requested, true)
+    pub fn revealed_value(&self, registry: &Registry, values_requested: bool) -> String {
+        self.value_line(registry, values_requested, true)
     }
 
-    fn value_line(&self, values_requested: bool, reveal: bool) -> String {
+    fn value_line(&self, registry: &Registry, values_requested: bool, reveal: bool) -> String {
         if self.stale {
             return match &self.stale_reason {
                 Some(reason) => format!("stale · {reason} — can no longer be proven"),
@@ -232,7 +232,7 @@ impl PoolAttribute {
             if reveal {
                 text
             } else {
-                self.claim_defaults().render(&text)
+                self.claim_defaults(registry).render(&text)
             }
         };
         match &self.value {
@@ -442,6 +442,15 @@ pub fn parse_typed_value(text: &str, value_type: ValueType) -> Result<Value, Str
 
 #[cfg(test)]
 mod tests {
+    use crate::persona::claim_types::Registry;
+
+    /// The compiled copy — spec 0.1 — as the table these tests resolve
+    /// against. A unit test must not depend on what a live agent happens to
+    /// serve, and every assertion below is about a token 0.1 declares.
+    fn reg() -> Registry {
+        Registry::vendored()
+    }
+
     use super::*;
 
     fn wire(provenance: &str) -> Value {
@@ -494,15 +503,18 @@ mod tests {
     #[test]
     fn the_three_reasons_for_an_absent_value_read_differently() {
         let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
-        assert_eq!(attr.display_value(false), "(hidden)");
-        assert_eq!(attr.display_value(true), "(no value)");
+        assert_eq!(attr.display_value(&reg(), false), "(hidden)");
+        assert_eq!(attr.display_value(&reg(), true), "(no value)");
         attr.stale = true;
-        assert!(attr.display_value(true).contains("can no longer be proven"));
+        assert!(
+            attr.display_value(&reg(), true)
+                .contains("can no longer be proven")
+        );
         // The reason is shown beside the word, never instead of it: "stale"
         // alone says something is wrong without saying what.
         attr.stale_reason = Some("revoked".into());
         assert_eq!(
-            attr.display_value(true),
+            attr.display_value(&reg(), true),
             "stale · revoked — can no longer be proven"
         );
     }
@@ -515,7 +527,7 @@ mod tests {
         let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
         attr.claim_type = "name.given".into();
         attr.value = Some(Value::String("Alice".into()));
-        assert_eq!(attr.display_value(true), "Alice");
+        assert_eq!(attr.display_value(&reg(), true), "Alice");
     }
 
     /// A typed field stores the type it declares. The number case is the one
@@ -551,9 +563,9 @@ mod tests {
         attr.claim_type = "payment.card".into();
         attr.value = Some(Value::String("4242424242424242".into()));
 
-        assert!(attr.is_masked());
-        assert_eq!(attr.display_value(true), "••••••••••••4242");
-        assert_eq!(attr.revealed_value(true), "4242424242424242");
+        assert!(attr.is_masked(&reg()));
+        assert_eq!(attr.display_value(&reg(), true), "••••••••••••4242");
+        assert_eq!(attr.revealed_value(&reg(), true), "4242424242424242");
     }
 
     /// A type whose style is `none` is shown as it is held. Masking every attribute
@@ -564,8 +576,8 @@ mod tests {
         let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
         attr.claim_type = "name.given".into();
         attr.value = Some(Value::String("Alice".into()));
-        assert!(!attr.is_masked());
-        assert_eq!(attr.display_value(true), "Alice");
+        assert!(!attr.is_masked(&reg()));
+        assert_eq!(attr.display_value(&reg(), true), "Alice");
     }
 
     /// Sensitivity is not what triggers the mask — the style is. An email
@@ -575,9 +587,9 @@ mod tests {
     fn a_normal_type_with_a_style_is_still_masked() {
         let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
         attr.value = Some(Value::String("alice@example.com".into()));
-        assert!(attr.is_masked());
-        assert_eq!(attr.display_value(true), "a•••@example.com");
-        assert_eq!(attr.revealed_value(true), "alice@example.com");
+        assert!(attr.is_masked(&reg()));
+        assert_eq!(attr.display_value(&reg(), true), "a•••@example.com");
+        assert_eq!(attr.revealed_value(&reg(), true), "alice@example.com");
     }
 
     /// A vocabulary this build has never seen is masked, because nothing here
@@ -587,8 +599,8 @@ mod tests {
         let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
         attr.claim_type = "x:employer.badge".into();
         attr.value = Some(Value::String("A-1174".into()));
-        assert!(attr.is_masked());
-        assert_eq!(attr.display_value(true), "••••••••");
+        assert!(attr.is_masked(&reg()));
+        assert_eq!(attr.display_value(&reg(), true), "••••••••");
     }
 
     /// Masked and absent are different states, and a caller has to be able to
@@ -598,12 +610,12 @@ mod tests {
     fn masked_is_not_the_same_state_as_absent() {
         let mut attr = PoolAttribute::from_wire(&wire("selfAsserted"));
         attr.claim_type = "person.birthDate".into();
-        assert!(!attr.is_masked(), "nothing held is nothing to mask");
-        assert_eq!(attr.display_value(true), "(no value)");
-        assert_eq!(attr.display_value(false), "(hidden)");
+        assert!(!attr.is_masked(&reg()), "nothing held is nothing to mask");
+        assert_eq!(attr.display_value(&reg(), true), "(no value)");
+        assert_eq!(attr.display_value(&reg(), false), "(hidden)");
 
         attr.value = Some(Value::String("1990-01-01".into()));
-        assert!(attr.is_masked());
+        assert!(attr.is_masked(&reg()));
     }
 
     /// A stale value keeps saying it is stale. The reason it cannot be shown is
@@ -617,9 +629,9 @@ mod tests {
         attr.stale = true;
         attr.stale_reason = Some("revoked".into());
 
-        assert!(!attr.is_masked());
+        assert!(!attr.is_masked(&reg()));
         assert_eq!(
-            attr.display_value(true),
+            attr.display_value(&reg(), true),
             "stale · revoked — can no longer be proven"
         );
     }

--- a/openvtc-core/src/persona/profile.rs
+++ b/openvtc-core/src/persona/profile.rs
@@ -37,7 +37,7 @@ use vta_sdk::client::VtaClient;
 use vta_sdk::protocols::persona::ProfileEntry;
 
 use crate::errors::OpenVTCError;
-use crate::persona::claim_types;
+use crate::persona::claim_types::Registry;
 use crate::persona::pool::ProvenanceKind;
 
 /// A profile as a list row.
@@ -146,8 +146,8 @@ impl ResolvedClaim {
     /// See [`revealed_value`](Self::revealed_value) for lifting the mask on one
     /// claim.
     #[must_use]
-    pub fn display_value(&self) -> String {
-        self.value_line(false)
+    pub fn display_value(&self, registry: &Registry) -> String {
+        self.value_line(registry, false)
     }
 
     /// The same line with the mask lifted, for a holder who asked for this one
@@ -169,11 +169,11 @@ impl ResolvedClaim {
     /// site had to *name*. A boolean gets passed through, and the caller that
     /// ends up passing `true` is rarely the one that meant to.
     #[must_use]
-    pub fn revealed_value(&self) -> String {
-        self.value_line(true)
+    pub fn revealed_value(&self, registry: &Registry) -> String {
+        self.value_line(registry, true)
     }
 
-    fn value_line(&self, reveal: bool) -> String {
+    fn value_line(&self, registry: &Registry, reveal: bool) -> String {
         if self.stale {
             return "stale — can no longer be proven".to_string();
         }
@@ -181,7 +181,7 @@ impl ResolvedClaim {
             if reveal {
                 text
             } else {
-                claim_types::resolve(&self.claim_type).render(&text)
+                registry.resolve(&self.claim_type).render(&text)
             }
         };
         match &self.value {
@@ -194,10 +194,8 @@ impl ResolvedClaim {
     /// Whether [`display_value`](Self::display_value) is reducing a value we
     /// hold, so a face can say *masked* rather than let the row read as empty.
     #[must_use]
-    pub fn is_masked(&self) -> bool {
-        !self.stale
-            && self.value.is_some()
-            && claim_types::resolve(&self.claim_type).masks_by_default()
+    pub fn is_masked(&self, registry: &Registry) -> bool {
+        !self.stale && self.value.is_some() && registry.resolve(&self.claim_type).masks_by_default()
     }
 }
 
@@ -379,6 +377,15 @@ fn string_at(value: &Value, key: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::persona::claim_types::Registry;
+
+    /// The compiled copy — spec 0.1 — as the table these tests resolve
+    /// against. A unit test must not depend on what a live agent happens to
+    /// serve, and every assertion below is about a token 0.1 declares.
+    fn reg() -> Registry {
+        Registry::vendored()
+    }
+
     use super::*;
 
     fn profile_wire(entries: Value) -> Value {
@@ -463,7 +470,7 @@ mod tests {
             "stale": false,
         }));
         assert!(claim.attribute_id.is_none());
-        assert_eq!(claim.display_value(), "Ace");
+        assert_eq!(claim.display_value(&reg()), "Ace");
     }
 
     /// A resolved read that came back without a value says so, rather than
@@ -475,7 +482,11 @@ mod tests {
             "value": Value::Null,
             "stale": true,
         }));
-        assert!(claim.display_value().contains("can no longer be proven"));
+        assert!(
+            claim
+                .display_value(&reg())
+                .contains("can no longer be proven")
+        );
     }
 
     /// A masked claim reads back whole when a caller asks for that one claim.
@@ -492,8 +503,8 @@ mod tests {
             "valueType": "string",
             "provenance": { "kind": "selfAsserted" },
         }));
-        assert_eq!(claim.display_value(), "••••••••••56");
-        assert_eq!(claim.revealed_value(), "+61400123456");
+        assert_eq!(claim.display_value(&reg()), "••••••••••56");
+        assert_eq!(claim.revealed_value(&reg()), "+61400123456");
     }
 
     /// A stale claim says it is stale under a reveal too.
@@ -508,7 +519,11 @@ mod tests {
             "value": "+61400123456",
             "stale": true,
         }));
-        assert!(claim.revealed_value().contains("can no longer be proven"));
+        assert!(
+            claim
+                .revealed_value(&reg())
+                .contains("can no longer be proven")
+        );
     }
 
     /// A face masks what its type says to mask, and says that it did.
@@ -524,16 +539,16 @@ mod tests {
             "valueType": "string",
             "provenance": { "kind": "selfAsserted" },
         }));
-        assert!(claim.is_masked());
-        assert_eq!(claim.display_value(), "••••••••••56");
+        assert!(claim.is_masked(&reg()));
+        assert_eq!(claim.display_value(&reg()), "••••••••••56");
 
         let normal = ResolvedClaim::from_wire(&serde_json::json!({
             "type": "name.given",
             "value": "Alice",
             "valueType": "string",
         }));
-        assert!(!normal.is_masked());
-        assert_eq!(normal.display_value(), "Alice");
+        assert!(!normal.is_masked(&reg()));
+        assert_eq!(normal.display_value(&reg()), "Alice");
     }
 
     /// Masked and absent stay distinguishable here too — a face that shows
@@ -545,8 +560,8 @@ mod tests {
             "type": "phone.mobile",
             "value": Value::Null,
         }));
-        assert!(!absent.is_masked());
-        assert_eq!(absent.display_value(), "(no value)");
+        assert!(!absent.is_masked(&reg()));
+        assert_eq!(absent.display_value(&reg()), "(no value)");
     }
 
     /// The put ordering: ticked entries first, preserved forms after, so the

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -240,6 +240,19 @@ pub enum PersonaAction {
     ProfileEdit(usize),
     ProfileDeleteArm(usize),
 
+    /// Open the picker: which world does this face belong to?
+    ///
+    /// On the Faces tab rather than the Worlds one, because the holder has to
+    /// be able to see the face they are moving. A world's membership is
+    /// therefore edited from exactly one place, which is what keeps the replace
+    /// semantics of `persona/facet/put` in one place too.
+    FacePlaceOpen(usize),
+
+    // ── Worlds ───────────────────────────────────────────────────────────
+    FacetNew,
+    FacetEdit(usize),
+    FacetDeleteArm(usize),
+
     // ── Communities ──────────────────────────────────────────────────────
     /// Open the picker: what should this persona present here?
     BindOpen(usize),

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -791,6 +791,25 @@ pub struct IdentityState {
     pub disclosure_selected: usize,
 
     // ── Shared ───────────────────────────────────────────────────────────
+    /// The claim-type registry this agent resolves against — how each value is
+    /// shown, and what it takes to let it leave.
+    ///
+    /// Read once per load and held for the session, because it is a constant
+    /// for a given agent. It starts as the compiled copy so the very first
+    /// frame has a table to draw with; the read replaces it, and
+    /// [`Registry::is_fallback`](openvtc_core::persona::claim_types::Registry::is_fallback)
+    /// is what lets the pane say when a masking decision came from a table the
+    /// holder's own agent did not supply.
+    pub claim_types: openvtc_core::persona::claim_types::Registry,
+    /// Whether [`claim_types`](Self::claim_types) is still the compiled copy
+    /// this pane started with.
+    ///
+    /// Separate from `Registry::is_fallback`, which answers a different
+    /// question: that one says *the agent told us it cannot serve the table*,
+    /// this one says *we have not asked yet*. Collapsing them would make a
+    /// refresh re-read a constant, or make a never-asked pane claim its agent
+    /// is old.
+    pub claim_types_loaded: bool,
     /// The `did:key` this install authenticates to the agent as, when the
     /// account is agent-managed.
     ///

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -416,6 +416,8 @@ pub enum PersonaTab {
     Attributes,
     /// Named projections over the pool.
     Profiles,
+    /// The facets: parts of a life, and the projections that belong to them.
+    Facets,
     /// Which persona each community sees, and what it presents there.
     Communities,
     /// What has actually left, and to whom.
@@ -425,11 +427,12 @@ pub enum PersonaTab {
 impl PersonaTab {
     /// Every tab, in display order.
     #[must_use]
-    pub fn all() -> [PersonaTab; 5] {
+    pub fn all() -> [PersonaTab; 6] {
         [
             PersonaTab::Personas,
             PersonaTab::Attributes,
             PersonaTab::Profiles,
+            PersonaTab::Facets,
             PersonaTab::Communities,
             PersonaTab::Disclosures,
         ]
@@ -442,13 +445,15 @@ impl PersonaTab {
     /// The variants keep the spec's nouns because that is what they address:
     /// `Profiles` is `persona/profile/*`. The screen says *Faces*, because
     /// "profile" already means three things in this product and "my LinkedIn
-    /// page" to everyone else.
+    /// page" to everyone else; `Facets` is `persona/facet/*` and the screen
+    /// says *Worlds*, because nobody says "my work facet" to a friend.
     #[must_use]
     pub fn label(self) -> &'static str {
         match self {
             PersonaTab::Personas => "Personas",
             PersonaTab::Attributes => "Your attributes",
             PersonaTab::Profiles => "Faces",
+            PersonaTab::Facets => "Worlds",
             PersonaTab::Communities => "Communities",
             PersonaTab::Disclosures => "What has left",
         }
@@ -466,6 +471,7 @@ impl PersonaTab {
             self,
             PersonaTab::Attributes
                 | PersonaTab::Profiles
+                | PersonaTab::Facets
                 | PersonaTab::Communities
                 | PersonaTab::Disclosures
         )
@@ -476,7 +482,8 @@ impl PersonaTab {
         match self {
             PersonaTab::Personas => PersonaTab::Attributes,
             PersonaTab::Attributes => PersonaTab::Profiles,
-            PersonaTab::Profiles => PersonaTab::Communities,
+            PersonaTab::Profiles => PersonaTab::Facets,
+            PersonaTab::Facets => PersonaTab::Communities,
             PersonaTab::Communities => PersonaTab::Disclosures,
             PersonaTab::Disclosures => PersonaTab::Personas,
         }
@@ -488,7 +495,8 @@ impl PersonaTab {
             PersonaTab::Personas => PersonaTab::Disclosures,
             PersonaTab::Attributes => PersonaTab::Personas,
             PersonaTab::Profiles => PersonaTab::Attributes,
-            PersonaTab::Communities => PersonaTab::Profiles,
+            PersonaTab::Facets => PersonaTab::Profiles,
+            PersonaTab::Communities => PersonaTab::Facets,
             PersonaTab::Disclosures => PersonaTab::Communities,
         }
     }
@@ -557,6 +565,19 @@ pub enum PersonaConfirm {
         profile_id: String,
         name: String,
         unbind: bool,
+    },
+    /// Delete a world. Named, not indexed, for the reason above.
+    ///
+    /// `faces` is how many faces belong to it now, so the prompt can say what
+    /// will *not* happen: a world arranges, it does not contain, and "delete
+    /// Work" reads to almost everyone as though the faces in it go too. The
+    /// count is resolved against the face list rather than taken from the
+    /// record, so it is the number the holder can see on screen.
+    DeleteFacet {
+        facet_id: String,
+        name: String,
+        expected_version: Option<u64>,
+        faces: usize,
     },
     /// Clear what one persona presents in one context — the pair the binding is
     /// addressed by, carried whole for the same reason as above.
@@ -685,6 +706,87 @@ pub struct BindPicker {
     pub error: Option<String>,
 }
 
+/// The editor for one world: its name, its colour, its mark.
+///
+/// Membership is **not** edited here, and the omission is deliberate. A world's
+/// faces are changed from the Faces tab, where the holder can see the face they
+/// are moving; a second membership editor would be a second place to get the
+/// replace semantics of `persona/facet/put` wrong. What the form does carry is
+/// the whole membership as read, so that saving a rename puts it back untouched
+/// — the field below is that copy, and it is why this form cannot be built from
+/// nothing.
+#[derive(Clone, Debug, Default)]
+pub struct FacetForm {
+    /// The world being edited; `None` creates a new one.
+    pub facet_id: Option<String>,
+    pub expected_version: Option<u64>,
+    pub name: tui_input::Input,
+    /// Cursor into [`Colour::all`](openvtc_core::persona::facet::Colour::all).
+    pub colour: usize,
+    /// One or two emoji, or nothing. Optional, and a terminal that cannot draw
+    /// it loses nothing that carries meaning.
+    pub icon: tui_input::Input,
+    pub focus: FacetFormFocus,
+    /// The membership as it was read, written back unchanged.
+    ///
+    /// `put` is a replace: omitting these means *empty them*, not "leave them
+    /// alone". A form that rebuilt the record from its own fields would empty
+    /// the world every time somebody renamed it, and the loss would be silent —
+    /// the world would still be there, just with nothing in it.
+    pub face_ids: Vec<String>,
+    pub attribute_ids: Vec<String>,
+    pub error: Option<String>,
+    pub working: bool,
+}
+
+/// Which field of [`FacetForm`] has the keyboard.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FacetFormFocus {
+    #[default]
+    Name,
+    Colour,
+    Icon,
+}
+
+impl FacetFormFocus {
+    #[must_use]
+    pub fn next(self) -> Self {
+        match self {
+            Self::Name => Self::Colour,
+            Self::Colour => Self::Icon,
+            Self::Icon => Self::Name,
+        }
+    }
+
+    #[must_use]
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Name => Self::Icon,
+            Self::Colour => Self::Name,
+            Self::Icon => Self::Colour,
+        }
+    }
+}
+
+/// The world picker for one face: which part of your life does this belong to?
+#[derive(Clone, Debug, Default)]
+pub struct FacePlacer {
+    /// The face being moved, named rather than indexed — the face list is
+    /// re-sorted by world on every read, so an index taken before a refresh
+    /// would name a different face afterwards, and this picker's whole job is
+    /// to move a specific one.
+    pub profile_id: String,
+    /// Display only: which face the holder is looking at.
+    pub face_name: String,
+    /// Cursor over the options, where 0 is always "belongs to no world" — a
+    /// first-class choice rather than the absence of one. Every face belonging
+    /// somewhere is fine too, and a picker with no way back out would make a
+    /// world a trap rather than an arrangement.
+    pub cursor: usize,
+    pub working: bool,
+    pub error: Option<String>,
+}
+
 /// What owns the keyboard inside the pane.
 #[derive(Clone, Debug, Default)]
 pub enum PersonaMode {
@@ -692,16 +794,19 @@ pub enum PersonaMode {
     View,
     Attribute(AttributeForm),
     Profile(ProfileForm),
+    Facet(FacetForm),
+    PlaceFace(FacePlacer),
     Bind(BindPicker),
 }
 
 /// The persona pane: every surface for the holder's own identity, in one place.
 ///
-/// Four of the five tabs are served by the agent and one by `Config`, and the
+/// Five of the six tabs are served by the agent and one by `Config`, and the
 /// difference is load-bearing rather than incidental. Personas are on disk, so
-/// they draw at launch with no session; the pool, the profiles and the bindings
-/// are the agent's, so each of them has to be able to say "I could not ask"
-/// distinctly from "you hold nothing" — see [`load_error`](Self::load_error).
+/// they draw at launch with no session; the pool, the profiles, the facets and
+/// the bindings are the agent's, so each of them has to be able to say "I could
+/// not ask" distinctly from "you hold nothing" — see
+/// [`load_error`](Self::load_error).
 #[derive(Clone, Debug, Default)]
 pub struct IdentityState {
     pub tab: PersonaTab,
@@ -758,6 +863,16 @@ pub struct IdentityState {
     /// that outlived the row it was granted for would be a global unmask
     /// arrived at one keypress at a time.
     pub revealed_attribute: Option<String>,
+
+    // ── Worlds (from the agent) ──────────────────────────────────────────
+    /// The parts of the holder's life, and which faces belong to them.
+    ///
+    /// Empty is a real answer and means the holder has arranged nothing yet —
+    /// or that the agent predates `persona/facet/*`, which amounts to the same
+    /// thing from here, because such a holder cannot have a world to show. A
+    /// read that *failed* lands in [`load_error`](Self::load_error) instead.
+    pub facets: Arc<[openvtc_core::persona::facet::Facet]>,
+    pub facet_selected: usize,
 
     // ── Profiles (from the agent) ────────────────────────────────────────
     pub profiles: Arc<[openvtc_core::persona::profile::ProfileSummary]>,

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -864,6 +864,19 @@ pub struct IdentityState {
     /// arrived at one keypress at a time.
     pub revealed_attribute: Option<String>,
 
+    // ── Links (from the agent) ───────────────────────────────────────────
+    /// Where the holder's identities join up, and which joins cross a world.
+    ///
+    /// Read alongside the pool rather than on demand: the answer is computed
+    /// across every attribute at once, so a per-row question would be one
+    /// round-trip each for a page the agent builds in one.
+    ///
+    /// Empty means the agent found nothing *or* does not serve
+    /// `persona/correlation/analyze`. Neither is a failure; a read that failed
+    /// lands in [`load_error`](Self::load_error), because a clean bill of
+    /// health nobody computed is the answer that misleads.
+    pub links: Arc<[openvtc_core::persona::correlation::Finding]>,
+
     // ── Worlds (from the agent) ──────────────────────────────────────────
     /// The parts of the holder's life, and which faces belong to them.
     ///

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -2962,6 +2962,7 @@ fn spawn_persona_effect(
                 admin_vta: admin_vta.clone(),
                 include_values: state.main_page.content_panel.identity.show_values,
                 targets: persona_actions::PersonaReadJob::targets(state),
+                needs_claim_types: !state.main_page.content_panel.identity.claim_types_loaded,
             };
             state.main_page.content_panel.identity.loading = true;
             background_dispatch::spawn_dispatch(dispatch_tx.clone(), domain, async move {

--- a/openvtc/src/state_handler/persona_actions.rs
+++ b/openvtc/src/state_handler/persona_actions.rs
@@ -38,7 +38,7 @@
 use std::collections::HashMap;
 
 use openvtc_core::persona::{
-    binding, disclosure,
+    binding, claim_types, disclosure,
     pool::{self, AttributeDraft, PoolAttribute},
     profile::{self, ProfileDetail, ProfileSummary},
 };
@@ -632,6 +632,12 @@ pub(crate) struct PersonaReadJob {
     pub(crate) admin_vta: VtaClient,
     pub(crate) include_values: bool,
     pub(crate) targets: Vec<BindingTarget>,
+    /// Whether this read should also fetch the claim-type registry.
+    ///
+    /// Once per session, not once per refresh: the table is a constant for a
+    /// given agent, and a round-trip on every `r` would buy nothing but
+    /// latency on the one action whose whole point is to feel immediate.
+    pub(crate) needs_claim_types: bool,
 }
 
 impl PersonaReadJob {
@@ -662,12 +668,22 @@ impl PersonaReadJob {
                 .map_err(|e| format!("{e}")),
             None => Ok(Vec::new()),
         };
+        let claim_types = match self.needs_claim_types {
+            true => Some(
+                claim_types::Registry::fetch(&self.admin_vta)
+                    .await
+                    .map(Box::new)
+                    .map_err(|e| format!("{e}")),
+            ),
+            false => None,
+        };
         let bindings = persona_binding_refresh::resolve_batch(self.admin_vta, self.targets).await;
         PersonaOutcome::Read {
             attributes,
             profiles,
             disclosures,
             bindings,
+            claim_types,
             include_values: self.include_values,
         }
     }
@@ -762,6 +778,16 @@ pub(crate) enum PersonaOutcome {
         profiles: Result<Vec<ProfileSummary>, String>,
         disclosures: Result<Vec<disclosure::DisclosureRow>, String>,
         bindings: HashMap<BindingTarget, openvtc_core::persona::binding::BindingSummary>,
+        /// The claim-type registry, when this read asked for it. `None` means
+        /// it was not asked for — a refresh over a table already held — which
+        /// is a different thing from a read that failed.
+        ///
+        /// Boxed because this variant is already the widest of the four and a
+        /// whole registry inline pushes `DispatchOutcome` past what
+        /// `clippy::large_enum_variant` will accept: every outcome, including
+        /// the three one-word ones, would then be moved at the width of the
+        /// table.
+        claim_types: Option<Result<Box<claim_types::Registry>, String>>,
         include_values: bool,
     },
     Written {
@@ -791,6 +817,7 @@ impl PersonaOutcome {
                 profiles,
                 disclosures,
                 bindings,
+                claim_types,
                 include_values,
             } => {
                 // A listing for a filter the operator has since flipped is
@@ -800,13 +827,27 @@ impl PersonaOutcome {
                     return;
                 }
                 // The first failure is the one shown, and it is shown *instead*
-                // of an empty list — the whole reason `load_error` exists.
+                // of an empty list — the whole reason `load_error` exists. The
+                // registry is in that chain rather than silently below it: a
+                // failed read leaves the pane drawing from the compiled copy,
+                // and a masking decision this binary made where the agent's own
+                // table was supposed to speak is exactly the kind of thing R6.4
+                // says must not pass for a normal screen.
                 p.load_error = attributes
                     .as_ref()
                     .err()
                     .or(profiles.as_ref().err())
                     .or(disclosures.as_ref().err())
+                    .or_else(|| claim_types.as_ref().and_then(|r| r.as_ref().err()))
                     .cloned();
+                // A successful read is kept whatever else failed, and marks the
+                // table read for the session; a failed one leaves the previous
+                // table in place and stays unmarked, so the next refresh asks
+                // again rather than settling for spec 0.1 forever.
+                if let Some(Ok(registry)) = claim_types {
+                    p.claim_types = *registry;
+                    p.claim_types_loaded = true;
+                }
                 if let Ok(list) = attributes {
                     p.attribute_selected = p.attribute_selected.min(list.len().saturating_sub(1));
                     p.attributes = list.into();
@@ -1079,6 +1120,7 @@ mod tests {
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
             bindings: HashMap::new(),
+            claim_types: None,
             include_values: false,
         }
         .apply(&mut state);
@@ -1172,7 +1214,10 @@ mod tests {
         let mut attr = attribute("01A");
         attr.claim_type = "payment.card".into();
         attr.value = Some(serde_json::json!("4242424242424242"));
-        assert!(attr.is_masked(), "the fixture has to be a masked one");
+        assert!(
+            attr.is_masked(&claim_types::Registry::vendored()),
+            "the fixture has to be a masked one"
+        );
 
         let mut state = state_with(IdentityState {
             attributes: vec![attr].into(),
@@ -1369,6 +1414,7 @@ mod tests {
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
             bindings: HashMap::new(),
+            claim_types: None,
             include_values: true,
         }
         .apply(&mut re_read);
@@ -1400,6 +1446,7 @@ mod tests {
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
             bindings: HashMap::new(),
+            claim_types: None,
             include_values: false,
         }
         .apply(&mut state);
@@ -1426,6 +1473,7 @@ mod tests {
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
             bindings: HashMap::new(),
+            claim_types: None,
             include_values: false,
         }
         .apply(&mut state);

--- a/openvtc/src/state_handler/persona_actions.rs
+++ b/openvtc/src/state_handler/persona_actions.rs
@@ -38,7 +38,7 @@
 use std::collections::HashMap;
 
 use openvtc_core::persona::{
-    binding, claim_types, disclosure, facet, family,
+    binding, claim_types, correlation, disclosure, facet, family,
     pool::{self, AttributeDraft, PoolAttribute},
     profile::{self, ProfileDetail, ProfileSummary},
 };
@@ -878,6 +878,9 @@ impl PersonaReadJob {
         let facets = facet::list(&self.admin_vta)
             .await
             .map_err(|e| format!("{e}"));
+        let links = correlation::analyze(&self.admin_vta)
+            .await
+            .map_err(|e| format!("{e}"));
         let disclosures = match std::num::NonZeroU64::new(DISCLOSURE_PAGE) {
             Some(limit) => disclosure::history(&self.admin_vta, limit)
                 .await
@@ -898,6 +901,7 @@ impl PersonaReadJob {
             attributes,
             profiles,
             facets,
+            links,
             disclosures,
             bindings,
             claim_types,
@@ -1055,6 +1059,7 @@ pub(crate) enum PersonaOutcome {
         attributes: Result<Vec<PoolAttribute>, String>,
         profiles: Result<Vec<ProfileSummary>, String>,
         facets: Result<Vec<facet::Facet>, String>,
+        links: Result<Vec<correlation::Finding>, String>,
         disclosures: Result<Vec<disclosure::DisclosureRow>, String>,
         bindings: HashMap<BindingTarget, openvtc_core::persona::binding::BindingSummary>,
         /// The claim-type registry, when this read asked for it. `None` means
@@ -1099,6 +1104,7 @@ impl PersonaOutcome {
                 attributes,
                 profiles,
                 facets,
+                links,
                 disclosures,
                 bindings,
                 claim_types,
@@ -1122,6 +1128,7 @@ impl PersonaOutcome {
                     .err()
                     .or(profiles.as_ref().err())
                     .or(facets.as_ref().err())
+                    .or(links.as_ref().err())
                     .or(disclosures.as_ref().err())
                     .or_else(|| claim_types.as_ref().and_then(|r| r.as_ref().err()))
                     .cloned();
@@ -1157,6 +1164,9 @@ impl PersonaOutcome {
                 // Worlds before faces: the face list is sorted by which world
                 // holds each face, so the sort needs the answer that is about
                 // to land rather than the one from the previous read.
+                if let Ok(list) = links {
+                    p.links = list.into();
+                }
                 if let Ok(list) = facets {
                     p.facet_selected = p.facet_selected.min(list.len().saturating_sub(1));
                     p.facets = list.into();
@@ -1449,6 +1459,7 @@ mod tests {
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
             facets: Ok(Vec::new()),
+            links: Ok(Vec::new()),
             bindings: HashMap::new(),
             claim_types: None,
             include_values: false,
@@ -1744,6 +1755,7 @@ mod tests {
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
             facets: Ok(Vec::new()),
+            links: Ok(Vec::new()),
             bindings: HashMap::new(),
             claim_types: None,
             include_values: true,
@@ -1777,6 +1789,7 @@ mod tests {
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
             facets: Ok(Vec::new()),
+            links: Ok(Vec::new()),
             bindings: HashMap::new(),
             claim_types: None,
             include_values: false,
@@ -1805,6 +1818,7 @@ mod tests {
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
             facets: Ok(Vec::new()),
+            links: Ok(Vec::new()),
             bindings: HashMap::new(),
             claim_types: None,
             include_values: false,

--- a/openvtc/src/state_handler/persona_actions.rs
+++ b/openvtc/src/state_handler/persona_actions.rs
@@ -38,7 +38,7 @@
 use std::collections::HashMap;
 
 use openvtc_core::persona::{
-    binding, claim_types, disclosure,
+    binding, claim_types, disclosure, family,
     pool::{self, AttributeDraft, PoolAttribute},
     profile::{self, ProfileDetail, ProfileSummary},
 };
@@ -848,7 +848,20 @@ impl PersonaOutcome {
                     p.claim_types = *registry;
                     p.claim_types_loaded = true;
                 }
-                if let Ok(list) = attributes {
+                if let Ok(mut list) = attributes {
+                    // Grouped order, decided here rather than in the renderer.
+                    // The pane draws the pool under family headings, and the
+                    // cursor walks `attributes` by index — so if the list order
+                    // were not the *drawn* order, `j` would move the highlight
+                    // between groups at random. `pool::list` cannot do this
+                    // sort: a family is a question about the claim-type table,
+                    // and the table is only known here.
+                    list.sort_by(|a, b| {
+                        family::Family::of(&a.claim_type, &p.claim_types)
+                            .cmp(&family::Family::of(&b.claim_type, &p.claim_types))
+                            .then_with(|| a.claim_type.cmp(&b.claim_type))
+                            .then_with(|| a.display_name().cmp(b.display_name()))
+                    });
                     p.attribute_selected = p.attribute_selected.min(list.len().saturating_sub(1));
                     p.attributes = list.into();
                     // The list under the reveal has been rebuilt and may be

--- a/openvtc/src/state_handler/persona_actions.rs
+++ b/openvtc/src/state_handler/persona_actions.rs
@@ -38,7 +38,7 @@
 use std::collections::HashMap;
 
 use openvtc_core::persona::{
-    binding, claim_types, disclosure, family,
+    binding, claim_types, disclosure, facet, family,
     pool::{self, AttributeDraft, PoolAttribute},
     profile::{self, ProfileDetail, ProfileSummary},
 };
@@ -46,8 +46,8 @@ use vta_sdk::client::VtaClient;
 
 use crate::state_handler::actions::PersonaAction;
 use crate::state_handler::main_page::content::{
-    AttributeField, AttributeForm, BindPicker, PersonaConfirm, PersonaMode, PersonaTab,
-    ProfileForm, ProfileFormFocus, VALUE_TYPES,
+    AttributeField, AttributeForm, BindPicker, FacePlacer, FacetForm, FacetFormFocus,
+    PersonaConfirm, PersonaMode, PersonaTab, ProfileForm, ProfileFormFocus, VALUE_TYPES,
 };
 use crate::state_handler::persona_binding_refresh::{self, BindingTarget};
 use crate::state_handler::state::State;
@@ -88,6 +88,23 @@ pub(crate) enum PersonaJob {
         /// to populate a form the holder may cancel is a read that did not need
         /// to happen.
         edit: bool,
+    },
+    /// Create or replace one world.
+    FacetPut(facet::FacetDraft),
+    FacetDelete {
+        facet_id: String,
+        expected_version: Option<u64>,
+    },
+    /// Move one face into a world, or out of every world.
+    ///
+    /// Carries the world list it was decided against, because placing is two
+    /// conditional writes and both need the versions that were on screen when
+    /// the holder chose. A job that re-read first would be deciding against a
+    /// list nobody looked at.
+    FacePlace {
+        facets: Vec<facet::Facet>,
+        profile_id: String,
+        into: Option<String>,
     },
     /// Decide what one persona presents in one context.
     Bind {
@@ -140,6 +157,7 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
                 PersonaTab::Personas => p.persona_selected = *index,
                 PersonaTab::Attributes => p.attribute_selected = *index,
                 PersonaTab::Profiles => p.profile_selected = *index,
+                PersonaTab::Facets => p.facet_selected = *index,
                 PersonaTab::Communities => p.membership_selected = *index,
                 PersonaTab::Disclosures => p.disclosure_selected = *index,
             }
@@ -295,6 +313,62 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
             PersonaEffect::None
         }
 
+        PersonaAction::FacePlaceOpen(index) => {
+            let p = &mut state.main_page.content_panel.identity;
+            let Some(face) = p.profiles.get(*index).cloned() else {
+                return PersonaEffect::None;
+            };
+            // Start on the world that holds it now, so ⏎ on an unchanged
+            // picker is a no-op rather than a silent removal.
+            let cursor = p
+                .facets
+                .iter()
+                .position(|f| f.holds_face(&face.profile_id))
+                .map_or(0, |i| i + 1);
+            p.mode = PersonaMode::PlaceFace(FacePlacer {
+                profile_id: face.profile_id.clone(),
+                face_name: face.display_name().to_string(),
+                cursor,
+                ..FacePlacer::default()
+            });
+            PersonaEffect::None
+        }
+
+        // ── Worlds ───────────────────────────────────────────────────────
+        PersonaAction::FacetNew => {
+            state.main_page.content_panel.identity.mode = PersonaMode::Facet(FacetForm::default());
+            PersonaEffect::None
+        }
+        PersonaAction::FacetEdit(index) => {
+            let p = &mut state.main_page.content_panel.identity;
+            let Some(facet) = p.facets.get(*index).cloned() else {
+                return PersonaEffect::None;
+            };
+            p.mode = PersonaMode::Facet(form_for_facet(&facet));
+            PersonaEffect::None
+        }
+        PersonaAction::FacetDeleteArm(index) => {
+            let p = &mut state.main_page.content_panel.identity;
+            let Some(facet) = p.facets.get(*index) else {
+                return PersonaEffect::None;
+            };
+            // Counted against the face list rather than off the record: a world
+            // may name faces that have since been deleted, and the prompt has
+            // to say the number the holder can see.
+            let faces = facet
+                .face_ids
+                .iter()
+                .filter(|id| p.profiles.iter().any(|x| &&x.profile_id == id))
+                .count();
+            p.confirm = PersonaConfirm::DeleteFacet {
+                facet_id: facet.facet_id.clone(),
+                name: facet.display_name().to_string(),
+                expected_version: Some(facet.version),
+                faces,
+            };
+            PersonaEffect::None
+        }
+
         // ── Communities ──────────────────────────────────────────────────
         PersonaAction::BindOpen(index) => {
             let p = &mut state.main_page.content_panel.identity;
@@ -359,7 +433,18 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
                         form.name.handle_event(&event);
                     }
                 }
-                PersonaMode::Bind(_) | PersonaMode::View => {}
+                PersonaMode::Facet(form) => match form.focus {
+                    FacetFormFocus::Name => {
+                        form.name.handle_event(&event);
+                    }
+                    FacetFormFocus::Icon => {
+                        form.icon.handle_event(&event);
+                    }
+                    // The colour is a choice, not a text field: ←/→ move it and
+                    // a keystroke here is not an edit.
+                    FacetFormFocus::Colour => {}
+                },
+                PersonaMode::PlaceFace(_) | PersonaMode::Bind(_) | PersonaMode::View => {}
             }
             PersonaEffect::None
         }
@@ -379,13 +464,23 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
                         ProfileFormFocus::Entries => ProfileFormFocus::Name,
                     };
                 }
-                PersonaMode::Bind(_) | PersonaMode::View => {}
+                PersonaMode::Facet(form) => {
+                    form.focus = if *forwards {
+                        form.focus.next()
+                    } else {
+                        form.focus.prev()
+                    };
+                }
+                PersonaMode::PlaceFace(_) | PersonaMode::Bind(_) | PersonaMode::View => {}
             }
             PersonaEffect::None
         }
         PersonaAction::FormCycle(forwards) => {
             let attribute_count = state.main_page.content_panel.identity.attributes.len();
             let option_count = state.main_page.content_panel.identity.profiles.len() + 1;
+            // …and one more than the worlds, because row 0 is always "belongs
+            // to no world".
+            let world_count = state.main_page.content_panel.identity.facets.len() + 1;
             let p = &mut state.main_page.content_panel.identity;
             match &mut p.mode {
                 PersonaMode::Attribute(form) => {
@@ -400,6 +495,14 @@ pub(crate) fn apply(state: &mut State, action: &PersonaAction) -> PersonaEffect 
                 }
                 PersonaMode::Profile(form) => {
                     form.cursor = step(form.cursor, attribute_count, *forwards);
+                }
+                PersonaMode::Facet(form) => {
+                    if form.focus == FacetFormFocus::Colour {
+                        form.colour = step(form.colour, facet::Colour::all().len(), *forwards);
+                    }
+                }
+                PersonaMode::PlaceFace(picker) => {
+                    picker.cursor = step(picker.cursor, world_count, *forwards);
                 }
                 PersonaMode::Bind(picker) => {
                     picker.cursor = step(picker.cursor, option_count, *forwards);
@@ -463,6 +566,14 @@ fn confirm_yes(state: &mut State) -> PersonaEffect {
         PersonaConfirm::DeleteProfile {
             profile_id, unbind, ..
         } => PersonaEffect::Job(PersonaJob::ProfileDelete { profile_id, unbind }),
+        PersonaConfirm::DeleteFacet {
+            facet_id,
+            expected_version,
+            ..
+        } => PersonaEffect::Job(PersonaJob::FacetDelete {
+            facet_id,
+            expected_version,
+        }),
         PersonaConfirm::Unbind {
             context_id,
             persona_did,
@@ -483,6 +594,17 @@ fn form_submit(state: &mut State) -> PersonaEffect {
         .content_panel
         .identity
         .profiles
+        .iter()
+        .cloned()
+        .collect();
+    // Taken here, before the mode is borrowed mutably, and handed to the job
+    // whole: placing a face is two conditional writes, and both need the
+    // versions that were on screen when the holder chose.
+    let facets: Vec<facet::Facet> = state
+        .main_page
+        .content_panel
+        .identity
+        .facets
         .iter()
         .cloned()
         .collect();
@@ -534,6 +656,53 @@ fn form_submit(state: &mut State) -> PersonaEffect {
                 expected_version: form.expected_version,
             })
         }
+        PersonaMode::Facet(form) => {
+            let name = form.name.value().trim().to_string();
+            if name.is_empty() {
+                form.error = Some("A world needs a name — \"Work\", \"Home\".".to_string());
+                return PersonaEffect::None;
+            }
+            let icon = form.icon.value().trim();
+            // Bounded at 8 bytes by the schema, because it is a mark and not a
+            // field: anything longer is text, and text belongs in the name
+            // where it will be laid out. Refused here rather than at the agent
+            // so the holder is told which field, while they are still in it.
+            if icon.len() > 8 {
+                form.error = Some(
+                    "A mark is one or two emoji. Longer text belongs in the name.".to_string(),
+                );
+                return PersonaEffect::None;
+            }
+            form.error = None;
+            form.working = true;
+            PersonaEffect::Job(PersonaJob::FacetPut(facet::FacetDraft {
+                facet_id: form.facet_id.clone(),
+                name,
+                colour: facet::Colour::all()[form.colour.min(facet::Colour::all().len() - 1)],
+                icon: (!icon.is_empty()).then(|| icon.to_string()),
+                // Straight back out as they came in. See `FacetForm`.
+                face_ids: form.face_ids.clone(),
+                attribute_ids: form.attribute_ids.clone(),
+                // `Some(0)` on a create, so a retry after a lost response
+                // cannot replace what the first attempt made.
+                expected_version: form.expected_version.or(Some(0)),
+            }))
+        }
+        PersonaMode::PlaceFace(picker) => {
+            // Row 0 is "belongs to no world"; the rest index the world list.
+            let into = picker
+                .cursor
+                .checked_sub(1)
+                .and_then(|i| facets.get(i))
+                .map(|f| f.facet_id.clone());
+            picker.error = None;
+            picker.working = true;
+            PersonaEffect::Job(PersonaJob::FacePlace {
+                facets,
+                profile_id: picker.profile_id.clone(),
+                into,
+            })
+        }
         PersonaMode::Bind(picker) => {
             // Row 0 is "nothing"; the rest index the profile list.
             let profile_id = picker
@@ -570,6 +739,14 @@ pub(crate) fn release_form(state: &mut State, reason: String) {
         PersonaMode::Profile(form) => {
             form.working = false;
             form.error = Some(reason);
+        }
+        PersonaMode::Facet(form) => {
+            form.working = false;
+            form.error = Some(reason);
+        }
+        PersonaMode::PlaceFace(picker) => {
+            picker.working = false;
+            picker.error = Some(reason);
         }
         PersonaMode::Bind(picker) => {
             picker.working = false;
@@ -619,6 +796,42 @@ fn step(cursor: usize, len: usize, forwards: bool) -> usize {
 // The jobs
 // ---------------------------------------------------------------------------
 
+/// The editor, filled from a world that already exists.
+///
+/// Membership comes across whole and untouched. `persona/facet/put` is a
+/// replace, so a form that carried only the fields it can edit would empty the
+/// world's faces and attributes the first time somebody renamed it — and the
+/// world would still be there afterwards, just with nothing in it.
+fn form_for_facet(facet: &facet::Facet) -> FacetForm {
+    FacetForm {
+        facet_id: Some(facet.facet_id.clone()),
+        expected_version: Some(facet.version),
+        name: tui_input::Input::new(facet.name.clone()),
+        colour: facet::Colour::all()
+            .iter()
+            .position(|c| *c == facet.colour)
+            .unwrap_or_default(),
+        icon: tui_input::Input::new(facet.icon.clone().unwrap_or_default()),
+        face_ids: facet.face_ids.clone(),
+        attribute_ids: facet.attribute_ids.clone(),
+        ..FacetForm::default()
+    }
+}
+
+/// Where a face sorts: by the world that holds it, in the order the worlds are
+/// listed, and after every placed face when no world holds it.
+///
+/// `usize::MAX` for a homeless face rather than a sentinel at the front,
+/// because "belongs to no world" is the group the console draws last and it is
+/// the honest end of the list: every face belonging somewhere is fine too, and
+/// leading with the ones that do not would read as a fault.
+fn world_rank(facets: &[facet::Facet], profile_id: &str) -> usize {
+    facets
+        .iter()
+        .position(|f| f.holds_face(profile_id))
+        .unwrap_or(usize::MAX)
+}
+
 /// How much of the disclosure history one read asks for.
 ///
 /// The record is append-only and never trimmed, so "all of it" is a query that
@@ -662,6 +875,9 @@ impl PersonaReadJob {
         let profiles = profile::list(&self.admin_vta)
             .await
             .map_err(|e| format!("{e}"));
+        let facets = facet::list(&self.admin_vta)
+            .await
+            .map_err(|e| format!("{e}"));
         let disclosures = match std::num::NonZeroU64::new(DISCLOSURE_PAGE) {
             Some(limit) => disclosure::history(&self.admin_vta, limit)
                 .await
@@ -681,6 +897,7 @@ impl PersonaReadJob {
         PersonaOutcome::Read {
             attributes,
             profiles,
+            facets,
             disclosures,
             bindings,
             claim_types,
@@ -750,6 +967,67 @@ impl PersonaJobRun {
                     .await
                     .map_err(|e| format!("{e}")),
             },
+            PersonaJob::FacetPut(draft) => PersonaOutcome::Written {
+                verb: match draft.facet_id.is_some() {
+                    true => "Saved the world",
+                    false => "Made the world",
+                },
+                error: facet::put(&client, draft)
+                    .await
+                    .err()
+                    .map(|e| format!("{e}")),
+            },
+            PersonaJob::FacetDelete {
+                facet_id,
+                expected_version,
+            } => match facet::delete(&client, &facet_id, expected_version).await {
+                // The count finishes the sentence honestly. "Deleted the world"
+                // on its own reads to almost everyone as though the faces in it
+                // went too, and they did not: a world arranges, it does not
+                // contain.
+                Ok(deletion) if deletion.released_faces > 0 => PersonaOutcome::Deleted {
+                    message: format!(
+                        "Deleted the world. {} face{} kept — {} belong{} to no world now.",
+                        deletion.released_faces,
+                        if deletion.released_faces == 1 {
+                            ""
+                        } else {
+                            "s"
+                        },
+                        if deletion.released_faces == 1 {
+                            "it"
+                        } else {
+                            "they"
+                        },
+                        if deletion.released_faces == 1 {
+                            "s"
+                        } else {
+                            ""
+                        },
+                    ),
+                },
+                Ok(_) => PersonaOutcome::Deleted {
+                    message: "Deleted the world. Nothing else changed.".to_string(),
+                },
+                Err(e) => PersonaOutcome::Written {
+                    verb: "Deleted the world",
+                    error: Some(format!("{e}")),
+                },
+            },
+            PersonaJob::FacePlace {
+                facets,
+                profile_id,
+                into,
+            } => PersonaOutcome::Written {
+                verb: match into.is_some() {
+                    true => "Moved the face",
+                    false => "Took the face out of its world",
+                },
+                error: facet::place_face(&client, &facets, &profile_id, into.as_deref())
+                    .await
+                    .err()
+                    .map(|e| format!("{e}")),
+            },
             PersonaJob::Bind {
                 context_id,
                 persona_did,
@@ -776,6 +1054,7 @@ pub(crate) enum PersonaOutcome {
     Read {
         attributes: Result<Vec<PoolAttribute>, String>,
         profiles: Result<Vec<ProfileSummary>, String>,
+        facets: Result<Vec<facet::Facet>, String>,
         disclosures: Result<Vec<disclosure::DisclosureRow>, String>,
         bindings: HashMap<BindingTarget, openvtc_core::persona::binding::BindingSummary>,
         /// The claim-type registry, when this read asked for it. `None` means
@@ -794,6 +1073,10 @@ pub(crate) enum PersonaOutcome {
         verb: &'static str,
         error: Option<String>,
     },
+    /// A deletion that succeeded and has something to say about what it left
+    /// behind. Distinct from a [`Written`](Self::Written) success, whose whole
+    /// message is its verb.
+    Deleted { message: String },
     ProfileRead {
         edit: bool,
         result: Result<ProfileDetail, String>,
@@ -815,6 +1098,7 @@ impl PersonaOutcome {
             PersonaOutcome::Read {
                 attributes,
                 profiles,
+                facets,
                 disclosures,
                 bindings,
                 claim_types,
@@ -837,6 +1121,7 @@ impl PersonaOutcome {
                     .as_ref()
                     .err()
                     .or(profiles.as_ref().err())
+                    .or(facets.as_ref().err())
                     .or(disclosures.as_ref().err())
                     .or_else(|| claim_types.as_ref().and_then(|r| r.as_ref().err()))
                     .cloned();
@@ -869,7 +1154,23 @@ impl PersonaOutcome {
                     // the holder chose.
                     p.revealed_attribute = None;
                 }
-                if let Ok(list) = profiles {
+                // Worlds before faces: the face list is sorted by which world
+                // holds each face, so the sort needs the answer that is about
+                // to land rather than the one from the previous read.
+                if let Ok(list) = facets {
+                    p.facet_selected = p.facet_selected.min(list.len().saturating_sub(1));
+                    p.facets = list.into();
+                }
+                if let Ok(mut list) = profiles {
+                    // Grouped order, for the reason the pool is grouped here
+                    // too: the cursor walks this slice by index, so the drawn
+                    // order has to *be* the list order or `j` moves the
+                    // highlight between worlds at random.
+                    list.sort_by(|a, b| {
+                        world_rank(&p.facets, &a.profile_id)
+                            .cmp(&world_rank(&p.facets, &b.profile_id))
+                            .then_with(|| a.display_name().cmp(b.display_name()))
+                    });
                     p.profile_selected = p.profile_selected.min(list.len().saturating_sub(1));
                     p.profiles = list.into();
                 }
@@ -910,6 +1211,14 @@ impl PersonaOutcome {
                                 form.working = false;
                                 form.error = Some(e.clone());
                             }
+                            PersonaMode::Facet(form) => {
+                                form.working = false;
+                                form.error = Some(e.clone());
+                            }
+                            PersonaMode::PlaceFace(picker) => {
+                                picker.working = false;
+                                picker.error = Some(e.clone());
+                            }
                             _ => p.status_message = Some(e.clone()),
                         }
                         state
@@ -917,6 +1226,13 @@ impl PersonaOutcome {
                             .log_error(format!("{verb} failed"), e.as_str());
                     }
                 }
+            }
+
+            PersonaOutcome::Deleted { message } => {
+                p.refresh_queued = true;
+                p.mode = PersonaMode::View;
+                p.status_message = Some(message.clone());
+                state.main_page.log(message);
             }
 
             PersonaOutcome::ProfileRead { edit, result } => match result {
@@ -1132,6 +1448,7 @@ mod tests {
             attributes: Ok(vec![attribute("01B"), attribute("01A")]),
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
+            facets: Ok(Vec::new()),
             bindings: HashMap::new(),
             claim_types: None,
             include_values: false,
@@ -1426,6 +1743,7 @@ mod tests {
             attributes: Ok(vec![attribute("01B"), attribute("01A")]),
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
+            facets: Ok(Vec::new()),
             bindings: HashMap::new(),
             claim_types: None,
             include_values: true,
@@ -1458,6 +1776,7 @@ mod tests {
             attributes: Ok(vec![attribute("01B"), attribute("01C")]),
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
+            facets: Ok(Vec::new()),
             bindings: HashMap::new(),
             claim_types: None,
             include_values: false,
@@ -1485,6 +1804,7 @@ mod tests {
             attributes: Err("connection refused".to_string()),
             profiles: Ok(Vec::new()),
             disclosures: Ok(Vec::new()),
+            facets: Ok(Vec::new()),
             bindings: HashMap::new(),
             claim_types: None,
             include_values: false,

--- a/openvtc/src/ui/pages/main/components/identity_panel.rs
+++ b/openvtc/src/ui/pages/main/components/identity_panel.rs
@@ -57,8 +57,6 @@ use crate::state_handler::{
     state::ConnectionState,
 };
 use openvtc_core::display::display_identifier;
-use openvtc_core::persona::pool::PoolAttribute;
-use openvtc_core::persona::profile::ResolvedClaim;
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
@@ -320,6 +318,65 @@ fn render_personas(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
 // Attributes
 // ---------------------------------------------------------------------------
 
+/// What the holder needs to know about the table these rows were painted from.
+///
+/// Two different sentences, and they are not variants of one:
+///
+/// - **The table is this build's, not the agent's.** Every mask on the screen
+///   below was decided by a compiled copy of spec 0.1 because the agent does
+///   not serve `persona/claim-types/list`. It is very likely right, and it
+///   cannot know about anything the deployment declared for itself — so the
+///   line says where the answers came from rather than claiming a fault.
+/// - **The agent refused part of its own configuration.** This one is a fault,
+///   and it is invisible without saying so: a refused row resolves exactly as
+///   it would with no configuration at all, so an operator's intended
+///   tightening is quietly not in force and the screen looks entirely normal.
+///
+/// Both are drawn under the mask explanation and above the rows, because they
+/// qualify the rows rather than the pane.
+fn push_registry_notes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
+    let registry = &state.claim_types;
+
+    if registry.is_fallback {
+        lines.push(
+            Line::from(
+                " Masking here follows this build's own copy of the claim-type table: your \
+                 agent is older than this client and does not serve one. Anything your \
+                 deployment added to it is not reflected below.",
+            )
+            .fg(COLOR_DARK_GRAY),
+        );
+        lines.push(Line::from(""));
+    }
+
+    if let Some(error) = &registry.unapplied.file_error {
+        lines.push(
+            Line::from(format!(
+                " Your agent could not read its own claim-type file, so none of what this \
+                 deployment declared is in force: {error}"
+            ))
+            .fg(COLOR_WARNING_ACCESSIBLE_RED),
+        );
+        lines.push(Line::from(""));
+    }
+
+    // Named one by one rather than counted. "3 claim types were rejected" sends
+    // the reader to a file to work out which; the token and the agent's own
+    // reason are the whole of what they need to fix it.
+    for rejected in &registry.unapplied.rejected {
+        lines.push(
+            Line::from(format!(
+                " Your agent would not apply `{}` from this deployment's claim types: {}",
+                rejected.claim_type, rejected.reason
+            ))
+            .fg(COLOR_WARNING_ACCESSIBLE_RED),
+        );
+    }
+    if !registry.unapplied.rejected.is_empty() {
+        lines.push(Line::from(""));
+    }
+}
+
 fn render_attributes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
     if push_agent_state(state, lines, "attributes") {
         return;
@@ -364,7 +421,11 @@ fn render_attributes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
     // key, and it says what the mask is worth. Only when something on screen is
     // actually masked — an explanation of a mechanism the holder is not looking
     // at is noise.
-    if state.attributes.iter().any(PoolAttribute::is_masked) {
+    if state
+        .attributes
+        .iter()
+        .any(|a| a.is_masked(&state.claim_types))
+    {
         lines.push(
             Line::from(
                 " Some attributes are masked by what they are — `s` shows the selected one. The \
@@ -375,6 +436,8 @@ fn render_attributes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
         );
         lines.push(Line::from(""));
     }
+
+    push_registry_notes(state, lines);
 
     for (i, attr) in state.attributes.iter().enumerate() {
         let is_selected = i == state.attribute_selected;
@@ -411,9 +474,9 @@ fn render_attributes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
         let revealed =
             is_selected && state.revealed_attribute.as_deref() == Some(attr.attribute_id.as_str());
         let value = if revealed {
-            attr.revealed_value(state.show_values)
+            attr.revealed_value(&state.claim_types, state.show_values)
         } else {
-            attr.display_value(state.show_values)
+            attr.display_value(&state.claim_types, state.show_values)
         };
         let mut value_spans = vec![Span::styled(
             format!("      {}", truncate(&value, 70)),
@@ -426,7 +489,7 @@ fn render_attributes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
         // Without this the row is a wrong answer rather than a reduced one:
         // `••••••••` and "(no value)" are the same shape, and a holder reading
         // the first as the second believes they hold nothing.
-        if attr.is_masked() {
+        if attr.is_masked(&state.claim_types) {
             value_spans.push(Span::styled(
                 if revealed {
                     "   showing — s to mask"
@@ -482,9 +545,9 @@ fn render_profiles(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
                 // a stale grant cannot open a row nobody chose.
                 let revealed = is_selected && state.revealed_face_claim == Some(i);
                 let value = if revealed {
-                    claim.revealed_value()
+                    claim.revealed_value(&state.claim_types)
                 } else {
-                    claim.display_value()
+                    claim.display_value(&state.claim_types)
                 };
                 let mut spans = vec![
                     Span::styled(
@@ -505,7 +568,7 @@ fn render_profiles(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
                 // one: `••••••••` and "(no value)" are the same shape, and a
                 // holder reading the first as the second believes the face
                 // shows nothing.
-                if claim.is_masked() && !revealed {
+                if claim.is_masked(&state.claim_types) && !revealed {
                     spans.push(Span::styled(
                         if is_selected {
                             "   masked — s to show"
@@ -533,7 +596,11 @@ fn render_profiles(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
         // Said once, above the keys, rather than on every row — and only when
         // something on screen is actually masked, because explaining a
         // mechanism the holder is not looking at is noise.
-        if detail.resolved.iter().any(ResolvedClaim::is_masked) {
+        if detail
+            .resolved
+            .iter()
+            .any(|c| c.is_masked(&state.claim_types))
+        {
             lines.push(
                 Line::from(
                     " Some values are masked by what they are — `s` shows the selected one. The \

--- a/openvtc/src/ui/pages/main/components/identity_panel.rs
+++ b/openvtc/src/ui/pages/main/components/identity_panel.rs
@@ -57,6 +57,7 @@ use crate::state_handler::{
     state::ConnectionState,
 };
 use openvtc_core::display::display_identifier;
+use openvtc_core::persona::family::Family;
 use ratatui::{
     style::{Style, Stylize},
     text::{Line, Span},
@@ -439,7 +440,31 @@ fn render_attributes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
 
     push_registry_notes(state, lines);
 
+    // The list arrives already in family order — `PersonaOutcome::Read` sorts
+    // it there, so that the cursor, which walks this slice by index, walks the
+    // groups in the order they are drawn. All this loop does is notice the
+    // boundary and put the heading on it.
+    let mut current_family: Option<Family> = None;
+
     for (i, attr) in state.attributes.iter().enumerate() {
+        let family = Family::of(&attr.claim_type, &state.claim_types);
+        if current_family != Some(family) {
+            if current_family.is_some() {
+                lines.push(Line::from(""));
+            }
+            lines.push(
+                Line::from(format!(" {}", family.label()))
+                    .fg(COLOR_TEXT_DEFAULT)
+                    .bold(),
+            );
+            // The heading names the group; this line says what the group *is*.
+            // Both, every time: "Your agent asks first" is a behaviour nobody
+            // can infer from four registered tokens, and a heading a reader has
+            // to decode is a heading that gets skipped.
+            lines.push(Line::from(format!("   {}", family.note())).fg(COLOR_DARK_GRAY));
+            current_family = Some(family);
+        }
+
         let is_selected = i == state.attribute_selected;
         let row_style = if is_selected {
             Style::new().fg(COLOR_SUCCESS).bold()
@@ -1530,6 +1555,83 @@ mod tests {
         assert!(
             shown.contains("(no value)"),
             "a listing that asked and got nothing says so: {shown}"
+        );
+    }
+
+    /// The pool is drawn under family headings, and each heading carries the
+    /// line that says what its group is.
+    ///
+    /// The wall this replaces is the failure mode: thirty rows in one
+    /// undifferentiated list is where the answer to "what do I actually keep
+    /// about myself" goes to hide.
+    #[test]
+    fn the_pool_is_drawn_under_family_headings() {
+        let mut state = populated(PersonaTab::Attributes);
+        loaded(&mut state);
+        let shown = text(&render(&state));
+
+        assert!(shown.contains("How to reach you"), "{shown}");
+        assert!(
+            shown.contains("an address someone can arrive at"),
+            "{shown}"
+        );
+        assert!(shown.contains("Your agent asks first"), "{shown}");
+
+        // …and in the declared order, not the order the rows happened to
+        // arrive in: `email.work` is contact, `payment.card` is gated, and
+        // contact comes first.
+        let contact = shown.find("How to reach you").expect("contact heading");
+        let gated = shown.find("Your agent asks first").expect("gated heading");
+        assert!(contact < gated, "groups are out of order:\n{shown}");
+    }
+
+    /// A token the registry does not declare is grouped as unregistered rather
+    /// than guessed at from its spelling — and the heading says which.
+    #[test]
+    fn an_undeclared_token_is_grouped_honestly() {
+        let mut state = populated(PersonaTab::Attributes);
+        loaded(&mut state);
+        let mut attrs = state.attributes.to_vec();
+        attrs.push(PoolAttribute {
+            attribute_id: "01C".into(),
+            claim_type: "profile.github".into(),
+            ..PoolAttribute::default()
+        });
+        state.attributes = attrs.into();
+
+        let shown = text(&render(&state));
+        assert!(shown.contains("Not in the registry"), "{shown}");
+        assert!(
+            shown.contains("does not declare these"),
+            "the heading has to say why, not just that: {shown}"
+        );
+    }
+
+    /// A pane drawing from the compiled table says so.
+    ///
+    /// Otherwise a masking decision this binary made is indistinguishable from
+    /// one the holder's own agent made, which is the confident wrong answer
+    /// R6.4 exists to refuse.
+    #[test]
+    fn a_compiled_table_is_disclosed_as_one() {
+        let mut state = populated(PersonaTab::Attributes);
+        loaded(&mut state);
+        let shown = text(&render(&state));
+        assert!(
+            shown.contains("this build's own copy of the claim-type table"),
+            "{shown}"
+        );
+
+        // …and a pane drawing from the agent's own table says nothing at all,
+        // because there is nothing to disclose. The flag is what the render
+        // keys on, so setting it is the whole of the difference under test —
+        // the rows themselves resolve identically either way.
+        state.claim_types.is_fallback = false;
+        state.claim_types_loaded = true;
+        let served = text(&render(&state));
+        assert!(
+            !served.contains("this build's own copy"),
+            "the agent's own table needs no apology: {served}"
         );
     }
 

--- a/openvtc/src/ui/pages/main/components/identity_panel.rs
+++ b/openvtc/src/ui/pages/main/components/identity_panel.rs
@@ -51,12 +51,14 @@ use crate::colors::{
 };
 use crate::state_handler::{
     main_page::content::{
-        AttributeField, AttributeForm, BindPicker, IdentityState, PersonaConfirm, PersonaMode,
-        PersonaTab, ProfileForm, ProfileFormFocus, VALUE_TYPES,
+        AttributeField, AttributeForm, BindPicker, FacePlacer, FacetForm, FacetFormFocus,
+        IdentityState, PersonaConfirm, PersonaMode, PersonaTab, ProfileForm, ProfileFormFocus,
+        VALUE_TYPES,
     },
     state::ConnectionState,
 };
 use openvtc_core::display::display_identifier;
+use openvtc_core::persona::facet::Colour;
 use openvtc_core::persona::family::Family;
 use ratatui::{
     style::{Style, Stylize},
@@ -91,6 +93,8 @@ pub fn render(state: &IdentityState) -> Vec<Line<'static>> {
     match &state.mode {
         PersonaMode::Attribute(form) => render_attribute_form(form),
         PersonaMode::Profile(form) => render_profile_form(state, form),
+        PersonaMode::Facet(form) => render_facet_form(form),
+        PersonaMode::PlaceFace(picker) => render_face_placer(state, picker),
         PersonaMode::Bind(picker) => render_bind_picker(state, picker),
         PersonaMode::View => render_tabs(state),
     }
@@ -128,6 +132,7 @@ fn render_tabs(state: &IdentityState) -> Vec<Line<'static>> {
         PersonaTab::Personas => render_personas(state, &mut lines),
         PersonaTab::Attributes => render_attributes(state, &mut lines),
         PersonaTab::Profiles => render_profiles(state, &mut lines),
+        PersonaTab::Facets => render_facets(state, &mut lines),
         PersonaTab::Communities => render_communities(state, &mut lines),
         PersonaTab::Disclosures => render_disclosures(state, &mut lines),
     }
@@ -193,6 +198,21 @@ fn confirm_prompt(state: &IdentityState) -> Option<String> {
                 ))
             }
         }
+        PersonaConfirm::DeleteFacet { name, faces, .. } => Some(match faces {
+            // The sentence a holder needs is about what *survives*. "Delete
+            // Work" reads to almost everyone as though the faces in it go too,
+            // and a prompt that leaves that uncorrected is answered under a
+            // belief nobody checked.
+            0 => format!("Delete the world \"{name}\"?   y: confirm    n: cancel"),
+            1 => format!(
+                "Delete the world \"{name}\"? The face in it is kept and belongs to no world \
+                 afterwards.   y: confirm    n: cancel"
+            ),
+            n => format!(
+                "Delete the world \"{name}\"? The {n} faces in it are kept and belong to no \
+                 world afterwards.   y: confirm    n: cancel"
+            ),
+        }),
         PersonaConfirm::Unbind { community, .. } => Some(format!(
             "Take it off — show {community} nothing?   Nothing already shared is affected \
              — that has left.   y: confirm    n: cancel"
@@ -210,7 +230,11 @@ fn hints(state: &IdentityState) -> &'static str {
              r: refresh   ⇥/⇧⇥: tab"
         }
         PersonaTab::Profiles => {
-            "↑/↓ select   ⏎: what it shows   n: make a face   e: edit   d: delete   r: refresh   ⇥/⇧⇥: tab"
+            "↑/↓ select   ⏎: what it shows   n: make a face   e: edit   m: move to a world   \
+             d: delete   r: refresh   ⇥/⇧⇥: tab"
+        }
+        PersonaTab::Facets => {
+            "↑/↓ select   n: new world   e: edit   d: delete   r: refresh   ⇥/⇧⇥: tab"
         }
         PersonaTab::Communities => {
             "↑/↓ select   b: change face   u: take it off   r: refresh   ⇥/⇧⇥: tab"
@@ -673,7 +697,35 @@ fn render_profiles(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
         return;
     }
 
+    // The list arrives sorted by which world holds each face, so a heading goes
+    // wherever that answer changes. Drawn only when the holder has arranged
+    // something: a single "Belongs to no world" heading over every face they
+    // own is a question asked of somebody who has not been offered the answer.
+    let arranged = !state.facets.is_empty();
+    let mut current_world: Option<Option<usize>> = None;
+
     for (i, profile) in state.profiles.iter().enumerate() {
+        if arranged {
+            let world = state
+                .facets
+                .iter()
+                .position(|f| f.holds_face(&profile.profile_id));
+            if current_world != Some(world) {
+                if current_world.is_some() {
+                    lines.push(Line::from(""));
+                }
+                match world.and_then(|w| state.facets.get(w)) {
+                    Some(facet) => lines.push(world_heading(facet)),
+                    None => lines.push(
+                        Line::from(" Belongs to no world")
+                            .fg(COLOR_DARK_GRAY)
+                            .bold(),
+                    ),
+                }
+                current_world = Some(world);
+            }
+        }
+
         let is_selected = i == state.profile_selected;
         let row_style = if is_selected {
             Style::new().fg(COLOR_SUCCESS).bold()
@@ -695,6 +747,128 @@ fn render_profiles(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
                 Style::new().fg(COLOR_DARK_GRAY),
             ),
         ]));
+    }
+}
+
+/// One world's heading: its mark, its name, and nothing else.
+///
+/// The colour is the holder's decoration and it is deliberately *not* drawn as
+/// a colour here. A terminal has one channel for emphasis and this pane already
+/// spends it on selection and on warnings; painting a world's own hue into that
+/// channel would make "Money" look like an error to anyone who did not choose
+/// it. The mark is the carrier that survives a terminal, and the name is the
+/// carrier that survives everything.
+fn world_heading(facet: &openvtc_core::persona::facet::Facet) -> Line<'static> {
+    let mark = facet
+        .icon
+        .as_deref()
+        .map(|i| format!("{i} "))
+        .unwrap_or_default();
+    Line::from(format!(" {mark}{}", facet.display_name()))
+        .fg(COLOR_TEXT_DEFAULT)
+        .bold()
+}
+
+// ---------------------------------------------------------------------------
+// Worlds
+// ---------------------------------------------------------------------------
+
+fn render_facets(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
+    if push_agent_state(state, lines, "worlds") {
+        return;
+    }
+
+    lines.push(
+        Line::from(format!(
+            " {} world{}",
+            state.facets.len(),
+            if state.facets.len() == 1 { "" } else { "s" }
+        ))
+        .fg(COLOR_TEXT_DEFAULT),
+    );
+    lines.push(Line::from(""));
+
+    if state.facets.is_empty() {
+        lines.push(
+            Line::from(
+                " No worlds yet. A world is a part of your life, and the faces that belong to \
+                 it — \"Work\", \"Home\", \"Play\". `n` makes one.",
+            )
+            .fg(COLOR_DARK_GRAY),
+        );
+        lines.push(Line::from(""));
+        lines.push(
+            Line::from(
+                " Keep your worlds apart. Two that share a value are two anyone who sees both \
+                 knows are the same person.",
+            )
+            .fg(COLOR_DARK_GRAY),
+        );
+        return;
+    }
+
+    for (i, facet) in state.facets.iter().enumerate() {
+        let is_selected = i == state.facet_selected;
+        let row_style = if is_selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+        let mark = facet
+            .icon
+            .as_deref()
+            .map(|m| format!("{m} "))
+            .unwrap_or_default();
+
+        // A world names ids; a face list may no longer contain them. The count
+        // that matters to a holder is what they will actually see under this
+        // heading, so it is resolved rather than taken from the record — and
+        // the difference is named below rather than quietly absorbed.
+        let live = facet
+            .face_ids
+            .iter()
+            .filter(|id| state.profiles.iter().any(|p| &&p.profile_id == id))
+            .count();
+
+        lines.push(Line::from(vec![
+            Span::styled(if is_selected { "▸ " } else { "  " }, row_style),
+            Span::styled(
+                format!(
+                    "{:<26}",
+                    truncate(&format!("{mark}{}", facet.display_name()), 25)
+                ),
+                row_style,
+            ),
+            Span::styled(
+                format!(
+                    "{live} face{}   {} attribute{}",
+                    if live == 1 { "" } else { "s" },
+                    facet.attribute_ids.len(),
+                    if facet.attribute_ids.len() == 1 {
+                        ""
+                    } else {
+                        "s"
+                    }
+                ),
+                Style::new().fg(COLOR_DARK_GRAY),
+            ),
+        ]));
+
+        // A world may name a face that has since been deleted. The agent keeps
+        // those deliberately — a dangling id is how a holder can be offered the
+        // chance to tidy — so saying so is the point of keeping them.
+        let dangling = facet.face_ids.len().saturating_sub(live);
+        if dangling > 0 {
+            lines.push(
+                Line::from(format!(
+                    "      {dangling} face{} this world names {} gone. Nothing was lost here — \
+                     editing this world tidies the reference.",
+                    if dangling == 1 { "" } else { "s" },
+                    if dangling == 1 { "is" } else { "are" },
+                ))
+                .fg(COLOR_ORANGE),
+            );
+        }
     }
 }
 
@@ -1119,6 +1293,186 @@ fn render_profile_form(state: &IdentityState, form: &ProfileForm) -> Vec<Line<'s
 // The bind picker
 // ---------------------------------------------------------------------------
 
+/// The world editor: a name, a colour, an optional mark.
+///
+/// No membership here. A world's faces are moved from the Faces tab, where the
+/// face being moved is on screen — see `PersonaAction::FacePlaceOpen`. What this
+/// form does carry, invisibly, is the membership it was opened with, so that
+/// saving a rename puts it back untouched.
+fn render_facet_form(form: &FacetForm) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+    lines.push(
+        Line::from(match form.facet_id.is_some() {
+            true => " Edit this world",
+            false => " A new part of your life",
+        })
+        .fg(COLOR_SUCCESS)
+        .bold(),
+    );
+    lines.push(Line::from(""));
+    lines.push(
+        Line::from(
+            " A world is a part of your life, and the faces that belong to it — \"Work\", \
+             \"Home\", \"Play\". It arranges what you keep; it never contains it, so deleting \
+             one keeps every face in it.",
+        )
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines.push(Line::from(""));
+
+    let focused = |field: FacetFormFocus| {
+        if form.focus == field {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        }
+    };
+
+    lines.push(Line::from(vec![
+        Span::styled(" What do you call it?  ", focused(FacetFormFocus::Name)),
+        Span::styled(form.name.value().to_string(), focused(FacetFormFocus::Name)),
+        Span::styled(
+            if form.focus == FacetFormFocus::Name {
+                "▏"
+            } else {
+                ""
+            },
+            focused(FacetFormFocus::Name),
+        ),
+    ]));
+    lines.push(
+        Line::from("   Only you ever see it — it is not a scope, and no counterparty is told it.")
+            .fg(COLOR_DARK_GRAY),
+    );
+    lines.push(Line::from(""));
+
+    // The colours are offered by name rather than painted. A terminal spends
+    // its one emphasis channel on selection and on warnings, and a world's own
+    // hue rendered into that channel would make "Money" read as an error to
+    // anyone who did not choose it.
+    let mut swatches = vec![Span::styled(
+        " Colour               ",
+        focused(FacetFormFocus::Colour),
+    )];
+    for (i, colour) in Colour::all().into_iter().enumerate() {
+        let chosen = i == form.colour;
+        swatches.push(Span::styled(
+            format!("{}{} ", if chosen { "▸" } else { " " }, colour.as_wire()),
+            if chosen {
+                Style::new().fg(COLOR_SUCCESS).bold()
+            } else {
+                Style::new().fg(COLOR_DARK_GRAY)
+            },
+        ));
+    }
+    lines.push(Line::from(swatches));
+    lines.push(Line::from("   ←/→ to choose.").fg(COLOR_DARK_GRAY));
+    lines.push(Line::from(""));
+
+    lines.push(Line::from(vec![
+        Span::styled(" A mark (optional)    ", focused(FacetFormFocus::Icon)),
+        Span::styled(form.icon.value().to_string(), focused(FacetFormFocus::Icon)),
+        Span::styled(
+            if form.focus == FacetFormFocus::Icon {
+                "▏"
+            } else {
+                ""
+            },
+            focused(FacetFormFocus::Icon),
+        ),
+    ]));
+    lines.push(
+        Line::from("   One or two emoji. A terminal that cannot draw it shows the name instead.")
+            .fg(COLOR_DARK_GRAY),
+    );
+    lines.push(Line::from(""));
+
+    if let Some(error) = &form.error {
+        super::status::push_status(&mut lines, error, " ");
+        lines.push(Line::from(""));
+    }
+    lines.push(
+        Line::from(if form.working {
+            " Saving…"
+        } else {
+            " ⇥/⇧⇥: field   ←/→: colour   ⏎: save   Esc: cancel"
+        })
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines
+}
+
+/// The world picker for one face.
+fn render_face_placer(state: &IdentityState, picker: &FacePlacer) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+    lines.push(
+        Line::from(format!(
+            " Which part of your life does \"{}\" belong to?",
+            picker.face_name
+        ))
+        .fg(COLOR_SUCCESS)
+        .bold(),
+    );
+    lines.push(Line::from(""));
+    lines.push(
+        Line::from(
+            " A face belongs to one world at a time. Moving it changes nothing about what \
+             the face shows or where it is already worn — a world is how you keep the parts \
+             of your life apart, not what holds them.",
+        )
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines.push(Line::from(""));
+
+    for (i, label) in place_options(state).into_iter().enumerate() {
+        let is_cursor = i == picker.cursor;
+        let style = if is_cursor {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            Style::new().fg(COLOR_TEXT_DEFAULT)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if is_cursor { " ▸ " } else { "   " }, style),
+            Span::styled(label, style),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+    if let Some(error) = &picker.error {
+        super::status::push_status(&mut lines, error, " ");
+        lines.push(Line::from(""));
+    }
+    lines.push(
+        Line::from(if picker.working {
+            " Moving…"
+        } else {
+            " ↑/↓: move   ⏎: apply   Esc: cancel"
+        })
+        .fg(COLOR_DARK_GRAY),
+    );
+    lines
+}
+
+/// The picker's rows: "belongs to no world", then every world.
+///
+/// Derived rather than stored, so a world renamed between opening the picker
+/// and reading it cannot show a stale name.
+pub fn place_options(state: &IdentityState) -> Vec<String> {
+    // Row 0, and a real answer rather than the absence of one: every face
+    // belonging somewhere is fine too, and a picker with no way back out would
+    // make a world a trap rather than an arrangement.
+    let mut options = vec!["Belongs to no world".to_string()];
+    options.extend(state.facets.iter().map(|facet| {
+        let mark = facet
+            .icon
+            .as_deref()
+            .map(|m| format!("{m} "))
+            .unwrap_or_default();
+        format!("{mark}{}", facet.display_name())
+    }));
+    options
+}
+
 fn render_bind_picker(state: &IdentityState, picker: &BindPicker) -> Vec<Line<'static>> {
     let mut lines = vec![Line::from("")];
     lines.push(
@@ -1216,6 +1570,7 @@ mod tests {
     use super::*;
     use crate::state_handler::main_page::content::{ManagedDid, PersonaMembership};
     use openvtc_core::persona::binding::BindingSummary;
+    use openvtc_core::persona::facet::Facet;
     use openvtc_core::persona::pool::PoolAttribute;
 
     fn text(lines: &[Line<'static>]) -> String {
@@ -1312,6 +1667,17 @@ mod tests {
         for mode in [
             PersonaMode::Attribute(AttributeForm::default()),
             PersonaMode::Profile(ProfileForm::default()),
+            PersonaMode::Facet(FacetForm::default()),
+            PersonaMode::Facet(FacetForm {
+                // The edit heading and the save path differ from the create
+                // ones, and only an id tells them apart.
+                facet_id: Some("01FACET".into()),
+                ..FacetForm::default()
+            }),
+            PersonaMode::PlaceFace(FacePlacer {
+                face_name: "Work".into(),
+                ..FacePlacer::default()
+            }),
             PersonaMode::Bind(BindPicker::default()),
         ] {
             let mut state = populated(PersonaTab::Personas);
@@ -1378,12 +1744,44 @@ mod tests {
             }]
             .into(),
             attributes: vec![attr, card].into(),
-            profiles: vec![ProfileSummary {
-                profile_id: "01P".into(),
-                name: "Work".into(),
-                entry_count: 3,
-                ..ProfileSummary::default()
-            }]
+            facets: vec![
+                Facet {
+                    facet_id: "01FACET".into(),
+                    name: "Working life".into(),
+                    colour: Colour::Moss,
+                    icon: Some("💼".into()),
+                    face_ids: vec!["01P".into(), "01GONE".into()],
+                    attribute_ids: vec!["01A".into()],
+                    version: 2,
+                    ..Facet::default()
+                },
+                // A second world with nothing in it, so the empty-group and
+                // the dangling-reference copy are both read by the guard.
+                Facet {
+                    facet_id: "02FACET".into(),
+                    name: "Home".into(),
+                    version: 1,
+                    ..Facet::default()
+                },
+            ]
+            .into(),
+            profiles: vec![
+                ProfileSummary {
+                    profile_id: "01P".into(),
+                    name: "Work".into(),
+                    entry_count: 3,
+                    ..ProfileSummary::default()
+                },
+                // In no world, so the "belongs to no world" group is drawn and
+                // the guard reads its copy. Every face belonging somewhere is a
+                // real arrangement and this is the other one.
+                ProfileSummary {
+                    profile_id: "02P".into(),
+                    name: "OSS Developer".into(),
+                    entry_count: 2,
+                    ..ProfileSummary::default()
+                },
+            ]
             .into(),
             memberships: vec![PersonaMembership {
                 community_name: "Acme".into(),
@@ -1632,6 +2030,99 @@ mod tests {
         assert!(
             !served.contains("this build's own copy"),
             "the agent's own table needs no apology: {served}"
+        );
+    }
+
+    /// The faces list is drawn under the world that holds each face, and the
+    /// ones no world holds are named as such rather than left unlabelled.
+    #[test]
+    fn faces_are_drawn_under_their_world() {
+        let mut state = populated(PersonaTab::Profiles);
+        loaded(&mut state);
+        state.open_profile = None;
+        let shown = text(&render(&state));
+
+        assert!(shown.contains("Working life"), "{shown}");
+        assert!(shown.contains("Belongs to no world"), "{shown}");
+    }
+
+    /// …and a holder who has arranged nothing is not asked a question they have
+    /// not been offered the answer to.
+    ///
+    /// A single "Belongs to no world" heading over every face somebody owns
+    /// says a world exists to belong to, when none does.
+    #[test]
+    fn an_unarranged_holder_sees_no_world_headings() {
+        let mut state = populated(PersonaTab::Profiles);
+        loaded(&mut state);
+        state.open_profile = None;
+        state.facets = Vec::new().into();
+        let shown = text(&render(&state));
+
+        assert!(!shown.contains("Belongs to no world"), "{shown}");
+    }
+
+    /// A world says how many faces it actually has, and says so about the ones
+    /// it names that are gone.
+    ///
+    /// The agent keeps a dangling id deliberately — it is how a holder can be
+    /// offered the chance to tidy — so a pane that silently resolved it away
+    /// would turn a deletion they may not have intended into one they cannot
+    /// see.
+    #[test]
+    fn a_world_says_what_it_still_holds() {
+        let mut state = populated(PersonaTab::Facets);
+        loaded(&mut state);
+        let shown = text(&render(&state));
+
+        assert!(shown.contains("Working life"), "{shown}");
+        // One live face (`01P`) of the two the world names.
+        assert!(shown.contains("1 face"), "{shown}");
+        assert!(
+            shown.contains("Nothing was lost here"),
+            "the dangling reference has to be named: {shown}"
+        );
+    }
+
+    /// Deleting a world says what survives it, because "delete Work" reads to
+    /// almost everyone as though the faces in it go too.
+    #[test]
+    fn deleting_a_world_says_what_it_keeps() {
+        let mut state = populated(PersonaTab::Facets);
+        loaded(&mut state);
+        state.confirm = PersonaConfirm::DeleteFacet {
+            facet_id: "01FACET".into(),
+            name: "Working life".into(),
+            expected_version: Some(2),
+            faces: 2,
+        };
+        let shown = text(&render(&state));
+        assert!(shown.contains("are kept"), "{shown}");
+        assert!(shown.contains("belong to no world afterwards"), "{shown}");
+
+        // …and a world with nothing in it makes no such promise, because there
+        // is nothing for the sentence to be about.
+        state.confirm = PersonaConfirm::DeleteFacet {
+            facet_id: "02FACET".into(),
+            name: "Home".into(),
+            expected_version: Some(1),
+            faces: 0,
+        };
+        let empty = text(&render(&state));
+        assert!(!empty.contains("are kept"), "{empty}");
+    }
+
+    /// The world picker leads with "belongs to no world", so a face can always
+    /// be taken back out of one.
+    #[test]
+    fn the_world_picker_offers_a_way_back_out() {
+        let mut state = populated(PersonaTab::Profiles);
+        loaded(&mut state);
+        let options = place_options(&state);
+        assert_eq!(options[0], "Belongs to no world");
+        assert!(
+            options.iter().any(|o| o.contains("Working life")),
+            "{options:?}"
         );
     }
 

--- a/openvtc/src/ui/pages/main/components/identity_panel.rs
+++ b/openvtc/src/ui/pages/main/components/identity_panel.rs
@@ -58,6 +58,7 @@ use crate::state_handler::{
     state::ConnectionState,
 };
 use openvtc_core::display::display_identifier;
+use openvtc_core::persona::correlation;
 use openvtc_core::persona::facet::Colour;
 use openvtc_core::persona::family::Family;
 use ratatui::{
@@ -463,6 +464,7 @@ fn render_attributes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
     }
 
     push_registry_notes(state, lines);
+    push_link_summary(state, lines);
 
     // The list arrives already in family order — `PersonaOutcome::Read` sorts
     // it there, so that the cursor, which walks this slice by index, walks the
@@ -553,7 +555,60 @@ fn render_attributes(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
             ));
         }
         lines.push(Line::from(value_spans));
+
+        // The link, under the value it is about. Only the cross-world ones get
+        // a row of their own: a value shared between two faces in the same
+        // world is linkage the holder arranged on purpose — a work email in
+        // every work face — and a pane that flagged it would teach them to
+        // scroll past the flag that matters.
+        if let Some(finding) = correlation::for_attribute(&state.links, &attr.attribute_id)
+            && finding.crosses_a_world()
+        {
+            lines.push(Line::from(format!("      {}", finding.headline())).fg(COLOR_ORANGE));
+            if is_selected {
+                // The cause and the ways out, but only under the cursor: on
+                // every row they would be four lines of prose per attribute,
+                // and a warning nobody can see past is one nobody reads.
+                if !finding.why.is_empty() {
+                    lines.push(Line::from(format!("      {}", finding.why)).fg(COLOR_DARK_GRAY));
+                }
+                for remedy in &finding.remedies {
+                    lines.push(
+                        Line::from(format!("        · {}", remedy.label())).fg(COLOR_DARK_GRAY),
+                    );
+                }
+            }
+        }
     }
+}
+
+/// How many links cross a part of the holder's life, said once above the rows.
+///
+/// Two things kept apart, because collapsing them is the whole failure mode
+/// this task's second axis exists to prevent. The count is of links that cross
+/// a **world** — parts of a life the holder has said belong apart — and not of
+/// links in general: most of those are arrangements they made on purpose, and
+/// counting them here would put a number on the screen whose only honest
+/// reading is "you have an identity".
+///
+/// Nothing is drawn when the holder has arranged no worlds, because
+/// `crossesFacets` is then absent from every finding and there is no question
+/// for this line to answer.
+fn push_link_summary(state: &IdentityState, lines: &mut Vec<Line<'static>>) {
+    let crossing = state.links.iter().filter(|f| f.crosses_a_world()).count();
+    if crossing == 0 {
+        return;
+    }
+
+    lines.push(
+        Line::from(format!(
+            " {crossing} value{} {} in more than one of your worlds. Keep your worlds apart:              anyone who sees both knows they are the same person.",
+            if crossing == 1 { "" } else { "s" },
+            if crossing == 1 { "is" } else { "are" },
+        ))
+        .fg(COLOR_ORANGE),
+    );
+    lines.push(Line::from(""));
 }
 
 // ---------------------------------------------------------------------------
@@ -1570,6 +1625,7 @@ mod tests {
     use super::*;
     use crate::state_handler::main_page::content::{ManagedDid, PersonaMembership};
     use openvtc_core::persona::binding::BindingSummary;
+    use openvtc_core::persona::correlation::{Finding, Remedy};
     use openvtc_core::persona::facet::Facet;
     use openvtc_core::persona::pool::PoolAttribute;
 
@@ -2124,6 +2180,70 @@ mod tests {
             options.iter().any(|o| o.contains("Working life")),
             "{options:?}"
         );
+    }
+
+    /// A value in two worlds is flagged, and the flag says why.
+    #[test]
+    fn a_link_across_worlds_is_raised() {
+        let mut state = populated(PersonaTab::Attributes);
+        loaded(&mut state);
+        state.links = vec![Finding {
+            attribute_id: Some("01B".into()),
+            crosses_worlds: Some(true),
+            why: "the same card is in your work and money worlds".into(),
+            remedies: vec![Remedy::UseDifferentValue],
+            ..Finding::default()
+        }]
+        .into();
+
+        let shown = text(&render(&state));
+        assert!(shown.contains("in more than one of your worlds"), "{shown}");
+        assert!(shown.contains("knows they are the same person"), "{shown}");
+    }
+
+    /// …and a link *inside* one world is not.
+    ///
+    /// A work email in every work face is an arrangement the holder made on
+    /// purpose. Flagging it teaches them to scroll past the flag that matters,
+    /// which is the failure the task's second axis exists to prevent.
+    #[test]
+    fn a_link_inside_one_world_is_left_alone() {
+        let mut state = populated(PersonaTab::Attributes);
+        loaded(&mut state);
+        state.links = vec![Finding {
+            attribute_id: Some("01B".into()),
+            crosses_worlds: Some(false),
+            // High severity, and still not raised: severity says how strongly
+            // a disclosure would link, not whether the holder would mind.
+            severity: openvtc_core::persona::correlation::Severity::High,
+            why: "the same card is in two of your work faces".into(),
+            ..Finding::default()
+        }]
+        .into();
+
+        let shown = text(&render(&state));
+        assert!(
+            !shown.contains("in more than one of your worlds"),
+            "{shown}"
+        );
+    }
+
+    /// An agent that does not implement worlds gets silence, not a clean bill
+    /// of health. A reassurance nobody computed is worse than none.
+    #[test]
+    fn an_agent_without_worlds_says_nothing_about_them() {
+        let mut state = populated(PersonaTab::Attributes);
+        loaded(&mut state);
+        state.links = vec![Finding {
+            attribute_id: Some("01B".into()),
+            crosses_worlds: None,
+            why: "the same card is in two faces".into(),
+            ..Finding::default()
+        }]
+        .into();
+
+        let shown = text(&render(&state));
+        assert!(!shown.contains("worlds"), "{shown}");
     }
 
     /// A persona shown to more than one community carries the linkage warning.

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -469,7 +469,7 @@ impl MainPage {
     fn handle_personas_key(&mut self, key: KeyEvent) -> bool {
         use crate::state_handler::actions::PersonaAction as PA;
         use crate::state_handler::main_page::content::{
-            PersonaConfirm, PersonaMode, PersonaTab, ProfileFormFocus,
+            FacetFormFocus, PersonaConfirm, PersonaMode, PersonaTab, ProfileFormFocus,
         };
 
         let personas = &self.props.main_page.content_panel.identity;
@@ -513,6 +513,38 @@ impl MainPage {
                     // would refuse to let a profile be called "Work laptop".
                     KeyCode::Char(' ') if on_entries => send(PA::FormToggleEntry),
                     _ => send(PA::FormKey(key)),
+                };
+            }
+            PersonaMode::Facet(form) => {
+                if form.working {
+                    return true;
+                }
+                let on_colour = form.focus == FacetFormFocus::Colour;
+                return match key.code {
+                    KeyCode::Esc => send(PA::FormCancel),
+                    KeyCode::Enter => send(PA::FormSubmit),
+                    KeyCode::Tab => send(PA::FormField(true)),
+                    KeyCode::BackTab => send(PA::FormField(false)),
+                    // ←/→ move the colour wherever the focus is, so a holder
+                    // who has not worked out that the swatch row is a field can
+                    // still change it. On the colour field ↑/↓ do it too.
+                    KeyCode::Right => send(PA::FormCycle(true)),
+                    KeyCode::Left => send(PA::FormCycle(false)),
+                    KeyCode::Down if on_colour => send(PA::FormCycle(true)),
+                    KeyCode::Up if on_colour => send(PA::FormCycle(false)),
+                    _ => send(PA::FormKey(key)),
+                };
+            }
+            PersonaMode::PlaceFace(picker) => {
+                if picker.working {
+                    return true;
+                }
+                return match key.code {
+                    KeyCode::Esc => send(PA::FormCancel),
+                    KeyCode::Enter => send(PA::FormSubmit),
+                    KeyCode::Down => send(PA::FormCycle(true)),
+                    KeyCode::Up => send(PA::FormCycle(false)),
+                    _ => true,
                 };
             }
             PersonaMode::Bind(picker) => {
@@ -672,6 +704,24 @@ impl MainPage {
                     KeyCode::Char('e') if selected < count => send(PA::ProfileEdit(selected)),
                     KeyCode::Char('d') | KeyCode::Delete if selected < count => {
                         send(PA::ProfileDeleteArm(selected))
+                    }
+                    // `m` for *move*, on the tab where the face being moved is
+                    // visible. A world's membership is edited from here and
+                    // nowhere else — see `PersonaAction::FacePlaceOpen`.
+                    KeyCode::Char('m') if selected < count => send(PA::FacePlaceOpen(selected)),
+                    _ => false,
+                }
+            }
+            PersonaTab::Facets => {
+                let count = personas.facets.len();
+                let selected = personas.facet_selected;
+                match key.code {
+                    KeyCode::Up if count > 0 => send(PA::Select(selected.saturating_sub(1))),
+                    KeyCode::Down if count > 0 => send(PA::Select((selected + 1).min(count - 1))),
+                    KeyCode::Char('n') => send(PA::FacetNew),
+                    KeyCode::Char('e') if selected < count => send(PA::FacetEdit(selected)),
+                    KeyCode::Char('d') | KeyCode::Delete if selected < count => {
+                        send(PA::FacetDeleteArm(selected))
                     }
                     _ => false,
                 }


### PR DESCRIPTION
Brings the TUI's identity pane back into line with the persona/faces/worlds model the VTA and the console moved to. The vocabulary sweep already landed (#285/#288/#289); what had opened since was structural, and this closes it.

Five commits, each self-contained and reviewable on its own.

## What was actually diverging

- **Worlds did not exist here at all.** Zero occurrences of `facet`/`world` in any `.rs`. The VTA has served `persona/facet/*` since VTI #1338 and the console has had the full surface since its own #212, so the two surfaces described different products to the same holder.
- **The claim-type table was vendored against a claim that had stopped being true.** `claim_types.rs` opened with *"the agent does not serve this table"*. VTI #1315 serves it, and #1327 lets a deployment declare its own types — so a compiled copy is not merely stale, it is structurally unable to describe the agent it is drawing for. That is the shape of the known `employer` / `profile.*` masking gap: our copy matched spec 0.1 exactly, and 0.1 declares neither.
- **The pool was one flat list.** At thirty rows that is a wall.
- **`persona/correlation/analyze` was in the SDK and this client called none of it.** The only linkability signal was a local heuristic over personas.

## Two defects found on the way

- **A family could loosen the floor.** When a served `strictness` ordering does not place both tokens, the tie-break returned the *prefix*, so an unregistered `name.somethingNew` would have inherited `name`'s `none` and rendered in the clear. It falls to the floor now — the only answer an absent ordering supports. Caught by a test written for the served path, not by the vendored one, which always supplies a full ordering.
- **One console string is off the shared vocabulary.** The gated-family note there reads *"a disclosure needs your approval each time"*, and `disclosure` is a word `persona-vocabulary.md` retires; the agreed phrase for that journey is *letting it leave*. The banned-word guard in `identity_panel` caught the borrowed copy. Reworded here — **the console still has the original**, and its own vocabulary test does not cover that string. Worth a one-liner in `pnm-browser-plugin`.

## The dependency pin, and when to remove it

`vta-sdk` 0.34.1 carries `persona/claim-types/list` but **not** the facet tasks: #1338 landed after that release was cut, so `TASK_PERSONA_FACET_*` exists on VTI `main` and nowhere on crates.io.

`[patch.crates-io]` therefore pins `vta-sdk` to **#1338's own merge commit**, not the head of `main` — at that point the crate is still the released 0.34.1, so the patch adds three Type URI constants and moves nothing else. Later revs carry the rooms and `present/0.2` work and pull the whole TDK line forward, which is a real bump and not one that belongs in a change about worlds.

**Delete the entry as soon as a `vta-sdk` release carries #1338**, and move the requirement to name it. The block now has three entries with an unwind obligation; the `did-git-sign` note above it is what one looks like after six cycles of not being unwound.

The graph still holds exactly one `vta-sdk` and one `trust-tasks-rs`.

## Design decisions worth reviewing

- **`put` is a replace, and every write is built around that.** Omitting `faceIds` means *empty them*, not "leave them alone" — the spec is explicit. So every write goes through a draft carrying the full membership, and the world editor holds the ids it was opened with and writes them straight back. Without that, renaming a world empties it, and the world is still there afterwards — just with nothing in it.
- **A world's membership is edited from exactly one surface.** The Faces tab, where the face being moved is on screen. A second membership editor is a second place to get the above wrong.
- **Severity and crossing are two axes and neither is read off the other.** Only a link that crosses a world raises a row. A value shared between two faces in the *same* world is an arrangement the holder made on purpose — a work email in every work face — and alarming on it teaches people to scroll past the alarm that matters.
- **Absent is not false.** `crossesFacets` is omitted entirely by an agent without worlds, which is not the same as "this link stays inside one part of your life". Carried as an `Option`; the pane says nothing rather than guessing.
- **Colour is carried and never painted.** A terminal has one emphasis channel and this pane spends it on selection and warnings. "Money" in the holder's own hue would read as an error to anyone who did not choose it.
- **Every fallback is disclosed.** A compiled claim-type table, a world naming a face that is gone, a holder who has arranged nothing — each says so rather than drawing a plausible screen (R6.4). A read that *failed* is never absorbed into a fallback.

## Deliberately not in scope

- **Attributes-in-worlds is carried but not editable here.** `attributeIds` round-trips faithfully so nothing is lost, but the TUI offers no way to change it; the console does.
- **The List/multi-select view and the starter-attribute suggestions.** Mouse-shaped, and the TUI already has a cursor.
- **`Released` vs `What has left`.** The console's third view is *Released*; the vocabulary table says *what has left*. The console looks like the one out of step, so nothing changed here.

## Checks

`cargo fmt`, `clippy` on both feature sets with `-D warnings`, `cargo test --workspace --all-features` including `--include-ignored` (the MockVta e2es), and `RUSTDOCFLAGS="-D warnings" cargo doc`. All green.

Not yet exercised against a live VTA — the facet and claim-types round-trips are covered by unit tests over served payloads, not by a real agent.
