### PR TITLE
chore(deps): take the vta-sdk 0.36 line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8396d9206908dc1d0fd6449c7cb5b5e4db455ca0a304f75444c9aa0c621b21bf"
+checksum = "28f6e935295f1c9eec0fa7ee609f3f6e88f855b788712dbfac334c50279dbdf0"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-sdk"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57125239a953a49c06b88746fd2aede838aa611274bf91f7952656c6c747d804"
+checksum = "d7e9685f131f40eacf50b705c282abf64d3226194787d90352563791dfb8a2be"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-authentication",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-test-mediator"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3a3e0f6b7c734f9e769344296cd5aba8f7cbd815b9012ee349261df9d6778a"
+checksum = "aed65109e4d4908f57201c680f9ac793123cd7a6dce53e2eed198b8a6724045d"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "affinidi-messaging-didcomm",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a2c38268859db8bdf250a3587a4a38e6ea5b9e6cc9f6a1cad2a8f25b30dbaf"
+checksum = "80929b92978b33a7a5f73c68430eaf962741eaad1477bbabbe1be4bf44b804d5"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -2763,8 +2763,7 @@ dependencies = [
 [[package]]
 name = "did-git-sign"
 version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725ee20f3e5dbf26efa23b8724bf80245a1847c4fed6d32eb78576b7cc009af3"
+source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?branch=chore%2Fvta-sdk-036#05daabc76251ea3cce343a8c031f1122b6c78efa"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -8906,9 +8905,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap 2.14.2",
  "serde_core",
@@ -9145,9 +9144,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.19.4"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b1db55c37c80f408d269a138a3d33669a16b6c7c3122757319d0ba6c8b9c4"
+checksum = "1a7b5f903a6209a0ae4fa4a8e3b33b9725e7037e0cdc3253402e5f293671cccd"
 dependencies = [
  "chrono",
  "serde",
@@ -9159,9 +9158,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.19.4"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe468e1b56e5975ade5d8447cfb2c4d435cc7c1ae0a50b7c135aec78f70e43e"
+checksum = "5a201c6a35b22a8dee360849713674088578fda52eec380c8ae7401ea6dda035"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -9175,9 +9174,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.19.4"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9f320762f0ead96841064a15c79d186a242c74c4789a6d1f3757fc2263fc1f"
+checksum = "60bc820b3fecfbd92b212519086e967fab2f9a2290788dd039f643382b752d9d"
 dependencies = [
  "axum",
  "chrono",
@@ -9194,9 +9193,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.19.4"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c67eff5d4adf428b36df13b57a6813fcd29fd81ec3c7a1f0a717a67b987b16e"
+checksum = "31443f250461a1718837ec744b666e23306125cc756055305ba7ed6cf600160f"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9211,9 +9210,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.19.4"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b445f62f4142dcce7d71d74526f815bed79bfb1d1f3b0161b86e4bb5497459"
+checksum = "f2dbddbfa65cacec94a8c6423fdde6bfd3236c1e2ac51fd6276c5f801682566f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9587,8 +9586,7 @@ dependencies = [
 [[package]]
 name = "vgi-core"
 version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47fbfe679ae3db10f3a9661510e232ffcf635592ca2f9aaa407ef157c3c71d00"
+source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?branch=chore%2Fvta-sdk-036#05daabc76251ea3cce343a8c031f1122b6c78efa"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -9617,11 +9615,15 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6fc8594fccfff2c35588bd2a904d18744453578d02f91c0f56cf971d478fa"
+version = "0.3.6"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "async-trait",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_json",
+ "tokio",
  "tracing",
  "uuid",
  "vta-sdk",
@@ -9630,9 +9632,8 @@ dependencies = [
 
 [[package]]
 name = "vta-backup"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cd2a3bd5bc93870b30ea0c1007c793be6b20ad3593b816ca1e8526a1686f8d"
+version = "0.3.6"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -9658,9 +9659,8 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2246a32d14ae46d13109264a95e72521ed46ceb41ea4e6e9e99657f9d292884f"
+version = "0.15.1"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9686,9 +9686,8 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d02557cdd6113ce3995b1919c2f10d14e931600a2b993a3b7c151bb598a31d"
+version = "0.4.6"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9703,9 +9702,8 @@ dependencies = [
 
 [[package]]
 name = "vta-keys"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47dbef1f8f1b1bd75a54172f144feae89176a71b542d67c03e99a3843e69f4d9"
+version = "0.4.6"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9738,17 +9736,15 @@ dependencies = [
 [[package]]
 name = "vta-keyspaces"
 version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6caa9b60da8192db125a00bb90ffa6b1c6be1ff42af08265505432bba644bb44"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "vti-common",
 ]
 
 [[package]]
 name = "vta-persona"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d948465efc87c78362a8ccb28dc0faaf9b5d26121bc12233bab068b82cfab797"
+version = "0.3.2"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -9765,9 +9761,8 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5819636ae5ddcbd3475a7c7b0d2f5e9e58be667f52d9e037ec628d259b6eaa"
+version = "0.3.6"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "hex",
  "multibase",
@@ -9785,9 +9780,8 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9734a402538deadd65191dc8a0e8965065b503ba2cacf75b86e3a8146e881daf"
+version = "0.36.0"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9838,9 +9832,8 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ca5b1e196af9dcf47b9513d8c9e36f707ee33cc1c7ca53c739cf20fb673ec9"
+version = "0.25.1"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9936,9 +9929,8 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9a5b3d32f11c3eb450a420c17b2efab3f1716769c4ceaffbfd38566bcf5a87"
+version = "0.3.5"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9958,8 +9950,7 @@ dependencies = [
 [[package]]
 name = "vta-sweepers"
 version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f903daaa27f0cb88c8f0c7ba4c4f1e0bc7c692a5bc5cc83c8955f2c34dd29d18"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9972,9 +9963,8 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4020134af22a67efecc25ac9f186bf0043a67126ebf8401d9ac8f095b617c084"
+version = "0.5.6"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10004,9 +9994,8 @@ dependencies = [
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a64279be8766892dd64012191379f25872dfbe5766163373614c84848960c20"
+version = "0.2.7"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10023,9 +10012,8 @@ dependencies = [
 
 [[package]]
 name = "vtc-client"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c8dd66761a0136c6c3a86ccba5c15deb9fa66eeb5edb0b6a1c8814948d2e98"
+version = "0.6.0"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10039,9 +10027,8 @@ dependencies = [
 
 [[package]]
 name = "vti-common"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1fbdd225c6df6665178e2855a7c6f38aba54acc39fd37b4dc3fee8cea4c9eb"
+version = "0.18.3"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10083,9 +10070,8 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f411ce3cbe26be38b2f1ccd478e0081fe5aa14b7de3088ef847bb303bc6a5"
+version = "0.2.1"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -10109,9 +10095,8 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms-dtg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926e356337d9aa874e10a39f875d0b9cafa8bb2daaae20d5fd40c078202f586a"
+version = "0.2.1"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10127,9 +10112,8 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680cae0e91109b37b8f7a2019e46d8aa4874e14c904c76711e4eec048286cc21"
+version = "0.3.5"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "hex",
  "serde",
@@ -10142,8 +10126,7 @@ dependencies = [
 [[package]]
 name = "vti-webauthn"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd90a117f0599d443b9eff0f790fd0990162f003a10ebfead1ab8275f51c011"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,10 @@ aes-gcm = "0.11"
 # `affinidi-messaging-sdk`, and no line we control moves it. The bump puts us on
 # the same copy as `vta-service` rather than on the older one.
 argon2 = "0.6"
-# The floor is set by the graph, not chosen here: `vta-sdk` 0.35 and
-# `vta-service` 0.25 both declare `^0.13`, and `affinidi-messaging-test-mediator`
-# 0.6 does too. This line only records it.
-affinidi-tdk = "0.13"
+# The floor is set by the graph, not chosen here: `vta-sdk` 0.36 and
+# `vta-service` on VTI `main` both declare `^0.14`, and `affinidi-messaging-test-mediator`
+# 0.7 does too. This line only records it.
+affinidi-tdk = "0.14"
 affinidi-data-integrity = "0.7"
 # The delivery layer (D1). Replaced `affinidi-messaging-didcomm-service`, the
 # type-routed framework both VTI services had already cut over from (#189).
@@ -84,9 +84,9 @@ affinidi-messaging-core = "0.1.6"
 # This crate carries `trust-tasks-rs` types in its own API (`MediatorAcl` reaches
 # `atm.trust_tasks().account_update`), so its line is not independent of the one
 # below: a copy left on an older trust-tasks is a *second* semver-incompatible
-# `trust-tasks-rs` whose types do not unify. 0.23 is the line built on
-# trust-tasks 0.19, and it is also what `vta-sdk` 0.35 and
-# `affinidi-messaging-test-mediator` 0.6 declare — so it is the graph's floor
+# `trust-tasks-rs` whose types do not unify. 0.24 is the line built on
+# trust-tasks 0.20, and it is also what `vta-sdk` 0.36 and
+# `affinidi-messaging-test-mediator` 0.7 declare — so it is the graph's floor
 # whether or not this line states it.
 #
 # Older floors are below this one by construction and kept in git history rather
@@ -99,7 +99,7 @@ affinidi-messaging-core = "0.1.6"
 # geometric reconnect cascade behind `#231`–`#234`; and 0.19.4 (#694) was the
 # `live_stream_next*` read guard that blocked `stop_websocket` for the remainder
 # of a 10s poll window.
-affinidi-messaging-sdk = "0.23"
+affinidi-messaging-sdk = "0.24"
 # `StreamExt::next` on the `BoxStream` returned by `MessagingService::subscribe`.
 futures-util = "0.3"
 # Agent names (DID shortcuts). `agent-names` carries the parse /
@@ -189,8 +189,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # our copy has to be the same crate version vta-sdk resolves, or the two are
 # distinct types that do not unify.
 #
-# Moved 0.18 → 0.19 when vta-sdk went to 0.35, as it moved 0.17 → 0.18 for 0.34,
-# 0.9 → 0.11 for 0.27, 0.6 → 0.9 for 0.25 and 0.4 → 0.6 for 0.23.3. This is a
+# Moved 0.19 → 0.20 when vta-sdk went to 0.36, as it moved 0.18 → 0.19 for 0.35,
+# 0.17 → 0.18 for 0.34, 0.9 → 0.11 for 0.27, 0.6 → 0.9 for 0.25 and 0.4 → 0.6 for 0.23.3. This is a
 # *follow*, not a lead: holding an older line here stops matching the stack and
 # starts splitting the type — on the 0.4 → 0.6 move a `cargo update` alone put
 # 0.4.1 and 0.6.5 in the same binary, which is the exact failure the paragraph
@@ -198,9 +198,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # rows means this pin has drifted from vta-sdk's again, whichever direction it
 # drifted.
 #
-# The patch is named because vta-sdk 0.35 declares `^0.19.4`, not a bare `^0.19`
+# The patch is named because vta-sdk 0.36 declares `^0.20.3`, not a bare `^0.20`
 # — a floor below what the sdk itself requires is a floor that does nothing.
-# 0.19.4 is the release VTI main pins across the whole stack, so that is the
+# 0.20.3 is the release VTI main pins across the whole stack, so that is the
 # line the services actually build against.
 #
 # `trust-tasks-capability-client` moves with it for the same reason — it
@@ -217,15 +217,22 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # messaging stack carries `trust-tasks-rs` types in its own API, so
 # `affinidi-messaging-sdk` (above) and the `affinidi-messaging-test-mediator`
 # dev-dependency both have to sit on the line built against it.
-trust-tasks-rs = "0.19.4"
-trust-tasks-capability-client = "0.19.4"
+trust-tasks-rs = "0.20.3"
+trust-tasks-capability-client = "0.20.3"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-# The 0.35 line — the one `vta-service` 0.25 is built on, the one VTI main
-# deploys, and the one that declares `trust-tasks-rs ^0.19.4`. As always this pin
-# *follows* the VTA rather than leading it; see the `trust-tasks-rs` note above
-# for why the two versions cannot be chosen independently.
+# The 0.36 line — the one VTI main builds `vta-service` on and deploys, and the
+# one that declares `trust-tasks-rs ^0.20.3`. As always this pin *follows* the
+# VTA rather than leading it; see the `trust-tasks-rs` note above for why the two
+# versions cannot be chosen independently.
+#
+# 0.36 is taken for peer identity vetting (`docs/design/vetting-process.md`): the
+# `vetting` feature and `protocols::vetting` land on this line (VTI #1425
+# onward, unreleased). Nothing else in 0.36 touches this repo's use of the sdk. Its one
+# breaking change, VTI #1417, domain-separates the opaque `keys/sign` oracle, and
+# nothing here calls it — every proof this repo produces is built locally by
+# `affinidi-data-integrity`.
 #
 # **0.35 refuses an unsigned trust-task reply by default, and that is a
 # deployment ordering constraint rather than a code one.** The only API change
@@ -279,18 +286,17 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 #
 # There are two such edges, and both move here:
 #
-# - `vta-service`, which `openvtc-core` dev-depends on for `MockVta` (0.25 is
-#   the line built on 0.35). Dev-only, which is exactly why it gets forgotten —
+# - `vta-service`, which `openvtc-core` dev-depends on for `MockVta`. The
+#   published 0.25.1 is still built on 0.35, so on this line it resolves from VTI
+#   `main` through the patch block at the foot of this file. Dev-only, which is exactly why it gets forgotten —
 #   the *shipped* graph looks clean while the harness tests this client against
 #   a server it is no longer paired with.
-# - `did-git-sign`, which was the standing obligation and **is not one on this
-#   line**. It blocked six consecutive minors (0.23, 0.25, 0.27, 0.31, 0.32,
-#   0.34), five of them absorbed by a `[patch.crates-io]` redirect to VGI's
-#   unreleased `main`. 0.4.8 is published, requires `vta-sdk ^0.35`, and
-#   resolves from crates.io — so the patch block is deleted rather than
-#   repointed. Read that as two release cadences having converged for once, not
-#   as a cost that is gone for good: the next minor can reintroduce it, and the
-#   note where the block used to be says what to do if it does.
+# - `did-git-sign`, the standing obligation, **back again on this line**. It
+#   blocked six consecutive minors (0.23, 0.25, 0.27, 0.31, 0.32, 0.34); 0.35 was
+#   the one it did not, because 0.4.8 resolved from crates.io. 0.36 reintroduces
+#   it — 0.4.8 requires `vta-sdk ^0.35` — so until VGI releases on 0.36 it
+#   resolves from VGI's `chore/vta-sdk-036` through the patch block at the foot
+#   of this file, which also says what makes it leave.
 #
 # `trql-client`, the third git-pinned edge in this ecosystem, does **not**
 # depend on `vta-sdk` at all, so the trust registry needs no release for an sdk
@@ -309,7 +315,7 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # pane now calls both. On 0.34.0 the pane compiles and then cannot find the
 # constants; naming the patch is what turns that into a resolver error at the
 # point where it can be read.
-vta-sdk = { version = "0.35", features = [
+vta-sdk = { version = "0.36", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses
@@ -356,28 +362,53 @@ codegen-units = 1
 strip = "symbols"
 
 
-# No `[patch.crates-io]`.
+# `[patch.crates-io]` is back, for two repositories and one release each.
 #
-# This workspace carried one for six consecutive `vta-sdk` minors, and for most
-# of that time it was the only way to move at all: `did-git-sign` 0.4.6 required
-# `vta-sdk ^0.27`, and against a newer sdk that edge did not merely duplicate a
-# crate — an older `vta-keys` would not compile against the current
-# `vti-common`, so the whole workspace failed to build. The pin redirected
-# `did-git-sign` and its path-dep `vgi-core` to VGI's `main`, which had the bump
-# but no release.
+# VGI. `did-git-sign` 0.4.8 — the latest published — requires `vta-sdk ^0.35`, so
+# on the 0.36 line it would put a second sdk in this binary (the `vta-sdk` note
+# above says why two do not unify). VGI's `chore/vta-sdk-036` moves it to 0.36;
+# until that is released, `did-git-sign` and its path dependency `vgi-core`
+# resolve from that branch.
 #
-# All of it is unwound as of the 0.35 line, and the block is deleted rather than
-# left empty so that adding one back is a visible decision:
+# VTI. `vta-sdk` 0.36.0 is published but the `vta-service` built on it is not:
+# 0.25.1 on crates.io still pulls `vta-sdk ^0.35` through its whole subsystem
+# closure, and that closure no longer compiles against `vta-sdk` 0.35.1
+# (`vta-keys` 0.4.5, missing `KeyRecord::exportable`). The release PR
+# (OpenVTC/verifiable-trust-infrastructure#1416) publishes the lot. Until it
+# merges, every VTI crate this graph reaches resolves from one checkout of the
+# repository, so there is exactly one of each. The list is every VTI crate in
+# `cargo tree`, not only the two named in a manifest: a crate left on crates.io
+# would pull its own `vti-common` beside the patched one.
 #
-# - `did-git-sign` **0.4.8** is published and requires `vta-sdk ^0.35`, so both
-#   VGI entries became a redirect to a version crates.io already serves.
-# - `vta-sdk` **0.35.0** is published and carries `persona/facet/*` (VTI #1338),
-#   which the third entry existed solely to reach.
-# - `trql-client` **0.17** is published, so VGI's own manifest no longer holds a
-#   git dependency either — which is what let it be released at all, `cargo
-#   publish` rejecting git dependencies outright.
+# Each block leaves when its release is published: delete its entries here and
+# its URL from `allow-git` in `deny.toml`. For VGI, also raise the `did-git-sign`
+# floor in `openvtc/Cargo.toml` to that release.
 #
-# `deny.toml`'s `allow-git` list is the other half of this, and is now empty too.
-# The two are edited together: `unknown-git = "deny"` means a patch added here
-# without an entry there fails `cargo deny check sources`, and nothing in either
-# file points at the other.
+# The history, kept short: this workspace carried a patch for six consecutive sdk
+# minors and unwound it on 0.35, when `did-git-sign` 0.4.8, `vta-sdk` 0.35.0 and
+# `trql-client` 0.17 were all published. As then, a patch here needs its entry in
+# `deny.toml` — `unknown-git = "deny"` — and a note on what makes it leave.
+[patch.crates-io]
+did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
+vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
+
+vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-config = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-keys = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-keyspaces = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-persona = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-policy = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-support = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-sweepers = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-vault = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-webvh = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vtc-client = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vti-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vti-rooms = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vti-rooms-dtg = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vti-secrets = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vti-webauthn = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -120,4 +120,11 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # Adding one back means adding it in both places, and writing down here what has
 # to happen for it to leave again. The entries that were removed each carried
 # that note, and it is the only reason the unwind was tractable six minors later.
-allow-git = []
+# Now two entries, each for as long as one release — see the patch block at the
+# foot of the root `Cargo.toml`. VGI's `chore/vta-sdk-036` carries `did-git-sign`
+# onto the vta-sdk 0.36 line; VTI's release PR publishes the `vta-service` closure
+# on that line. Each URL leaves with its patch entries when its release publishes.
+allow-git = [
+    "https://github.com/OpenVTC/verifiable-git-infrastructure",
+    "https://github.com/OpenVTC/verifiable-trust-infrastructure",
+]

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -101,19 +101,23 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # Track this with `affinidi-messaging-sdk`, for the same reason `vta-service`
 # below tracks `vta-sdk`: 0.5 is the line built on messaging-sdk 0.22 / TDK 0.12
 # / trust-tasks 0.18, and the 0.4 line declares `^0.21.0` / `^0.11` / `^0.17`.
+# 0.7 is the line built on messaging-sdk 0.24 / TDK 0.14 / trust-tasks 0.20.
 # Leaving it behind puts a second copy of each in the **dev** graph — including
 # `trust-tasks-rs`, whose types the messaging sdk carries in its own API.
-affinidi-messaging-test-mediator = "0.6"
+affinidi-messaging-test-mediator = "0.7"
 # In-process MockVta for the bootstrap e2e (VTI#406/#427 test-support seams).
 # `vta-service` is the VTA server crate; it carries the credential-vault
 # lifecycle tasks (receive/query/archive/delete/restore/purge) + the
 # `MockVta::start_provisionable` seams used by the e2e tests. Track this with
-# the vta-sdk major: 0.25 is the line built against vta-sdk 0.35, as 0.24 was
+# the vta-sdk major: on the 0.36 line this resolves from VTI `main` through the
+# root manifest's `[patch.crates-io]` — the published 0.25.1 is still built on
+# 0.35 — and the floor moves to the release that publishes it (VTI #1416). 0.25
+# was the line built against 0.35, as 0.24 was
 # against 0.34, 0.23 against 0.32, 0.19 against 0.27, 0.17 against 0.25, 0.15
 # against 0.23 and 0.14 against 0.21. An older line pulls an older sdk into the test build and the two
 # disagree about the wire types the e2e tests assert on.
 #
-# 0.25 also carries `trust-tasks-rs ^0.19.4` and `affinidi-tdk ^0.13`, which is
+# VTI `main` also carries `trust-tasks-rs ^0.20.3` and `affinidi-tdk ^0.14`, which is
 # what keeps the **dev** graph from growing the second copy of each that the
 # root manifest's notes warn about.
 #
@@ -130,7 +134,7 @@ affinidi-messaging-test-mediator = "0.6"
 # ApproveScope, ContextDirection}` as its own public API, so a graph holding two
 # sdks has two distinct `ApproveScope` types that do not unify. VTI republished
 # this crate for exactly this reason (see its Cargo.toml note on `publish`).
-vta-service = { version = "0.25", default-features = false, features = ["test-support", "rest", "didcomm"] }
+vta-service = { version = "0.25.1", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -33,8 +33,13 @@ anyhow.workspace = true
 # own repo (OpenVTC/verifiable-git-infrastructure); openvtc is a downstream
 # consumer of the published crate.
 #
-# Floor is 0.4.8, and for the first time in six minors it is also where this
-# actually resolves from. 0.4.8 is published and requires `vta-sdk ^0.35`, so
+# On the vta-sdk 0.36 line this resolves from VGI's `chore/vta-sdk-036` through
+# the root manifest's `[patch.crates-io]`, until VGI publishes that move; 0.4.8
+# requires `vta-sdk ^0.35`. The floor stays 0.4.8, which the patched branch
+# satisfies, and moves to the release when the patch leaves.
+#
+# Floor is 0.4.8, and on the 0.35 line it was also where this actually resolved
+# from. 0.4.8 is published and requires `vta-sdk ^0.35`, so
 # the `[patch.crates-io]` redirect to VGI's unreleased `main` is deleted rather
 # than repointed — see the note where that block used to be, at the foot of the
 # root manifest.


### PR DESCRIPTION
Stacked on #292.

Moves openvtc to the **vta-sdk 0.36 line**, which is where peer identity vetting lands. The SDK side is in VTI #1425 (wire types and crypto), with the VTC side in #1426–#1428. This PR changes no code, only the dependency graph, so the vetting client work that follows it has a clean base.

## What moves

| Crate | From | To |
|---|---|---|
| `vta-sdk` | 0.35 | 0.36 |
| `affinidi-tdk` | 0.13 | 0.14 |
| `affinidi-messaging-sdk` | 0.23 | 0.24 |
| `trust-tasks-rs`, `trust-tasks-capability-client` | 0.19.4 | 0.20.3 |
| `affinidi-messaging-test-mediator` (dev) | 0.6 | 0.7 |

These all move together for the reason the manifest notes already give: the messaging stack carries `trust-tasks-rs` types in its API, so a crate left behind becomes a second, incompatible copy.

## Two patch entries, each with a way out

`deny.toml` has an `allow-git` entry for each, and a note next to each says what makes it leave.

- **VGI.** `did-git-sign` 0.4.8 requires `vta-sdk ^0.35`, so it resolves from VGI `chore/vta-sdk-036` (OpenVTC/verifiable-git-infrastructure#41). It leaves when VGI publishes.
- **VTI.** `vta-sdk` 0.36.0 is published, but the `vta-service` built on it is not.
  - The published `vta-service` 0.25.1 still pulls `vta-sdk ^0.35` across its subsystem closure.
  - That closure no longer compiles against `vta-sdk` 0.35.1 (`vta-keys` 0.4.5 is missing `KeyRecord::exportable`).
  - So every VTI crate in `cargo tree` resolves from one checkout of VTI `main`. It is the whole list, not just the two named in a manifest, because a crate left on crates.io would pull its own `vti-common` in beside the patched one.
  - It leaves when the release PR (OpenVTC/verifiable-trust-infrastructure#1416) publishes.

## One of each

- `cargo tree` shows exactly one `vta-sdk`, `trust-tasks-rs`, `affinidi-tdk` and `affinidi-messaging-sdk`.
- `dtg-credentials` still resolves as both 0.6 (openvtc) and 0.9 (vta-service, dev only). `main` already has that split; this PR does not change it.

## Checks run locally

- `cargo test --workspace --no-fail-fast`: every target passes, 0 failures. The mediator e2e tests stay `#[ignore]`, as on `main`.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- **`cargo deny` was not run locally** because it isn't installed here; CI's deny job is the check for the new `allow-git` entry.
