### PR TITLE
feat(core): peer identity vetting for applicants and vetters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -897,7 +897,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2874,7 +2874,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5585,7 +5585,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6234,7 +6234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7066,7 +7066,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7661,7 +7661,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7719,7 +7719,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8367,7 +8367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8579,7 +8579,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8592,7 +8592,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9616,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "vta-audit"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9633,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "vta-backup"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -9660,7 +9660,7 @@ dependencies = [
 [[package]]
 name = "vta-cli-common"
 version = "0.15.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9687,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "vta-config"
 version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "vta-keys"
 version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9736,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "vta-keyspaces"
 version = "0.2.7"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "vti-common",
 ]
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "vta-persona"
 version = "0.3.2"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "vta-policy"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "hex",
  "multibase",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.36.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9807,6 +9807,7 @@ dependencies = [
  "dbus-secret-service-keyring-store",
  "didwebvh-rs",
  "dirs",
+ "dtg-credentials 0.9.1",
  "ed25519-dalek 3.0.0",
  "futures-util",
  "getrandom 0.4.3",
@@ -9833,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "vta-service"
 version = "0.25.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9930,7 +9931,7 @@ dependencies = [
 [[package]]
 name = "vta-support"
 version = "0.3.5"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9950,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "vta-sweepers"
 version = "0.3.4"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9964,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "vta-vault"
 version = "0.5.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9995,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "vta-webvh"
 version = "0.2.7"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10013,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "vtc-client"
 version = "0.6.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10028,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "vti-common"
 version = "0.18.3"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10071,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "vti-rooms"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -10096,7 +10097,7 @@ dependencies = [
 [[package]]
 name = "vti-rooms-dtg"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10113,7 +10114,7 @@ dependencies = [
 [[package]]
 name = "vti-secrets"
 version = "0.3.5"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "hex",
  "serde",
@@ -10126,7 +10127,7 @@ dependencies = [
 [[package]]
 name = "vti-webauthn"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=main#8541848176ec9707e24b24f57b09eb9650935a95"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -10518,7 +10519,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,6 +325,10 @@ vta-sdk = { version = "0.36", features = [
   "keyring",
   "didcomm",
   "provision-client",
+  # Peer identity vetting: the Vetting Card and Statement, their verification,
+  # requirement evaluation and the session match code
+  # (`docs/design/vetting-process.md`).
+  "vetting",
   # Routes the Trust-Task surface over TSP as a leg of the existing DIDComm
   # session (VTI #803 / #810) — no second socket, no second mediator connection.
   # This arrived across 0.20.2–0.20.6 (the leg itself, then the
@@ -380,6 +384,11 @@ strip = "symbols"
 # `cargo tree`, not only the two named in a manifest: a crate left on crates.io
 # would pull its own `vti-common` beside the patched one.
 #
+# The branch is the top of the VTI vetting stack (#1425–#1428), not `main`:
+# `vta-sdk`'s `vetting` feature, which this workspace enables, exists only there
+# until that stack merges. Once it has, point these back at `main`, and remove
+# them with the release that follows.
+#
 # Each block leaves when its release is published: delete its entries here and
 # its URL from `allow-git` in `deny.toml`. For VGI, also raise the `did-git-sign`
 # floor in `openvtc/Cargo.toml` to that release.
@@ -392,23 +401,23 @@ strip = "symbols"
 did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
 vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
 
-vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-config = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-keys = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-keyspaces = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-persona = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-policy = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-support = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-sweepers = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-vault = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vta-webvh = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vtc-client = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vti-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vti-rooms = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vti-rooms-dtg = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vti-secrets = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
-vti-webauthn = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "main" }
+vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-config = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-keys = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-keyspaces = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-persona = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-policy = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-support = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-sweepers = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-vault = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-webvh = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vtc-client = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vti-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vti-rooms = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vti-rooms-dtg = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vti-secrets = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vti-webauthn = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }

--- a/openvtc-core/README.md
+++ b/openvtc-core/README.md
@@ -22,7 +22,7 @@ the Linux Foundation's decentralized trust infrastructure.
 | `relationships` | Peer-to-peer trust relationship lifecycle — request, accept, reject, and finalize flows over DIDComm. |
 | `vrc` | Verifiable Relationship Credentials — request, issue, and verify VRCs that attest to established relationships. |
 | `tasks` | Async task tracker for long-running DIDComm operations (message send/receive, credential issuance). |
-| `maintainers` | Community maintainer list management and DIDComm-based list exchange. |
+| `vetting` | Peer identity vetting: tickets, applications, the vetter desk, and the peer Trust Tasks between them. |
 | `bip32` | BIP32 hierarchical key derivation from a seed, with helpers to derive Ed25519 signing keys and X25519 encryption keys. |
 | `openpgp_card` | Hardware token (OpenPGP smart card) support for key storage and signing. Feature-gated behind `openpgp-card`. |
 | `errors` | Unified error type (`OpenVTCError`) used across the library. |

--- a/openvtc-core/src/config/protected_config.rs
+++ b/openvtc-core/src/config/protected_config.rs
@@ -12,6 +12,7 @@ use crate::{
     logs::{LogFamily, Logs},
     relationships::Relationships,
     tasks::Tasks,
+    vetting::VettingBook,
     vrc::Vrcs,
 };
 use affinidi_tdk::TDK;
@@ -246,6 +247,12 @@ pub struct ProtectedConfig {
     #[serde(default)]
     pub agent_names: HashMap<String, CachedAgentName>,
 
+    /// Peer identity vetting: our applications, and our desk as a vetter
+    /// ([`crate::vetting`]). Skipped when empty, so a config that has never
+    /// vetted round-trips byte-identically.
+    #[serde(default, skip_serializing_if = "VettingBook::is_empty")]
+    pub vetting: VettingBook,
+
     /// Fields written by a newer build, preserved verbatim (D19).
     ///
     /// The protected tier is where the account lives, so an older build
@@ -304,6 +311,7 @@ impl Default for ProtectedConfig {
             vrcs_issued: Vrcs::default(),
             vrcs_received: Vrcs::default(),
             agent_names: HashMap::default(),
+            vetting: VettingBook::default(),
         }
     }
 }

--- a/openvtc-core/src/didcomm.rs
+++ b/openvtc-core/src/didcomm.rs
@@ -1300,6 +1300,8 @@ pub const OPENVTC_CATCH_ALL_PATTERN: &str = concat!(
     r"|https://trusttasks\.org/openvtc/vtc/.*",
     r"|https://trusttasks\.org/spec/vtc/.*",
     r"|https://trusttasks\.org/spec/credential-exchange/.*",
+    r"|https://trusttasks\.org/spec/vetting/.*",
+    r"|https://trusttasks\.org/spec/trust-task-error/.*",
     r"|https://didcomm\.org/report-problem/.*",
 );
 
@@ -2531,6 +2533,26 @@ mod catch_all_tests {
             "https://trusttasks.org/spec/vtc/join-requests/submit/0.1#response",
             "https://trusttasks.org/spec/vtc/join-requests/status/0.1#response",
             "https://trusttasks.org/spec/vtc/members/self-remove/0.1",
+        ] {
+            assert!(matches(uri), "{uri} must reach the OpenVTC handler");
+        }
+    }
+
+    /// Peer vetting tasks travel member to member, not through a community,
+    /// so they live under their own prefix; and a refusal of any Trust Task
+    /// arrives as a `trust-task-error`, which a vetter uses to refuse a request.
+    /// Without these arms both are dropped before dispatch.
+    #[test]
+    fn vetting_tasks_and_trust_task_errors_are_routed() {
+        for uri in [
+            "https://trusttasks.org/spec/vetting/request/0.1",
+            "https://trusttasks.org/spec/vetting/request/0.1#response",
+            "https://trusttasks.org/spec/vetting/session/0.1",
+            "https://trusttasks.org/spec/vetting/session/0.1#response",
+            "https://trusttasks.org/spec/vetting/decline/0.1",
+            "https://trusttasks.org/spec/vtc/vetting/revoke-statement/0.1#response",
+            "https://trusttasks.org/spec/vtc/join-requests/manifest/0.2#response",
+            "https://trusttasks.org/spec/trust-task-error/0.5",
         ] {
             assert!(matches(uri), "{uri} must reach the OpenVTC handler");
         }

--- a/openvtc-core/src/join.rs
+++ b/openvtc-core/src/join.rs
@@ -37,7 +37,9 @@ use crate::errors::OpenVTCError;
 /// Submit a join request to a VTC (`vtc_did`) over DIDComm, presenting
 /// `persona_did` as the applicant.
 ///
-/// `vp` is the holder presentation the VTC's `join.rego` decides over.
+/// `presentation` is the holder presentation the VTC's `join.rego` decides
+/// over, with any submission `extensions` (a plain `Value` VP converts, with
+/// none).
 /// The message is packed authcrypt and forwarded via the persona's
 /// `mediator_did`; the VTC authenticates the applicant from the
 /// envelope's `from`.
@@ -65,14 +67,14 @@ pub async fn submit_join_request(
     persona_did: &str,
     vtc_did: &str,
     mediator_did: &str,
-    vp: Value,
+    presentation: impl Into<JoinPresentation>,
     tsp_mediator_did: Option<&str>,
 ) -> Result<Uuid, OpenVTCError> {
     // One id, used as both the document id and — on the DIDComm path — the
     // message id, so the two transports' threading conventions coincide.
     let request_id = Uuid::new_v4();
     let document_id = format!("urn:uuid:{request_id}");
-    let body = build_join_submit_document(persona_did, vtc_did, vp, &document_id)?;
+    let body = build_join_submit_document(persona_did, vtc_did, presentation, &document_id)?;
 
     match tsp_mediator_did {
         // TSP carries the Trust Task document as-is: no DIDComm envelope, and
@@ -189,13 +191,14 @@ fn build_trust_task_document<T: serde::Serialize>(
 fn build_join_submit_document(
     persona_did: &str,
     vtc_did: &str,
-    vp: Value,
+    presentation: impl Into<JoinPresentation>,
     document_id: &str,
 ) -> Result<Value, OpenVTCError> {
+    let JoinPresentation { vp, extensions } = presentation.into();
     let payload = JoinRequestSubmitBody {
         vp,
         registry_consent: false,
-        extensions: Value::Null,
+        extensions,
     };
     // `document_id` is supplied rather than minted here: on the DIDComm path this
     // same id is the message id, which is what makes the two transports' reply
@@ -288,6 +291,45 @@ pub fn build_join_vp(
         });
     }
     vp
+}
+
+/// What a join request presents: the VP, and the submission's `extensions`.
+///
+/// `extensions` is where an applicant names the `requirementsDigest` its
+/// vetting statements were gathered against, so the community evaluates them
+/// under the same criterion ([`crate::vetting::applicant::Application::join_extensions`]).
+#[derive(Debug, Clone, PartialEq)]
+pub struct JoinPresentation {
+    /// The holder presentation.
+    pub vp: Value,
+    /// Submission extensions; `Null` for none.
+    pub extensions: Value,
+}
+
+impl From<Value> for JoinPresentation {
+    fn from(vp: Value) -> Self {
+        Self {
+            vp,
+            extensions: Value::Null,
+        }
+    }
+}
+
+/// Add `credentials` to a VP's `verifiableCredential`, after anything already
+/// there. Used for the vetting statements an application gathered.
+pub fn attach_credentials(vp: &mut Value, credentials: impl IntoIterator<Item = Value>) {
+    let mut credentials = credentials.into_iter().peekable();
+    if credentials.peek().is_none() {
+        return;
+    }
+    let list = vp
+        .as_object_mut()
+        .expect("a VP is an object")
+        .entry("verifiableCredential")
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if let Value::Array(list) = list {
+        list.extend(credentials);
+    }
 }
 
 /// Domain tag the VIC subject signs over for a subject-linkage proof. **Must
@@ -634,6 +676,44 @@ mod tests {
             "did:webvh:example.com:alice#key-0"
         );
         assert_eq!(vp["subjectLinkage"]["signature"], "deadbeef");
+    }
+
+    #[test]
+    fn vetting_statements_ride_beside_the_invitation_and_the_digest_in_extensions() {
+        let vic = sample_vic();
+        let mut vp = build_join_vp("did:webvh:example.com:alice", Some(&vic), None);
+        attach_credentials(
+            &mut vp,
+            [
+                json!({ "id": "urn:uuid:s1" }),
+                json!({ "id": "urn:uuid:s2" }),
+            ],
+        );
+        let creds = vp["verifiableCredential"].as_array().unwrap();
+        assert_eq!(creds.len(), 3);
+        assert_eq!(creds[0], vic, "the invitation stays first");
+
+        let mut bare = build_join_vp("did:webvh:example.com:alice", None, None);
+        attach_credentials(&mut bare, Vec::new());
+        assert!(
+            bare.get("verifiableCredential").is_none(),
+            "nothing to attach adds nothing"
+        );
+
+        let doc = build_join_submit_document(
+            "did:webvh:example.com:alice",
+            "did:webvh:example.com:community",
+            JoinPresentation {
+                vp,
+                extensions: json!({ "requirementsDigest": "zDigest" }),
+            },
+            "urn:uuid:submit-2",
+        )
+        .unwrap();
+        assert_eq!(
+            doc["payload"]["extensions"]["requirementsDigest"],
+            "zDigest"
+        );
     }
 
     #[test]

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -48,6 +48,7 @@ pub mod relationships;
 pub mod secure_store;
 pub mod tasks;
 pub mod tsp;
+pub mod vetting;
 pub mod vrc;
 
 /// Primary Linux Foundation Mediator DID.
@@ -163,10 +164,6 @@ pub mod protocol_urls {
     pub const VRC_REJECTED: &str = "https://firstperson.network/vrc/1.0/rejected";
     /// URL for issuing a VRC.
     pub const VRC_ISSUED: &str = "https://firstperson.network/vrc/1.0/issued";
-    /// URL for requesting a list of known maintainers.
-    pub const MAINTAINERS_LIST_REQUEST: &str = "https://kernel.org/maintainers/1.0/list";
-    /// URL for responding with a list of known maintainers.
-    pub const MAINTAINERS_LIST_RESPONSE: &str = "https://kernel.org/maintainers/1.0/list/response";
     /// URL for a DIDComm MessagePickup 3.0 status message.
     pub const MESSAGEPICKUP_STATUS: &str = "https://didcomm.org/messagepickup/3.0/status";
 }
@@ -210,10 +207,6 @@ pub enum MessageType {
     VRCRequestRejected,
     /// A VRC has been issued and delivered.
     VRCIssued,
-    /// Request for a list of known kernel maintainers.
-    MaintainersListRequest,
-    /// Response containing a list of known kernel maintainers.
-    MaintainersListResponse,
 }
 
 impl MessageType {
@@ -229,8 +222,6 @@ impl MessageType {
             MessageType::VRCRequest => "VRC Request",
             MessageType::VRCRequestRejected => "VRC Request Rejected",
             MessageType::VRCIssued => "VRC Issued",
-            MessageType::MaintainersListRequest => "List Known Maintainers (request)",
-            MessageType::MaintainersListResponse => "List Known Maintainers (response)",
         }
         .to_string()
     }
@@ -250,8 +241,6 @@ impl From<MessageType> for String {
             MessageType::VRCRequest => VRC_REQUEST,
             MessageType::VRCRequestRejected => VRC_REJECTED,
             MessageType::VRCIssued => VRC_ISSUED,
-            MessageType::MaintainersListRequest => MAINTAINERS_LIST_REQUEST,
-            MessageType::MaintainersListResponse => MAINTAINERS_LIST_RESPONSE,
         }
         .to_string()
     }
@@ -273,8 +262,6 @@ impl TryFrom<&str> for MessageType {
             VRC_REQUEST => Ok(MessageType::VRCRequest),
             VRC_REJECTED => Ok(MessageType::VRCRequestRejected),
             VRC_ISSUED => Ok(MessageType::VRCIssued),
-            MAINTAINERS_LIST_REQUEST => Ok(MessageType::MaintainersListRequest),
-            MAINTAINERS_LIST_RESPONSE => Ok(MessageType::MaintainersListResponse),
             _ => Err(OpenVTCError::InvalidMessage(value.to_string())),
         }
     }
@@ -432,7 +419,7 @@ impl From<KeyType> for KeyPurpose {
 mod tests {
     use super::*;
 
-    fn all_message_types() -> [MessageType; 11] {
+    fn all_message_types() -> [MessageType; 9] {
         [
             MessageType::RelationshipRequest,
             MessageType::RelationshipRequestRejected,
@@ -443,8 +430,6 @@ mod tests {
             MessageType::VRCRequest,
             MessageType::VRCRequestRejected,
             MessageType::VRCIssued,
-            MessageType::MaintainersListRequest,
-            MessageType::MaintainersListResponse,
         ]
     }
 
@@ -461,8 +446,6 @@ mod tests {
             (VRC_REQUEST, "VRCRequest"),
             (VRC_REJECTED, "VRCRequestRejected"),
             (VRC_ISSUED, "VRCIssued"),
-            (MAINTAINERS_LIST_REQUEST, "MaintainersListRequest"),
-            (MAINTAINERS_LIST_RESPONSE, "MaintainersListResponse"),
         ];
 
         for (url, expected_debug_contains) in cases {
@@ -554,14 +537,6 @@ mod tests {
             (MessageType::VRCRequest, "VRC Request"),
             (MessageType::VRCRequestRejected, "VRC Request Rejected"),
             (MessageType::VRCIssued, "VRC Issued"),
-            (
-                MessageType::MaintainersListRequest,
-                "List Known Maintainers (request)",
-            ),
-            (
-                MessageType::MaintainersListResponse,
-                "List Known Maintainers (response)",
-            ),
         ];
         for (ty, want) in cases {
             assert_eq!(ty.friendly_name(), want);

--- a/openvtc-core/src/tasks.rs
+++ b/openvtc-core/src/tasks.rs
@@ -77,6 +77,34 @@ pub enum TaskType {
     VRCRequestRejected,
     /// A VRC has been issued (either by us or received from a remote party).
     VRCIssued { vrc: Box<DTGCredential> },
+    /// Vetter: an applicant redeemed one of our tickets. Open a session when
+    /// the two of you are together.
+    VettingRequestInbound {
+        /// Our desk handle (`crate::vetting::VettingBook::desk_entry`).
+        request_id: String,
+        /// The applicant's join DID.
+        applicant: Arc<String>,
+        /// The community they are applying to.
+        community: String,
+    },
+    /// Applicant: a vetter opened a session. Read the match code to each
+    /// other, then send the card.
+    VettingSessionInbound {
+        /// The application.
+        application_id: String,
+        /// The session document id.
+        session_id: String,
+        /// The vetter.
+        vetter: Arc<String>,
+    },
+    /// Vetter: the applicant's card arrived and verified. Check the person,
+    /// then attest or decline.
+    VettingCardReceived {
+        /// Our desk handle.
+        request_id: String,
+        /// The applicant's join DID.
+        applicant: Arc<String>,
+    },
 }
 
 impl Display for TaskType {
@@ -93,6 +121,9 @@ impl Display for TaskType {
             TaskType::VRCRequestInbound { .. } => "VRC Request Received",
             TaskType::VRCRequestRejected => "VRC Request Rejected",
             TaskType::VRCIssued { .. } => "VRC Issued",
+            TaskType::VettingRequestInbound { .. } => "Vetting Request (Inbound)",
+            TaskType::VettingSessionInbound { .. } => "Vetting Session (Send Card)",
+            TaskType::VettingCardReceived { .. } => "Vetting Card Received",
         };
         write!(f, "{}", friendly_name)
     }

--- a/openvtc-core/src/vetting/applicant.rs
+++ b/openvtc-core/src/vetting/applicant.rs
@@ -1,0 +1,767 @@
+//! The applicant's side: one application to one community (design §9–§12).
+//!
+//! An application collects statements from vetters until the community's
+//! published requirements are met, then rides the join request. Each vetter
+//! goes through the same short life:
+//!
+//! ```text
+//! Sent ──#response──▶ Accepted ──vetting/session──▶ Session ──statement──▶ Attested
+//!   │                    │                             │
+//!   └─trust-task-error─▶ Refused        vetting/decline └──▶ Declined
+//! ```
+//!
+//! The checklist ([`Application::checklist`]) is **advisory**. It counts what
+//! this client can verify — proofs, subject, community, commitment, age,
+//! method floors — and assumes every vetter is eligible, because only the
+//! community knows that. Copy built on it says "meets the published
+//! requirements", never "approved" (D12).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use uuid::Uuid;
+use vta_sdk::protocols::join_requests::JoinRequestManifestResponseBody;
+use vta_sdk::protocols::vetting::{
+    CardClaim, DeclaredRelationship, DeclineCode, ShapeError, TicketPresentation,
+    VettingDeclineBody, VettingMethod, VettingRequestAcceptedBody, VettingRequestBody,
+    VettingRequirements, VettingSessionBody,
+};
+use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+use vta_sdk::vetting::VettingError;
+use vta_sdk::vetting::card::{
+    CardDraft, CardExpectations, MAX_CARD_VALIDITY, new_commitment_salt, verify_card,
+};
+use vta_sdk::vetting::match_code::vetting_match_code;
+use vta_sdk::vetting::requirements::{
+    Evaluation, REQUIREMENTS_DIGEST_MEMBER, StatementFacts, evaluate,
+};
+use vta_sdk::vetting::statement::verify_statement;
+
+use crate::config::account::PersonaId;
+
+/// Why an applicant-side step was refused.
+#[derive(Debug, thiserror::Error)]
+pub enum ApplicantError {
+    /// Nothing we sent matches this reply.
+    #[error("no request of ours matches this reply")]
+    NoMatchingRequest,
+    /// The request exists but cannot take this step now.
+    #[error("the request cannot {0} in its current state")]
+    WrongState(&'static str),
+    /// A payload broke its schema.
+    #[error(transparent)]
+    Shape(#[from] ShapeError),
+    /// The session names another community.
+    #[error("the session is for a different community")]
+    WrongCommunity,
+    /// The session has closed.
+    #[error("the session has expired")]
+    SessionExpired,
+    /// The card would lack a claim the session requires.
+    #[error("the card needs a `{0}` claim")]
+    MissingClaim(String),
+    /// Building or verifying an artifact failed.
+    #[error(transparent)]
+    Vetting(#[from] VettingError),
+    /// A statement is not about this application.
+    #[error("the statement's {0} does not match this application")]
+    Binding(&'static str),
+    /// The community's manifest names no vetting.
+    #[error("the community does not ask for vetting")]
+    NoVettingCriterion,
+    /// The community's requirements cannot be evaluated.
+    #[error("the community's vetting requirements are unusable: {0}")]
+    InvalidRequirements(String),
+}
+
+/// One application.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Application {
+    /// Local handle.
+    pub id: String,
+    /// The community's VTC DID.
+    pub community: String,
+    /// The persona joining.
+    pub persona: PersonaId,
+    /// The DID every card is signed by and every statement names (D13).
+    pub join_did: String,
+    /// The manifest criterion being gathered for.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub criterion_id: Option<String>,
+    /// What that criterion requires, as last read from the manifest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements: Option<VettingRequirements>,
+    /// The criterion's `requirementsDigest`, sent with requests and the join.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements_digest: Option<String>,
+    /// One salt for the whole application, so every vetter sees the same
+    /// identity commitment. Goes to vetters, never to the community.
+    pub commitment_salt: String,
+    /// The identity the applicant shows every vetter, entered once. Reusing it
+    /// is what keeps the commitment identical across cards: two cards that
+    /// spell a name differently commit to different identities, and the
+    /// community refers the application.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub identity_claims: Vec<CardClaim>,
+    /// Requests to vetters, newest last.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requests: Vec<OutboundRequest>,
+    /// Statements received.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub statements: Vec<HeldStatement>,
+    /// When the application started.
+    pub created_at: DateTime<Utc>,
+    /// Fields written by a newer build, preserved verbatim (D19).
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, Value>,
+}
+
+/// One request to one vetter.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct OutboundRequest {
+    /// Our `vetting/request` document id — what the vetter's reply threads on.
+    pub document_id: String,
+    /// The vetter's DID.
+    pub vetter: String,
+    /// Where it stands.
+    pub state: RequestState,
+    /// When we sent it.
+    pub sent_at: DateTime<Utc>,
+    /// When it last moved.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Where a request stands.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum RequestState {
+    /// Sent; no answer yet.
+    Sent,
+    /// The vetter took it.
+    Accepted {
+        /// The vetter's handle.
+        request_id: String,
+        /// What documentation the vetter accepts.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        accepts_documentation: Vec<String>,
+        /// How the vetter proposes to meet.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_hint: Option<String>,
+    },
+    /// The vetter opened a session; we owe them a card.
+    Session {
+        /// The vetter's handle.
+        request_id: String,
+        /// The open session.
+        session: OpenSession,
+        /// The card we sent, once we have.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        card: Option<SentCard>,
+    },
+    /// We hold the vetter's statement.
+    Attested {
+        /// The vetter's handle.
+        request_id: String,
+        /// The statement's id.
+        statement_id: String,
+    },
+    /// The vetter declined.
+    Declined {
+        /// Their reason code, if they gave one.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<DeclineCode>,
+        /// Their note, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+    /// The vetter refused the request itself (`trust-task-error`).
+    Refused {
+        /// The error code, e.g. `vetting/request:capacity`.
+        code: String,
+        /// Their note, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<String>,
+    },
+}
+
+/// A session a vetter opened with us.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct OpenSession {
+    /// The `vetting/session` document id.
+    pub id: String,
+    /// What the card must carry.
+    pub challenge: String,
+    /// What the card must carry.
+    pub domain: String,
+    /// The method.
+    pub method: VettingMethod,
+    /// Claim types the card must carry.
+    pub required_claims: Vec<String>,
+    /// Claim types the card may carry.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub optional_claims: Vec<String>,
+    /// After this we do not present.
+    pub expires_at: DateTime<Utc>,
+    /// The code both people read aloud.
+    pub match_code: String,
+}
+
+/// The card we sent into a session.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SentCard {
+    /// The card id.
+    pub id: String,
+    /// Its `digestMultibase` — the statement must name it.
+    pub digest_multibase: String,
+    /// Its commitment — the statement must repeat it.
+    pub identity_commitment: String,
+    /// When we sent it.
+    pub sent_at: DateTime<Utc>,
+}
+
+/// A statement we hold.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct HeldStatement {
+    /// The statement id.
+    pub id: String,
+    /// The vetter.
+    pub vetter: String,
+    /// How they vetted us.
+    pub method: VettingMethod,
+    /// The relationship they declared.
+    pub declared_relationship: DeclaredRelationship,
+    /// What they relied on.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub document_classes: Vec<String>,
+    /// Claim types they verified.
+    pub claims_verified: Vec<String>,
+    /// Our identity commitment, as they signed it.
+    pub identity_commitment: String,
+    /// Start of validity.
+    pub valid_from: DateTime<Utc>,
+    /// End of validity.
+    pub valid_until: DateTime<Utc>,
+    /// When it arrived.
+    pub received_at: DateTime<Utc>,
+    /// The signed credential, exactly as received.
+    pub credential: Value,
+}
+
+/// What a request to a vetter says besides the ticket.
+#[derive(Clone, Debug, Default)]
+pub struct RequestDraft {
+    /// The method the applicant would prefer.
+    pub preferred_method: Option<VettingMethod>,
+    /// BCP 47 tags.
+    pub languages: Vec<String>,
+    /// A short note.
+    pub message: Option<String>,
+    /// Free-text availability.
+    pub availability: Option<String>,
+}
+
+impl Application {
+    /// A new application with a fresh commitment salt.
+    ///
+    /// # Errors
+    ///
+    /// Only if the platform has no randomness.
+    pub fn new(
+        community: &str,
+        persona: PersonaId,
+        join_did: &str,
+        now: DateTime<Utc>,
+    ) -> Result<Self, VettingError> {
+        Ok(Self {
+            id: Uuid::new_v4().to_string(),
+            community: community.to_string(),
+            persona,
+            join_did: join_did.to_string(),
+            criterion_id: None,
+            requirements: None,
+            requirements_digest: None,
+            commitment_salt: new_commitment_salt()?,
+            identity_claims: Vec::new(),
+            requests: Vec::new(),
+            statements: Vec::new(),
+            created_at: now,
+            extra: serde_json::Map::new(),
+        })
+    }
+
+    /// Take the community's requirements from its manifest (0.2). Keeps the
+    /// criterion already chosen when it still exists; otherwise the first that
+    /// asks for vetting. Returns whether the requirements changed — a changed
+    /// digest mid-application is worth telling the applicant about.
+    ///
+    /// # Errors
+    ///
+    /// [`ApplicantError::NoVettingCriterion`] or
+    /// [`ApplicantError::InvalidRequirements`].
+    pub fn adopt_manifest(
+        &mut self,
+        manifest: &JoinRequestManifestResponseBody,
+    ) -> Result<bool, ApplicantError> {
+        let with_vetting =
+            |c: &&vta_sdk::protocols::join_requests::ManifestCriterion| c.vetting.is_some();
+        let chosen = self
+            .criterion_id
+            .as_deref()
+            .and_then(|id| {
+                manifest
+                    .criteria
+                    .iter()
+                    .filter(with_vetting)
+                    .find(|c| c.id == id)
+            })
+            .or_else(|| manifest.criteria.iter().find(with_vetting))
+            .ok_or(ApplicantError::NoVettingCriterion)?;
+        let requirements = chosen.vetting.clone().expect("filtered on vetting");
+        requirements
+            .validate()
+            .map_err(|e| ApplicantError::InvalidRequirements(e.0))?;
+        let changed = self.requirements.as_ref() != Some(&requirements)
+            || self.requirements_digest != chosen.requirements_digest;
+        self.criterion_id = Some(chosen.id.clone());
+        self.requirements = Some(requirements);
+        self.requirements_digest = chosen.requirements_digest.clone();
+        Ok(changed)
+    }
+
+    /// Build the `vetting/request` payload to `vetter` and record it as sent
+    /// under `document_id`.
+    ///
+    /// # Errors
+    ///
+    /// [`ShapeError`] if the payload breaks the schema.
+    pub fn prepare_request(
+        &mut self,
+        document_id: &str,
+        vetter: &str,
+        ticket: TicketPresentation,
+        draft: RequestDraft,
+        now: DateTime<Utc>,
+    ) -> Result<VettingRequestBody, ShapeError> {
+        let body = VettingRequestBody {
+            community: self.community.clone(),
+            requirements_digest: self.requirements_digest.clone(),
+            join_did: self.join_did.clone(),
+            ticket: Some(ticket),
+            introduction: None,
+            preferred_method: draft.preferred_method,
+            languages: draft.languages,
+            message: draft.message,
+            availability: draft.availability,
+            ext: None,
+        };
+        body.check_shape(&self.join_did)?;
+        self.requests.push(OutboundRequest {
+            document_id: document_id.to_string(),
+            vetter: vetter.to_string(),
+            state: RequestState::Sent,
+            sent_at: now,
+            updated_at: now,
+        });
+        Ok(body)
+    }
+
+    /// Forget a request that never left — its send failed — so a retry is not
+    /// shadowed by a record the vetter never saw. Returns whether one was removed.
+    pub fn forget_unsent(&mut self, document_id: &str) -> bool {
+        let before = self.requests.len();
+        self.requests
+            .retain(|r| !(r.document_id == document_id && r.state == RequestState::Sent));
+        self.requests.len() != before
+    }
+
+    /// Whether we sent the request `document_id` (a reply's thread).
+    #[must_use]
+    pub fn sent(&self, document_id: &str) -> bool {
+        self.requests.iter().any(|r| r.document_id == document_id)
+    }
+
+    fn by_thread(
+        &mut self,
+        thread: &str,
+        vetter: &str,
+    ) -> Result<&mut OutboundRequest, ApplicantError> {
+        self.requests
+            .iter_mut()
+            .find(|r| r.document_id == thread && r.vetter == vetter)
+            .ok_or(ApplicantError::NoMatchingRequest)
+    }
+
+    fn by_request_id(
+        &mut self,
+        request_id: &str,
+        vetter: &str,
+    ) -> Result<&mut OutboundRequest, ApplicantError> {
+        self.requests
+            .iter_mut()
+            .rev()
+            .find(|r| {
+                r.vetter == vetter
+                    && match &r.state {
+                        RequestState::Accepted { request_id: id, .. }
+                        | RequestState::Session { request_id: id, .. }
+                        | RequestState::Attested { request_id: id, .. } => id == request_id,
+                        _ => false,
+                    }
+            })
+            .ok_or(ApplicantError::NoMatchingRequest)
+    }
+
+    /// The vetter accepted (`vetting/request#response`, threaded on our
+    /// request). A repeat of the same acceptance is harmless.
+    ///
+    /// # Errors
+    ///
+    /// No matching request, a request already past acceptance, or a payload
+    /// breaking its schema.
+    pub fn on_accepted(
+        &mut self,
+        thread: &str,
+        vetter: &str,
+        body: VettingRequestAcceptedBody,
+        now: DateTime<Utc>,
+    ) -> Result<(), ApplicantError> {
+        body.check_shape()?;
+        let request = self.by_thread(thread, vetter)?;
+        match &request.state {
+            RequestState::Sent => {}
+            RequestState::Accepted { request_id, .. } if *request_id == body.request_id => {}
+            _ => return Err(ApplicantError::WrongState("be accepted")),
+        }
+        request.state = RequestState::Accepted {
+            request_id: body.request_id,
+            accepts_documentation: body.accepts_documentation,
+            session_hint: body.session_hint,
+        };
+        request.updated_at = now;
+        Ok(())
+    }
+
+    /// The vetter refused the request (`trust-task-error`, threaded on it).
+    ///
+    /// # Errors
+    ///
+    /// No matching request, or one that was already answered.
+    pub fn on_refused(
+        &mut self,
+        thread: &str,
+        vetter: &str,
+        code: String,
+        message: Option<String>,
+        now: DateTime<Utc>,
+    ) -> Result<(), ApplicantError> {
+        let request = self.by_thread(thread, vetter)?;
+        if request.state != RequestState::Sent {
+            return Err(ApplicantError::WrongState("be refused"));
+        }
+        request.state = RequestState::Refused { code, message };
+        request.updated_at = now;
+        Ok(())
+    }
+
+    /// The vetter opened a session (`vetting/session`). Returns it, with the
+    /// match code the two people read to each other.
+    ///
+    /// # Errors
+    ///
+    /// A malformed or expired session, one for another community, or one for
+    /// a request this vetter never accepted.
+    pub fn on_session(
+        &mut self,
+        session_document_id: &str,
+        vetter: &str,
+        body: VettingSessionBody,
+        now: DateTime<Utc>,
+    ) -> Result<OpenSession, ApplicantError> {
+        body.check_shape()?;
+        if body.domain != self.community {
+            return Err(ApplicantError::WrongCommunity);
+        }
+        if body.expires_at <= now {
+            return Err(ApplicantError::SessionExpired);
+        }
+        let request = self.by_request_id(&body.request_id, vetter)?;
+        if matches!(request.state, RequestState::Attested { .. }) {
+            return Err(ApplicantError::WrongState("open another session"));
+        }
+        let session = OpenSession {
+            id: session_document_id.to_string(),
+            challenge: body.challenge,
+            domain: body.domain,
+            method: body.method,
+            required_claims: body.required_claims,
+            optional_claims: body.optional_claims,
+            expires_at: body.expires_at,
+            match_code: vetting_match_code(session_document_id),
+        };
+        request.state = RequestState::Session {
+            request_id: body.request_id,
+            session: session.clone(),
+            card: None,
+        };
+        request.updated_at = now;
+        Ok(session)
+    }
+
+    /// The open session `session_id` and the vetter it is with.
+    #[must_use]
+    pub fn session(&self, session_id: &str) -> Option<(&str, &OpenSession)> {
+        self.requests.iter().find_map(|r| match &r.state {
+            RequestState::Session { session, .. } if session.id == session_id => {
+                Some((r.vetter.as_str(), session))
+            }
+            _ => None,
+        })
+    }
+
+    /// The card to sign for `session_id`, from the claims the applicant chose
+    /// to disclose. Only the session's required and optional claim types are
+    /// kept; the identity commitment covers the required ones.
+    ///
+    /// # Errors
+    ///
+    /// No such session, an expired one, or a required claim missing.
+    pub fn card_draft(
+        &self,
+        session_id: &str,
+        claims: Vec<CardClaim>,
+        now: DateTime<Utc>,
+    ) -> Result<CardDraft, ApplicantError> {
+        let (vetter, session) = self
+            .session(session_id)
+            .ok_or(ApplicantError::NoMatchingRequest)?;
+        if session.expires_at <= now {
+            return Err(ApplicantError::SessionExpired);
+        }
+        let claims: Vec<CardClaim> = claims
+            .into_iter()
+            .filter(|c| {
+                session.required_claims.contains(&c.claim_type)
+                    || session.optional_claims.contains(&c.claim_type)
+            })
+            .collect();
+        if let Some(missing) = session
+            .required_claims
+            .iter()
+            .find(|t| !claims.iter().any(|c| &c.claim_type == *t))
+        {
+            return Err(ApplicantError::MissingClaim(missing.clone()));
+        }
+        Ok(CardDraft {
+            id: format!("urn:uuid:{}", Uuid::new_v4()),
+            publisher: self.join_did.clone(),
+            audience: vetter.to_string(),
+            community: self.community.clone(),
+            challenge: session.challenge.clone(),
+            domain: session.domain.clone(),
+            issued_at: now,
+            validity: MAX_CARD_VALIDITY.min(session.expires_at - now),
+            claims,
+            identity_types: session.required_claims.clone(),
+            salt: self.commitment_salt.clone(),
+        })
+    }
+
+    /// Record the signed card we are sending into `session_id`. Verifies it the
+    /// way the vetter will, so a card that would be refused never leaves.
+    ///
+    /// # Errors
+    ///
+    /// No such session, or a card that does not verify.
+    pub async fn record_card(
+        &mut self,
+        session_id: &str,
+        card: &Value,
+        resolver: &TrustTaskVmResolver,
+        now: DateTime<Utc>,
+    ) -> Result<(), ApplicantError> {
+        let join_did = self.join_did.clone();
+        let community = self.community.clone();
+        let request = self
+            .requests
+            .iter_mut()
+            .find(|r| matches!(&r.state, RequestState::Session { session, .. } if session.id == session_id))
+            .ok_or(ApplicantError::NoMatchingRequest)?;
+        let RequestState::Session {
+            session,
+            card: sent,
+            ..
+        } = &mut request.state
+        else {
+            unreachable!("matched a session above");
+        };
+        let verified = verify_card(
+            card,
+            &CardExpectations {
+                audience: &request.vetter,
+                publisher: &join_did,
+                community: &community,
+                challenge: &session.challenge,
+                domain: &session.domain,
+                required_claims: &session.required_claims,
+                now,
+            },
+            resolver,
+        )
+        .await?;
+        *sent = Some(SentCard {
+            id: verified.card().id.clone(),
+            digest_multibase: verified.digest_multibase().to_string(),
+            identity_commitment: verified.card().identity_commitment.clone(),
+            sent_at: now,
+        });
+        request.updated_at = now;
+        Ok(())
+    }
+
+    /// A statement arrived from `vetter`. Verified and bound to this
+    /// application — our join DID, this community, and the card we sent that
+    /// vetter — before it is kept.
+    ///
+    /// # Errors
+    ///
+    /// A statement that does not verify, is about someone or something else,
+    /// or answers no card of ours.
+    pub async fn on_statement(
+        &mut self,
+        vetter: &str,
+        credential: &Value,
+        resolver: &TrustTaskVmResolver,
+        now: DateTime<Utc>,
+    ) -> Result<HeldStatement, ApplicantError> {
+        let verified = verify_statement(credential, now, resolver).await?;
+        if verified.issuer() != vetter {
+            return Err(ApplicantError::Binding("issuer"));
+        }
+        if verified.subject() != self.join_did {
+            return Err(ApplicantError::Binding("subject"));
+        }
+        let endorsement = verified.endorsement();
+        if endorsement.community != self.community {
+            return Err(ApplicantError::Binding("community"));
+        }
+        if let Some(held) = self.statements.iter().find(|s| s.id == verified.id()) {
+            return Ok(held.clone());
+        }
+        let request = self
+            .requests
+            .iter_mut()
+            .find(|r| {
+                r.vetter == vetter
+                    && matches!(&r.state, RequestState::Session { session, .. }
+                        if session.id == verified.task_context())
+            })
+            .ok_or(ApplicantError::NoMatchingRequest)?;
+        let RequestState::Session {
+            request_id, card, ..
+        } = &request.state
+        else {
+            unreachable!("matched a session above");
+        };
+        let card = card
+            .as_ref()
+            .ok_or(ApplicantError::WrongState("take a statement before a card"))?;
+        if endorsement.card_digest_multibase != card.digest_multibase {
+            return Err(ApplicantError::Binding("cardDigestMultibase"));
+        }
+        if endorsement.identity_commitment != card.identity_commitment {
+            return Err(ApplicantError::Binding("identityCommitment"));
+        }
+        let held = HeldStatement {
+            id: verified.id().to_string(),
+            vetter: vetter.to_string(),
+            method: endorsement.method,
+            declared_relationship: endorsement.declared_relationship,
+            document_classes: endorsement.document_classes.clone(),
+            claims_verified: endorsement.claims_verified.clone(),
+            identity_commitment: endorsement.identity_commitment.clone(),
+            valid_from: verified.valid_from(),
+            valid_until: verified.valid_until(),
+            received_at: now,
+            credential: credential.clone(),
+        };
+        request.state = RequestState::Attested {
+            request_id: request_id.clone(),
+            statement_id: held.id.clone(),
+        };
+        request.updated_at = now;
+        self.statements.push(held.clone());
+        Ok(held)
+    }
+
+    /// The vetter declined (`vetting/decline`).
+    ///
+    /// # Errors
+    ///
+    /// A malformed decline, or one for a request this vetter never accepted.
+    pub fn on_decline(
+        &mut self,
+        vetter: &str,
+        body: VettingDeclineBody,
+        now: DateTime<Utc>,
+    ) -> Result<(), ApplicantError> {
+        body.check_shape()?;
+        let request = self.by_request_id(&body.request_id, vetter)?;
+        if matches!(request.state, RequestState::Attested { .. }) {
+            return Err(ApplicantError::WrongState("be declined after attesting"));
+        }
+        request.state = RequestState::Declined {
+            code: body.code,
+            message: body.message,
+        };
+        request.updated_at = now;
+        Ok(())
+    }
+
+    /// Progress against the published requirements, as far as this client can
+    /// tell. `None` until the requirements are known.
+    #[must_use]
+    pub fn checklist(&self, now: DateTime<Utc>) -> Option<Evaluation> {
+        let requirements = self.requirements.as_ref()?;
+        let facts: Vec<StatementFacts> = self
+            .statements
+            .iter()
+            .filter(|s| s.valid_until > now)
+            .map(|s| StatementFacts {
+                statement_id: s.id.clone(),
+                vetter: s.vetter.clone(),
+                method: s.method,
+                claims_verified: s.claims_verified.clone(),
+                document_classes: s.document_classes.clone(),
+                declared_relationship: s.declared_relationship,
+                identity_commitment: s.identity_commitment.clone(),
+                valid_from: s.valid_from,
+                community_matches: true,
+                // Only the community can say; see the module docs.
+                eligible: true,
+                revoked: false,
+            })
+            .collect();
+        Some(evaluate(requirements, &facts, now))
+    }
+
+    /// The statements to present with the join request.
+    #[must_use]
+    pub fn presentable_statements(&self, now: DateTime<Utc>) -> Vec<Value> {
+        self.statements
+            .iter()
+            .filter(|s| s.valid_until > now)
+            .map(|s| s.credential.clone())
+            .collect()
+    }
+
+    /// The join submission's `extensions`: the digest of the requirements the
+    /// statements were gathered against, so the community applies the same
+    /// criterion.
+    #[must_use]
+    pub fn join_extensions(&self) -> Value {
+        match &self.requirements_digest {
+            Some(digest) => json!({ REQUIREMENTS_DIGEST_MEMBER: digest }),
+            None => Value::Null,
+        }
+    }
+}

--- a/openvtc-core/src/vetting/book.rs
+++ b/openvtc-core/src/vetting/book.rs
@@ -1,0 +1,374 @@
+//! Everything vetting persists, in one place: `ProtectedConfig::vetting`.
+//!
+//! Protected rather than public because it names people. An application lists
+//! who is vetting the applicant; the vetter desk lists who asked to be vetted
+//! and, briefly, the card they showed. None of it belongs in plaintext config.
+//!
+//! V0 keeps this client-local. Moving tickets and the desk into VTA appstate is
+//! V1, once `spec/vta/appstate/*` exists (design §11.2).
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use vta_sdk::protocols::join_requests::JoinRequestManifestResponseBody;
+use vta_sdk::protocols::vetting::{VettingRequirements, documentation};
+
+use super::applicant::{Application, RequestState};
+use super::tickets::{GuessThrottle, Ticket};
+use super::vetter::{DeskEntry, DeskState, IssuedStatement};
+use crate::config::account::PersonaId;
+
+/// A vetter's own rules (design §11.2). Every number is the vetter's choice;
+/// the community decides what counts, not what a vetter must accept.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct VetterPolicy {
+    /// Requests a persona holds open at once; more are refused with
+    /// `capacity`.
+    pub max_open_requests: usize,
+    /// How long a session stays open for the applicant to answer.
+    pub session_minutes: i64,
+    /// `validUntil` of a statement, from issue. A community's
+    /// `maxStatementAge` is applied by the community regardless.
+    pub statement_validity_days: i64,
+    /// Days a received card is kept after the statement is issued or the
+    /// request declined; afterwards only its digest remains.
+    pub card_retention_days: i64,
+    /// The documentation this vetter accepts (D16), offered to applicants.
+    pub accepts_documentation: Vec<String>,
+}
+
+impl Default for VetterPolicy {
+    fn default() -> Self {
+        Self {
+            max_open_requests: 10,
+            session_minutes: 15,
+            statement_validity_days: 180,
+            card_retention_days: 7,
+            accepts_documentation: vec![
+                documentation::PASSPORT.into(),
+                documentation::NATIONAL_ID.into(),
+                documentation::DRIVER_LICENCE.into(),
+            ],
+        }
+    }
+}
+
+impl VetterPolicy {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    /// [`Self::session_minutes`] as a duration.
+    #[must_use]
+    pub fn session_length(&self) -> Duration {
+        Duration::minutes(self.session_minutes.clamp(1, 60))
+    }
+
+    /// [`Self::statement_validity_days`] as a duration.
+    #[must_use]
+    pub fn statement_validity(&self) -> Duration {
+        Duration::days(self.statement_validity_days.max(1))
+    }
+}
+
+/// The claim types a session asks for when the community's requirements are
+/// not known. Every vetter of one application must ask for the same set, or
+/// the cards commit to different identities — so a vetter should fetch the
+/// manifest rather than rely on this.
+pub const FALLBACK_REQUIRED_CLAIMS: &[&str] = &["name.legal"];
+
+/// A community's vetting criterion, as last read from its manifest.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct KnownCriterion {
+    /// The community.
+    pub community: String,
+    /// The criterion id.
+    pub criterion_id: String,
+    /// Its `requirementsDigest`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements_digest: Option<String>,
+    /// What it requires.
+    pub requirements: VettingRequirements,
+    /// When it was read.
+    pub fetched_at: DateTime<Utc>,
+}
+
+/// All vetting state, for both sides.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct VettingBook {
+    /// Our applications, one per community and persona.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub applications: Vec<Application>,
+    /// Tickets we have issued as a vetter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tickets: Vec<Ticket>,
+    /// Requests people have made of us as a vetter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub desk: Vec<DeskEntry>,
+    /// Statements we have signed, kept so we can withdraw them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issued: Vec<IssuedStatement>,
+    /// Recent wrong ticket codes.
+    #[serde(default, skip_serializing_if = "GuessThrottle::is_empty")]
+    pub throttle: GuessThrottle,
+    /// Vetting criteria read from community manifests.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub criteria: Vec<KnownCriterion>,
+    /// Our rules as a vetter.
+    #[serde(default, skip_serializing_if = "VetterPolicy::is_default")]
+    pub policy: VetterPolicy,
+    /// Fields written by a newer build, preserved verbatim (D19).
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl VettingBook {
+    /// Nothing to persist — keeps a config without vetting byte-identical.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.applications.is_empty()
+            && self.tickets.is_empty()
+            && self.desk.is_empty()
+            && self.issued.is_empty()
+            && self.throttle.is_empty()
+            && self.criteria.is_empty()
+            && self.policy.is_default()
+            && self.extra.is_empty()
+    }
+
+    /// Remember `community`'s vetting criteria from its manifest, replacing
+    /// what was known. Returns whether anything changed.
+    pub fn learn_manifest(
+        &mut self,
+        community: &str,
+        manifest: &JoinRequestManifestResponseBody,
+        now: DateTime<Utc>,
+    ) -> bool {
+        let fresh: Vec<KnownCriterion> = manifest
+            .criteria
+            .iter()
+            .filter_map(|c| {
+                let requirements = c.vetting.clone()?;
+                requirements.validate().ok()?;
+                Some(KnownCriterion {
+                    community: community.to_string(),
+                    criterion_id: c.id.clone(),
+                    requirements_digest: c.requirements_digest.clone(),
+                    requirements,
+                    fetched_at: now,
+                })
+            })
+            .collect();
+        let known: Vec<&KnownCriterion> = self
+            .criteria
+            .iter()
+            .filter(|k| k.community == community)
+            .collect();
+        let unchanged = known.len() == fresh.len()
+            && known.iter().zip(&fresh).all(|(a, b)| {
+                a.criterion_id == b.criterion_id
+                    && a.requirements_digest == b.requirements_digest
+                    && a.requirements == b.requirements
+            });
+        self.criteria.retain(|k| k.community != community);
+        self.criteria.extend(fresh);
+        !unchanged
+    }
+
+    /// The claim types a session for `community` should require: those of the
+    /// criterion with `digest` (what the applicant named), else the community's
+    /// first vetting criterion, else [`FALLBACK_REQUIRED_CLAIMS`]. The second
+    /// value says whether the community's requirements were known.
+    #[must_use]
+    pub fn required_claims_for(
+        &self,
+        community: &str,
+        digest: Option<&str>,
+    ) -> (Vec<String>, bool) {
+        let mut ours = self.criteria.iter().filter(|k| k.community == community);
+        let chosen = digest
+            .and_then(|d| {
+                self.criteria.iter().find(|k| {
+                    k.community == community && k.requirements_digest.as_deref() == Some(d)
+                })
+            })
+            .or_else(|| ours.next());
+        match chosen {
+            Some(k) if !k.requirements.required_claims.is_empty() => {
+                (k.requirements.required_claims.clone(), true)
+            }
+            Some(_) => (Vec::new(), true),
+            None => (
+                FALLBACK_REQUIRED_CLAIMS
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+                false,
+            ),
+        }
+    }
+
+    /// Our application to `community` as `persona`.
+    #[must_use]
+    pub fn application(&self, community: &str, persona: PersonaId) -> Option<&Application> {
+        self.applications
+            .iter()
+            .find(|a| a.community == community && a.persona == persona)
+    }
+
+    /// Mutable [`Self::application`].
+    pub fn application_mut(
+        &mut self,
+        community: &str,
+        persona: PersonaId,
+    ) -> Option<&mut Application> {
+        self.applications
+            .iter_mut()
+            .find(|a| a.community == community && a.persona == persona)
+    }
+
+    /// The application with this id.
+    pub fn application_by_id_mut(&mut self, id: &str) -> Option<&mut Application> {
+        self.applications.iter_mut().find(|a| a.id == id)
+    }
+
+    /// The application `persona` is making to `community`, started if there is
+    /// none yet. `join_did` is the persona's DID, and the design fixes it when
+    /// the application starts (D13).
+    ///
+    /// # Errors
+    ///
+    /// Only if the platform has no randomness for the commitment salt.
+    pub fn start_application(
+        &mut self,
+        community: &str,
+        persona: PersonaId,
+        join_did: &str,
+        now: DateTime<Utc>,
+    ) -> Result<&mut Application, vta_sdk::vetting::VettingError> {
+        if let Some(i) = self
+            .applications
+            .iter()
+            .position(|a| a.community == community && a.persona == persona)
+        {
+            return Ok(&mut self.applications[i]);
+        }
+        self.applications
+            .push(Application::new(community, persona, join_did, now)?);
+        Ok(self.applications.last_mut().expect("just pushed"))
+    }
+
+    /// The desk entry with our `request_id`.
+    #[must_use]
+    pub fn desk_entry(&self, request_id: &str) -> Option<&DeskEntry> {
+        self.desk.iter().find(|e| e.request_id == request_id)
+    }
+
+    /// Mutable [`Self::desk_entry`].
+    pub fn desk_entry_mut(&mut self, request_id: &str) -> Option<&mut DeskEntry> {
+        self.desk.iter_mut().find(|e| e.request_id == request_id)
+    }
+
+    /// Requests `persona` has accepted and not yet finished.
+    #[must_use]
+    pub fn open_requests(&self, persona: PersonaId) -> usize {
+        self.desk
+            .iter()
+            .filter(|e| e.persona == persona && e.state.is_open())
+            .count()
+    }
+
+    /// Let time pass: close sessions nobody answered, forget cards past their
+    /// retention, and drop tickets that can admit nothing. Returns whether
+    /// anything changed.
+    pub fn prune(&mut self, now: DateTime<Utc>) -> bool {
+        let mut changed = false;
+
+        let before = self.tickets.len();
+        self.tickets
+            .retain(|t| t.is_live(now) || now - t.expires_at.min(now) < Duration::days(1));
+        changed |= self.tickets.len() != before;
+
+        let retention = Duration::days(self.policy.card_retention_days.max(0));
+        for entry in &mut self.desk {
+            changed |= entry.expire_session(now);
+            changed |= entry.forget_card_after(retention, now);
+        }
+
+        for application in &mut self.applications {
+            for request in &mut application.requests {
+                if let RequestState::Session {
+                    request_id,
+                    session,
+                    ..
+                } = &request.state
+                    && session.expires_at <= now
+                {
+                    request.state = RequestState::Accepted {
+                        request_id: request_id.clone(),
+                        accepts_documentation: Vec::new(),
+                        session_hint: None,
+                    };
+                    request.updated_at = now;
+                    changed = true;
+                }
+            }
+        }
+        changed
+    }
+}
+
+impl DeskState {
+    /// Still needs the vetter.
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        matches!(
+            self,
+            DeskState::Accepted | DeskState::Session { .. } | DeskState::CardReceived { .. }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_book_is_not_written() {
+        let book = VettingBook::default();
+        assert!(book.is_empty());
+        assert_eq!(serde_json::to_value(&book).unwrap(), serde_json::json!({}));
+    }
+
+    #[test]
+    fn one_application_per_community_and_persona() {
+        let mut book = VettingBook::default();
+        let persona = PersonaId::new();
+        let now = Utc::now();
+        let first = book
+            .start_application("did:web:vtc", persona, "did:key:zA", now)
+            .unwrap()
+            .id
+            .clone();
+        let again = book
+            .start_application("did:web:vtc", persona, "did:key:zA", now)
+            .unwrap()
+            .id
+            .clone();
+        assert_eq!(first, again);
+        book.start_application("did:web:other", persona, "did:key:zA", now)
+            .unwrap();
+        assert_eq!(book.applications.len(), 2);
+    }
+
+    #[test]
+    fn unknown_members_survive_a_round_trip() {
+        let mut v = serde_json::to_value(VettingBook::default()).unwrap();
+        v["vetterDirectory"] = serde_json::json!({ "listed": true });
+        let book: VettingBook = serde_json::from_value(v).unwrap();
+        assert!(!book.is_empty());
+        assert_eq!(
+            serde_json::to_value(&book).unwrap()["vetterDirectory"]["listed"],
+            true
+        );
+    }
+}

--- a/openvtc-core/src/vetting/inbound.rs
+++ b/openvtc-core/src/vetting/inbound.rs
@@ -1,0 +1,658 @@
+//! Routing an inbound message to the applicant or the vetter side.
+//!
+//! [`handle`] claims the messages that belong to vetting and returns `None` for
+//! everything else, so the caller's existing routing is untouched. Two message
+//! types are shared, and those are claimed only when they are vetting's:
+//!
+//! - `credential-exchange/issue` carries both a community's membership
+//!   credential and a vetter's statement. Only an identity-vetting statement
+//!   is claimed ([`wire::delivered_statement`]); a membership credential still
+//!   reaches the join handler, which would refuse a vetter as its issuer.
+//! - `trust-task-error` answers any Trust Task. Only one threaded on a request
+//!   or withdrawal of ours is claimed.
+//!
+//! Handling never sends. A reply comes back unsigned in [`Handled::reply`] for
+//! the caller to sign as the named persona and send ([`wire::sign_and_send`]);
+//! anything a person should see comes back as a [`Notice`].
+
+use std::sync::Arc;
+
+use affinidi_tdk::didcomm::Message;
+use chrono::{DateTime, Utc};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use tracing::{debug, info, warn};
+use trust_tasks_rs::TrustTask;
+use vta_sdk::protocols::credential_exchange::ISSUE as CREDENTIAL_ISSUE_TYPE;
+use vta_sdk::protocols::join_requests::{
+    JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, JoinRequestManifestResponseBody,
+};
+use vta_sdk::protocols::vetting::{
+    RevokeStatementResponseBody, VETTING_DECLINE_TYPE, VETTING_REQUEST_RESPONSE_TYPE,
+    VETTING_REQUEST_TYPE, VETTING_REVOKE_STATEMENT_RESPONSE_TYPE, VETTING_SESSION_RESPONSE_TYPE,
+    VETTING_SESSION_TYPE, VettingDeclineBody, VettingRequestAcceptedBody, VettingRequestBody,
+    VettingSessionBody, VettingSessionResponseBody,
+};
+use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+
+use super::book::VettingBook;
+use super::vetter::{IncomingRequest, Intake};
+use super::wire;
+use crate::config::account::{Account, PersonaId};
+use crate::messaging::is_trust_task_error_type;
+use crate::tasks::TaskType;
+
+/// What handling needs to know about us.
+pub struct Context<'a> {
+    /// Our memberships — a vetter must be an active member.
+    pub account: &'a Account,
+    /// Resolves the DIDs whose proofs are checked.
+    pub resolver: &'a TrustTaskVmResolver,
+    /// Our persona the message was addressed to, and its DID.
+    pub recipient: Option<(PersonaId, &'a str)>,
+    /// The clock.
+    pub now: DateTime<Utc>,
+}
+
+/// The result of handling one message.
+#[derive(Debug, Default)]
+pub struct Handled {
+    /// The book changed and wants saving.
+    pub changed: bool,
+    /// A reply to sign and send.
+    pub reply: Option<Reply>,
+    /// Something a person should see.
+    pub notice: Option<Notice>,
+}
+
+/// A reply to sign as `persona` and send to the document's recipient.
+#[derive(Debug)]
+pub struct Reply {
+    /// The persona to sign as.
+    pub persona: PersonaId,
+    /// The unsigned document.
+    pub document: TrustTask<Value>,
+}
+
+/// Something that happened that a person should know about. The ones marked
+/// *act* need them to do something.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Notice {
+    /// Vetter: someone redeemed a ticket. *Act:* open a session when together.
+    RequestAccepted {
+        /// Our handle.
+        request_id: String,
+        /// Their join DID.
+        applicant: String,
+        /// The community.
+        community: String,
+    },
+    /// Applicant: a vetter took our request.
+    VetterAccepted {
+        /// The application.
+        application_id: String,
+        /// The vetter.
+        vetter: String,
+    },
+    /// Applicant: a vetter refused our request.
+    VetterRefused {
+        /// The application.
+        application_id: String,
+        /// The vetter.
+        vetter: String,
+        /// The error code.
+        code: String,
+    },
+    /// Applicant: a vetter opened a session. *Act:* confirm the code, send the card.
+    SessionOpened {
+        /// The application.
+        application_id: String,
+        /// The session.
+        session_id: String,
+        /// The vetter.
+        vetter: String,
+        /// The code to read aloud.
+        match_code: String,
+    },
+    /// Vetter: a card arrived and verified. *Act:* check the person, attest or decline.
+    CardReceived {
+        /// Our handle.
+        request_id: String,
+        /// Their join DID.
+        applicant: String,
+    },
+    /// Applicant: a statement arrived and verified.
+    StatementReceived {
+        /// The application.
+        application_id: String,
+        /// The statement.
+        statement_id: String,
+        /// The vetter.
+        vetter: String,
+    },
+    /// Applicant: a vetter declined.
+    Declined {
+        /// The application.
+        application_id: String,
+        /// The vetter.
+        vetter: String,
+    },
+    /// Applicant: the community's requirements are now known, or changed.
+    RequirementsUpdated {
+        /// The application.
+        application_id: String,
+        /// The community.
+        community: String,
+    },
+    /// Vetter: the community recorded our withdrawal.
+    WithdrawalRecorded {
+        /// The statement.
+        statement_id: String,
+    },
+    /// Vetter: the community refused our withdrawal.
+    WithdrawalRefused {
+        /// The statement.
+        statement_id: String,
+        /// The error code.
+        code: String,
+    },
+}
+
+impl Notice {
+    /// One line for the activity log.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            Notice::RequestAccepted { applicant, .. } => {
+                format!(
+                    "Vetting request from {applicant} accepted — open a session when you are together."
+                )
+            }
+            Notice::VetterAccepted { vetter, .. } => {
+                format!("{vetter} accepted your vetting request.")
+            }
+            Notice::VetterRefused { vetter, code, .. } => {
+                format!("{vetter} refused your vetting request [{code}].")
+            }
+            Notice::SessionOpened {
+                vetter, match_code, ..
+            } => format!(
+                "{vetter} opened a vetting session. Read the code {match_code} to each other, then send your card."
+            ),
+            Notice::CardReceived { applicant, .. } => {
+                format!(
+                    "Vetting card from {applicant} verified — check the person, then attest or decline."
+                )
+            }
+            Notice::StatementReceived { vetter, .. } => {
+                format!("{vetter} signed a vetting statement for you.")
+            }
+            Notice::Declined { vetter, .. } => format!("{vetter} declined to vet you."),
+            Notice::RequirementsUpdated { community, .. } => {
+                format!("Vetting requirements for {community} updated.")
+            }
+            Notice::WithdrawalRecorded { statement_id } => {
+                format!("The community recorded the withdrawal of statement {statement_id}.")
+            }
+            Notice::WithdrawalRefused { statement_id, code } => format!(
+                "The community refused the withdrawal of statement {statement_id} [{code}]."
+            ),
+        }
+    }
+}
+
+impl Notice {
+    /// The inbox task this notice raises, keyed by a stable id so a repeated
+    /// message does not raise a second one. `None` for notices that only inform.
+    #[must_use]
+    pub fn task(&self) -> Option<(String, TaskType)> {
+        match self {
+            Notice::RequestAccepted {
+                request_id,
+                applicant,
+                community,
+            } => Some((
+                format!("vetting-request-{request_id}"),
+                TaskType::VettingRequestInbound {
+                    request_id: request_id.clone(),
+                    applicant: Arc::new(applicant.clone()),
+                    community: community.clone(),
+                },
+            )),
+            Notice::SessionOpened {
+                application_id,
+                session_id,
+                vetter,
+                ..
+            } => Some((
+                format!("vetting-session-{session_id}"),
+                TaskType::VettingSessionInbound {
+                    application_id: application_id.clone(),
+                    session_id: session_id.clone(),
+                    vetter: Arc::new(vetter.clone()),
+                },
+            )),
+            Notice::CardReceived {
+                request_id,
+                applicant,
+            } => Some((
+                format!("vetting-card-{request_id}"),
+                TaskType::VettingCardReceived {
+                    request_id: request_id.clone(),
+                    applicant: Arc::new(applicant.clone()),
+                },
+            )),
+            _ => None,
+        }
+    }
+}
+
+/// Whether [`handle`] could claim a message of type `typ`. A cheap pre-check,
+/// so a caller builds a DID resolver only for messages that may need one.
+#[must_use]
+pub fn may_claim(typ: &str) -> bool {
+    typ.starts_with("https://trusttasks.org/spec/vetting/")
+        || matches!(
+            typ,
+            VETTING_REVOKE_STATEMENT_RESPONSE_TYPE
+                | JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE
+                | CREDENTIAL_ISSUE_TYPE
+        )
+        || is_trust_task_error_type(typ)
+}
+
+/// Handle `message` from the authenticated `sender` if it is vetting's.
+pub async fn handle(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    message: &Message,
+    sender: &str,
+) -> Option<Handled> {
+    let handled = match message.typ.as_str() {
+        VETTING_REQUEST_TYPE => take_request(book, ctx, message, sender).await,
+        VETTING_REQUEST_RESPONSE_TYPE => accepted(book, ctx, message, sender).await,
+        VETTING_SESSION_TYPE => session(book, ctx, message, sender).await,
+        VETTING_SESSION_RESPONSE_TYPE => card(book, ctx, message, sender).await,
+        VETTING_DECLINE_TYPE => declined(book, ctx, message, sender).await,
+        VETTING_REVOKE_STATEMENT_RESPONSE_TYPE => withdrawal_recorded(book, message, sender),
+        JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE => manifest(book, message, sender),
+        CREDENTIAL_ISSUE_TYPE => return statement(book, ctx, message, sender).await,
+        t if is_trust_task_error_type(t) => return refused(book, ctx, message, sender),
+        _ => return None,
+    };
+    Some(handled)
+}
+
+async fn opened<P: DeserializeOwned>(
+    message: &Message,
+    sender: &str,
+    resolver: &TrustTaskVmResolver,
+) -> Option<wire::Opened<P>> {
+    match wire::open(message, sender, resolver).await {
+        Ok(opened) => Some(opened),
+        Err(e) => {
+            warn!(typ = %message.typ, %sender, error = %e, "vetting document refused");
+            None
+        }
+    }
+}
+
+/// A document from a community, whose replies are authenticated by transport
+/// and not always signed: read the payload without requiring a proof.
+fn community_reply<P: DeserializeOwned>(message: &Message) -> Option<(Option<String>, P)> {
+    let thread = message.thid.clone().or_else(|| {
+        message
+            .body
+            .get("threadId")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    });
+    let payload = message.body.get("payload").cloned().unwrap_or(Value::Null);
+    match serde_json::from_value(payload) {
+        Ok(p) => Some((thread, p)),
+        Err(e) => {
+            warn!(typ = %message.typ, error = %e, "malformed community reply");
+            None
+        }
+    }
+}
+
+async fn take_request(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    message: &Message,
+    sender: &str,
+) -> Handled {
+    let Some((persona, _)) = ctx.recipient else {
+        return Handled::default();
+    };
+    let Some(opened) = opened::<VettingRequestBody>(message, sender, ctx.resolver).await else {
+        return Handled::default();
+    };
+    let community = opened.payload.community.clone();
+    let is_member = ctx
+        .account
+        .membership(&community, persona)
+        .is_some_and(|m| m.status.is_active());
+    let throttle = book.throttle.clone();
+    let intake = book.take_request(
+        IncomingRequest {
+            document_id: &opened.document.id,
+            sender,
+            persona,
+            body: opened.payload,
+            is_member,
+        },
+        ctx.now,
+    );
+    let throttled = book.throttle != throttle;
+    match intake {
+        Intake::Accepted(body) => {
+            let request_id = body.request_id.clone();
+            Handled {
+                changed: true,
+                reply: wire::response(&opened.document, &body)
+                    .ok()
+                    .map(|document| Reply { persona, document }),
+                notice: Some(Notice::RequestAccepted {
+                    request_id,
+                    applicant: sender.to_string(),
+                    community,
+                }),
+            }
+        }
+        Intake::Refused(code) => {
+            info!(%sender, %code, "vetting request refused");
+            Handled {
+                changed: throttled,
+                reply: wire::refusal(&opened.document, code, None)
+                    .ok()
+                    .map(|document| Reply { persona, document }),
+                notice: None,
+            }
+        }
+        Intake::Silent => {
+            debug!(%sender, "vetting request without a matching ticket — no answer");
+            Handled {
+                changed: throttled,
+                ..Handled::default()
+            }
+        }
+    }
+}
+
+async fn accepted(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    message: &Message,
+    sender: &str,
+) -> Handled {
+    let Some(opened) = opened::<VettingRequestAcceptedBody>(message, sender, ctx.resolver).await
+    else {
+        return Handled::default();
+    };
+    let Some(thread) = opened.document.thread_id.as_deref() else {
+        return Handled::default();
+    };
+    let Some(application) = book.applications.iter_mut().find(|a| a.sent(thread)) else {
+        warn!(%sender, "vetting acceptance for no request of ours");
+        return Handled::default();
+    };
+    match application.on_accepted(thread, sender, opened.payload, ctx.now) {
+        Ok(()) => Handled {
+            changed: true,
+            notice: Some(Notice::VetterAccepted {
+                application_id: application.id.clone(),
+                vetter: sender.to_string(),
+            }),
+            ..Handled::default()
+        },
+        Err(e) => {
+            warn!(%sender, error = %e, "vetting acceptance not applied");
+            Handled::default()
+        }
+    }
+}
+
+async fn session(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    message: &Message,
+    sender: &str,
+) -> Handled {
+    let Some((persona, _)) = ctx.recipient else {
+        return Handled::default();
+    };
+    let Some(opened) = opened::<VettingSessionBody>(message, sender, ctx.resolver).await else {
+        return Handled::default();
+    };
+    let Some(application) = book.application_mut(&opened.payload.domain, persona) else {
+        warn!(%sender, "vetting session for a community we are not applying to");
+        return Handled::default();
+    };
+    match application.on_session(&opened.document.id, sender, opened.payload, ctx.now) {
+        Ok(session) => Handled {
+            changed: true,
+            notice: Some(Notice::SessionOpened {
+                application_id: application.id.clone(),
+                session_id: session.id,
+                vetter: sender.to_string(),
+                match_code: session.match_code,
+            }),
+            ..Handled::default()
+        },
+        Err(e) => {
+            warn!(%sender, error = %e, "vetting session not opened");
+            Handled::default()
+        }
+    }
+}
+
+async fn card(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    message: &Message,
+    sender: &str,
+) -> Handled {
+    let Some((_, our_did)) = ctx.recipient else {
+        return Handled::default();
+    };
+    let Some(opened) = opened::<VettingSessionResponseBody>(message, sender, ctx.resolver).await
+    else {
+        return Handled::default();
+    };
+    let Some(session_id) = opened.document.thread_id.clone() else {
+        return Handled::default();
+    };
+    match book
+        .receive_card(
+            our_did,
+            sender,
+            &session_id,
+            opened.payload,
+            ctx.resolver,
+            ctx.now,
+        )
+        .await
+    {
+        Ok(entry) => Handled {
+            changed: true,
+            notice: Some(Notice::CardReceived {
+                request_id: entry.request_id.clone(),
+                applicant: sender.to_string(),
+            }),
+            ..Handled::default()
+        },
+        Err(e) => {
+            warn!(%sender, error = %e, "vetting card refused");
+            Handled::default()
+        }
+    }
+}
+
+async fn declined(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    message: &Message,
+    sender: &str,
+) -> Handled {
+    let Some(opened) = opened::<VettingDeclineBody>(message, sender, ctx.resolver).await else {
+        return Handled::default();
+    };
+    for application in &mut book.applications {
+        if application
+            .on_decline(sender, opened.payload.clone(), ctx.now)
+            .is_ok()
+        {
+            return Handled {
+                changed: true,
+                notice: Some(Notice::Declined {
+                    application_id: application.id.clone(),
+                    vetter: sender.to_string(),
+                }),
+                ..Handled::default()
+            };
+        }
+    }
+    warn!(%sender, "vetting decline for no request of ours");
+    Handled::default()
+}
+
+async fn statement(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    message: &Message,
+    sender: &str,
+) -> Option<Handled> {
+    let credential = wire::delivered_statement(&message.body)?;
+    let Some((persona, _)) = ctx.recipient else {
+        return Some(Handled::default());
+    };
+    for application in book
+        .applications
+        .iter_mut()
+        .filter(|a| a.persona == persona && a.requests.iter().any(|r| r.vetter == sender))
+    {
+        match application
+            .on_statement(sender, credential, ctx.resolver, ctx.now)
+            .await
+        {
+            Ok(held) => {
+                return Some(Handled {
+                    changed: true,
+                    notice: Some(Notice::StatementReceived {
+                        application_id: application.id.clone(),
+                        statement_id: held.id,
+                        vetter: sender.to_string(),
+                    }),
+                    ..Handled::default()
+                });
+            }
+            Err(e) => warn!(%sender, error = %e, "vetting statement refused"),
+        }
+    }
+    Some(Handled::default())
+}
+
+fn refused(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    message: &Message,
+    sender: &str,
+) -> Option<Handled> {
+    let thread = message
+        .thid
+        .as_deref()
+        .or_else(|| message.body.get("threadId").and_then(Value::as_str))?;
+    let code = message
+        .body
+        .pointer("/payload/code")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let detail = message
+        .body
+        .pointer("/payload/message")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+
+    if let Some(application) = book.applications.iter_mut().find(|a| a.sent(thread)) {
+        return Some(
+            match application.on_refused(thread, sender, code.clone(), detail, ctx.now) {
+                Ok(()) => Handled {
+                    changed: true,
+                    notice: Some(Notice::VetterRefused {
+                        application_id: application.id.clone(),
+                        vetter: sender.to_string(),
+                        code,
+                    }),
+                    ..Handled::default()
+                },
+                Err(e) => {
+                    warn!(%sender, error = %e, "vetting refusal not applied");
+                    Handled::default()
+                }
+            },
+        );
+    }
+    let statement_id = book
+        .issued
+        .iter()
+        .find(|s| {
+            s.community == sender
+                && s.withdrawal
+                    .as_ref()
+                    .is_some_and(|w| w.document_id == thread)
+        })?
+        .id
+        .clone();
+    warn!(community = %sender, %code, "vetting statement withdrawal refused");
+    Some(Handled {
+        notice: Some(Notice::WithdrawalRefused { statement_id, code }),
+        ..Handled::default()
+    })
+}
+
+fn withdrawal_recorded(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
+    let Some((Some(thread), body)) = community_reply::<RevokeStatementResponseBody>(message) else {
+        return Handled::default();
+    };
+    match book.on_withdrawal_recorded(sender, &thread, body.recorded_at) {
+        Some(issued) => Handled {
+            changed: true,
+            notice: Some(Notice::WithdrawalRecorded {
+                statement_id: issued.id.clone(),
+            }),
+            ..Handled::default()
+        },
+        None => Handled::default(),
+    }
+}
+
+fn manifest(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
+    let Some((_, body)) = community_reply::<JoinRequestManifestResponseBody>(message) else {
+        return Handled::default();
+    };
+    let mut handled = Handled {
+        changed: book.learn_manifest(sender, &body, chrono::Utc::now()),
+        ..Handled::default()
+    };
+    for application in book
+        .applications
+        .iter_mut()
+        .filter(|a| a.community == sender)
+    {
+        match application.adopt_manifest(&body) {
+            Ok(true) => {
+                handled.changed = true;
+                handled.notice = Some(Notice::RequirementsUpdated {
+                    application_id: application.id.clone(),
+                    community: sender.to_string(),
+                });
+            }
+            Ok(false) => {}
+            Err(e) => warn!(community = %sender, error = %e, "community manifest not adopted"),
+        }
+    }
+    handled
+}

--- a/openvtc-core/src/vetting/mod.rs
+++ b/openvtc-core/src/vetting/mod.rs
@@ -1,0 +1,38 @@
+//! Peer identity vetting — the client half of `docs/design/vetting-process.md`.
+//!
+//! Someone who wants to join a community is vetted by members the community
+//! trusts to do it. The applicant shows each vetter a signed card of who they
+//! say they are; the vetter checks it against the person and their documents
+//! and signs a statement; the applicant presents the statements with their join
+//! request, and the community's policy decides.
+//!
+//! This is the Linux kernel's web of trust with the keyring taken out: no
+//! public graph of who vouched for whom, no signing parties, and a community
+//! policy — not a path length through strangers' keys — deciding what is enough.
+//!
+//! - [`book`] — everything persisted, in `ProtectedConfig::vetting`.
+//! - [`tickets`] — how a vetter lets someone ask them, and how everyone else is
+//!   ignored (design §8).
+//! - [`applicant`] — one application per community and persona: requests out,
+//!   sessions and statements in, and the advisory checklist.
+//! - [`vetter`] — the vetter desk: requests in, sessions out, the card check,
+//!   the statement, declines and withdrawals.
+//! - [`wire`] — the Trust Task documents and DIDComm messages on the peer path.
+//! - [`inbound`] — routing an inbound message to the right side.
+//!
+//! Every artifact's shape, signature and verification is vta-sdk's
+//! (`protocols::vetting`, and `vetting` behind the feature of that name). This
+//! module owns state and sequencing only; it never re-implements a check the
+//! SDK makes.
+
+pub mod applicant;
+pub mod book;
+pub mod inbound;
+pub mod tickets;
+pub mod vetter;
+pub mod wire;
+
+#[cfg(test)]
+mod tests;
+
+pub use book::VettingBook;

--- a/openvtc-core/src/vetting/tests.rs
+++ b/openvtc-core/src/vetting/tests.rs
@@ -1,0 +1,469 @@
+//! The whole exchange between an applicant and a vetter, message by message,
+//! through the same [`super::inbound::handle`] the TUI's dispatch calls.
+//!
+//! Each party keeps its own book and account; the only thing that passes
+//! between them is a DIDComm `Message`, built and signed the way the client
+//! sends it. Nothing here touches a network: every DID is a `did:key`.
+
+use affinidi_tdk::didcomm::Message;
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+use chrono::Utc;
+use serde_json::{Value, json};
+use trust_tasks_rs::TrustTask;
+use uuid::Uuid;
+use vta_sdk::protocols::join_requests::{
+    JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, JoinRequestManifestResponseBody, ManifestCriterion,
+};
+use vta_sdk::protocols::vetting::{
+    CardClaim, DeclaredRelationship, DeclineCode, IDENTITY_VETTING_ENDORSEMENT_TYPE,
+    RevocationReason, TicketPresentation, VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_INVALID_TICKET,
+    VETTING_REQUEST_ERR_NOT_ELIGIBLE, VETTING_REQUEST_TYPE, VETTING_SESSION_TYPE, VettingMethod,
+    VettingRequirements, VettingSessionResponseBody,
+};
+use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+use vta_sdk::vetting::card::sign_card;
+use vta_sdk::vetting::statement::sign_statement;
+
+use super::VettingBook;
+use super::applicant::{RequestDraft, RequestState};
+use super::inbound::{Context, Handled, Notice, handle};
+use super::tickets::{DEFAULT_VALIDITY, Ticket};
+use super::vetter::{Attestation, DeskState};
+use super::wire::{
+    self,
+    tests::{did, secret},
+};
+use crate::config::account::{Account, CommunityRecord, PersonaId};
+
+const COMMUNITY: &str = "did:web:vtc.example";
+
+struct Party {
+    secret: Secret,
+    did: String,
+    persona: PersonaId,
+    book: VettingBook,
+    account: Account,
+}
+
+impl Party {
+    fn new(seed: u8) -> Self {
+        let secret = secret(seed);
+        Self {
+            did: did(&secret),
+            secret,
+            persona: PersonaId::new(),
+            book: VettingBook::default(),
+            account: Account::default(),
+        }
+    }
+
+    fn member_of(mut self, community: &str) -> Self {
+        let mut record = CommunityRecord::new_pending(
+            community.to_string(),
+            None,
+            "openvtc/test".to_string(),
+            self.persona,
+            Uuid::new_v4(),
+            Utc::now(),
+        );
+        record.activate(Utc::now());
+        self.account.add_membership(record);
+        self
+    }
+
+    async fn receive(&mut self, message: &Message, sender: &str) -> Handled {
+        let resolver = TrustTaskVmResolver::did_key_only();
+        let ctx = Context {
+            account: &self.account,
+            resolver: &resolver,
+            recipient: Some((self.persona, &self.did)),
+            now: Utc::now(),
+        };
+        handle(&mut self.book, &ctx, message, sender)
+            .await
+            .expect("a vetting message is claimed")
+    }
+
+    fn application(&mut self) -> &mut super::applicant::Application {
+        self.book
+            .application_mut(COMMUNITY, self.persona)
+            .expect("application started")
+    }
+}
+
+async fn signed(mut document: TrustTask<Value>, signer: &Secret) -> Message {
+    wire::sign(&mut document, signer).await.unwrap();
+    wire::to_message(&document).unwrap()
+}
+
+fn requirements() -> VettingRequirements {
+    serde_json::from_value(json!({
+        "version": "0.1",
+        "statementType": IDENTITY_VETTING_ENDORSEMENT_TYPE,
+        "minStatements": 1,
+        "minByMethod": { "inPerson": 1 },
+        "acceptedMethods": ["inPerson", "video"],
+        "requiredClaims": ["name.legal"],
+        "eligibleVetters": { "role": "vetter" }
+    }))
+    .unwrap()
+}
+
+/// The community's manifest 0.2 reply, as its dispatcher sends it.
+fn manifest_reply() -> Message {
+    let body = JoinRequestManifestResponseBody {
+        community_did: COMMUNITY.into(),
+        criteria: vec![ManifestCriterion {
+            id: "vetted".into(),
+            description: None,
+            presentation_definition: json!({}),
+            vetting: Some(requirements()),
+            requirements_digest: Some("zRequirementsDigest".into()),
+        }],
+    };
+    Message::build(
+        wire::new_id(),
+        JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE.to_string(),
+        json!({ "type": JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, "payload": body }),
+    )
+    .from(COMMUNITY.to_string())
+    .thid(wire::new_id())
+    .finalize()
+}
+
+/// An applicant with requirements in hand, and a vetter with a ticket for them.
+async fn ready() -> (Party, Party, TicketPresentation) {
+    let mut applicant = Party::new(1);
+    let mut vetter = Party::new(2).member_of(COMMUNITY);
+    let now = Utc::now();
+    applicant
+        .book
+        .start_application(COMMUNITY, applicant.persona, &applicant.did, now)
+        .unwrap();
+    let handled = applicant.receive(&manifest_reply(), COMMUNITY).await;
+    assert!(matches!(
+        handled.notice,
+        Some(Notice::RequirementsUpdated { .. })
+    ));
+    let ticket = Ticket::issue(COMMUNITY, vetter.persona, vec![], 1, DEFAULT_VALIDITY, now);
+    let presented = ticket.code_presentation();
+    vetter.book.tickets.push(ticket);
+    (applicant, vetter, presented)
+}
+
+async fn request(applicant: &mut Party, vetter: &Party, ticket: TicketPresentation) -> Message {
+    let id = wire::new_id();
+    let vetter_did = vetter.did.clone();
+    let body = applicant
+        .application()
+        .prepare_request(
+            &id,
+            &vetter_did,
+            ticket,
+            RequestDraft::default(),
+            Utc::now(),
+        )
+        .unwrap();
+    let doc = wire::document(VETTING_REQUEST_TYPE, &applicant.did, &vetter.did, id, &body).unwrap();
+    signed(doc, &applicant.secret).await
+}
+
+/// Request, accept and open a session. Returns the vetter's request id and the
+/// session document.
+async fn in_session(applicant: &mut Party, vetter: &mut Party) -> (String, TrustTask<Value>) {
+    let ticket = vetter.book.tickets[0].code_presentation();
+    let message = request(applicant, vetter, ticket).await;
+    let handled = vetter.receive(&message, &applicant.did).await;
+    let Some(Notice::RequestAccepted { request_id, .. }) = handled.notice.clone() else {
+        panic!("the request is accepted");
+    };
+    let reply = handled.reply.expect("an accepted request is answered");
+    let message = signed(reply.document, &vetter.secret).await;
+    let handled = applicant.receive(&message, &vetter.did).await;
+    assert!(matches!(
+        handled.notice,
+        Some(Notice::VetterAccepted { .. })
+    ));
+
+    let session_id = wire::new_id();
+    let body = vetter
+        .book
+        .open_session(
+            &request_id,
+            VettingMethod::InPerson,
+            vec!["name.legal".into()],
+            vec![],
+            &session_id,
+            Utc::now(),
+        )
+        .unwrap();
+    let doc = wire::document(
+        VETTING_SESSION_TYPE,
+        &vetter.did,
+        &applicant.did,
+        session_id,
+        &body,
+    )
+    .unwrap();
+    (request_id, doc)
+}
+
+#[tokio::test]
+async fn an_applicant_is_vetted_end_to_end() {
+    let (mut applicant, mut vetter, _) = ready().await;
+    let resolver = TrustTaskVmResolver::did_key_only();
+    let (request_id, session_doc) = in_session(&mut applicant, &mut vetter).await;
+
+    // The session reaches the applicant; both screens show the same code.
+    let message = signed(session_doc.clone(), &vetter.secret).await;
+    let handled = applicant.receive(&message, &vetter.did).await;
+    let Some(Notice::SessionOpened {
+        session_id,
+        match_code,
+        ..
+    }) = handled.notice.clone()
+    else {
+        panic!("the session opens");
+    };
+    assert_eq!(
+        Some(match_code.as_str()),
+        vetter.book.desk_entry(&request_id).unwrap().match_code()
+    );
+    assert!(
+        handled.notice.unwrap().task().is_some(),
+        "the applicant must act"
+    );
+
+    // The applicant signs a card and sends it back.
+    let draft = applicant
+        .application()
+        .card_draft(
+            &session_id,
+            vec![CardClaim {
+                claim_type: "name.legal".into(),
+                value: json!("Alice Example"),
+                provenance: "selfAsserted".into(),
+            }],
+            Utc::now(),
+        )
+        .unwrap();
+    let card = sign_card(draft, &applicant.secret).await.unwrap();
+    applicant
+        .application()
+        .record_card(&session_id, &card, &resolver, Utc::now())
+        .await
+        .unwrap();
+    let doc = wire::response(
+        &session_doc,
+        &VettingSessionResponseBody { card, ext: None },
+    )
+    .unwrap();
+    let message = signed(doc, &applicant.secret).await;
+    let handled = vetter.receive(&message, &applicant.did).await;
+    assert!(matches!(handled.notice, Some(Notice::CardReceived { .. })));
+
+    // The vetter checks the person and attests.
+    let draft = vetter
+        .book
+        .statement_draft(
+            &request_id,
+            &vetter.did,
+            Attestation {
+                method: VettingMethod::InPerson,
+                document_classes: vec!["passport".into()],
+                claims_verified: vec!["name.legal".into()],
+                liveness_confirmed: true,
+                declared_relationship: DeclaredRelationship::None,
+                attestation_text_digest: None,
+            },
+            Utc::now(),
+        )
+        .unwrap();
+    let statement = sign_statement(draft, &vetter.secret).await.unwrap();
+    let issued = vetter
+        .book
+        .record_statement(&request_id, &statement, &resolver, Utc::now())
+        .await
+        .unwrap();
+    assert!(matches!(
+        vetter.book.desk_entry(&request_id).unwrap().state,
+        DeskState::Attested { .. }
+    ));
+
+    // The statement reaches the applicant, who now meets the requirements.
+    let message =
+        wire::credential_delivery(&vetter.did, &applicant.did, &statement, &session_id).unwrap();
+    let handled = applicant.receive(&message, &vetter.did).await;
+    assert!(matches!(
+        handled.notice,
+        Some(Notice::StatementReceived { .. })
+    ));
+    let application = applicant.application();
+    assert!(application.checklist(Utc::now()).unwrap().satisfied());
+    assert_eq!(application.presentable_statements(Utc::now()).len(), 1);
+    assert_eq!(
+        application.join_extensions()["requirementsDigest"],
+        "zRequirementsDigest"
+    );
+
+    // Later, the vetter withdraws it.
+    let notice_id = wire::new_id();
+    let (body, _) = vetter
+        .book
+        .withdrawal(
+            &issued.id,
+            Some(RevocationReason::Mistake),
+            &notice_id,
+            Utc::now(),
+        )
+        .unwrap();
+    assert_eq!(body.statement_digest_multibase, issued.digest_multibase);
+    assert!(
+        vetter
+            .book
+            .on_withdrawal_recorded(COMMUNITY, &notice_id, Utc::now())
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn without_a_ticket_there_is_no_answer_at_all() {
+    let (mut applicant, mut vetter, _) = ready().await;
+    let message = request(
+        &mut applicant,
+        &vetter,
+        TicketPresentation::Code {
+            code: "0000-0000".into(),
+        },
+    )
+    .await;
+    let handled = vetter.receive(&message, &applicant.did).await;
+    assert!(handled.reply.is_none() && handled.notice.is_none());
+    assert!(vetter.book.desk.is_empty());
+}
+
+#[tokio::test]
+async fn a_bad_scanned_ticket_is_refused_and_the_applicant_hears_why() {
+    let (mut applicant, mut vetter, _) = ready().await;
+    let ticket_id = vetter.book.tickets[0].id.clone();
+    let message = request(
+        &mut applicant,
+        &vetter,
+        TicketPresentation::Scanned {
+            ticket_id,
+            secret: "A".repeat(43),
+        },
+    )
+    .await;
+    let handled = vetter.receive(&message, &applicant.did).await;
+    let reply = handled.reply.expect("a scanned ticket is answered");
+    assert_eq!(
+        reply.document.payload["code"],
+        VETTING_REQUEST_ERR_INVALID_TICKET
+    );
+    let message = signed(reply.document, &vetter.secret).await;
+    let handled = applicant.receive(&message, &vetter.did).await;
+    assert!(matches!(handled.notice, Some(Notice::VetterRefused { .. })));
+    assert!(matches!(
+        applicant.application().requests[0].state,
+        RequestState::Refused { .. }
+    ));
+}
+
+#[tokio::test]
+async fn someone_who_is_not_a_member_cannot_vet() {
+    let (mut applicant, _, _) = ready().await;
+    let mut outsider = Party::new(3);
+    let ticket = Ticket::issue(
+        COMMUNITY,
+        outsider.persona,
+        vec![],
+        1,
+        DEFAULT_VALIDITY,
+        Utc::now(),
+    );
+    let presented = ticket.code_presentation();
+    outsider.book.tickets.push(ticket);
+    let message = request(&mut applicant, &outsider, presented).await;
+    let handled = outsider.receive(&message, &applicant.did).await;
+    assert_eq!(
+        handled.reply.unwrap().document.payload["code"],
+        VETTING_REQUEST_ERR_NOT_ELIGIBLE
+    );
+}
+
+#[tokio::test]
+async fn a_vetter_can_decline_without_a_reason() {
+    let (mut applicant, mut vetter, _) = ready().await;
+    let (request_id, _) = in_session(&mut applicant, &mut vetter).await;
+    let body = vetter
+        .book
+        .decline(
+            &request_id,
+            Some(DeclineCode::NotComfortable),
+            None,
+            Utc::now(),
+        )
+        .unwrap();
+    let doc = wire::document(
+        VETTING_DECLINE_TYPE,
+        &vetter.did,
+        &applicant.did,
+        wire::new_id(),
+        &body,
+    )
+    .unwrap();
+    let message = signed(doc, &vetter.secret).await;
+    let handled = applicant.receive(&message, &vetter.did).await;
+    assert!(matches!(handled.notice, Some(Notice::Declined { .. })));
+    assert!(applicant.application().checklist(Utc::now()).is_some());
+}
+
+#[tokio::test]
+async fn a_membership_credential_is_left_for_the_join_handler() {
+    let mut applicant = Party::new(1);
+    let vmc = json!({ "credential_response": { "credential": {
+        "type": ["VerifiableCredential", "MembershipCredential"],
+        "issuer": COMMUNITY
+    } } });
+    let message = Message::build(
+        wire::new_id(),
+        vta_sdk::protocols::credential_exchange::ISSUE.to_string(),
+        vmc,
+    )
+    .from(COMMUNITY.to_string())
+    .finalize();
+    let resolver = TrustTaskVmResolver::did_key_only();
+    let ctx = Context {
+        account: &applicant.account,
+        resolver: &resolver,
+        recipient: Some((applicant.persona, &applicant.did)),
+        now: Utc::now(),
+    };
+    assert!(
+        handle(&mut applicant.book, &ctx, &message, COMMUNITY)
+            .await
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn a_vetter_asks_for_the_claims_the_community_requires() {
+    let mut vetter = Party::new(2).member_of(COMMUNITY);
+    assert_eq!(
+        vetter.book.required_claims_for(COMMUNITY, None),
+        (vec!["name.legal".to_string()], false),
+        "without the manifest, the fallback — and it says so"
+    );
+    let handled = vetter.receive(&manifest_reply(), COMMUNITY).await;
+    assert!(handled.changed, "the criteria are remembered");
+    let (claims, known) = vetter
+        .book
+        .required_claims_for(COMMUNITY, Some("zRequirementsDigest"));
+    assert!(known);
+    assert_eq!(claims, requirements().required_claims);
+    assert!(
+        !vetter.receive(&manifest_reply(), COMMUNITY).await.changed,
+        "the same manifest again changes nothing"
+    );
+}

--- a/openvtc-core/src/vetting/tickets.rs
+++ b/openvtc-core/src/vetting/tickets.rs
@@ -1,0 +1,513 @@
+//! Vetting Tickets: how a vetter lets someone ask them for vetting (design §8).
+//!
+//! A vetter never takes unsolicited requests. They hand a ticket to a person
+//! out of band — read aloud at a conference desk, pasted into a chat, shown as
+//! a QR code — and only a request carrying a live ticket gets any answer.
+//!
+//! A ticket has two forms:
+//!
+//! - the **code**, `XXXX-XXXX` in Crockford base32. Forty bits, short enough to
+//!   say, and therefore guessable in principle. A wrong code is never answered,
+//!   so a guesser cannot even learn that the vetter exists, and wrong codes are
+//!   throttled per sender and overall ([`GuessThrottle`]);
+//! - the **scanned** form, a ticket id and a 32-byte secret. Nobody guesses
+//!   that by accident, so a wrong secret is answered with `invalidTicket` and
+//!   the applicant learns to ask for a fresh one.
+//!
+//! Tickets are client-local in V0. Moving them to the VTA
+//! (`vetting/tickets/*`) is V1.
+
+use base64::{Engine, prelude::BASE64_URL_SAFE_NO_PAD};
+use chrono::{DateTime, Duration, Utc};
+use rand::{RngCore, rngs::OsRng};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use vta_sdk::protocols::vetting::{
+    TicketPresentation, VETTING_REQUEST_ERR_INVALID_TICKET, VettingMethod,
+};
+
+use crate::config::account::PersonaId;
+
+/// Crockford base32: no `I`, `L`, `O` or `U`, so nothing is misheard.
+pub const CROCKFORD: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/// How long a ticket lives unless the vetter says otherwise.
+pub const DEFAULT_VALIDITY: Duration = Duration::days(14);
+
+/// The window wrong codes are counted over.
+pub const GUESS_WINDOW: Duration = Duration::hours(1);
+
+/// Wrong codes one sender may send in [`GUESS_WINDOW`] before every further
+/// code from them is ignored, right or wrong.
+pub const MAX_WRONG_CODES_PER_SENDER: usize = 5;
+
+/// Wrong codes from everyone together in [`GUESS_WINDOW`]. A sender who mints a
+/// fresh DID per guess gets past the per-sender limit; this bounds them too.
+/// Scanned tickets are unaffected, so a real applicant is never locked out.
+pub const MAX_WRONG_CODES: usize = 60;
+
+/// One ticket, as the vetter keeps it.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Ticket {
+    /// `ticketId` in the scanned form.
+    pub id: String,
+    /// `XXXX-XXXX`.
+    pub code: String,
+    /// 32 bytes, base64url.
+    pub secret: String,
+    /// The community the ticket is for.
+    pub community: String,
+    /// The vetter's member persona in that community.
+    pub persona: PersonaId,
+    /// Methods the vetter offers on this ticket; empty means any.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub methods: Vec<VettingMethod>,
+    /// Requests it can still admit. A conference-desk ticket has more than one.
+    pub uses_left: u32,
+    /// When it was made.
+    pub created_at: DateTime<Utc>,
+    /// After this it admits nothing.
+    pub expires_at: DateTime<Utc>,
+    /// The vetter's own note ("LPC desk", "for Alice").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+impl Ticket {
+    /// Mint a ticket. `uses` is at least one.
+    #[must_use]
+    pub fn issue(
+        community: impl Into<String>,
+        persona: PersonaId,
+        methods: Vec<VettingMethod>,
+        uses: u32,
+        validity: Duration,
+        now: DateTime<Utc>,
+    ) -> Ticket {
+        let mut code = [0u8; 5];
+        OsRng.fill_bytes(&mut code);
+        let mut secret = [0u8; 32];
+        OsRng.fill_bytes(&mut secret);
+        Ticket {
+            id: format!("vt-{}", Uuid::new_v4().simple()),
+            code: encode_code(code),
+            secret: BASE64_URL_SAFE_NO_PAD.encode(secret),
+            community: community.into(),
+            persona,
+            methods,
+            uses_left: uses.max(1),
+            created_at: now,
+            expires_at: now + validity,
+            label: None,
+        }
+    }
+
+    /// It can still admit a request.
+    #[must_use]
+    pub fn is_live(&self, now: DateTime<Utc>) -> bool {
+        self.uses_left > 0 && now < self.expires_at
+    }
+
+    /// It offers `method`, or the applicant expressed no preference.
+    #[must_use]
+    pub fn offers(&self, method: Option<VettingMethod>) -> bool {
+        self.methods.is_empty() || method.is_none_or(|m| self.methods.contains(&m))
+    }
+
+    /// The spoken form, as an applicant presents it.
+    #[must_use]
+    pub fn code_presentation(&self) -> TicketPresentation {
+        TicketPresentation::Code {
+            code: self.code.clone(),
+        }
+    }
+
+    /// The scanned form, as an applicant presents it.
+    #[must_use]
+    pub fn scanned_presentation(&self) -> TicketPresentation {
+        TicketPresentation::Scanned {
+            ticket_id: self.id.clone(),
+            secret: self.secret.clone(),
+        }
+    }
+}
+
+/// Forty bits → `XXXX-XXXX`.
+fn encode_code(bytes: [u8; 5]) -> String {
+    let bits = bytes
+        .iter()
+        .fold(0u64, |acc, byte| (acc << 8) | u64::from(*byte));
+    let mut out = String::with_capacity(9);
+    for i in 0..8 {
+        if i == 4 {
+            out.push('-');
+        }
+        out.push(char::from(
+            CROCKFORD[((bits >> (35 - 5 * i)) & 0x1f) as usize],
+        ));
+    }
+    out
+}
+
+/// Read a code the way a person types it: any case, with or without the dash
+/// or spaces, and with the letters Crockford reads as digits (`O` → `0`,
+/// `I`/`L` → `1`). `None` if it cannot be a code at all.
+#[must_use]
+pub fn normalise_code(input: &str) -> Option<String> {
+    let mut chars = String::with_capacity(8);
+    for c in input.chars() {
+        let c = match c.to_ascii_uppercase() {
+            '-' | ' ' => continue,
+            'O' => '0',
+            'I' | 'L' => '1',
+            other => other,
+        };
+        if !c.is_ascii() || !CROCKFORD.contains(&(c as u8)) {
+            return None;
+        }
+        chars.push(c);
+    }
+    (chars.len() == 8).then(|| format!("{}-{}", &chars[..4], &chars[4..]))
+}
+
+/// Equal-length comparison that does not stop at the first difference.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    a.len() == b.len()
+        && a.bytes()
+            .zip(b.bytes())
+            .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+            == 0
+}
+
+/// Recent wrong codes.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct GuessThrottle {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    wrong: Vec<WrongCode>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct WrongCode {
+    sender: String,
+    at: DateTime<Utc>,
+}
+
+impl GuessThrottle {
+    /// Nothing recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.wrong.is_empty()
+    }
+
+    fn prune(&mut self, now: DateTime<Utc>) {
+        self.wrong.retain(|w| now - w.at < GUESS_WINDOW);
+    }
+
+    fn allows(&self, sender: &str) -> bool {
+        self.wrong.len() < MAX_WRONG_CODES
+            && self.wrong.iter().filter(|w| w.sender == sender).count() < MAX_WRONG_CODES_PER_SENDER
+    }
+
+    fn record(&mut self, sender: &str, now: DateTime<Utc>) {
+        self.wrong.push(WrongCode {
+            sender: sender.to_string(),
+            at: now,
+        });
+    }
+}
+
+/// What a presented ticket earns the request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Redemption {
+    /// A live ticket matches. Nothing is consumed yet: the request may still
+    /// be refused for another reason, and a refused request should not cost
+    /// the applicant their ticket. Call [`consume`] once it is accepted.
+    Matched {
+        /// The matching ticket.
+        ticket_id: String,
+    },
+    /// Say nothing at all.
+    Silent,
+    /// Refuse with this `vetting/request` error code.
+    Refused(&'static str),
+}
+
+/// Check a presented ticket against `persona`'s tickets for `community`.
+pub fn check(
+    tickets: &[Ticket],
+    throttle: &mut GuessThrottle,
+    presented: &TicketPresentation,
+    sender: &str,
+    community: &str,
+    persona: PersonaId,
+    now: DateTime<Utc>,
+) -> Redemption {
+    match presented {
+        TicketPresentation::Code { code } => {
+            throttle.prune(now);
+            if !throttle.allows(sender) {
+                return Redemption::Silent;
+            }
+            let found = normalise_code(code).and_then(|code| {
+                tickets.iter().find(|t| {
+                    t.persona == persona
+                        && t.community == community
+                        && t.is_live(now)
+                        && constant_time_eq(&t.code, &code)
+                })
+            });
+            match found {
+                Some(ticket) => Redemption::Matched {
+                    ticket_id: ticket.id.clone(),
+                },
+                None => {
+                    throttle.record(sender, now);
+                    Redemption::Silent
+                }
+            }
+        }
+        TicketPresentation::Scanned { ticket_id, secret } => {
+            match tickets
+                .iter()
+                .find(|t| &t.id == ticket_id && t.persona == persona)
+            {
+                Some(ticket)
+                    if ticket.community == community
+                        && ticket.is_live(now)
+                        && constant_time_eq(&ticket.secret, secret) =>
+                {
+                    Redemption::Matched {
+                        ticket_id: ticket.id.clone(),
+                    }
+                }
+                _ => Redemption::Refused(VETTING_REQUEST_ERR_INVALID_TICKET),
+            }
+        }
+    }
+}
+
+/// Spend one use of the ticket. `false` if it is gone.
+pub fn consume(tickets: &mut [Ticket], ticket_id: &str) -> bool {
+    match tickets
+        .iter_mut()
+        .find(|t| t.id == ticket_id && t.uses_left > 0)
+    {
+        Some(ticket) => {
+            ticket.uses_left -= 1;
+            true
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vta_sdk::protocols::vetting::VettingRequestBody;
+
+    const COMMUNITY: &str = "did:web:vtc.example";
+
+    fn ticket(persona: PersonaId, now: DateTime<Utc>) -> Ticket {
+        Ticket::issue(COMMUNITY, persona, vec![], 1, DEFAULT_VALIDITY, now)
+    }
+
+    #[test]
+    fn both_forms_satisfy_the_request_schema() {
+        let t = ticket(PersonaId::new(), Utc::now());
+        for presented in [t.code_presentation(), t.scanned_presentation()] {
+            let body = VettingRequestBody {
+                community: COMMUNITY.into(),
+                requirements_digest: None,
+                join_did: "did:key:zApplicant".into(),
+                ticket: Some(presented),
+                introduction: None,
+                preferred_method: None,
+                languages: vec![],
+                message: None,
+                availability: None,
+                ext: None,
+            };
+            body.check_shape("did:key:zApplicant").unwrap();
+        }
+    }
+
+    #[test]
+    fn a_code_is_read_the_way_people_type_it() {
+        assert_eq!(normalise_code("k7qf 2m9x").as_deref(), Some("K7QF-2M9X"));
+        assert_eq!(normalise_code("K7QF-2M9X").as_deref(), Some("K7QF-2M9X"));
+        assert_eq!(normalise_code("o1il-0000").as_deref(), Some("0111-0000"));
+        assert_eq!(normalise_code("K7QF-2M9"), None);
+        assert_eq!(normalise_code("K7QF-2M9U"), None, "U is not Crockford");
+    }
+
+    #[test]
+    fn the_right_code_matches_and_is_spent_only_when_consumed() {
+        let persona = PersonaId::new();
+        let now = Utc::now();
+        let mut tickets = vec![ticket(persona, now)];
+        let mut throttle = GuessThrottle::default();
+        let presented = TicketPresentation::Code {
+            code: tickets[0].code.to_lowercase(),
+        };
+        let r = check(
+            &tickets,
+            &mut throttle,
+            &presented,
+            "did:key:zA",
+            COMMUNITY,
+            persona,
+            now,
+        );
+        let Redemption::Matched { ticket_id } = r else {
+            panic!("expected a match, got {r:?}");
+        };
+        assert_eq!(tickets[0].uses_left, 1);
+        assert!(consume(&mut tickets, &ticket_id));
+        assert_eq!(
+            check(
+                &tickets,
+                &mut throttle,
+                &presented,
+                "did:key:zA",
+                COMMUNITY,
+                persona,
+                now
+            ),
+            Redemption::Silent,
+            "a spent ticket admits nothing"
+        );
+    }
+
+    #[test]
+    fn wrong_codes_get_silence_and_then_nothing_at_all() {
+        let persona = PersonaId::new();
+        let now = Utc::now();
+        let tickets = vec![ticket(persona, now)];
+        let mut throttle = GuessThrottle::default();
+        let wrong = TicketPresentation::Code {
+            code: "0000-0000".into(),
+        };
+        for _ in 0..MAX_WRONG_CODES_PER_SENDER {
+            assert_eq!(
+                check(
+                    &tickets,
+                    &mut throttle,
+                    &wrong,
+                    "did:key:zGuesser",
+                    COMMUNITY,
+                    persona,
+                    now
+                ),
+                Redemption::Silent
+            );
+        }
+        // The throttled sender now gets silence even for the right code…
+        let right = tickets[0].code_presentation();
+        assert_eq!(
+            check(
+                &tickets,
+                &mut throttle,
+                &right,
+                "did:key:zGuesser",
+                COMMUNITY,
+                persona,
+                now
+            ),
+            Redemption::Silent
+        );
+        // …while someone else is unaffected, and the window passes.
+        assert!(matches!(
+            check(
+                &tickets,
+                &mut throttle,
+                &right,
+                "did:key:zApplicant",
+                COMMUNITY,
+                persona,
+                now
+            ),
+            Redemption::Matched { .. }
+        ));
+        assert!(matches!(
+            check(
+                &tickets,
+                &mut throttle,
+                &right,
+                "did:key:zGuesser",
+                COMMUNITY,
+                persona,
+                now + GUESS_WINDOW
+            ),
+            Redemption::Matched { .. }
+        ));
+    }
+
+    #[test]
+    fn a_wrong_secret_is_refused_rather_than_ignored() {
+        let persona = PersonaId::new();
+        let now = Utc::now();
+        let tickets = vec![ticket(persona, now)];
+        let mut throttle = GuessThrottle::default();
+        let presented = TicketPresentation::Scanned {
+            ticket_id: tickets[0].id.clone(),
+            secret: "A".repeat(43),
+        };
+        assert_eq!(
+            check(
+                &tickets,
+                &mut throttle,
+                &presented,
+                "did:key:zA",
+                COMMUNITY,
+                persona,
+                now
+            ),
+            Redemption::Refused(VETTING_REQUEST_ERR_INVALID_TICKET)
+        );
+        assert!(throttle.is_empty(), "scanned tickets are not guesses");
+    }
+
+    #[test]
+    fn a_ticket_admits_only_its_own_community_persona_and_window() {
+        let persona = PersonaId::new();
+        let now = Utc::now();
+        let tickets = vec![ticket(persona, now)];
+        let right = tickets[0].scanned_presentation();
+        let mut throttle = GuessThrottle::default();
+        let refused = Redemption::Refused(VETTING_REQUEST_ERR_INVALID_TICKET);
+        let run = |throttle: &mut GuessThrottle, community, persona, at| {
+            check(
+                &tickets,
+                throttle,
+                &right,
+                "did:key:zA",
+                community,
+                persona,
+                at,
+            )
+        };
+        assert_eq!(run(&mut throttle, "did:web:other", persona, now), refused);
+        assert_eq!(
+            run(&mut throttle, COMMUNITY, PersonaId::new(), now),
+            refused
+        );
+        assert_eq!(
+            run(&mut throttle, COMMUNITY, persona, now + DEFAULT_VALIDITY),
+            refused
+        );
+        assert!(matches!(
+            run(&mut throttle, COMMUNITY, persona, now),
+            Redemption::Matched { .. }
+        ));
+    }
+
+    #[test]
+    fn a_ticket_can_restrict_the_method() {
+        let mut t = ticket(PersonaId::new(), Utc::now());
+        assert!(t.offers(Some(VettingMethod::Video)));
+        t.methods = vec![VettingMethod::InPerson];
+        assert!(t.offers(None));
+        assert!(t.offers(Some(VettingMethod::InPerson)));
+        assert!(!t.offers(Some(VettingMethod::Video)));
+    }
+}

--- a/openvtc-core/src/vetting/vetter.rs
+++ b/openvtc-core/src/vetting/vetter.rs
@@ -1,0 +1,706 @@
+//! The vetter desk: requests people make of us as a vetter (design §8–§9).
+//!
+//! ```text
+//! request+ticket ──▶ Accepted ──open session──▶ Session ──card──▶ CardReceived ──attest──▶ Attested
+//!                        │                                            │
+//!                        └──────────────────── decline ───────────────┴──▶ Declined
+//! ```
+//!
+//! A request earns an answer only with a live ticket ([`super::tickets`]).
+//! Accepting is automatic: the ticket was the vetter's consent to be asked,
+//! and an immediate answer tells the applicant their request arrived.
+//! Everything after — opening the session with the person present, the human
+//! check, attesting or declining — is the vetter's decision.
+//!
+//! Signing the statement is attributable and the vetter is accountable for it
+//! within the community, so it is never automatic. In V0 the confirmation is
+//! the client's; VTA step-up is the V1 target (design D19).
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+use vta_sdk::protocols::vetting::{
+    CardClaim, DeclaredRelationship, DeclineCode, IDENTITY_VETTING_ENDORSEMENT_TYPE,
+    IdentityVettingEndorsement, RevocationReason, RevokeStatementBody, ShapeError,
+    VETTING_REQUEST_ERR_CAPACITY, VETTING_REQUEST_ERR_DECLINED,
+    VETTING_REQUEST_ERR_METHOD_UNAVAILABLE, VETTING_REQUEST_ERR_NOT_ELIGIBLE, VettingDeclineBody,
+    VettingMethod, VettingRequestAcceptedBody, VettingRequestBody, VettingSessionBody,
+    VettingSessionResponseBody,
+};
+use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+use vta_sdk::vetting::VettingError;
+use vta_sdk::vetting::card::{CardExpectations, new_commitment_salt, verify_card};
+use vta_sdk::vetting::match_code::vetting_match_code;
+use vta_sdk::vetting::statement::{StatementDraft, verify_statement};
+
+use super::book::{VetterPolicy, VettingBook};
+use super::tickets::{self, Redemption};
+use crate::config::account::PersonaId;
+
+/// Why a desk step was refused.
+#[derive(Debug, thiserror::Error)]
+pub enum VetterError {
+    /// No request with that id.
+    #[error("no such vetting request")]
+    NoSuchRequest,
+    /// The request cannot take this step now.
+    #[error("the request cannot {0} in its current state")]
+    WrongState(&'static str),
+    /// A payload broke its schema.
+    #[error(transparent)]
+    Shape(#[from] ShapeError),
+    /// Building or verifying an artifact failed.
+    #[error(transparent)]
+    Vetting(#[from] VettingError),
+    /// Liveness is required for this method (D10).
+    #[error("confirm the match code with the person before attesting")]
+    LivenessNotConfirmed,
+    /// A document method with nothing recorded.
+    #[error("say which documentation you relied on, or `none`")]
+    NoDocumentation,
+    /// Attesting to a claim the applicant did not show.
+    #[error("the card has no `{0}` claim, so it cannot be marked verified")]
+    ClaimNotOnCard(String),
+    /// A required claim left unverified.
+    #[error("`{0}` is required and has not been verified")]
+    RequiredClaimNotVerified(String),
+    /// No statement of ours with that id.
+    #[error("no statement of ours has that id")]
+    NoSuchStatement,
+    /// The community already recorded the withdrawal.
+    #[error("the community has already recorded this withdrawal")]
+    AlreadyWithdrawn,
+}
+
+/// One request at the desk.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DeskEntry {
+    /// Our handle, sent to the applicant.
+    pub request_id: String,
+    /// The applicant's `vetting/request` document id.
+    pub request_document_id: String,
+    /// The applicant's join DID (and authenticated sender).
+    pub applicant: String,
+    /// The community.
+    pub community: String,
+    /// Our member persona in that community.
+    pub persona: PersonaId,
+    /// The ticket it came in on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ticket_id: Option<String>,
+    /// What they asked.
+    pub request: VettingRequestBody,
+    /// Where it stands.
+    pub state: DeskState,
+    /// When it arrived.
+    pub received_at: DateTime<Utc>,
+    /// When it last moved.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Where a desk request stands.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum DeskState {
+    /// Waiting for the vetter to open a session.
+    Accepted,
+    /// A session is open; waiting for the applicant's card.
+    Session {
+        /// The session.
+        session: DeskSession,
+    },
+    /// The card is in and verified; the human check is next.
+    CardReceived {
+        /// The session.
+        session: DeskSession,
+        /// The card.
+        card: ReceivedCard,
+    },
+    /// We signed a statement.
+    Attested {
+        /// Its id.
+        statement_id: String,
+        /// When.
+        issued_at: DateTime<Utc>,
+        /// The card it attests to, kept for [`VetterPolicy::card_retention_days`].
+        card: ReceivedCard,
+    },
+    /// We declined.
+    Declined {
+        /// The reason code we gave, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<DeclineCode>,
+        /// When.
+        at: DateTime<Utc>,
+        /// The card, if one had arrived.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        card: Option<ReceivedCard>,
+    },
+}
+
+/// A session we opened.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DeskSession {
+    /// The `vetting/session` document id.
+    pub id: String,
+    /// The challenge the card must carry.
+    pub challenge: String,
+    /// The method.
+    pub method: VettingMethod,
+    /// Claim types the card must carry.
+    pub required_claims: Vec<String>,
+    /// Claim types the card may carry.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub optional_claims: Vec<String>,
+    /// When it closes.
+    pub expires_at: DateTime<Utc>,
+    /// The code both people read aloud.
+    pub match_code: String,
+}
+
+/// A verified card. The claims and the card itself are forgotten after
+/// [`VetterPolicy::card_retention_days`]; the digest and commitment remain.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ReceivedCard {
+    /// `digestMultibase` of the card.
+    pub digest_multibase: String,
+    /// The applicant's identity commitment.
+    pub identity_commitment: String,
+    /// What the card showed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub claims: Vec<CardClaim>,
+    /// The signed card, exactly as received.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub card: Option<Value>,
+    /// When it arrived.
+    pub received_at: DateTime<Utc>,
+}
+
+/// A statement we signed.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IssuedStatement {
+    /// The statement id.
+    pub id: String,
+    /// Its `digestMultibase` — what a withdrawal names.
+    pub digest_multibase: String,
+    /// Who it is about.
+    pub applicant: String,
+    /// The community it counts in.
+    pub community: String,
+    /// The persona that signed it.
+    pub persona: PersonaId,
+    /// The method.
+    pub method: VettingMethod,
+    /// When.
+    pub issued_at: DateTime<Utc>,
+    /// Its `validUntil`.
+    pub valid_until: DateTime<Utc>,
+    /// Our withdrawal, once sent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub withdrawal: Option<Withdrawal>,
+}
+
+/// A withdrawal we sent.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Withdrawal {
+    /// The notice's document id — what the community's reply threads on.
+    pub document_id: String,
+    /// The reason we gave, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<RevocationReason>,
+    /// When we sent it.
+    pub sent_at: DateTime<Utc>,
+    /// When the community recorded it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recorded_at: Option<DateTime<Utc>>,
+}
+
+/// An inbound `vetting/request`, already opened and bound to its sender.
+#[derive(Clone, Debug)]
+pub struct IncomingRequest<'a> {
+    /// The request document id.
+    pub document_id: &'a str,
+    /// The authenticated sender.
+    pub sender: &'a str,
+    /// Our persona it was addressed to.
+    pub persona: PersonaId,
+    /// The payload.
+    pub body: VettingRequestBody,
+    /// `persona` is an active member of `body.community`.
+    pub is_member: bool,
+}
+
+/// What an inbound request earns.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Intake {
+    /// Accepted; answer with this `#response`.
+    Accepted(VettingRequestAcceptedBody),
+    /// Refused; answer with a `trust-task-error` carrying this code.
+    Refused(&'static str),
+    /// No answer at all.
+    Silent,
+}
+
+/// What the vetter attests to, from the checklist (design §9.3).
+#[derive(Clone, Debug)]
+pub struct Attestation {
+    /// The method actually used.
+    pub method: VettingMethod,
+    /// What the vetter relied on — their own choice (D16).
+    pub document_classes: Vec<String>,
+    /// Claim types verified; at least the session's required ones.
+    pub claims_verified: Vec<String>,
+    /// The two people read the match code to each other.
+    pub liveness_confirmed: bool,
+    /// The vetter's declared relationship to the applicant.
+    pub declared_relationship: DeclaredRelationship,
+    /// Digest of the attestation text the vetter was shown.
+    pub attestation_text_digest: Option<String>,
+}
+
+impl DeskEntry {
+    /// The open session's match code, if a session is open.
+    #[must_use]
+    pub fn match_code(&self) -> Option<&str> {
+        match &self.state {
+            DeskState::Session { session } | DeskState::CardReceived { session, .. } => {
+                Some(&session.match_code)
+            }
+            _ => None,
+        }
+    }
+
+    /// A session nobody answered closes; the request waits for another.
+    pub(crate) fn expire_session(&mut self, now: DateTime<Utc>) -> bool {
+        if let DeskState::Session { session } = &self.state
+            && session.expires_at <= now
+        {
+            self.state = DeskState::Accepted;
+            self.updated_at = now;
+            return true;
+        }
+        false
+    }
+
+    /// Forget what a card showed once `retention` has passed since the request
+    /// closed; keep only what identifies it.
+    pub(crate) fn forget_card_after(&mut self, retention: Duration, now: DateTime<Utc>) -> bool {
+        let (closed_at, card) = match &mut self.state {
+            DeskState::Attested {
+                issued_at, card, ..
+            } => (*issued_at, Some(card)),
+            DeskState::Declined { at, card, .. } => (*at, card.as_mut()),
+            _ => return false,
+        };
+        match card {
+            Some(card) if now - closed_at >= retention && card.card.is_some() => {
+                card.card = None;
+                card.claims.clear();
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+fn accepted_reply(entry: &DeskEntry, policy: &VetterPolicy) -> VettingRequestAcceptedBody {
+    VettingRequestAcceptedBody {
+        request_id: entry.request_id.clone(),
+        eligibility_vp: None,
+        accepts_documentation: policy.accepts_documentation.clone(),
+        session_hint: None,
+        ext: None,
+    }
+}
+
+impl VettingBook {
+    /// Decide what an inbound request earns, and record it if accepted.
+    ///
+    /// The order of checks is deliberate: nothing that would tell a stranger
+    /// about this vetter — membership, capacity, methods — is answered before
+    /// a ticket has matched.
+    pub fn take_request(&mut self, incoming: IncomingRequest<'_>, now: DateTime<Utc>) -> Intake {
+        let IncomingRequest {
+            document_id,
+            sender,
+            persona,
+            body,
+            is_member,
+        } = incoming;
+        if body.check_shape(sender).is_err() {
+            return Intake::Silent;
+        }
+        if let Some(existing) = self
+            .desk
+            .iter()
+            .find(|e| e.request_document_id == document_id && e.applicant == sender)
+        {
+            return Intake::Accepted(accepted_reply(existing, &self.policy));
+        }
+        let Some(ticket) = body.ticket.as_ref() else {
+            // Introductions are a vetter opt-in that V0 does not offer.
+            return if body.introduction.is_some() {
+                Intake::Refused(VETTING_REQUEST_ERR_DECLINED)
+            } else {
+                Intake::Silent
+            };
+        };
+        let ticket_id = match tickets::check(
+            &self.tickets,
+            &mut self.throttle,
+            ticket,
+            sender,
+            &body.community,
+            persona,
+            now,
+        ) {
+            Redemption::Matched { ticket_id } => ticket_id,
+            Redemption::Silent => return Intake::Silent,
+            Redemption::Refused(code) => return Intake::Refused(code),
+        };
+        if !self
+            .tickets
+            .iter()
+            .find(|t| t.id == ticket_id)
+            .is_some_and(|t| t.offers(body.preferred_method))
+        {
+            return Intake::Refused(VETTING_REQUEST_ERR_METHOD_UNAVAILABLE);
+        }
+        if !is_member {
+            return Intake::Refused(VETTING_REQUEST_ERR_NOT_ELIGIBLE);
+        }
+        if self.open_requests(persona) >= self.policy.max_open_requests {
+            return Intake::Refused(VETTING_REQUEST_ERR_CAPACITY);
+        }
+        tickets::consume(&mut self.tickets, &ticket_id);
+        let entry = DeskEntry {
+            request_id: Uuid::new_v4().to_string(),
+            request_document_id: document_id.to_string(),
+            applicant: sender.to_string(),
+            community: body.community.clone(),
+            persona,
+            ticket_id: Some(ticket_id),
+            request: body,
+            state: DeskState::Accepted,
+            received_at: now,
+            updated_at: now,
+        };
+        let reply = accepted_reply(&entry, &self.policy);
+        self.desk.push(entry);
+        Intake::Accepted(reply)
+    }
+
+    /// Open a session for `request_id` — with the person in front of us or on
+    /// the call. Reopening replaces an earlier session, whose card will no
+    /// longer be accepted.
+    ///
+    /// # Errors
+    ///
+    /// No such request, one already closed, or a malformed session.
+    pub fn open_session(
+        &mut self,
+        request_id: &str,
+        method: VettingMethod,
+        required_claims: Vec<String>,
+        optional_claims: Vec<String>,
+        session_document_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<VettingSessionBody, VetterError> {
+        let length = self.policy.session_length();
+        let entry = self
+            .desk_entry_mut(request_id)
+            .ok_or(VetterError::NoSuchRequest)?;
+        if !entry.state.is_open() {
+            return Err(VetterError::WrongState("open a session"));
+        }
+        let body = VettingSessionBody {
+            request_id: request_id.to_string(),
+            challenge: new_commitment_salt()?,
+            domain: entry.community.clone(),
+            method,
+            required_claims,
+            optional_claims,
+            expires_at: now + length,
+            ext: None,
+        };
+        body.check_shape()?;
+        entry.state = DeskState::Session {
+            session: DeskSession {
+                id: session_document_id.to_string(),
+                challenge: body.challenge.clone(),
+                method,
+                required_claims: body.required_claims.clone(),
+                optional_claims: body.optional_claims.clone(),
+                expires_at: body.expires_at,
+                match_code: vetting_match_code(session_document_id),
+            },
+        };
+        entry.updated_at = now;
+        Ok(body)
+    }
+
+    /// The applicant's card for session `session_id`
+    /// (`vetting/session#response`). Verified against everything the session
+    /// bound it to before the vetter sees it.
+    ///
+    /// # Errors
+    ///
+    /// No open session from this applicant, a closed one, or a card that does
+    /// not verify.
+    pub async fn receive_card(
+        &mut self,
+        vetter_did: &str,
+        applicant: &str,
+        session_id: &str,
+        body: VettingSessionResponseBody,
+        resolver: &TrustTaskVmResolver,
+        now: DateTime<Utc>,
+    ) -> Result<&DeskEntry, VetterError> {
+        let entry = self
+            .desk
+            .iter_mut()
+            .find(|e| {
+                e.applicant == applicant
+                    && matches!(&e.state, DeskState::Session { session } if session.id == session_id)
+            })
+            .ok_or(VetterError::NoSuchRequest)?;
+        let DeskState::Session { session } = &entry.state else {
+            unreachable!("matched a session above");
+        };
+        let session = session.clone();
+        if session.expires_at <= now {
+            return Err(VetterError::WrongState(
+                "take a card after its session closed",
+            ));
+        }
+        let verified = verify_card(
+            &body.card,
+            &CardExpectations {
+                audience: vetter_did,
+                publisher: applicant,
+                community: &entry.community,
+                challenge: &session.challenge,
+                domain: &entry.community,
+                required_claims: &session.required_claims,
+                now,
+            },
+            resolver,
+        )
+        .await?;
+        let card = ReceivedCard {
+            digest_multibase: verified.digest_multibase().to_string(),
+            identity_commitment: verified.card().identity_commitment.clone(),
+            claims: verified.card().claims.clone(),
+            card: Some(body.card),
+            received_at: now,
+        };
+        entry.state = DeskState::CardReceived { session, card };
+        entry.updated_at = now;
+        Ok(entry)
+    }
+
+    /// The statement to sign for `request_id`, from the vetter's checklist.
+    ///
+    /// # Errors
+    ///
+    /// No card yet, a checklist that does not support the statement, or a
+    /// malformed endorsement.
+    pub fn statement_draft(
+        &self,
+        request_id: &str,
+        vetter_did: &str,
+        attestation: Attestation,
+        now: DateTime<Utc>,
+    ) -> Result<StatementDraft, VetterError> {
+        let entry = self
+            .desk_entry(request_id)
+            .ok_or(VetterError::NoSuchRequest)?;
+        let DeskState::CardReceived { session, card } = &entry.state else {
+            return Err(VetterError::WrongState("be attested"));
+        };
+        let documentary = attestation.method != VettingMethod::PriorAcquaintance;
+        if documentary && !attestation.liveness_confirmed {
+            return Err(VetterError::LivenessNotConfirmed);
+        }
+        if documentary && attestation.document_classes.is_empty() {
+            return Err(VetterError::NoDocumentation);
+        }
+        if let Some(missing) = attestation
+            .claims_verified
+            .iter()
+            .find(|t| !card.claims.iter().any(|c| &c.claim_type == *t))
+        {
+            return Err(VetterError::ClaimNotOnCard(missing.clone()));
+        }
+        if let Some(unverified) = session
+            .required_claims
+            .iter()
+            .find(|t| !attestation.claims_verified.contains(t))
+        {
+            return Err(VetterError::RequiredClaimNotVerified(unverified.clone()));
+        }
+        let endorsement = IdentityVettingEndorsement {
+            endorsement_type: IDENTITY_VETTING_ENDORSEMENT_TYPE.into(),
+            community: entry.community.clone(),
+            method: attestation.method,
+            document_classes: attestation.document_classes,
+            claims_verified: attestation.claims_verified,
+            liveness_confirmed: attestation.liveness_confirmed,
+            identity_commitment: card.identity_commitment.clone(),
+            card_digest_multibase: card.digest_multibase.clone(),
+            declared_relationship: attestation.declared_relationship,
+            attestation_text_digest: attestation.attestation_text_digest,
+        };
+        endorsement.check_shape()?;
+        Ok(StatementDraft {
+            id: format!("urn:uuid:{}", Uuid::new_v4()),
+            issuer: vetter_did.to_string(),
+            subject: entry.applicant.clone(),
+            endorsement,
+            valid_from: now,
+            valid_until: now + self.policy.statement_validity(),
+            task_context: session.id.clone(),
+        })
+    }
+
+    /// Record the statement we signed for `request_id`, which closes the
+    /// request. Verified first, so what we keep is what the applicant receives.
+    ///
+    /// # Errors
+    ///
+    /// No card to attest to, or a statement that does not verify.
+    pub async fn record_statement(
+        &mut self,
+        request_id: &str,
+        signed: &Value,
+        resolver: &TrustTaskVmResolver,
+        now: DateTime<Utc>,
+    ) -> Result<IssuedStatement, VetterError> {
+        let verified = verify_statement(signed, now, resolver).await?;
+        let entry = self
+            .desk_entry_mut(request_id)
+            .ok_or(VetterError::NoSuchRequest)?;
+        let DeskState::CardReceived { card, .. } = &entry.state else {
+            return Err(VetterError::WrongState("be attested"));
+        };
+        let issued = IssuedStatement {
+            id: verified.id().to_string(),
+            digest_multibase: verified.digest_multibase().to_string(),
+            applicant: entry.applicant.clone(),
+            community: entry.community.clone(),
+            persona: entry.persona,
+            method: verified.endorsement().method,
+            issued_at: now,
+            valid_until: verified.valid_until(),
+            withdrawal: None,
+        };
+        entry.state = DeskState::Attested {
+            statement_id: issued.id.clone(),
+            issued_at: now,
+            card: card.clone(),
+        };
+        entry.updated_at = now;
+        self.issued.push(issued.clone());
+        Ok(issued)
+    }
+
+    /// Decline `request_id`. A vetter never has to give a reason.
+    ///
+    /// # Errors
+    ///
+    /// No such request, one already closed, or a malformed message.
+    pub fn decline(
+        &mut self,
+        request_id: &str,
+        code: Option<DeclineCode>,
+        message: Option<String>,
+        now: DateTime<Utc>,
+    ) -> Result<VettingDeclineBody, VetterError> {
+        let entry = self
+            .desk_entry_mut(request_id)
+            .ok_or(VetterError::NoSuchRequest)?;
+        if !entry.state.is_open() {
+            return Err(VetterError::WrongState("be declined"));
+        }
+        let body = VettingDeclineBody {
+            request_id: request_id.to_string(),
+            code,
+            message,
+            ext: None,
+        };
+        body.check_shape()?;
+        let card = match &entry.state {
+            DeskState::CardReceived { card, .. } => Some(card.clone()),
+            _ => None,
+        };
+        entry.state = DeskState::Declined {
+            code,
+            at: now,
+            card,
+        };
+        entry.updated_at = now;
+        Ok(body)
+    }
+
+    /// The withdrawal notice for statement `statement_id`, recorded as sent
+    /// under `document_id`. Sending again before the community has recorded it
+    /// is allowed: withdrawal converges.
+    ///
+    /// # Errors
+    ///
+    /// No such statement, or one the community already recorded withdrawn.
+    pub fn withdrawal(
+        &mut self,
+        statement_id: &str,
+        reason: Option<RevocationReason>,
+        document_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(RevokeStatementBody, IssuedStatement), VetterError> {
+        let issued = self
+            .issued
+            .iter_mut()
+            .find(|s| s.id == statement_id)
+            .ok_or(VetterError::NoSuchStatement)?;
+        if issued
+            .withdrawal
+            .as_ref()
+            .is_some_and(|w| w.recorded_at.is_some())
+        {
+            return Err(VetterError::AlreadyWithdrawn);
+        }
+        let body = RevokeStatementBody {
+            statement_id: issued.id.clone(),
+            statement_digest_multibase: issued.digest_multibase.clone(),
+            reason,
+            ext: None,
+        };
+        body.check_shape()?;
+        issued.withdrawal = Some(Withdrawal {
+            document_id: document_id.to_string(),
+            reason,
+            sent_at: now,
+            recorded_at: None,
+        });
+        Ok((body, issued.clone()))
+    }
+
+    /// The community recorded the withdrawal threaded on `document_id`.
+    pub fn on_withdrawal_recorded(
+        &mut self,
+        community: &str,
+        document_id: &str,
+        recorded_at: DateTime<Utc>,
+    ) -> Option<&IssuedStatement> {
+        let issued = self.issued.iter_mut().find(|s| {
+            s.community == community
+                && s.withdrawal
+                    .as_ref()
+                    .is_some_and(|w| w.document_id == document_id)
+        })?;
+        if let Some(w) = issued.withdrawal.as_mut() {
+            w.recorded_at = Some(recorded_at);
+        }
+        Some(issued)
+    }
+}

--- a/openvtc-core/src/vetting/wire.rs
+++ b/openvtc-core/src/vetting/wire.rs
@@ -1,0 +1,369 @@
+//! The peer path: Trust Task documents between applicant and vetter, and
+//! between a vetter and their community (design §5).
+//!
+//! Every vetting task carries a Data Integrity proof by its issuer — the specs
+//! make it REQUIRED — even though DIDComm authcrypt already authenticates the
+//! sender. The proof is what survives the transport: a statement dispute or an
+//! audit reads the document, not the envelope it arrived in. [`open`] therefore
+//! checks both, and that they name the same party.
+//!
+//! The Vetting Statement itself travels as `credential-exchange/issue/0.1`,
+//! the same message a community uses to deliver a membership credential
+//! ([`credential_delivery`]).
+
+use std::str::FromStr;
+
+use affinidi_tdk::didcomm::Message;
+use affinidi_tdk::secrets_resolver::secrets::Secret;
+use chrono::Utc;
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::{Value, json};
+use trust_tasks_rs::{ErrorPayload, TrustTask, TrustTaskCode};
+use uuid::Uuid;
+use vta_sdk::protocols::credential_exchange::ISSUE as CREDENTIAL_ISSUE_TYPE;
+use vta_sdk::trust_task_proof::{TrustTaskVmResolver, verify_trust_task_proof_with};
+
+use crate::errors::OpenVTCError;
+use crate::messaging::{MESSAGE_EXPIRY_SECS, build_didcomm_message, unix_now};
+
+/// Why an inbound vetting document was not accepted.
+#[derive(Debug, thiserror::Error)]
+pub enum WireError {
+    /// Not a Trust Task document, or a payload of the wrong shape.
+    #[error("malformed vetting document: {0}")]
+    Malformed(String),
+    /// The document's `type` differs from the message's.
+    #[error("document type does not match the message type")]
+    TypeMismatch,
+    /// The in-band `issuer` is not the transport-authenticated sender.
+    #[error("document issuer is not the authenticated sender")]
+    IssuerNotSender,
+    /// Missing or failing proof.
+    #[error("document proof did not verify")]
+    Proof(String),
+    /// Signed, but by someone other than the issuer.
+    #[error("document is not signed by its issuer")]
+    WrongSigner,
+}
+
+/// A fresh `urn:uuid:` document id.
+#[must_use]
+pub fn new_id() -> String {
+    format!("urn:uuid:{}", Uuid::new_v4())
+}
+
+fn config_error(what: &str, e: impl std::fmt::Display) -> OpenVTCError {
+    OpenVTCError::Config(format!("{what}: {e}"))
+}
+
+/// A new request document from `issuer` to `recipient`.
+pub fn document<P: Serialize>(
+    type_uri: &str,
+    issuer: &str,
+    recipient: &str,
+    id: String,
+    payload: &P,
+) -> Result<TrustTask<Value>, OpenVTCError> {
+    let type_uri = type_uri
+        .parse()
+        .map_err(|e| config_error("vetting type URI", e))?;
+    let payload = serde_json::to_value(payload).map_err(|e| config_error("vetting payload", e))?;
+    let mut doc = TrustTask::new(id, type_uri, payload);
+    doc.issuer = Some(issuer.to_string());
+    doc.recipient = Some(recipient.to_string());
+    doc.issued_at = Some(Utc::now());
+    Ok(doc)
+}
+
+/// The `#response` to `request`, threaded on it.
+pub fn response<P: Serialize>(
+    request: &TrustTask<Value>,
+    payload: &P,
+) -> Result<TrustTask<Value>, OpenVTCError> {
+    let payload = serde_json::to_value(payload).map_err(|e| config_error("vetting payload", e))?;
+    Ok(request.respond_with(new_id(), payload))
+}
+
+/// The `trust-task-error` refusing `request` with `code`.
+pub fn refusal(
+    request: &TrustTask<Value>,
+    code: &str,
+    message: Option<&str>,
+) -> Result<TrustTask<Value>, OpenVTCError> {
+    let code = TrustTaskCode::from_str(code).map_err(|e| config_error("error code", e))?;
+    let mut payload = ErrorPayload::new(code);
+    if let Some(message) = message {
+        payload = payload.with_message(message);
+    }
+    let error = request.reject_with(new_id(), payload);
+    serde_json::to_value(&error)
+        .and_then(serde_json::from_value)
+        .map_err(|e| config_error("error document", e))
+}
+
+/// Sign `doc` as its issuer.
+pub async fn sign(doc: &mut TrustTask<Value>, signer: &Secret) -> Result<(), OpenVTCError> {
+    crate::capabilities::sign_document(doc, signer).await
+}
+
+/// Wrap `doc` for DIDComm. The message id is the document id, and the thread is
+/// the document's, so a reply correlates the same way on DIDComm and TSP.
+pub fn to_message(doc: &TrustTask<Value>) -> Result<Message, OpenVTCError> {
+    let from = doc
+        .issuer
+        .clone()
+        .ok_or_else(|| OpenVTCError::Config("vetting document has no issuer".into()))?;
+    let to = doc
+        .recipient
+        .clone()
+        .ok_or_else(|| OpenVTCError::Config("vetting document has no recipient".into()))?;
+    let body = serde_json::to_value(doc).map_err(|e| config_error("vetting document", e))?;
+    let now = unix_now();
+    let mut builder = Message::build(doc.id.clone(), doc.type_uri.to_string(), body)
+        .from(from)
+        .to(to)
+        .created_time(now)
+        .expires_time(now + MESSAGE_EXPIRY_SECS);
+    if let Some(thread) = &doc.thread_id {
+        builder = builder.thid(thread.clone());
+    }
+    Ok(builder.finalize())
+}
+
+/// The DIDComm message delivering a signed Vetting Statement to the applicant,
+/// threaded on the session it came out of.
+pub fn credential_delivery(
+    vetter_did: &str,
+    applicant_did: &str,
+    statement: &Value,
+    session_id: &str,
+) -> Result<Message, OpenVTCError> {
+    build_didcomm_message(
+        CREDENTIAL_ISSUE_TYPE,
+        json!({ "credential_response": { "credential": statement } }),
+        vetter_did,
+        applicant_did,
+        Some(session_id),
+    )
+    .map_err(|e| config_error("statement delivery", e))
+}
+
+/// A verified inbound document.
+#[derive(Debug, Clone)]
+pub struct Opened<P> {
+    /// The document as received.
+    pub document: TrustTask<Value>,
+    /// Its payload, parsed.
+    pub payload: P,
+}
+
+/// Read an inbound vetting document: parse it, bind its issuer to the
+/// authenticated `sender`, verify its proof, and parse the payload.
+pub async fn open<P: DeserializeOwned>(
+    message: &Message,
+    sender: &str,
+    resolver: &TrustTaskVmResolver,
+) -> Result<Opened<P>, WireError> {
+    let document: TrustTask<Value> = serde_json::from_value(message.body.clone())
+        .map_err(|e| WireError::Malformed(e.to_string()))?;
+    if document.type_uri.to_string() != message.typ {
+        return Err(WireError::TypeMismatch);
+    }
+    if document.issuer.as_deref() != Some(sender) {
+        return Err(WireError::IssuerNotSender);
+    }
+    let signer = verify_trust_task_proof_with(&document, resolver)
+        .await
+        .map_err(|e| WireError::Proof(e.cause().unwrap_or("no detail").to_string()))?;
+    if signer != sender {
+        return Err(WireError::WrongSigner);
+    }
+    let payload = serde_json::from_value(document.payload.clone())
+        .map_err(|e| WireError::Malformed(e.to_string()))?;
+    Ok(Opened { document, payload })
+}
+
+/// The `join-requests/manifest/0.2` request an applicant sends a community to
+/// learn what it requires. The payload is empty.
+pub fn manifest_request(
+    applicant_did: &str,
+    community_did: &str,
+) -> Result<TrustTask<Value>, OpenVTCError> {
+    document(
+        vta_sdk::protocols::join_requests::JOIN_REQUEST_MANIFEST_0_2_TYPE,
+        applicant_did,
+        community_did,
+        new_id(),
+        &json!({}),
+    )
+}
+
+/// Sign `document` with `persona`'s key and send it over DIDComm to its
+/// recipient. Returns the document id — what a reply threads on.
+///
+/// `Ok` means handed to the transport, not delivered (R1.1): every step that
+/// waits on the other party is driven by their reply, never by this.
+pub async fn sign_and_send(
+    config: &crate::config::Config,
+    tdk: &affinidi_tdk::TDK,
+    service: &crate::didcomm::Messaging,
+    persona: crate::config::account::PersonaId,
+    mut document: TrustTask<Value>,
+) -> Result<String, OpenVTCError> {
+    let keys = config.get_persona_keys_for(persona, tdk).await?;
+    sign(&mut document, &keys.signing.secret).await?;
+    let message = to_message(&document)?;
+    let (from, to) = (
+        document.issuer.as_deref().unwrap_or_default(),
+        document.recipient.as_deref().unwrap_or_default(),
+    );
+    crate::didcomm::send_message(service, config, &message, from, to)
+        .await
+        .map_err(|e| config_error("send vetting document", e))?;
+    Ok(document.id)
+}
+
+/// Deliver a signed statement to the applicant.
+pub async fn send_statement(
+    config: &crate::config::Config,
+    service: &crate::didcomm::Messaging,
+    vetter_did: &str,
+    applicant_did: &str,
+    statement: &Value,
+    session_id: &str,
+) -> Result<(), OpenVTCError> {
+    let message = credential_delivery(vetter_did, applicant_did, statement, session_id)?;
+    crate::didcomm::send_message(service, config, &message, vetter_did, applicant_did)
+        .await
+        .map_err(|e| config_error("send vetting statement", e))
+}
+
+/// The statement a `credential-exchange/issue` message carries, if it is an
+/// identity-vetting statement rather than a community-issued credential.
+#[must_use]
+pub fn delivered_statement(body: &Value) -> Option<&Value> {
+    let credential = body.pointer("/credential_response/credential")?;
+    (credential
+        .pointer("/credentialSubject/endorsement/type")
+        .and_then(Value::as_str)
+        == Some(vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE))
+    .then_some(credential)
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use vta_sdk::protocols::vetting::{
+        VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_CAPACITY, VETTING_REQUEST_TYPE,
+        VettingDeclineBody,
+    };
+
+    /// A `did:key` Ed25519 secret from a fixed seed, `id` = `<did>#<multibase>`.
+    pub(crate) fn secret(seed_byte: u8) -> Secret {
+        let mut secret = Secret::generate_ed25519(None, Some(&[seed_byte; 32]));
+        let public = secret.get_public_keymultibase().unwrap();
+        secret.id = format!("did:key:{public}#{public}");
+        secret
+    }
+
+    pub(crate) fn did(secret: &Secret) -> String {
+        secret.id.split('#').next().unwrap().to_string()
+    }
+
+    fn decline() -> VettingDeclineBody {
+        VettingDeclineBody {
+            request_id: "r1".into(),
+            code: None,
+            message: None,
+            ext: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_signed_document_opens_for_its_sender_only() {
+        let (vetter, applicant, other) = (secret(1), secret(2), secret(3));
+        let mut doc = document(
+            VETTING_DECLINE_TYPE,
+            &did(&vetter),
+            &did(&applicant),
+            new_id(),
+            &decline(),
+        )
+        .unwrap();
+        sign(&mut doc, &vetter).await.unwrap();
+        let message = to_message(&doc).unwrap();
+        assert_eq!(message.id, doc.id);
+
+        let resolver = TrustTaskVmResolver::did_key_only();
+        let opened: Opened<VettingDeclineBody> =
+            open(&message, &did(&vetter), &resolver).await.unwrap();
+        assert_eq!(opened.payload.request_id, "r1");
+
+        assert!(matches!(
+            open::<VettingDeclineBody>(&message, &did(&other), &resolver).await,
+            Err(WireError::IssuerNotSender)
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_unsigned_document_does_not_open() {
+        let (vetter, applicant) = (secret(1), secret(2));
+        let doc = document(
+            VETTING_DECLINE_TYPE,
+            &did(&vetter),
+            &did(&applicant),
+            new_id(),
+            &decline(),
+        )
+        .unwrap();
+        let message = to_message(&doc).unwrap();
+        assert!(matches!(
+            open::<VettingDeclineBody>(
+                &message,
+                &did(&vetter),
+                &TrustTaskVmResolver::did_key_only()
+            )
+            .await,
+            Err(WireError::Proof(_))
+        ));
+    }
+
+    #[test]
+    fn responses_and_refusals_thread_on_the_request() {
+        let request = document(
+            VETTING_REQUEST_TYPE,
+            "did:key:zApplicant",
+            "did:key:zVetter",
+            new_id(),
+            &json!({}),
+        )
+        .unwrap();
+        let reply = response(&request, &json!({ "requestId": "r1" })).unwrap();
+        assert_eq!(reply.thread_id.as_deref(), Some(request.id.as_str()));
+        assert_eq!(reply.issuer.as_deref(), Some("did:key:zVetter"));
+        assert!(reply.type_uri.to_string().ends_with("#response"));
+
+        let refused = refusal(&request, VETTING_REQUEST_ERR_CAPACITY, None).unwrap();
+        assert_eq!(refused.thread_id.as_deref(), Some(request.id.as_str()));
+        assert_eq!(refused.payload["code"], VETTING_REQUEST_ERR_CAPACITY);
+        assert!(
+            crate::messaging::is_trust_task_error_type(&refused.type_uri.to_string()),
+            "the inbound router must recognise it"
+        );
+    }
+
+    #[test]
+    fn only_identity_vetting_statements_are_picked_out_of_an_issue() {
+        let statement = json!({
+            "credentialSubject": { "endorsement": {
+                "type": vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE
+            } }
+        });
+        let body = json!({ "credential_response": { "credential": statement } });
+        assert!(delivered_statement(&body).is_some());
+        let vmc = json!({ "credential_response": { "credential": {
+            "type": ["VerifiableCredential", "MembershipCredential"]
+        } } });
+        assert!(delivered_statement(&vmc).is_none());
+    }
+}

--- a/openvtc-core/tests/message_types.rs
+++ b/openvtc-core/tests/message_types.rs
@@ -34,14 +34,6 @@ const ALL_TYPES: &[(&str, &str)] = &[
         "VRCRequestRejected",
     ),
     ("https://firstperson.network/vrc/1.0/issued", "VRCIssued"),
-    (
-        "https://kernel.org/maintainers/1.0/list",
-        "MaintainersListRequest",
-    ),
-    (
-        "https://kernel.org/maintainers/1.0/list/response",
-        "MaintainersListResponse",
-    ),
 ];
 
 #[test]

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -1276,11 +1276,31 @@ async fn run_join_sequence(
     // subject, prove the subject authorized this presenter (signed with the
     // subject persona's key). On the join-as-subject path (#1a) this is `None`.
     let linkage = build_linkage_proof(config, admin_vta, state, &applicant_did).await;
-    let vp = openvtc_core::join::build_join_vp(
+    let mut vp = openvtc_core::join::build_join_vp(
         &applicant_did,
         state.invitation_credential.as_ref(),
         linkage.as_ref(),
     );
+    // Peer identity vetting: present the statements gathered for this community
+    // under this persona, and name the requirements they were gathered against
+    // so the community applies the same criterion (vetting-process.md §10.1).
+    let presentation = match config.private.vetting.application(&vtc_did, persona_id) {
+        Some(application) if application.join_did == applicant_did => {
+            let statements = application.presentable_statements(chrono::Utc::now());
+            if !statements.is_empty() {
+                state.join.info(format!(
+                    "Presenting {} vetting statement(s) to the community…",
+                    statements.len()
+                ));
+            }
+            openvtc_core::join::attach_credentials(&mut vp, statements);
+            openvtc_core::join::JoinPresentation {
+                vp,
+                extensions: application.join_extensions(),
+            }
+        }
+        _ => vp.into(),
+    };
     // Settle the wire. TSP needs **both** legs, which is the workspace rule that
     // the protocol is the highest-preference one present in *both* parties'
     // documents — and here it is not a formality. A TSP send posts the raw CESR
@@ -1341,7 +1361,7 @@ async fn run_join_sequence(
         &applicant_did,
         &vtc_did,
         &persona_mediator,
-        vp,
+        presentation,
         vtc_tsp_mediator.as_deref(),
     )
     .await

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -213,6 +213,57 @@ pub async fn process_inbound_message(
         return Ok(false);
     }
 
+    // Peer identity vetting (docs/design/vetting-process.md): requests,
+    // sessions, cards, statements, declines and refusals between members, and a
+    // community's vetting requirements. Tried before the join and credential
+    // routes below because it shares two of their types; `handle` returns
+    // `None` for anything that is not vetting's, which falls through unchanged.
+    if openvtc_core::vetting::inbound::may_claim(&message.typ) {
+        let resolver =
+            vta_sdk::trust_task_proof::TrustTaskVmResolver::new(tdk.did_resolver().clone());
+        let ctx = openvtc_core::vetting::inbound::Context {
+            account: &config.account,
+            resolver: &resolver,
+            recipient: recipient_persona.map(|p| (p, recipient_did.as_str())),
+            now: chrono::Utc::now(),
+        };
+        if let Some(handled) = openvtc_core::vetting::inbound::handle(
+            &mut config.private.vetting,
+            &ctx,
+            message,
+            &from_did,
+        )
+        .await
+        {
+            if let Some(reply) = handled.reply
+                && let Err(e) = openvtc_core::vetting::wire::sign_and_send(
+                    config,
+                    tdk,
+                    service,
+                    reply.persona,
+                    reply.document,
+                )
+                .await
+            {
+                warn!(to = %from_did, error = %e, "could not send vetting reply");
+            }
+            let noticed = handled.notice.is_some();
+            if let Some(notice) = handled.notice {
+                config
+                    .public
+                    .logs
+                    .insert(LogFamily::Community, notice.describe());
+                if let Some((id, task)) = notice.task() {
+                    config
+                        .private
+                        .tasks
+                        .new_task_for(&Arc::new(id), task, recipient_persona);
+                }
+            }
+            return Ok(handled.changed || noticed);
+        }
+    }
+
     // Trust Task envelope replies (governance/capability/*): parse the body
     // document, classify it, and hand it to the state loop keyed by the
     // document's `threadId` (== our request id). Foreign trust tasks riding


### PR DESCRIPTION
Stacked on #293.

This PR makes the client able to vet and be vetted over the wire (`docs/design/vetting-process.md`). It adds `openvtc-core::vetting`, which keeps the state and the order of each step for both sides of the exchange, and wires it into inbound dispatch and the join request. The screens for driving it come in the next PR in this stack. With this PR alone, the protocol runs end to end in tests, and a real client already answers and records every message type.

## What's in `openvtc-core::vetting`

| Module | What it does |
|---|---|
| `book` | `VettingBook`, persisted as `ProtectedConfig::vetting`. It is protected because it names people. When empty it is skipped, so a config that has never vetted round-trips byte-identically. |
| `tickets` | The anti-spam gate (§8). Ticket codes are `XXXX-XXXX` in Crockford base32, typed however a person types them, with a scanned form that adds a 32-byte secret. A wrong code gets **no answer at all**. Wrong codes are throttled per sender (5 an hour) and overall (60 an hour), and scanned tickets are exempt from both, so a real applicant is never locked out. A use is spent only once a request is accepted. |
| `applicant` | One application per community and persona. It starts from the manifest 0.2 requirements, sends requests, opens sessions with the match code, builds the card draft from an identity entered once (so every card commits to the same identity), verifies statements against the card we sent, and runs the advisory checklist. It also supplies the join `extensions`. |
| `vetter` | The desk. It takes a request (ticket first, so a stranger learns nothing about membership, capacity or methods), opens a session, verifies the card, builds the statement draft from the checklist, and records, declines and withdraws. Every check the design names is here: liveness except for `priorAcquaintance`, documentation named, required claims verified, and only claims the card actually carried. |
| `wire` | Trust Task documents on the peer path. Each is signed by its issuer, and `open` requires the in-band issuer, the authenticated sender and the proof signer to be the same party. It also builds refusals, the statement delivery over `credential-exchange/issue`, the manifest request, and `sign_and_send`. |
| `inbound` | Routes an inbound message to the right side. It claims only what is vetting's, including the two shared types: a membership credential still reaches the join handler, and a `trust-task-error` is claimed only when it is threaded on one of our requests. It returns an unsigned reply, a notice for the log, and an inbox task for the three steps that need a person. |

All shapes, signatures and checks come from vta-sdk's `vetting` feature (VTI #1425). Nothing here re-implements them.

## Wiring

- **Dispatch:** `process_inbound_message` tries vetting before the join and credential routes, and signs and sends any reply as the addressed persona.
- **Routing:** the catch-all now admits `trusttasks.org/spec/vetting/*` and `spec/trust-task-error/*`. Without those, both were dropped before dispatch. A test pins the new arms.
- **Join:** the join request presents the statements held for that community and persona, and names the `requirementsDigest` they were gathered against in `extensions` (§10.1). `submit_join_request` now takes `impl Into<JoinPresentation>`, so a plain VP still works.
- **Vetters use the community's claims:** vetters record the criteria from any manifest they read. A session asks for the community's `requiredClaims` rather than a guess, because two vetters asking for different claims would produce different identity commitments.
- **Inbox:** three new task types (`VettingRequestInbound`, `VettingSessionInbound`, `VettingCardReceived`).
- **Kernel stubs removed:** the `kernel.org/maintainers` stubs are gone, as §14.1 asks. They were a message pair with no handler.

## Dependencies

- vta-sdk gains its `vetting` feature.
- The VTI `[patch]` entries now point at the top of the vetting stack (`feat/vtc-vetting-revocation`) instead of `main`, because that is the only place the feature exists until the stack merges. The Cargo.toml note says to point them back at `main` then, and to drop them with the release.

## Tests

- **`vetting::tests` runs the whole exchange, message by message,** through the same `inbound::handle` the TUI calls. Each party has its own book and account, all DIDs are `did:key`, and nothing touches the network. The steps:
  - manifest → requirements;
  - ticket → request → accepted;
  - session → the same match code on both sides;
  - card → verified at the vetter;
  - attest → statement received and bound to the card;
  - checklist satisfied → join extensions;
  - withdrawal recorded.
- **The refusal paths:**
  - no ticket gets silence;
  - a bad scanned ticket is refused, and the applicant sees why;
  - a non-member cannot vet;
  - a decline;
  - a membership credential is left for the join handler;
  - a vetter uses the community's required claims once it has read the manifest.
- **Unit tests** cover tickets (normalisation, throttle, spending, scoping), the wire (proof and sender binding, response and refusal threading), the book (empty round-trip, unknown members preserved) and the join VP (statements beside the invitation, the digest in `extensions`).
- **Local runs:** `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`. Results are in the PR checks.

## Not in this PR

- **The TUI:** Vetting menu, applicant and vetter screens, and ticket issuing come in the next PR.
- **Card claims are typed, not read from a persona face.** The identity is entered once per application; reading it from a face is a follow-up.
- **`decisionSla`** has not yet replaced the fixed 7-day pending expiry.
- **The eligibility VP** in the acceptance is not sent in V0. The community checks eligibility regardless.
