### PR TITLE
feat(tui): the Vetting page for applicants and vetters

### DIFF
--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -566,9 +566,16 @@ impl CommunityRecord {
     /// with a `requested_at` at least the timeout old. Returns `true` if it
     /// transitioned to `Expired`.
     pub fn expire_if_stale(&mut self, now: DateTime<Utc>) -> bool {
+        self.expire_if_stale_after(now, TimeDelta::days(PENDING_TIMEOUT_DAYS))
+    }
+
+    /// [`Self::expire_if_stale`] with the timeout given — a community's
+    /// published `decisionSla` for a vetted join, which may be longer or shorter
+    /// than the client default.
+    pub fn expire_if_stale_after(&mut self, now: DateTime<Utc>, timeout: TimeDelta) -> bool {
         if matches!(self.status, CommunityStatus::Pending { .. })
             && let Some(requested) = self.requested_at
-            && now - requested >= TimeDelta::days(PENDING_TIMEOUT_DAYS)
+            && now - requested >= timeout
         {
             self.status = CommunityStatus::Expired;
             self.acknowledged = false;
@@ -891,9 +898,21 @@ impl Account {
     /// transitioned to `Expired` so the caller can persist and raise the
     /// actions-required indicator (R-S-2).
     pub fn expire_stale_pending(&mut self, now: DateTime<Utc>) -> Vec<(VtcDid, PersonaId)> {
+        self.expire_stale_pending_with(now, |_| TimeDelta::days(PENDING_TIMEOUT_DAYS))
+    }
+
+    /// [`Self::expire_stale_pending`] with a timeout chosen per membership, so a
+    /// community that publishes a `decisionSla` is waited on for that long
+    /// rather than the fixed client default (vetting-process.md §14.1).
+    pub fn expire_stale_pending_with(
+        &mut self,
+        now: DateTime<Utc>,
+        timeout_for: impl Fn(&CommunityRecord) -> TimeDelta,
+    ) -> Vec<(VtcDid, PersonaId)> {
         let mut expired = Vec::new();
         for community in self.memberships_mut() {
-            if community.expire_if_stale(now) {
+            let timeout = timeout_for(community);
+            if community.expire_if_stale_after(now, timeout) {
                 expired.push((community.vtc_did.clone(), community.persona_ref));
             }
         }
@@ -1667,6 +1686,36 @@ mod tests {
         let removed = acct.delete_membership("left", pid).unwrap();
         assert_eq!(removed.vtc_did, "left");
         assert!(acct.membership("left", pid).is_none());
+    }
+
+    #[test]
+    fn a_published_decision_sla_replaces_the_client_timeout() {
+        let now = Utc::now();
+        let mut acct = Account::default();
+        let mut record = CommunityRecord::new_pending(
+            "did:webvh:vetted".into(),
+            None,
+            "top/vetted".into(),
+            PersonaId::new(),
+            Uuid::new_v4(),
+            now,
+        );
+        // Older than the 7-day default, younger than a 30-day SLA.
+        record.requested_at = Some(now - TimeDelta::days(PENDING_TIMEOUT_DAYS + 3));
+        acct.add_membership(record);
+
+        let expired = acct.expire_stale_pending_with(now, |c| {
+            if c.vtc_did == "did:webvh:vetted" {
+                TimeDelta::days(30)
+            } else {
+                TimeDelta::days(PENDING_TIMEOUT_DAYS)
+            }
+        });
+        assert!(expired.is_empty(), "the community said it may take 30 days");
+        assert!(
+            !acct.expire_stale_pending(now).is_empty(),
+            "the default would have expired it"
+        );
     }
 
     #[test]

--- a/openvtc-core/src/vetting/book.rs
+++ b/openvtc-core/src/vetting/book.rs
@@ -207,6 +207,26 @@ impl VettingBook {
         }
     }
 
+    /// How long `community` says it takes to decide a join (`decisionSla`),
+    /// from our application as `persona` or else what we know of its criteria.
+    /// `None` when it has not said, or said something unparseable.
+    #[must_use]
+    pub fn decision_sla(&self, community: &str, persona: PersonaId) -> Option<Duration> {
+        let from_application = self
+            .application(community, persona)
+            .and_then(|a| a.requirements.as_ref())
+            .and_then(|r| r.decision_sla.as_deref());
+        let from_criteria = || {
+            self.criteria
+                .iter()
+                .filter(|k| k.community == community)
+                .find_map(|k| k.requirements.decision_sla.as_deref())
+        };
+        from_application
+            .or_else(from_criteria)
+            .and_then(vta_sdk::protocols::vetting::parse_iso8601_duration)
+    }
+
     /// Our application to `community` as `persona`.
     #[must_use]
     pub fn application(&self, community: &str, persona: PersonaId) -> Option<&Application> {

--- a/openvtc-core/src/vetting/tests.rs
+++ b/openvtc-core/src/vetting/tests.rs
@@ -467,3 +467,40 @@ async fn a_vetter_asks_for_the_claims_the_community_requires() {
         "the same manifest again changes nothing"
     );
 }
+
+#[tokio::test]
+async fn the_communitys_decision_sla_is_known_once_its_manifest_is() {
+    let (applicant, _, _) = ready().await;
+    let persona = applicant.persona;
+    assert_eq!(applicant.book.decision_sla(COMMUNITY, persona), None);
+
+    let mut with_sla = Party::new(4);
+    with_sla
+        .book
+        .start_application(COMMUNITY, with_sla.persona, &with_sla.did, Utc::now())
+        .unwrap();
+    let mut requirements = requirements();
+    requirements.decision_sla = Some("P21D".into());
+    let body = JoinRequestManifestResponseBody {
+        community_did: COMMUNITY.into(),
+        criteria: vec![ManifestCriterion {
+            id: "vetted".into(),
+            description: None,
+            presentation_definition: json!({}),
+            vetting: Some(requirements),
+            requirements_digest: Some("zOther".into()),
+        }],
+    };
+    let reply = Message::build(
+        wire::new_id(),
+        JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE.to_string(),
+        json!({ "type": JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, "payload": body }),
+    )
+    .from(COMMUNITY.to_string())
+    .finalize();
+    with_sla.receive(&reply, COMMUNITY).await;
+    assert_eq!(
+        with_sla.book.decision_sla(COMMUNITY, with_sla.persona),
+        chrono::Duration::try_days(21)
+    );
+}

--- a/openvtc-core/src/vetting/wire.rs
+++ b/openvtc-core/src/vetting/wire.rs
@@ -46,6 +46,10 @@ pub enum WireError {
     WrongSigner,
 }
 
+/// A Trust Task document on the peer path. Named here so callers need not
+/// depend on `trust-tasks-rs` to hold one.
+pub type Document = TrustTask<Value>;
+
 /// A fresh `urn:uuid:` document id.
 #[must_use]
 pub fn new_id() -> String {

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -278,6 +278,46 @@ pub enum PersonaAction {
     FormCancel,
 }
 
+/// Vetting-page actions (`docs/design/vetting-process.md` §12).
+///
+/// Forms are driven generically — the focused field takes text, cycles through
+/// choices, or ticks — so the page needs no variant per field.
+pub enum VettingAction {
+    /// Show the next tab.
+    SwitchTab,
+    /// Move the selection.
+    Select(usize),
+    /// Leave the open form.
+    Back,
+    /// Replace the focused text field's value.
+    Input(String),
+    /// Focus the next field.
+    NextField,
+    /// Focus the previous field.
+    PrevField,
+    /// Cycle the focused choice (`true` = forwards).
+    Cycle(bool),
+    /// Tick or untick the focused field.
+    Toggle,
+    /// Commit the open form.
+    Submit,
+    /// Show a status line (e.g. a clipboard result).
+    Status(String),
+    // ── Applicant ────────────────────────────────────────────────────────
+    StartApplication,
+    EditIdentity,
+    RequestVetter,
+    RefreshRequirements,
+    ReviewCard,
+    // ── Vetter ───────────────────────────────────────────────────────────
+    NewTicket,
+    DeleteTicket,
+    OpenSession,
+    StartAttest,
+    ArmDecline,
+    ArmWithdraw,
+}
+
 // ============================================================================
 // Top-level Action enum
 // ============================================================================
@@ -308,6 +348,8 @@ pub enum Action {
     Settings(SettingsAction),
     /// Identity pane (personas / pool / profiles / bindings).
     Persona(PersonaAction),
+    /// Vetting page (applications / desk / tickets / issued statements).
+    Vetting(VettingAction),
 
     /// Dismiss the startup loading screen (Enter, once loading has completed) and
     /// reveal the main page. Phase-2 connections are already running in the

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -109,6 +109,9 @@ pub(crate) enum DispatchDomain {
     /// the VIC list, `i` to flip the filter — and an inline await made the
     /// focus change itself wait on the round-trip, which read as a frozen key.
     Vic,
+    /// A vetting send: a request, session, card, statement, decline,
+    /// withdrawal or requirements fetch. One at a time, like every peer send.
+    Vetting,
 }
 
 impl DispatchDomain {
@@ -129,6 +132,7 @@ impl DispatchDomain {
             DispatchDomain::PersonaBinding => "Persona binding refresh",
             DispatchDomain::PersonaManage => "Identity request",
             DispatchDomain::Vic => "Invitation credential refresh",
+            DispatchDomain::Vetting => "Vetting send",
         }
     }
 }
@@ -249,6 +253,8 @@ pub(crate) enum DispatchOutcome {
     /// otherwise leave its domain busy forever) and a generic failure status is
     /// surfaced. Carries the domain to release + label.
     Panicked(DispatchDomain),
+    /// A vetting send finished (or failed, and was undone).
+    Vetting(crate::state_handler::vetting_actions::VettingOutcome),
 }
 
 impl DispatchOutcome {
@@ -273,6 +279,7 @@ impl DispatchOutcome {
             DispatchOutcome::PersonaManage(_) => DispatchDomain::PersonaManage,
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::VicMutation(_) => DispatchDomain::Vic,
+            DispatchOutcome::Vetting(_) => DispatchDomain::Vetting,
             DispatchOutcome::Panicked(domain) => *domain,
         }
     }
@@ -404,6 +411,7 @@ pub(crate) fn apply_outcome(
             }
         },
         DispatchOutcome::Relationship(outcome) => outcome.apply(state, config, save),
+        DispatchOutcome::Vetting(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Inbox(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Did(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::AgentName(results) => {

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use dtg_credentials::DTGCredential;
+use openvtc_core::config::account::PersonaId;
+use vta_sdk::protocols::vetting::{DeclaredRelationship, RevocationReason, VettingMethod};
 
 /// Lazily-rendered raw credential JSON for credential detail views.
 ///
@@ -72,6 +74,8 @@ pub struct ContentPanelState {
     /// The holder's own identity: personas, pool, profiles, and what each persona
     /// presents where.
     pub identity: IdentityState,
+    /// Peer identity vetting: our applications, and our desk as a vetter.
+    pub vetting: VettingState,
 }
 
 // ****************************************************************************
@@ -1269,6 +1273,323 @@ pub struct ActiveDid {
     pub agent_name: Option<String>,
     /// Human-readable label
     pub label: String,
+}
+
+// ****************************************************************************
+// Vetting State
+// ****************************************************************************
+
+/// Vetting methods, in the order the page cycles through them.
+pub const VETTING_METHODS: [VettingMethod; 3] = [
+    VettingMethod::InPerson,
+    VettingMethod::Video,
+    VettingMethod::PriorAcquaintance,
+];
+
+/// Declared relationships, in the order the page cycles through them.
+pub const VETTING_RELATIONSHIPS: [DeclaredRelationship; 5] = [
+    DeclaredRelationship::None,
+    DeclaredRelationship::CommunityColleague,
+    DeclaredRelationship::SameEmployer,
+    DeclaredRelationship::Family,
+    DeclaredRelationship::OtherPersonal,
+];
+
+/// Reasons a vetter may give for withdrawing a statement.
+pub const VETTING_WITHDRAWAL_REASONS: [RevocationReason; 4] = [
+    RevocationReason::Mistake,
+    RevocationReason::NewInformation,
+    RevocationReason::KeyCompromise,
+    RevocationReason::Other,
+];
+
+/// How many requests a new ticket admits: one person, or a conference desk.
+pub const VETTING_TICKET_USES: [u32; 4] = [1, 5, 10, 25];
+
+/// How a method reads on the page.
+#[must_use]
+pub fn method_label(method: VettingMethod) -> &'static str {
+    match method {
+        VettingMethod::InPerson => "in person",
+        VettingMethod::Video => "video call",
+        VettingMethod::PriorAcquaintance => "prior acquaintance",
+        _ => "other",
+    }
+}
+
+/// How a declared relationship reads on the page.
+#[must_use]
+pub fn relationship_label(relationship: DeclaredRelationship) -> &'static str {
+    match relationship {
+        DeclaredRelationship::None => "no prior relationship",
+        DeclaredRelationship::CommunityColleague => "we work together in the community",
+        DeclaredRelationship::SameEmployer => "same employer",
+        DeclaredRelationship::Family => "family",
+        DeclaredRelationship::OtherPersonal => "another personal relationship",
+        _ => "other",
+    }
+}
+
+/// How a withdrawal reason reads on the page.
+#[must_use]
+pub fn reason_label(reason: RevocationReason) -> &'static str {
+    match reason {
+        RevocationReason::Mistake => "I made a mistake",
+        RevocationReason::NewInformation => "I learned something new",
+        RevocationReason::KeyCompromise => "my signing key was compromised",
+        _ => "another reason",
+    }
+}
+
+/// Which list the Vetting page shows.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum VettingTab {
+    /// Our applications to be vetted.
+    #[default]
+    Applications,
+    /// Requests people have made of us as a vetter.
+    Desk,
+    /// Tickets we have handed out.
+    Tickets,
+    /// Statements we have signed.
+    Issued,
+}
+
+impl VettingTab {
+    /// The tab after this one.
+    #[must_use]
+    pub fn next(self) -> Self {
+        match self {
+            VettingTab::Applications => VettingTab::Desk,
+            VettingTab::Desk => VettingTab::Tickets,
+            VettingTab::Tickets => VettingTab::Issued,
+            VettingTab::Issued => VettingTab::Applications,
+        }
+    }
+}
+
+/// State for the Vetting page, rebuilt from the book on every config change.
+#[derive(Clone, Debug, Default)]
+pub struct VettingState {
+    pub tab: VettingTab,
+    pub selected: usize,
+    pub mode: VettingMode,
+    pub status_message: Option<String>,
+    pub applications: Arc<[ApplicationRow]>,
+    pub desk: Arc<[DeskRow]>,
+    pub tickets: Arc<[TicketRow]>,
+    pub issued: Arc<[IssuedRow]>,
+    /// Personas an application can join with.
+    pub personas: Arc<[VettingPersona]>,
+    /// Communities we are an active member of, and so can vet for.
+    pub memberships: Arc<[VettingMembership]>,
+    /// The documentation this vetter accepts, then `none`.
+    pub documentation: Arc<[String]>,
+    /// Communities a vetter has already asked for requirements this run, so a
+    /// second attempt to open a session proceeds instead of asking again.
+    pub requirements_requested: Vec<String>,
+}
+
+impl VettingState {
+    /// Rows in the active tab.
+    #[must_use]
+    pub fn tab_len(&self) -> usize {
+        match self.tab {
+            VettingTab::Applications => self.applications.len(),
+            VettingTab::Desk => self.desk.len(),
+            VettingTab::Tickets => self.tickets.len(),
+            VettingTab::Issued => self.issued.len(),
+        }
+    }
+}
+
+/// What the Vetting page is doing.
+#[derive(Clone, Debug, Default)]
+pub enum VettingMode {
+    /// Browsing the active tab.
+    #[default]
+    List,
+    /// Start an application: which community, as which persona.
+    NewApplication {
+        community: String,
+        persona_index: usize,
+        field: usize,
+    },
+    /// The identity every vetter is shown, one value per claim type.
+    EditIdentity {
+        application_id: String,
+        claims: Vec<(String, String)>,
+        field: usize,
+    },
+    /// Ask a vetter, with the ticket code they gave us.
+    RequestVetter {
+        application_id: String,
+        vetter: String,
+        code: String,
+        field: usize,
+    },
+    /// Read the match code with the vetter, then send the card.
+    SendCard {
+        application_id: String,
+        session_id: String,
+    },
+    /// Hand out a ticket for one of our memberships.
+    NewTicket {
+        membership_index: usize,
+        uses_index: usize,
+        field: usize,
+    },
+    /// Open a session with the person in front of us.
+    OpenSession {
+        request_id: String,
+        method_index: usize,
+    },
+    /// The human check, and the statement.
+    Attest {
+        request_id: String,
+        form: AttestForm,
+    },
+    /// Confirm declining a request.
+    ConfirmDecline { request_id: String },
+    /// Withdraw a statement we signed.
+    Withdraw {
+        statement_id: String,
+        reason_index: usize,
+    },
+}
+
+impl VettingMode {
+    /// The value of the focused field, when that field takes text.
+    #[must_use]
+    pub fn focused_text(&self) -> Option<&str> {
+        match self {
+            VettingMode::NewApplication {
+                community,
+                field: 0,
+                ..
+            } => Some(community),
+            VettingMode::EditIdentity { claims, field, .. } => {
+                claims.get(*field).map(|(_, value)| value.as_str())
+            }
+            VettingMode::RequestVetter {
+                vetter, field: 0, ..
+            } => Some(vetter),
+            VettingMode::RequestVetter { code, field: 1, .. } => Some(code),
+            _ => None,
+        }
+    }
+}
+
+/// The vetter's checklist (design §9.3).
+#[derive(Clone, Debug, Default)]
+pub struct AttestForm {
+    pub field: usize,
+    pub method_index: usize,
+    pub documentation_index: usize,
+    pub relationship_index: usize,
+    /// We read the match code to each other.
+    pub liveness_confirmed: bool,
+    /// The vetter has read the attestation and stands behind it.
+    pub attested: bool,
+}
+
+impl AttestForm {
+    /// Method, documentation, relationship, match code, attestation.
+    pub const FIELDS: usize = 5;
+}
+
+/// One application, for display.
+#[derive(Clone, Debug)]
+pub struct ApplicationRow {
+    pub id: String,
+    pub community: String,
+    pub community_name: Option<String>,
+    pub join_did: String,
+    /// What the community requires, in a line; `None` until its manifest arrives.
+    pub requirements: Option<String>,
+    /// Progress against those requirements.
+    pub progress: Option<String>,
+    pub satisfied: bool,
+    /// Claim type and the value we show vetters (empty when not set).
+    pub identity: Vec<(String, String)>,
+    pub requests: Vec<RequestRow>,
+    pub statements: usize,
+}
+
+/// One request to a vetter, for display.
+#[derive(Clone, Debug)]
+pub struct RequestRow {
+    pub vetter: String,
+    pub vetter_name: Option<String>,
+    pub state: String,
+    pub match_code: Option<String>,
+    /// The open session still waiting for our card.
+    pub card_session: Option<String>,
+}
+
+/// Where a desk request is, for choosing what the keys do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeskStage {
+    Accepted,
+    Session,
+    Card,
+    Closed,
+}
+
+/// One request at our desk, for display.
+#[derive(Clone, Debug)]
+pub struct DeskRow {
+    pub request_id: String,
+    pub applicant: String,
+    pub applicant_name: Option<String>,
+    pub community: String,
+    pub state: String,
+    pub stage: DeskStage,
+    pub method: Option<String>,
+    pub match_code: Option<String>,
+    /// What their card showed, while we still hold it.
+    pub claims: Vec<(String, String)>,
+    pub required_claims: Vec<String>,
+    pub message: Option<String>,
+}
+
+/// One ticket, for display.
+#[derive(Clone, Debug)]
+pub struct TicketRow {
+    pub id: String,
+    pub code: String,
+    pub community: String,
+    pub uses_left: u32,
+    pub expires: String,
+    pub live: bool,
+}
+
+/// One statement we signed, for display.
+#[derive(Clone, Debug)]
+pub struct IssuedRow {
+    pub id: String,
+    pub applicant: String,
+    pub community: String,
+    pub method: String,
+    pub issued: String,
+    pub valid_until: String,
+    pub withdrawal: Option<String>,
+}
+
+/// A persona an application can use.
+#[derive(Clone, Debug)]
+pub struct VettingPersona {
+    pub persona: PersonaId,
+    pub did: String,
+    pub label: String,
+}
+
+/// A community we can vet for.
+#[derive(Clone, Debug)]
+pub struct VettingMembership {
+    pub community: String,
+    pub name: String,
+    pub persona: PersonaId,
 }
 
 // ****************************************************************************

--- a/openvtc/src/state_handler/main_page/menu.rs
+++ b/openvtc/src/state_handler/main_page/menu.rs
@@ -29,6 +29,9 @@ pub enum MainMenu {
     Inbox,
     Relationships,
     Credentials,
+    /// Peer identity vetting: applications to be vetted, and the vetter desk
+    /// (`docs/design/vetting-process.md`).
+    Vetting,
     /// The holder's own identity — personas, the attribute pool behind them, the
     /// profiles over that pool, and what each persona presents in each community.
     ///
@@ -52,6 +55,7 @@ impl Display for MainMenu {
             MainMenu::Inbox => write!(f, "Inbox"),
             MainMenu::Relationships => write!(f, "My Relationships"),
             MainMenu::Credentials => write!(f, "My Credentials"),
+            MainMenu::Vetting => write!(f, "Vetting"),
             MainMenu::Identity => write!(f, "My Identity"),
             MainMenu::Settings => write!(f, "Settings"),
             MainMenu::Vta => write!(f, "VTA Service"),
@@ -70,7 +74,8 @@ impl MainMenu {
             MainMenu::Inbox => MainMenu::Communities,
             MainMenu::Relationships => MainMenu::Inbox,
             MainMenu::Credentials => MainMenu::Relationships,
-            MainMenu::Identity => MainMenu::Credentials,
+            MainMenu::Vetting => MainMenu::Credentials,
+            MainMenu::Identity => MainMenu::Vetting,
             MainMenu::Settings => MainMenu::Identity,
             MainMenu::Vta => MainMenu::Settings,
             MainMenu::Logs => MainMenu::Vta,
@@ -85,7 +90,8 @@ impl MainMenu {
             MainMenu::Communities => MainMenu::Inbox,
             MainMenu::Inbox => MainMenu::Relationships,
             MainMenu::Relationships => MainMenu::Credentials,
-            MainMenu::Credentials => MainMenu::Identity,
+            MainMenu::Credentials => MainMenu::Vetting,
+            MainMenu::Vetting => MainMenu::Identity,
             MainMenu::Identity => MainMenu::Settings,
             MainMenu::Settings => MainMenu::Vta,
             MainMenu::Vta => MainMenu::Logs,

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -168,6 +168,8 @@ impl MainPageState {
         // Update header config
         self.config = MainMenuConfigState::from(config);
 
+        crate::state_handler::vetting_actions::sync(&mut self.content_panel.vetting, config);
+
         // The working community's persona scopes the relationship/inbox/VRC
         // panels (D10 / R-C-6): only items owned by it (plus untagged legacy
         // items in a single-persona account) are shown.

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -261,6 +261,7 @@ mod setup_token_actions;
 mod setup_vta_actions;
 mod setup_wizard;
 pub mod state;
+mod vetting_actions;
 mod vic;
 mod vta_transports;
 
@@ -1568,10 +1569,29 @@ impl StateHandler {
                     }
                 }
                 _ = pending_expiry_tick.tick() => {
-                    // R-B-7: expire Pending joins unanswered for 7 days, raising
+                    // R-B-7: expire Pending joins unanswered for 7 days — or for
+                    // the `decisionSla` a vetting community publishes — raising
                     // actions-required, and tear down each one's now-dead session
                     // (R-S-3). Records are retained read-only (R-S-1).
-                    let expired = config.account.expire_stale_pending(chrono::Utc::now());
+                    let vetting = &config.private.vetting;
+                    let default_timeout = chrono::TimeDelta::days(
+                        openvtc_core::config::account::PENDING_TIMEOUT_DAYS,
+                    );
+                    let timeouts: std::collections::HashMap<_, _> = config
+                        .account
+                        .memberships()
+                        .filter_map(|c| {
+                            vetting
+                                .decision_sla(&c.vtc_did, c.persona_ref)
+                                .map(|sla| ((c.vtc_did.clone(), c.persona_ref), sla))
+                        })
+                        .collect();
+                    let expired = config.account.expire_stale_pending_with(chrono::Utc::now(), |c| {
+                        timeouts
+                            .get(&(c.vtc_did.clone(), c.persona_ref))
+                            .copied()
+                            .unwrap_or(default_timeout)
+                    });
                     if !expired.is_empty() {
                         save.mark_dirty();
                         for (vtc, persona) in &expired {
@@ -1587,7 +1607,7 @@ impl StateHandler {
                         }
                         state.main_page.sync_from_config(&config);
                         state.main_page.log(format!(
-                            "{} pending join{} expired (no response within 7 days).",
+                            "{} pending join{} expired (no decision within the time allowed).",
                             expired.len(),
                             if expired.len() == 1 { "" } else { "s" },
                         ));
@@ -2282,6 +2302,15 @@ impl StateHandler {
                     #[cfg(feature = "openpgp-card")]
                     Action::GetTokens | Action::SetAdminPin(..) | Action::SetTouchPolicy(..) |
                     Action::SetTokenName(..) | Action::FactoryReset(..) | Action::TokenWriteKeys(..) => {}
+
+                    // Vetting sends and receives peer messages as a persona, and
+                    // this loop has neither a persona nor an inbound arm.
+                    Action::Vetting(..) => {
+                        state.main_page.log(
+                            "Vetting needs a persona — create one under My Identity, then \
+                             restart OpenVTC to apply or to vet.",
+                        );
+                    }
 
                     // Genuinely unavailable: these need a live community and the
                     // messaging runtime that comes with it. Inert, but not

--- a/openvtc/src/state_handler/runtime_actions.rs
+++ b/openvtc/src/state_handler/runtime_actions.rs
@@ -1038,6 +1038,7 @@ pub(crate) async fn handle_action(ctx: &mut ActionCtx<'_>, action: Action) -> Ha
                 credential_actions::dispatch(ca, ctx.config, ctx.state, ctx.save);
             }
         }
+        Action::Vetting(va) => vetting_actions::dispatch(ctx, va).await,
         Action::Settings(sa) => {
             match settings_actions::dispatch(
                 sa,

--- a/openvtc/src/state_handler/vetting_actions.rs
+++ b/openvtc/src/state_handler/vetting_actions.rs
@@ -1,0 +1,1569 @@
+//! The Vetting page: applying to be vetted, and vetting others
+//! (`docs/design/vetting-process.md` §12).
+//!
+//! State and sequencing live in `openvtc_core::vetting`. This module maps the
+//! page's actions onto the book, signs what has to be sent on the loop (the
+//! keys are local, so signing is quick), and hands the send itself to a
+//! background job. A send that fails puts the book back the way it was, so the
+//! step can simply be tried again.
+
+use std::sync::Arc;
+
+use affinidi_tdk::didcomm::Message;
+use chrono::Utc;
+use openvtc_core::config::Config;
+use openvtc_core::config::account::PersonaId;
+use openvtc_core::didcomm::Messaging;
+use openvtc_core::vetting::applicant::{RequestDraft, RequestState};
+use openvtc_core::vetting::book::FALLBACK_REQUIRED_CLAIMS;
+use openvtc_core::vetting::tickets::{DEFAULT_VALIDITY, Ticket, normalise_code};
+use openvtc_core::vetting::vetter::{Attestation, DeskState};
+use openvtc_core::vetting::wire::{self, Document};
+use serde_json::Value;
+use vta_sdk::protocols::vetting::{
+    CardClaim, TicketPresentation, VETTING_DECLINE_TYPE, VETTING_REQUEST_TYPE,
+    VETTING_REVOKE_STATEMENT_TYPE, VETTING_SESSION_RESPONSE_TYPE, VETTING_SESSION_TYPE,
+    VettingMethod, VettingRequirements, VettingSessionResponseBody, documentation,
+};
+use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+use vta_sdk::vetting::card::sign_card;
+use vta_sdk::vetting::requirements::{Evaluation, Need};
+use vta_sdk::vetting::statement::sign_statement;
+
+use crate::state_handler::actions::VettingAction;
+use crate::state_handler::background_dispatch::{self, DispatchDomain, DispatchOutcome, InFlight};
+use crate::state_handler::dispatch_util::{self, Persist, SyncLog};
+use crate::state_handler::main_page::content::{
+    ApplicationRow, AttestForm, DeskRow, DeskStage, IssuedRow, RequestRow, TicketRow,
+    VETTING_METHODS, VETTING_RELATIONSHIPS, VETTING_TICKET_USES, VETTING_WITHDRAWAL_REASONS,
+    VettingMembership, VettingMode, VettingPersona, VettingState, VettingTab, method_label,
+};
+use crate::state_handler::main_page::{sanitize_display, shorten_did};
+use crate::state_handler::runtime_actions::ActionCtx;
+use crate::state_handler::save_coalesce::SaveScheduler;
+use crate::state_handler::state::State;
+
+// ============================================================================
+// Config → display
+// ============================================================================
+
+/// Rebuild the page's rows from the book.
+pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
+    let now = Utc::now();
+    let book = &config.private.vetting;
+    let name = |did: &str| config.agent_name_for(did).map(|n| sanitize_display(n, 256));
+    let community_name = |did: &str| {
+        config
+            .account
+            .memberships()
+            .find(|m| m.vtc_did == did)
+            .and_then(|m| m.display_name.as_deref())
+            .map(|n| sanitize_display(n, 128))
+    };
+
+    vetting.personas = config
+        .identities
+        .iter()
+        .map(|(persona, identity)| VettingPersona {
+            persona: *persona,
+            did: identity.persona_did().to_string(),
+            label: sanitize_display(&config.persona_profile_label_for(*persona), 128),
+        })
+        .collect();
+
+    vetting.memberships = config
+        .account
+        .memberships()
+        .filter(|m| m.status.is_active())
+        .map(|m| VettingMembership {
+            community: m.vtc_did.clone(),
+            name: m
+                .display_name
+                .as_deref()
+                .map(|n| sanitize_display(n, 128))
+                .unwrap_or_else(|| shorten_did(&m.vtc_did, 48)),
+            persona: m.persona_ref,
+        })
+        .collect();
+
+    vetting.documentation = book
+        .policy
+        .accepts_documentation
+        .iter()
+        .cloned()
+        .chain(std::iter::once(documentation::NONE.to_string()))
+        .collect();
+
+    vetting.applications = book
+        .applications
+        .iter()
+        .map(|app| {
+            let required: Vec<String> = app
+                .requirements
+                .as_ref()
+                .map(|r| r.required_claims.clone())
+                .filter(|claims| !claims.is_empty())
+                .unwrap_or_else(|| {
+                    FALLBACK_REQUIRED_CLAIMS
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect()
+                });
+            let identity = required
+                .iter()
+                .map(|claim_type| {
+                    let value = app
+                        .identity_claims
+                        .iter()
+                        .find(|c| &c.claim_type == claim_type)
+                        .map(|c| claim_text(&c.value))
+                        .unwrap_or_default();
+                    (claim_type.clone(), value)
+                })
+                .collect();
+            let evaluation = app.checklist(now);
+            ApplicationRow {
+                id: app.id.clone(),
+                community: app.community.clone(),
+                community_name: community_name(&app.community),
+                join_did: app.join_did.clone(),
+                requirements: app.requirements.as_ref().map(requirements_line),
+                progress: evaluation.as_ref().map(progress_line),
+                satisfied: evaluation.as_ref().is_some_and(Evaluation::satisfied),
+                identity,
+                statements: app.statements.len(),
+                requests: app
+                    .requests
+                    .iter()
+                    .map(|r| {
+                        let (state, match_code, card_session) = match &r.state {
+                            RequestState::Sent => {
+                                ("sent — waiting for the vetter".to_string(), None, None)
+                            }
+                            RequestState::Accepted { session_hint, .. } => (
+                                match session_hint {
+                                    Some(hint) => {
+                                        format!("accepted — {}", sanitize_display(hint, 200))
+                                    }
+                                    None => "accepted — waiting for a session".to_string(),
+                                },
+                                None,
+                                None,
+                            ),
+                            RequestState::Session {
+                                session,
+                                card: None,
+                                ..
+                            } => (
+                                "session open — read the code together, then send your card"
+                                    .to_string(),
+                                Some(session.match_code.clone()),
+                                Some(session.id.clone()),
+                            ),
+                            RequestState::Session { session, .. } => (
+                                "card sent — waiting for their statement".to_string(),
+                                Some(session.match_code.clone()),
+                                None,
+                            ),
+                            RequestState::Attested { .. } => {
+                                ("statement received".to_string(), None, None)
+                            }
+                            RequestState::Declined { .. } => ("declined".to_string(), None, None),
+                            RequestState::Refused { code, .. } => (
+                                format!("refused ({})", sanitize_display(code, 80)),
+                                None,
+                                None,
+                            ),
+                        };
+                        RequestRow {
+                            vetter: r.vetter.clone(),
+                            vetter_name: name(&r.vetter),
+                            state,
+                            match_code,
+                            card_session,
+                        }
+                    })
+                    .collect(),
+            }
+        })
+        .collect();
+
+    vetting.desk = book
+        .desk
+        .iter()
+        .map(|entry| {
+            let (state, stage, session, card) = match &entry.state {
+                DeskState::Accepted => (
+                    "accepted — open a session when you are together",
+                    DeskStage::Accepted,
+                    None,
+                    None,
+                ),
+                DeskState::Session { session } => (
+                    "session open — waiting for their card",
+                    DeskStage::Session,
+                    Some(session),
+                    None,
+                ),
+                DeskState::CardReceived { session, card } => (
+                    "card verified — check the person, then attest or decline",
+                    DeskStage::Card,
+                    Some(session),
+                    Some(card),
+                ),
+                DeskState::Attested { card, .. } => {
+                    ("statement signed", DeskStage::Closed, None, Some(card))
+                }
+                DeskState::Declined { card, .. } => {
+                    ("declined", DeskStage::Closed, None, card.as_ref())
+                }
+            };
+            DeskRow {
+                request_id: entry.request_id.clone(),
+                applicant: entry.applicant.clone(),
+                applicant_name: name(&entry.applicant),
+                community: entry.community.clone(),
+                state: state.to_string(),
+                stage,
+                method: session.map(|s| method_label(s.method).to_string()),
+                match_code: entry.match_code().map(str::to_string),
+                claims: card
+                    .map(|c| {
+                        c.claims
+                            .iter()
+                            .map(|claim| {
+                                (
+                                    sanitize_display(&claim.claim_type, 64),
+                                    sanitize_display(&claim_text(&claim.value), 256),
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                required_claims: session
+                    .map(|s| s.required_claims.clone())
+                    .unwrap_or_default(),
+                message: entry
+                    .request
+                    .message
+                    .as_deref()
+                    .map(|m| sanitize_display(m, 500)),
+            }
+        })
+        .collect();
+
+    vetting.tickets = book
+        .tickets
+        .iter()
+        .map(|t| TicketRow {
+            id: t.id.clone(),
+            code: t.code.clone(),
+            community: community_name(&t.community)
+                .unwrap_or_else(|| shorten_did(&t.community, 48)),
+            uses_left: t.uses_left,
+            expires: t.expires_at.format("%Y-%m-%d").to_string(),
+            live: t.is_live(now),
+        })
+        .collect();
+
+    vetting.issued = book
+        .issued
+        .iter()
+        .map(|s| IssuedRow {
+            id: s.id.clone(),
+            applicant: s.applicant.clone(),
+            community: community_name(&s.community)
+                .unwrap_or_else(|| shorten_did(&s.community, 48)),
+            method: method_label(s.method).to_string(),
+            issued: s.issued_at.format("%Y-%m-%d").to_string(),
+            valid_until: s.valid_until.format("%Y-%m-%d").to_string(),
+            withdrawal: s.withdrawal.as_ref().map(|w| match w.recorded_at {
+                Some(at) => format!("withdrawn — recorded {}", at.format("%Y-%m-%d")),
+                None => "withdrawal sent — not yet recorded".to_string(),
+            }),
+        })
+        .collect();
+
+    vetting.selected = vetting.selected.min(vetting.tab_len().saturating_sub(1));
+}
+
+fn claim_text(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn requirements_line(r: &VettingRequirements) -> String {
+    let mut line = format!(
+        "{} statement{} from distinct vetters",
+        r.min_statements,
+        if r.min_statements == 1 { "" } else { "s" }
+    );
+    for (method, n) in &r.min_by_method {
+        line.push_str(&format!(", at least {n} {}", method_label(*method)));
+    }
+    if let Some(age) = &r.max_statement_age {
+        line.push_str(&format!(", none older than {}", sanitize_display(age, 32)));
+    }
+    line
+}
+
+fn progress_line(evaluation: &Evaluation) -> String {
+    if evaluation.satisfied() {
+        return "meets the published requirements — join from Communities".to_string();
+    }
+    let needs: Vec<String> = evaluation
+        .needs
+        .iter()
+        .map(|need| match need {
+            Need::Statements(n) => format!("{n} more statement{}", if *n == 1 { "" } else { "s" }),
+            Need::Method(method, n) => format!("{n} more {}", method_label(*method)),
+            other => other.to_wire(),
+        })
+        .collect();
+    if needs.is_empty() {
+        // Enough statements, but they disagree or a relationship cap is hit.
+        "statements disagree or are not independent — the community will review".to_string()
+    } else {
+        format!(
+            "{} counted — still needed: {}",
+            evaluation.counted.len(),
+            needs.join(", ")
+        )
+    }
+}
+
+// ============================================================================
+// Actions
+// ============================================================================
+
+fn page<'a>(ctx: &'a mut ActionCtx<'_>) -> &'a mut VettingState {
+    &mut ctx.state.main_page.content_panel.vetting
+}
+
+fn status(ctx: &mut ActionCtx<'_>, message: impl Into<String>) {
+    page(ctx).status_message = Some(message.into());
+}
+
+/// Persist the book and show `message`.
+fn persist(ctx: &mut ActionCtx<'_>, message: impl Into<String>) {
+    let message = message.into();
+    dispatch_util::save_and_sync(
+        &mut ctx.state.main_page,
+        ctx.config,
+        ctx.save,
+        Persist::SaveAndSync,
+        |mp| &mut mp.content_panel.vetting.status_message,
+        message.clone(),
+        SyncLog::Plain(message),
+    );
+}
+
+/// Handle one Vetting-page action.
+pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
+    match action {
+        VettingAction::SwitchTab => {
+            let v = page(ctx);
+            v.tab = v.tab.next();
+            v.selected = 0;
+            v.mode = VettingMode::List;
+            v.status_message = None;
+        }
+        VettingAction::Select(i) => {
+            let v = page(ctx);
+            v.selected = i.min(v.tab_len().saturating_sub(1));
+        }
+        VettingAction::Back => page(ctx).mode = VettingMode::List,
+        VettingAction::Status(message) => status(ctx, message),
+        VettingAction::Input(text) => input(&mut page(ctx).mode, text),
+        VettingAction::NextField => move_field(page(ctx), true),
+        VettingAction::PrevField => move_field(page(ctx), false),
+        VettingAction::Cycle(forward) => cycle(page(ctx), forward),
+        VettingAction::Toggle => {
+            if let VettingMode::Attest { form, .. } = &mut page(ctx).mode {
+                match form.field {
+                    3 => form.liveness_confirmed = !form.liveness_confirmed,
+                    4 => form.attested = !form.attested,
+                    _ => {}
+                }
+            }
+        }
+        VettingAction::StartApplication => {
+            if page(ctx).personas.is_empty() {
+                status(
+                    ctx,
+                    "Create a persona under My Identity first — it is the DID you join with.",
+                );
+            } else {
+                page(ctx).mode = VettingMode::NewApplication {
+                    community: String::new(),
+                    persona_index: 0,
+                    field: 0,
+                };
+            }
+        }
+        VettingAction::EditIdentity => {
+            let v = page(ctx);
+            if let Some(row) = v.applications.get(v.selected).cloned() {
+                v.mode = VettingMode::EditIdentity {
+                    application_id: row.id,
+                    claims: row.identity,
+                    field: 0,
+                };
+            }
+        }
+        VettingAction::RequestVetter => {
+            let v = page(ctx);
+            if let Some(row) = v.applications.get(v.selected).cloned() {
+                v.mode = VettingMode::RequestVetter {
+                    application_id: row.id,
+                    vetter: String::new(),
+                    code: String::new(),
+                    field: 0,
+                };
+            }
+        }
+        VettingAction::RefreshRequirements => {
+            let v = page(ctx);
+            if let Some(row) = v.applications.get(v.selected).cloned() {
+                refresh_requirements(ctx, &row.id).await;
+            }
+        }
+        VettingAction::ReviewCard => {
+            let v = page(ctx);
+            let Some(row) = v.applications.get(v.selected).cloned() else {
+                return;
+            };
+            match row.requests.iter().find_map(|r| r.card_session.clone()) {
+                Some(session_id) => {
+                    v.mode = VettingMode::SendCard {
+                        application_id: row.id,
+                        session_id,
+                    };
+                }
+                None => status(ctx, "No vetter is waiting for your card."),
+            }
+        }
+        VettingAction::NewTicket => {
+            if page(ctx).memberships.is_empty() {
+                status(
+                    ctx,
+                    "You can hand out tickets once you are an active member of a community.",
+                );
+            } else {
+                page(ctx).mode = VettingMode::NewTicket {
+                    membership_index: 0,
+                    uses_index: 0,
+                    field: 0,
+                };
+            }
+        }
+        VettingAction::DeleteTicket => {
+            let v = page(ctx);
+            if let Some(row) = v.tickets.get(v.selected).cloned() {
+                ctx.config
+                    .private
+                    .vetting
+                    .tickets
+                    .retain(|t| t.id != row.id);
+                persist(
+                    ctx,
+                    format!("Ticket {} deleted — it admits nothing now.", row.code),
+                );
+            }
+        }
+        VettingAction::OpenSession => {
+            let v = page(ctx);
+            match v.desk.get(v.selected).cloned() {
+                Some(row) if matches!(row.stage, DeskStage::Accepted | DeskStage::Session) => {
+                    v.mode = VettingMode::OpenSession {
+                        request_id: row.request_id,
+                        method_index: 0,
+                    };
+                }
+                Some(_) => status(ctx, "That request has moved past opening a session."),
+                None => {}
+            }
+        }
+        VettingAction::StartAttest => {
+            let v = page(ctx);
+            match v.desk.get(v.selected).cloned() {
+                Some(row) if row.stage == DeskStage::Card => {
+                    v.mode = VettingMode::Attest {
+                        request_id: row.request_id,
+                        form: AttestForm::default(),
+                    };
+                }
+                Some(_) => status(ctx, "You can attest once their card has arrived."),
+                None => {}
+            }
+        }
+        VettingAction::ArmDecline => {
+            let v = page(ctx);
+            match v.desk.get(v.selected).cloned() {
+                Some(row) if row.stage != DeskStage::Closed => {
+                    v.mode = VettingMode::ConfirmDecline {
+                        request_id: row.request_id,
+                    };
+                }
+                Some(_) => status(ctx, "That request is already closed."),
+                None => {}
+            }
+        }
+        VettingAction::ArmWithdraw => {
+            let v = page(ctx);
+            match v.issued.get(v.selected).cloned() {
+                Some(row) if row.withdrawal.is_none() => {
+                    v.mode = VettingMode::Withdraw {
+                        statement_id: row.id,
+                        reason_index: 0,
+                    };
+                }
+                Some(_) => status(ctx, "That statement is already withdrawn."),
+                None => {}
+            }
+        }
+        VettingAction::Submit => submit(ctx).await,
+    }
+}
+
+fn input(mode: &mut VettingMode, text: String) {
+    match mode {
+        VettingMode::NewApplication {
+            community,
+            field: 0,
+            ..
+        } => *community = text,
+        VettingMode::EditIdentity { claims, field, .. } => {
+            if let Some((_, value)) = claims.get_mut(*field) {
+                *value = text;
+            }
+        }
+        VettingMode::RequestVetter {
+            vetter, field: 0, ..
+        } => *vetter = text,
+        VettingMode::RequestVetter { code, field: 1, .. } => *code = text,
+        _ => {}
+    }
+}
+
+fn move_field(v: &mut VettingState, forward: bool) {
+    let step = |field: &mut usize, count: usize| {
+        if count == 0 {
+            return;
+        }
+        *field = if forward {
+            (*field + 1) % count
+        } else {
+            (*field + count - 1) % count
+        };
+    };
+    match &mut v.mode {
+        VettingMode::NewApplication { field, .. }
+        | VettingMode::RequestVetter { field, .. }
+        | VettingMode::NewTicket { field, .. } => step(field, 2),
+        VettingMode::EditIdentity { claims, field, .. } => step(field, claims.len()),
+        VettingMode::Attest { form, .. } => step(&mut form.field, AttestForm::FIELDS),
+        _ => {}
+    }
+}
+
+fn cycle(v: &mut VettingState, forward: bool) {
+    let turn = |index: &mut usize, count: usize| {
+        if count == 0 {
+            return;
+        }
+        *index = if forward {
+            (*index + 1) % count
+        } else {
+            (*index + count - 1) % count
+        };
+    };
+    let (personas, memberships, documentation) =
+        (v.personas.len(), v.memberships.len(), v.documentation.len());
+    match &mut v.mode {
+        VettingMode::NewApplication {
+            persona_index,
+            field: 1,
+            ..
+        } => turn(persona_index, personas),
+        VettingMode::NewTicket {
+            membership_index,
+            field: 0,
+            ..
+        } => turn(membership_index, memberships),
+        VettingMode::NewTicket {
+            uses_index,
+            field: 1,
+            ..
+        } => turn(uses_index, VETTING_TICKET_USES.len()),
+        VettingMode::OpenSession { method_index, .. } => {
+            turn(method_index, VETTING_METHODS.len());
+        }
+        VettingMode::Attest { form, .. } => match form.field {
+            0 => turn(&mut form.method_index, VETTING_METHODS.len()),
+            1 => turn(&mut form.documentation_index, documentation),
+            2 => turn(&mut form.relationship_index, VETTING_RELATIONSHIPS.len()),
+            _ => {}
+        },
+        VettingMode::Withdraw { reason_index, .. } => {
+            turn(reason_index, VETTING_WITHDRAWAL_REASONS.len());
+        }
+        _ => {}
+    }
+}
+
+async fn submit(ctx: &mut ActionCtx<'_>) {
+    match page(ctx).mode.clone() {
+        VettingMode::List => {}
+        VettingMode::NewApplication {
+            community,
+            persona_index,
+            ..
+        } => start_application(ctx, community.trim(), persona_index).await,
+        VettingMode::EditIdentity {
+            application_id,
+            claims,
+            ..
+        } => save_identity(ctx, &application_id, claims),
+        VettingMode::RequestVetter {
+            application_id,
+            vetter,
+            code,
+            ..
+        } => request_vetter(ctx, &application_id, vetter.trim(), &code).await,
+        VettingMode::SendCard {
+            application_id,
+            session_id,
+        } => send_card(ctx, &application_id, &session_id).await,
+        VettingMode::NewTicket {
+            membership_index,
+            uses_index,
+            ..
+        } => issue_ticket(ctx, membership_index, uses_index),
+        VettingMode::OpenSession {
+            request_id,
+            method_index,
+        } => open_session(ctx, &request_id, method_index).await,
+        VettingMode::Attest { request_id, form } => attest(ctx, &request_id, &form).await,
+        VettingMode::ConfirmDecline { request_id } => decline(ctx, &request_id).await,
+        VettingMode::Withdraw {
+            statement_id,
+            reason_index,
+        } => withdraw(ctx, &statement_id, reason_index).await,
+    }
+}
+
+// ============================================================================
+// Sending
+// ============================================================================
+
+/// Claim the vetting domain, or say why not.
+fn begin(ctx: &mut ActionCtx<'_>) -> bool {
+    if ctx.in_flight.try_begin(DispatchDomain::Vetting) {
+        return true;
+    }
+    status(ctx, InFlight::busy_message(DispatchDomain::Vetting));
+    false
+}
+
+/// Give up on a send before it started: release the domain, say why, and show
+/// whatever the book now holds.
+fn abandon(ctx: &mut ActionCtx<'_>, what: &str, error: impl std::fmt::Display) {
+    ctx.in_flight.finish(DispatchDomain::Vetting);
+    let message = format!("{what}: {error}");
+    ctx.state.main_page.log(message.clone());
+    ctx.state.main_page.sync_from_config(ctx.config);
+    status(ctx, message);
+}
+
+fn persona_did(config: &Config, persona: PersonaId) -> Option<String> {
+    config
+        .identities
+        .get(&persona)
+        .map(|identity| identity.persona_did().to_string())
+}
+
+fn resolver(ctx: &ActionCtx<'_>) -> TrustTaskVmResolver {
+    TrustTaskVmResolver::new(ctx.tdk.did_resolver().clone())
+}
+
+/// Sign `document` as `persona`, then hand the send to a background job. The
+/// caller has claimed the domain; on error it is still claimed.
+async fn sign_and_send(
+    ctx: &mut ActionCtx<'_>,
+    persona: PersonaId,
+    mut document: Document,
+    sent: Sent,
+) -> Result<(), String> {
+    let keys = ctx
+        .config
+        .get_persona_keys_for(persona, ctx.tdk)
+        .await
+        .map_err(|e| e.to_string())?;
+    wire::sign(&mut document, &keys.signing.secret)
+        .await
+        .map_err(|e| e.to_string())?;
+    let message = wire::to_message(&document).map_err(|e| e.to_string())?;
+    let from = document.issuer.clone().unwrap_or_default();
+    let to = document.recipient.clone().unwrap_or_default();
+    spawn_send(ctx, message, &from, &to, sent);
+    Ok(())
+}
+
+fn spawn_send(ctx: &mut ActionCtx<'_>, message: Message, from: &str, to: &str, sent: Sent) {
+    let job = SendJob {
+        service: ctx.didcomm_service.clone(),
+        listener_id: openvtc_core::didcomm::listener_id_for_did(from, ctx.config),
+        to: to.to_string(),
+        message: Box::new(message),
+        sent,
+    };
+    background_dispatch::spawn_dispatch(
+        ctx.dispatch_tx.clone(),
+        DispatchDomain::Vetting,
+        async move { DispatchOutcome::Vetting(job.run().await) },
+    );
+}
+
+async fn refresh_requirements(ctx: &mut ActionCtx<'_>, application_id: &str) {
+    let Some(app) = ctx
+        .config
+        .private
+        .vetting
+        .applications
+        .iter()
+        .find(|a| a.id == application_id)
+        .cloned()
+    else {
+        return;
+    };
+    if !begin(ctx) {
+        return;
+    }
+    let document = match wire::manifest_request(&app.join_did, &app.community) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not ask the community", e),
+    };
+    status(ctx, "Asking the community what it requires…");
+    let sent = Sent::Manifest {
+        community: app.community.clone(),
+    };
+    if let Err(e) = sign_and_send(ctx, app.persona, document, sent).await {
+        abandon(ctx, "Could not ask the community", e);
+    }
+}
+
+async fn start_application(ctx: &mut ActionCtx<'_>, community: &str, persona_index: usize) {
+    if !community.starts_with("did:") {
+        return status(ctx, "Enter the community's DID (it starts with did:).");
+    }
+    let Some(persona) = page(ctx).personas.get(persona_index).cloned() else {
+        return status(ctx, "Choose the persona you will join with.");
+    };
+    let application_id = match ctx.config.private.vetting.start_application(
+        community,
+        persona.persona,
+        &persona.did,
+        Utc::now(),
+    ) {
+        Ok(app) => app.id.clone(),
+        Err(e) => return status(ctx, format!("Could not start the application: {e}")),
+    };
+    {
+        let v = page(ctx);
+        v.mode = VettingMode::List;
+        v.tab = VettingTab::Applications;
+    }
+    persist(ctx, "Application started.");
+    if let Some(i) = page(ctx)
+        .applications
+        .iter()
+        .position(|a| a.id == application_id)
+    {
+        page(ctx).selected = i;
+    }
+    refresh_requirements(ctx, &application_id).await;
+}
+
+fn save_identity(ctx: &mut ActionCtx<'_>, application_id: &str, claims: Vec<(String, String)>) {
+    if claims.iter().any(|(_, value)| value.trim().is_empty()) {
+        return status(
+            ctx,
+            "Fill in every claim — a vetter checks each one against you and your documents.",
+        );
+    }
+    let Some(app) = ctx
+        .config
+        .private
+        .vetting
+        .application_by_id_mut(application_id)
+    else {
+        return;
+    };
+    let shown = app.requests.iter().any(|r| {
+        matches!(
+            &r.state,
+            RequestState::Session { card: Some(_), .. } | RequestState::Attested { .. }
+        )
+    });
+    if shown {
+        return status(
+            ctx,
+            "A vetter has already seen this identity. Changing it now would make your \
+             statements disagree, and the community would refer the application.",
+        );
+    }
+    app.identity_claims = claims
+        .into_iter()
+        .map(|(claim_type, value)| CardClaim {
+            claim_type,
+            value: Value::String(value.trim().to_string()),
+            provenance: "selfAsserted".to_string(),
+        })
+        .collect();
+    page(ctx).mode = VettingMode::List;
+    persist(ctx, "Identity saved — every vetter is shown exactly this.");
+}
+
+async fn request_vetter(ctx: &mut ActionCtx<'_>, application_id: &str, vetter: &str, code: &str) {
+    if !vetter.starts_with("did:") {
+        return status(ctx, "Enter the vetter's DID (it starts with did:).");
+    }
+    let Some(code) = normalise_code(code) else {
+        return status(ctx, "That is not a ticket code — they look like K7QF-2M9X.");
+    };
+    if !begin(ctx) {
+        return;
+    }
+    let document_id = wire::new_id();
+    let Some(app) = ctx
+        .config
+        .private
+        .vetting
+        .application_by_id_mut(application_id)
+    else {
+        return abandon(ctx, "Could not send the request", "the application is gone");
+    };
+    let (persona, join_did) = (app.persona, app.join_did.clone());
+    let body = match app.prepare_request(
+        &document_id,
+        vetter,
+        TicketPresentation::Code { code },
+        RequestDraft::default(),
+        Utc::now(),
+    ) {
+        Ok(body) => body,
+        Err(e) => return abandon(ctx, "Could not send the request", e),
+    };
+    let document = match wire::document(
+        VETTING_REQUEST_TYPE,
+        &join_did,
+        vetter,
+        document_id.clone(),
+        &body,
+    ) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not send the request", e),
+    };
+    page(ctx).mode = VettingMode::List;
+    persist(ctx, "Sending your request…");
+    let sent = Sent::Request {
+        application_id: application_id.to_string(),
+        document_id: document_id.clone(),
+        vetter: vetter.to_string(),
+    };
+    if let Err(e) = sign_and_send(ctx, persona, document, sent).await {
+        if let Some(app) = ctx
+            .config
+            .private
+            .vetting
+            .application_by_id_mut(application_id)
+        {
+            app.forget_unsent(&document_id);
+        }
+        abandon(ctx, "Could not send the request", e);
+    }
+}
+
+async fn send_card(ctx: &mut ActionCtx<'_>, application_id: &str, session_id: &str) {
+    let now = Utc::now();
+    let Some(app) = ctx
+        .config
+        .private
+        .vetting
+        .applications
+        .iter()
+        .find(|a| a.id == application_id)
+        .cloned()
+    else {
+        return;
+    };
+    if app.identity_claims.is_empty() {
+        return status(
+            ctx,
+            "First enter the identity you will show vetters (i on the application).",
+        );
+    }
+    let draft = match app.card_draft(session_id, app.identity_claims.clone(), now) {
+        Ok(draft) => draft,
+        Err(e) => return status(ctx, format!("Cannot send a card: {e}")),
+    };
+    if !begin(ctx) {
+        return;
+    }
+    let (vetter, join_did) = (draft.audience.clone(), draft.publisher.clone());
+    let keys = match ctx.config.get_persona_keys_for(app.persona, ctx.tdk).await {
+        Ok(keys) => keys,
+        Err(e) => return abandon(ctx, "Could not sign the card", e),
+    };
+    let card = match sign_card(draft, &keys.signing.secret).await {
+        Ok(card) => card,
+        Err(e) => return abandon(ctx, "Could not sign the card", e),
+    };
+    let resolver = resolver(ctx);
+    let recorded = match ctx
+        .config
+        .private
+        .vetting
+        .application_by_id_mut(application_id)
+    {
+        Some(app) => app.record_card(session_id, &card, &resolver, now).await,
+        None => return abandon(ctx, "Could not send the card", "the application is gone"),
+    };
+    if let Err(e) = recorded {
+        return abandon(ctx, "The card did not verify", e);
+    }
+    let mut document = match wire::document(
+        VETTING_SESSION_RESPONSE_TYPE,
+        &join_did,
+        &vetter,
+        wire::new_id(),
+        &VettingSessionResponseBody { card, ext: None },
+    ) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not send the card", e),
+    };
+    document.thread_id = Some(session_id.to_string());
+    page(ctx).mode = VettingMode::List;
+    persist(ctx, "Sending your card…");
+    let sent = Sent::Card {
+        session_id: session_id.to_string(),
+    };
+    if let Err(e) = sign_and_send(ctx, app.persona, document, sent).await {
+        abandon(ctx, "Could not send the card", e);
+    }
+}
+
+fn issue_ticket(ctx: &mut ActionCtx<'_>, membership_index: usize, uses_index: usize) {
+    let Some(membership) = page(ctx).memberships.get(membership_index).cloned() else {
+        return;
+    };
+    let uses = VETTING_TICKET_USES[uses_index.min(VETTING_TICKET_USES.len() - 1)];
+    let ticket = Ticket::issue(
+        &membership.community,
+        membership.persona,
+        vec![],
+        uses,
+        DEFAULT_VALIDITY,
+        Utc::now(),
+    );
+    let code = ticket.code.clone();
+    ctx.config.private.vetting.tickets.push(ticket);
+    {
+        let v = page(ctx);
+        v.mode = VettingMode::List;
+        v.tab = VettingTab::Tickets;
+    }
+    persist(
+        ctx,
+        format!(
+            "Ticket {code} for {} — read it to the person, or copy it with y. It admits {uses} \
+             request{} for 14 days.",
+            membership.name,
+            if uses == 1 { "" } else { "s" }
+        ),
+    );
+    let last = page(ctx).tickets.len().saturating_sub(1);
+    page(ctx).selected = last;
+}
+
+async fn open_session(ctx: &mut ActionCtx<'_>, request_id: &str, method_index: usize) {
+    let Some(entry) = ctx.config.private.vetting.desk_entry(request_id).cloned() else {
+        return;
+    };
+    let Some(vetter_did) = persona_did(ctx.config, entry.persona) else {
+        return status(
+            ctx,
+            "The persona this request was made to is not available.",
+        );
+    };
+    let (required, known) = ctx.config.private.vetting.required_claims_for(
+        &entry.community,
+        entry.request.requirements_digest.as_deref(),
+    );
+    let asked = page(ctx).requirements_requested.contains(&entry.community);
+    if !known && !asked {
+        // Every vetter of one application must ask for the same claims, or the
+        // cards commit to different identities. Ask the community first.
+        if !begin(ctx) {
+            return;
+        }
+        page(ctx)
+            .requirements_requested
+            .push(entry.community.clone());
+        let document = match wire::manifest_request(&vetter_did, &entry.community) {
+            Ok(d) => d,
+            Err(e) => return abandon(ctx, "Could not ask the community", e),
+        };
+        status(
+            ctx,
+            "Asking the community which claims it requires — open the session again in a moment.",
+        );
+        let sent = Sent::Manifest {
+            community: entry.community.clone(),
+        };
+        if let Err(e) = sign_and_send(ctx, entry.persona, document, sent).await {
+            abandon(ctx, "Could not ask the community", e);
+        }
+        return;
+    }
+    if !begin(ctx) {
+        return;
+    }
+    let session_id = wire::new_id();
+    let method: VettingMethod = VETTING_METHODS[method_index.min(VETTING_METHODS.len() - 1)];
+    let body = match ctx.config.private.vetting.open_session(
+        request_id,
+        method,
+        required,
+        vec![],
+        &session_id,
+        Utc::now(),
+    ) {
+        Ok(body) => body,
+        Err(e) => return abandon(ctx, "Could not open the session", e),
+    };
+    let document = match wire::document(
+        VETTING_SESSION_TYPE,
+        &vetter_did,
+        &entry.applicant,
+        session_id,
+        &body,
+    ) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not open the session", e),
+    };
+    let code = ctx
+        .config
+        .private
+        .vetting
+        .desk_entry(request_id)
+        .and_then(|e| e.match_code().map(str::to_string))
+        .unwrap_or_default();
+    page(ctx).mode = VettingMode::List;
+    persist(
+        ctx,
+        format!(
+            "Session open. Read the match code {code} to each other{}.",
+            if known {
+                ""
+            } else {
+                " — the community's requirements are still unknown, so this asks for a legal name only"
+            }
+        ),
+    );
+    let sent = Sent::Session {
+        request_id: request_id.to_string(),
+    };
+    if let Err(e) = sign_and_send(ctx, entry.persona, document, sent).await {
+        abandon(ctx, "Could not send the session", e);
+    }
+}
+
+async fn attest(ctx: &mut ActionCtx<'_>, request_id: &str, form: &AttestForm) {
+    if !form.attested {
+        return status(
+            ctx,
+            "Tick the attestation (the last line) — signing is attributable to you in this community.",
+        );
+    }
+    let now = Utc::now();
+    let Some(entry) = ctx.config.private.vetting.desk_entry(request_id).cloned() else {
+        return;
+    };
+    let DeskState::CardReceived { session, .. } = &entry.state else {
+        return status(ctx, "You can attest once their card has arrived.");
+    };
+    let Some(vetter_did) = persona_did(ctx.config, entry.persona) else {
+        return status(
+            ctx,
+            "The persona this request was made to is not available.",
+        );
+    };
+    let method = VETTING_METHODS[form.method_index.min(VETTING_METHODS.len() - 1)];
+    let documentation_choice = page(ctx)
+        .documentation
+        .get(form.documentation_index)
+        .cloned()
+        .unwrap_or_else(|| documentation::NONE.to_string());
+    let document_classes = if method == VettingMethod::PriorAcquaintance
+        && documentation_choice == documentation::NONE
+    {
+        Vec::new()
+    } else {
+        vec![documentation_choice]
+    };
+    let attestation = Attestation {
+        method,
+        document_classes,
+        claims_verified: session.required_claims.clone(),
+        liveness_confirmed: form.liveness_confirmed,
+        declared_relationship: VETTING_RELATIONSHIPS
+            [form.relationship_index.min(VETTING_RELATIONSHIPS.len() - 1)],
+        attestation_text_digest: None,
+    };
+    let draft =
+        match ctx
+            .config
+            .private
+            .vetting
+            .statement_draft(request_id, &vetter_did, attestation, now)
+        {
+            Ok(draft) => draft,
+            Err(e) => return status(ctx, format!("Cannot attest yet: {e}")),
+        };
+    if !begin(ctx) {
+        return;
+    }
+    let keys = match ctx
+        .config
+        .get_persona_keys_for(entry.persona, ctx.tdk)
+        .await
+    {
+        Ok(keys) => keys,
+        Err(e) => return abandon(ctx, "Could not sign the statement", e),
+    };
+    let statement = match sign_statement(draft, &keys.signing.secret).await {
+        Ok(statement) => statement,
+        Err(e) => return abandon(ctx, "Could not sign the statement", e),
+    };
+    let resolver = resolver(ctx);
+    let issued = match ctx
+        .config
+        .private
+        .vetting
+        .record_statement(request_id, &statement, &resolver, now)
+        .await
+    {
+        Ok(issued) => issued,
+        Err(e) => return abandon(ctx, "The statement did not verify", e),
+    };
+    let message =
+        match wire::credential_delivery(&vetter_did, &entry.applicant, &statement, &session.id) {
+            Ok(message) => message,
+            Err(e) => {
+                ctx.config
+                    .private
+                    .vetting
+                    .issued
+                    .retain(|s| s.id != issued.id);
+                if let Some(e2) = ctx.config.private.vetting.desk_entry_mut(request_id) {
+                    e2.state = entry.state.clone();
+                }
+                return abandon(ctx, "Could not send the statement", e);
+            }
+        };
+    page(ctx).mode = VettingMode::List;
+    persist(ctx, "Sending your statement…");
+    let sent = Sent::Statement {
+        request_id: request_id.to_string(),
+        statement_id: issued.id,
+        previous: entry.state.clone(),
+    };
+    spawn_send(ctx, message, &vetter_did, &entry.applicant, sent);
+}
+
+async fn decline(ctx: &mut ActionCtx<'_>, request_id: &str) {
+    let Some(entry) = ctx.config.private.vetting.desk_entry(request_id).cloned() else {
+        return;
+    };
+    let Some(vetter_did) = persona_did(ctx.config, entry.persona) else {
+        return status(
+            ctx,
+            "The persona this request was made to is not available.",
+        );
+    };
+    if !begin(ctx) {
+        return;
+    }
+    let body = match ctx
+        .config
+        .private
+        .vetting
+        .decline(request_id, None, None, Utc::now())
+    {
+        Ok(body) => body,
+        Err(e) => return abandon(ctx, "Could not decline", e),
+    };
+    let document = match wire::document(
+        VETTING_DECLINE_TYPE,
+        &vetter_did,
+        &entry.applicant,
+        wire::new_id(),
+        &body,
+    ) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not decline", e),
+    };
+    page(ctx).mode = VettingMode::List;
+    persist(ctx, "Declining…");
+    let sent = Sent::Decline {
+        request_id: request_id.to_string(),
+        previous: entry.state.clone(),
+    };
+    if let Err(e) = sign_and_send(ctx, entry.persona, document, sent).await {
+        if let Some(desk) = ctx.config.private.vetting.desk_entry_mut(request_id) {
+            desk.state = entry.state;
+        }
+        abandon(ctx, "Could not send the decline", e);
+    }
+}
+
+async fn withdraw(ctx: &mut ActionCtx<'_>, statement_id: &str, reason_index: usize) {
+    let Some(issued) = ctx
+        .config
+        .private
+        .vetting
+        .issued
+        .iter()
+        .find(|s| s.id == statement_id)
+        .cloned()
+    else {
+        return;
+    };
+    let Some(vetter_did) = persona_did(ctx.config, issued.persona) else {
+        return status(
+            ctx,
+            "The persona that signed this statement is not available.",
+        );
+    };
+    if !begin(ctx) {
+        return;
+    }
+    let document_id = wire::new_id();
+    let reason = VETTING_WITHDRAWAL_REASONS[reason_index.min(VETTING_WITHDRAWAL_REASONS.len() - 1)];
+    let body = match ctx.config.private.vetting.withdrawal(
+        statement_id,
+        Some(reason),
+        &document_id,
+        Utc::now(),
+    ) {
+        Ok((body, _)) => body,
+        Err(e) => return abandon(ctx, "Could not withdraw", e),
+    };
+    let document = match wire::document(
+        VETTING_REVOKE_STATEMENT_TYPE,
+        &vetter_did,
+        &issued.community,
+        document_id,
+        &body,
+    ) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not withdraw", e),
+    };
+    page(ctx).mode = VettingMode::List;
+    persist(ctx, "Telling the community…");
+    let sent = Sent::Withdrawal {
+        statement_id: statement_id.to_string(),
+    };
+    if let Err(e) = sign_and_send(ctx, issued.persona, document, sent).await {
+        if let Some(s) = ctx
+            .config
+            .private
+            .vetting
+            .issued
+            .iter_mut()
+            .find(|s| s.id == statement_id)
+        {
+            s.withdrawal = None;
+        }
+        abandon(ctx, "Could not send the withdrawal", e);
+    }
+}
+
+// ============================================================================
+// The background send
+// ============================================================================
+
+/// What was sent, and what undoing it takes if the send fails.
+pub(crate) enum Sent {
+    Manifest {
+        community: String,
+    },
+    Request {
+        application_id: String,
+        document_id: String,
+        vetter: String,
+    },
+    Card {
+        session_id: String,
+    },
+    Session {
+        request_id: String,
+    },
+    Statement {
+        request_id: String,
+        statement_id: String,
+        previous: DeskState,
+    },
+    Decline {
+        request_id: String,
+        previous: DeskState,
+    },
+    Withdrawal {
+        statement_id: String,
+    },
+}
+
+/// One vetting send. I/O only.
+pub(crate) struct SendJob {
+    service: Messaging,
+    listener_id: String,
+    to: String,
+    message: Box<Message>,
+    sent: Sent,
+}
+
+impl SendJob {
+    pub(crate) async fn run(self) -> VettingOutcome {
+        let result = openvtc_core::didcomm::send_message_via(
+            &self.service,
+            &self.message,
+            &self.listener_id,
+            &self.to,
+        )
+        .await;
+        VettingOutcome {
+            sent: self.sent,
+            error: result.err().map(|e| e.to_string()),
+        }
+    }
+}
+
+/// How a vetting send went. Applied on the loop thread.
+pub(crate) struct VettingOutcome {
+    sent: Sent,
+    error: Option<String>,
+}
+
+impl VettingOutcome {
+    /// Report success, clearing the inbox task the step answered; or undo the
+    /// step and say why.
+    pub(crate) fn apply(self, state: &mut State, config: &mut Config, save: &mut SaveScheduler) {
+        let tasks = &mut config.private.tasks;
+        let book = &mut config.private.vetting;
+        let clear = |tasks: &mut openvtc_core::tasks::Tasks, id: String| {
+            tasks.remove(&Arc::new(id));
+        };
+        let (message, persist) = match (self.sent, self.error) {
+            (Sent::Manifest { community }, None) => (
+                format!(
+                    "Asked {} for its vetting requirements.",
+                    shorten_did(&community, 48)
+                ),
+                false,
+            ),
+            (Sent::Request { vetter, .. }, None) => (
+                format!(
+                    "Request sent to {} — it is answered only if your ticket is valid.",
+                    shorten_did(&vetter, 48)
+                ),
+                false,
+            ),
+            (Sent::Card { session_id }, None) => {
+                clear(tasks, format!("vetting-session-{session_id}"));
+                (
+                    "Card sent — the vetter checks it against you and your documents.".to_string(),
+                    true,
+                )
+            }
+            (Sent::Session { request_id }, None) => {
+                clear(tasks, format!("vetting-request-{request_id}"));
+                ("Session sent — waiting for their card.".to_string(), true)
+            }
+            (Sent::Statement { request_id, .. }, None) => {
+                clear(tasks, format!("vetting-card-{request_id}"));
+                ("Statement signed and sent.".to_string(), true)
+            }
+            (Sent::Decline { request_id, .. }, None) => {
+                clear(tasks, format!("vetting-card-{request_id}"));
+                clear(tasks, format!("vetting-request-{request_id}"));
+                ("Declined.".to_string(), true)
+            }
+            (Sent::Withdrawal { .. }, None) => (
+                "Withdrawal sent — the community confirms when it has recorded it.".to_string(),
+                false,
+            ),
+            (
+                Sent::Request {
+                    application_id,
+                    document_id,
+                    ..
+                },
+                Some(e),
+            ) => {
+                if let Some(app) = book.application_by_id_mut(&application_id) {
+                    app.forget_unsent(&document_id);
+                }
+                (format!("Could not send the request: {e}"), true)
+            }
+            (
+                Sent::Statement {
+                    request_id,
+                    statement_id,
+                    previous,
+                },
+                Some(e),
+            ) => {
+                book.issued.retain(|s| s.id != statement_id);
+                if let Some(entry) = book.desk_entry_mut(&request_id) {
+                    entry.state = previous;
+                }
+                (
+                    format!("Could not send the statement, so it was not issued: {e}"),
+                    true,
+                )
+            }
+            (
+                Sent::Decline {
+                    request_id,
+                    previous,
+                },
+                Some(e),
+            ) => {
+                if let Some(entry) = book.desk_entry_mut(&request_id) {
+                    entry.state = previous;
+                }
+                (format!("Could not send the decline: {e}"), true)
+            }
+            (Sent::Withdrawal { statement_id }, Some(e)) => {
+                if let Some(s) = book.issued.iter_mut().find(|s| s.id == statement_id) {
+                    s.withdrawal = None;
+                }
+                (format!("Could not send the withdrawal: {e}"), true)
+            }
+            (Sent::Manifest { .. } | Sent::Card { .. } | Sent::Session { .. }, Some(e)) => {
+                (format!("Could not send — try again: {e}"), false)
+            }
+        };
+        dispatch_util::save_and_sync(
+            &mut state.main_page,
+            config,
+            save,
+            if persist {
+                Persist::SaveAndSync
+            } else {
+                Persist::SyncOnly
+            },
+            |mp| &mut mp.content_panel.vetting.status_message,
+            message.clone(),
+            SyncLog::Plain(message),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+    use openvtc_core::vetting::applicant::Application;
+
+    fn outcome(sent: Sent, error: Option<&str>) -> VettingOutcome {
+        VettingOutcome {
+            sent,
+            error: error.map(ToString::to_string),
+        }
+    }
+
+    /// A request that never left is forgotten, so retrying is not shadowed by
+    /// a record the vetter never saw.
+    #[test]
+    fn a_failed_request_is_forgotten() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        let mut app = Application::new(
+            "did:web:vtc.example",
+            PersonaId::new(),
+            "did:key:zApplicant",
+            Utc::now(),
+        )
+        .unwrap();
+        app.prepare_request(
+            "urn:uuid:r1",
+            "did:key:zVetter",
+            TicketPresentation::Code {
+                code: "K7QF-2M9X".into(),
+            },
+            RequestDraft::default(),
+            Utc::now(),
+        )
+        .unwrap();
+        let application_id = app.id.clone();
+        config.private.vetting.applications.push(app);
+
+        outcome(
+            Sent::Request {
+                application_id,
+                document_id: "urn:uuid:r1".into(),
+                vetter: "did:key:zVetter".into(),
+            },
+            Some("mediator unreachable"),
+        )
+        .apply(&mut state, &mut config, &mut save);
+
+        assert!(config.private.vetting.applications[0].requests.is_empty());
+        assert!(
+            state
+                .main_page
+                .content_panel
+                .vetting
+                .status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("unreachable"))
+        );
+    }
+
+    /// The page lists what the book holds.
+    #[test]
+    fn sync_lists_applications_and_tickets() {
+        let mut config = test_config();
+        let persona = PersonaId::new();
+        config
+            .private
+            .vetting
+            .start_application("did:web:vtc.example", persona, "did:key:zA", Utc::now())
+            .unwrap();
+        config.private.vetting.tickets.push(Ticket::issue(
+            "did:web:vtc.example",
+            persona,
+            vec![],
+            1,
+            DEFAULT_VALIDITY,
+            Utc::now(),
+        ));
+        let mut v = VettingState::default();
+        sync(&mut v, &config);
+        assert_eq!(v.applications.len(), 1);
+        assert_eq!(
+            v.applications[0].identity,
+            vec![("name.legal".to_string(), String::new())],
+            "without requirements the page asks for a legal name"
+        );
+        assert_eq!(v.tickets.len(), 1);
+        assert!(v.tickets[0].live);
+        assert!(v.documentation.iter().any(|d| d == "none"));
+    }
+}

--- a/openvtc/src/ui/pages/main/components/content_panel.rs
+++ b/openvtc/src/ui/pages/main/components/content_panel.rs
@@ -83,6 +83,7 @@ impl ContentPanelState {
             MainMenu::Settings => Some(Box::new(SettingsPanel)),
             MainMenu::Vta => Some(Box::new(VtaPanel)),
             MainMenu::Identity => Some(Box::new(super::identity_panel::IdentityPanel)),
+            MainMenu::Vetting => Some(Box::new(super::vetting_panel::VettingPanel)),
             _ => None,
         };
 

--- a/openvtc/src/ui/pages/main/components/mod.rs
+++ b/openvtc/src/ui/pages/main/components/mod.rs
@@ -13,4 +13,5 @@ pub mod panel;
 pub mod relationships_panel;
 pub mod settings_panel;
 pub mod status;
+pub mod vetting_panel;
 pub mod vta_panel;

--- a/openvtc/src/ui/pages/main/components/vetting_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vetting_panel.rs
@@ -1,0 +1,754 @@
+//! The Vetting page (`docs/design/vetting-process.md` §12).
+//!
+//! Four tabs: our applications to be vetted, requests at our vetter desk, the
+//! tickets we have handed out, and the statements we have signed. Copy says
+//! "meets the published requirements", never "approved": only the community
+//! decides (D12).
+
+use super::panel::Panel;
+use crate::colors::{
+    COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+    COLOR_WARNING_ACCESSIBLE_RED,
+};
+use crate::state_handler::{
+    main_page::content::{
+        AttestForm, ContentPanelState, DeskStage, VETTING_METHODS, VETTING_RELATIONSHIPS,
+        VETTING_TICKET_USES, VETTING_WITHDRAWAL_REASONS, VettingMode, VettingState, VettingTab,
+        method_label, reason_label, relationship_label,
+    },
+    state::ConnectionState,
+};
+use openvtc_core::display::display_identifier;
+use ratatui::{
+    style::{Style, Stylize},
+    text::{Line, Span},
+};
+
+/// Vetting content panel.
+pub struct VettingPanel;
+
+impl Panel for VettingPanel {
+    fn render(
+        &self,
+        state: &ContentPanelState,
+        _connection: &ConnectionState,
+    ) -> Vec<Line<'static>> {
+        render(&state.vetting)
+    }
+}
+
+/// The view identifier, so switching mode resets the scroll.
+#[must_use]
+pub fn mode_id(state: &VettingState) -> &'static str {
+    match (&state.mode, state.tab) {
+        (VettingMode::List, VettingTab::Applications) => "applications",
+        (VettingMode::List, VettingTab::Desk) => "desk",
+        (VettingMode::List, VettingTab::Tickets) => "tickets",
+        (VettingMode::List, VettingTab::Issued) => "issued",
+        (VettingMode::NewApplication { .. }, _) => "new-application",
+        (VettingMode::EditIdentity { .. }, _) => "identity",
+        (VettingMode::RequestVetter { .. }, _) => "request",
+        (VettingMode::SendCard { .. }, _) => "card",
+        (VettingMode::NewTicket { .. }, _) => "new-ticket",
+        (VettingMode::OpenSession { .. }, _) => "session",
+        (VettingMode::Attest { .. }, _) => "attest",
+        (VettingMode::ConfirmDecline { .. }, _) => "decline",
+        (VettingMode::Withdraw { .. }, _) => "withdraw",
+    }
+}
+
+fn label() -> Style {
+    Style::new().fg(COLOR_TEXT_DEFAULT)
+}
+fn value() -> Style {
+    Style::new().fg(COLOR_SOFT_PURPLE)
+}
+fn dim() -> Style {
+    Style::new().fg(COLOR_DARK_GRAY)
+}
+fn heading(text: impl Into<String>) -> Line<'static> {
+    Line::from(text.into()).fg(COLOR_SUCCESS).bold()
+}
+fn hint(text: impl Into<String>) -> Line<'static> {
+    Line::from(text.into()).fg(COLOR_DARK_GRAY)
+}
+
+/// A labelled form field, marked when focused. `text` fields show a cursor.
+fn field(name: &str, shown: String, focused: bool, text: bool) -> Line<'static> {
+    let marker = if focused { "▸ " } else { "  " };
+    let mut spans = vec![
+        Span::styled(
+            marker,
+            if focused {
+                Style::new().fg(COLOR_SUCCESS).bold()
+            } else {
+                dim()
+            },
+        ),
+        Span::styled(format!("{name:<22}"), label()),
+        Span::styled(shown, value()),
+    ];
+    if focused && text {
+        spans.push(Span::styled("▎", Style::new().fg(COLOR_SUCCESS)));
+    } else if focused {
+        spans.push(Span::styled("  ←/→", dim()));
+    }
+    Line::from(spans)
+}
+
+fn tick(on: bool) -> String {
+    if on { "[x]" } else { "[ ]" }.to_string()
+}
+
+/// Render the Vetting page.
+pub fn render(v: &VettingState) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+
+    let tab_style = |tab: VettingTab| {
+        if v.tab == tab {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            dim()
+        }
+    };
+    let sep = || Span::styled(" | ", dim());
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!(" Applications ({}) ", v.applications.len()),
+            tab_style(VettingTab::Applications),
+        ),
+        sep(),
+        Span::styled(
+            format!(" Vetter desk ({}) ", v.desk.len()),
+            tab_style(VettingTab::Desk),
+        ),
+        sep(),
+        Span::styled(
+            format!(" Tickets ({}) ", v.tickets.len()),
+            tab_style(VettingTab::Tickets),
+        ),
+        sep(),
+        Span::styled(
+            format!(" Issued ({}) ", v.issued.len()),
+            tab_style(VettingTab::Issued),
+        ),
+    ]));
+    lines.push(Line::from(""));
+
+    if let Some(message) = &v.status_message {
+        super::status::push_status(&mut lines, message, "");
+        lines.push(Line::from(""));
+    }
+
+    match &v.mode {
+        VettingMode::List => match v.tab {
+            VettingTab::Applications => applications(&mut lines, v),
+            VettingTab::Desk => desk(&mut lines, v),
+            VettingTab::Tickets => tickets(&mut lines, v),
+            VettingTab::Issued => issued(&mut lines, v),
+        },
+        VettingMode::NewApplication {
+            community,
+            persona_index,
+            field: f,
+        } => {
+            lines.push(heading("Apply to be vetted"));
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "The community's DID, and the persona you will join with. The persona is fixed",
+            ));
+            lines.push(hint(
+                "for the whole application: every card is signed by it, and every statement names it.",
+            ));
+            lines.push(Line::from(""));
+            lines.push(field("Community DID", community.clone(), *f == 0, true));
+            let persona = v
+                .personas
+                .get(*persona_index)
+                .map(|p| format!("{}  ({})", p.label, p.did))
+                .unwrap_or_else(|| "no personas".to_string());
+            lines.push(field("Join as", persona, *f == 1, false));
+            lines.push(Line::from(""));
+            lines.push(hint("Enter: start  Tab: next field  Esc: cancel"));
+        }
+        VettingMode::EditIdentity {
+            claims, field: f, ..
+        } => {
+            lines.push(heading("The identity you show vetters"));
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "Enter it exactly as it appears on the documents you will show. Every vetter sees",
+            ));
+            lines.push(hint(
+                "the same values; a difference between two cards makes the community refer you.",
+            ));
+            lines.push(Line::from(""));
+            for (i, (claim_type, current)) in claims.iter().enumerate() {
+                lines.push(field(claim_type, current.clone(), i == *f, true));
+            }
+            lines.push(Line::from(""));
+            lines.push(hint("Enter: save  ↑/↓: field  Esc: cancel"));
+        }
+        VettingMode::RequestVetter {
+            vetter,
+            code,
+            field: f,
+            ..
+        } => {
+            lines.push(heading("Ask a vetter"));
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "A vetter only answers a request carrying their ticket code — ask them for one first.",
+            ));
+            lines.push(Line::from(""));
+            lines.push(field("Vetter DID", vetter.clone(), *f == 0, true));
+            lines.push(field("Ticket code", code.clone(), *f == 1, true));
+            lines.push(Line::from(""));
+            lines.push(hint("Enter: send  Tab: next field  Esc: cancel"));
+        }
+        VettingMode::SendCard {
+            application_id,
+            session_id,
+        } => send_card(&mut lines, v, application_id, session_id),
+        VettingMode::NewTicket {
+            membership_index,
+            uses_index,
+            field: f,
+        } => {
+            lines.push(heading("Hand out a ticket"));
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "A ticket lets one person — or a queue at a desk — ask you. Requests without one",
+            ));
+            lines.push(hint("are never answered."));
+            lines.push(Line::from(""));
+            let community = v
+                .memberships
+                .get(*membership_index)
+                .map(|m| m.name.clone())
+                .unwrap_or_default();
+            lines.push(field("Community", community, *f == 0, false));
+            let uses = VETTING_TICKET_USES[(*uses_index).min(VETTING_TICKET_USES.len() - 1)];
+            lines.push(field(
+                "Admits",
+                format!("{uses} request{}", if uses == 1 { "" } else { "s" }),
+                *f == 1,
+                false,
+            ));
+            lines.push(Line::from(""));
+            lines.push(hint("Enter: issue  Tab: next field  Esc: cancel"));
+        }
+        VettingMode::OpenSession {
+            request_id,
+            method_index,
+        } => {
+            lines.push(heading("Open a session"));
+            lines.push(Line::from(""));
+            if let Some(row) = v.desk.iter().find(|d| &d.request_id == request_id) {
+                lines.push(Line::from(vec![
+                    Span::styled("With   ", label()),
+                    Span::styled(
+                        display_identifier(row.applicant_name.as_deref(), &row.applicant, 256)
+                            .into_owned(),
+                        value(),
+                    ),
+                ]));
+            }
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "Open it with the person in front of you or on the call: both screens will show a",
+            ));
+            lines.push(hint(
+                "code you read to each other before their card is sent.",
+            ));
+            lines.push(Line::from(""));
+            let method = VETTING_METHODS[(*method_index).min(VETTING_METHODS.len() - 1)];
+            lines.push(field(
+                "Method",
+                method_label(method).to_string(),
+                true,
+                false,
+            ));
+            lines.push(Line::from(""));
+            lines.push(hint("Enter: open  Esc: cancel"));
+        }
+        VettingMode::Attest { request_id, form } => attest(&mut lines, v, request_id, form),
+        VettingMode::ConfirmDecline { request_id } => {
+            lines.push(heading("Decline this request?"));
+            lines.push(Line::from(""));
+            if let Some(row) = v.desk.iter().find(|d| &d.request_id == request_id) {
+                lines.push(Line::from(vec![
+                    Span::styled("Applicant  ", label()),
+                    Span::styled(
+                        display_identifier(row.applicant_name.as_deref(), &row.applicant, 256)
+                            .into_owned(),
+                        value(),
+                    ),
+                ]));
+            }
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "You never have to give a reason, and the community is not told.",
+            ));
+            lines.push(Line::from(""));
+            lines.push(
+                Line::from("y: decline    n: keep it")
+                    .fg(COLOR_ORANGE)
+                    .bold(),
+            );
+        }
+        VettingMode::Withdraw {
+            statement_id,
+            reason_index,
+        } => {
+            lines.push(heading("Withdraw a statement"));
+            lines.push(Line::from(""));
+            if let Some(row) = v.issued.iter().find(|s| &s.id == statement_id) {
+                lines.push(Line::from(vec![
+                    Span::styled("About      ", label()),
+                    Span::styled(row.applicant.clone(), value()),
+                ]));
+                lines.push(Line::from(vec![
+                    Span::styled("Community  ", label()),
+                    Span::styled(row.community.clone(), value()),
+                ]));
+            }
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "The community stops counting it. If it already helped someone join, the",
+            ));
+            lines.push(hint("community records the withdrawal for review."));
+            lines.push(Line::from(""));
+            let reason = VETTING_WITHDRAWAL_REASONS
+                [(*reason_index).min(VETTING_WITHDRAWAL_REASONS.len() - 1)];
+            lines.push(field(
+                "Reason",
+                reason_label(reason).to_string(),
+                true,
+                false,
+            ));
+            lines.push(Line::from(""));
+            lines.push(hint("Enter: withdraw  Esc: cancel"));
+        }
+    }
+
+    lines
+}
+
+fn applications(lines: &mut Vec<Line<'static>>, v: &VettingState) {
+    if v.applications.is_empty() {
+        lines.push(hint("You are not applying to any community."));
+        lines.push(Line::from(""));
+        lines.push(hint(
+            "A community that vets its members publishes what it requires. Start an application,",
+        ));
+        lines.push(hint(
+            "then ask vetters for their ticket codes and send each a request.",
+        ));
+        lines.push(Line::from(""));
+        lines.push(hint("n: new application"));
+        return;
+    }
+    for (i, app) in v.applications.iter().enumerate() {
+        let selected = i == v.selected;
+        let style = if selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            label()
+        };
+        let name = app
+            .community_name
+            .clone()
+            .unwrap_or_else(|| app.community.clone());
+        lines.push(Line::from(vec![
+            Span::styled(if selected { "▸ " } else { "  " }, style),
+            Span::styled(name, style),
+            Span::styled(
+                format!("  {} statement(s)", app.statements),
+                if app.satisfied {
+                    Style::new().fg(COLOR_SUCCESS)
+                } else {
+                    dim()
+                },
+            ),
+        ]));
+    }
+    let Some(app) = v.applications.get(v.selected) else {
+        return;
+    };
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("Joining as   ", label()),
+        Span::styled(app.join_did.clone(), value()),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Requires     ", label()),
+        match &app.requirements {
+            Some(r) => Span::styled(r.clone(), value()),
+            None => Span::styled(
+                "not known yet — m asks the community",
+                Style::new().fg(COLOR_ORANGE),
+            ),
+        },
+    ]));
+    if let Some(progress) = &app.progress {
+        lines.push(Line::from(vec![
+            Span::styled("Progress     ", label()),
+            Span::styled(
+                progress.clone(),
+                if app.satisfied {
+                    Style::new().fg(COLOR_SUCCESS)
+                } else {
+                    Style::new().fg(COLOR_ORANGE)
+                },
+            ),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(" Identity shown to vetters").fg(COLOR_SUCCESS));
+    for (claim_type, shown) in &app.identity {
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {claim_type:<20}"), label()),
+            if shown.is_empty() {
+                Span::styled("not set — press i", Style::new().fg(COLOR_ORANGE))
+            } else {
+                Span::styled(shown.clone(), value())
+            },
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(" Vetters").fg(COLOR_SUCCESS));
+    if app.requests.is_empty() {
+        lines.push(hint("  none yet — r asks a vetter"));
+    }
+    for request in &app.requests {
+        lines.push(Line::from(vec![
+            Span::styled("  ", label()),
+            Span::styled(
+                display_identifier(request.vetter_name.as_deref(), &request.vetter, 60)
+                    .into_owned(),
+                value(),
+            ),
+        ]));
+        let mut state = vec![Span::styled(format!("    {}", request.state), dim())];
+        if let Some(code) = &request.match_code {
+            state.push(Span::styled("   code ", label()));
+            state.push(Span::styled(
+                code.clone(),
+                Style::new().fg(COLOR_SUCCESS).bold(),
+            ));
+        }
+        lines.push(Line::from(state));
+    }
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "n: new  i: identity  r: ask a vetter  c: send card  m: refresh requirements  Tab: next tab",
+    ));
+}
+
+fn send_card(
+    lines: &mut Vec<Line<'static>>,
+    v: &VettingState,
+    application_id: &str,
+    session_id: &str,
+) {
+    lines.push(heading("Send your card"));
+    lines.push(Line::from(""));
+    let Some(app) = v.applications.iter().find(|a| a.id == application_id) else {
+        return;
+    };
+    let request = app
+        .requests
+        .iter()
+        .find(|r| r.card_session.as_deref() == Some(session_id));
+    if let Some(request) = request {
+        lines.push(Line::from(vec![
+            Span::styled("To      ", label()),
+            Span::styled(
+                display_identifier(request.vetter_name.as_deref(), &request.vetter, 256)
+                    .into_owned(),
+                value(),
+            ),
+        ]));
+        if let Some(code) = &request.match_code {
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("Match code   ", label()),
+                Span::styled(code.clone(), Style::new().fg(COLOR_SUCCESS).bold()),
+            ]));
+            lines.push(Line::from(""));
+            lines.push(
+                Line::from(
+                    "Read this code to the vetter, and hear it read back. Send only if it matches.",
+                )
+                .fg(COLOR_ORANGE),
+            );
+        }
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(" The card shows").fg(COLOR_SUCCESS));
+    for (claim_type, shown) in &app.identity {
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {claim_type:<20}"), label()),
+            if shown.is_empty() {
+                Span::styled(
+                    "not set — Esc, then i",
+                    Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
+                )
+            } else {
+                Span::styled(shown.clone(), value())
+            },
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "No document numbers or images are sent: the vetter looks at your document, not a copy.",
+    ));
+    lines.push(Line::from(""));
+    lines.push(hint("Enter: sign and send  Esc: not now"));
+}
+
+fn desk(lines: &mut Vec<Line<'static>>, v: &VettingState) {
+    if v.desk.is_empty() {
+        lines.push(hint("No one has asked you to vet them."));
+        lines.push(Line::from(""));
+        lines.push(hint(
+            "Requests arrive only with one of your tickets — hand them out from the Tickets tab.",
+        ));
+        return;
+    }
+    for (i, row) in v.desk.iter().enumerate() {
+        let selected = i == v.selected;
+        let style = if selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            label()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if selected { "▸ " } else { "  " }, style),
+            Span::styled(
+                display_identifier(row.applicant_name.as_deref(), &row.applicant, 60).into_owned(),
+                style,
+            ),
+            Span::styled(format!("  {}", row.state), dim()),
+        ]));
+    }
+    let Some(row) = v.desk.get(v.selected) else {
+        return;
+    };
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled("Community    ", label()),
+        Span::styled(row.community.clone(), value()),
+    ]));
+    if let Some(message) = &row.message {
+        lines.push(Line::from(vec![
+            Span::styled("Their note   ", label()),
+            Span::styled(message.clone(), Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]));
+    }
+    if let Some(method) = &row.method {
+        lines.push(Line::from(vec![
+            Span::styled("Method       ", label()),
+            Span::styled(method.clone(), value()),
+        ]));
+    }
+    if let Some(code) = &row.match_code {
+        lines.push(Line::from(vec![
+            Span::styled("Match code   ", label()),
+            Span::styled(code.clone(), Style::new().fg(COLOR_SUCCESS).bold()),
+        ]));
+    }
+    if !row.claims.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(" Their card").fg(COLOR_SUCCESS));
+        for (claim_type, shown) in &row.claims {
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {claim_type:<20}"), label()),
+                Span::styled(shown.clone(), value()),
+            ]));
+        }
+    }
+    lines.push(Line::from(""));
+    let keys = match row.stage {
+        DeskStage::Accepted => "o: open session  x: decline  Tab: next tab",
+        DeskStage::Session => "o: reopen session  x: decline  Tab: next tab",
+        DeskStage::Card => "a: check and attest  x: decline  Tab: next tab",
+        DeskStage::Closed => "Tab: next tab",
+    };
+    lines.push(hint(keys));
+}
+
+fn attest(lines: &mut Vec<Line<'static>>, v: &VettingState, request_id: &str, form: &AttestForm) {
+    lines.push(heading("Check the person, then attest"));
+    lines.push(Line::from(""));
+    let Some(row) = v.desk.iter().find(|d| d.request_id == request_id) else {
+        return;
+    };
+    lines.push(Line::from(vec![
+        Span::styled("Applicant    ", label()),
+        Span::styled(
+            display_identifier(row.applicant_name.as_deref(), &row.applicant, 256).into_owned(),
+            value(),
+        ),
+    ]));
+    if let Some(code) = &row.match_code {
+        lines.push(Line::from(vec![
+            Span::styled("Match code   ", label()),
+            Span::styled(code.clone(), Style::new().fg(COLOR_SUCCESS).bold()),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(" Their card").fg(COLOR_SUCCESS));
+    for (claim_type, shown) in &row.claims {
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {claim_type:<20}"), label()),
+            Span::styled(shown.clone(), value()),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "Look at their document in person or on camera. Check it appears genuine, the photo is",
+    ));
+    lines.push(hint(
+        "the person you are talking to, and the name matches the card. Do not keep a copy.",
+    ));
+    lines.push(Line::from(""));
+
+    let method = VETTING_METHODS[form.method_index.min(VETTING_METHODS.len() - 1)];
+    lines.push(field(
+        "Method",
+        method_label(method).to_string(),
+        form.field == 0,
+        false,
+    ));
+    let documentation = v
+        .documentation
+        .get(form.documentation_index)
+        .cloned()
+        .unwrap_or_default();
+    lines.push(field(
+        "Documentation",
+        documentation,
+        form.field == 1,
+        false,
+    ));
+    let relationship =
+        VETTING_RELATIONSHIPS[form.relationship_index.min(VETTING_RELATIONSHIPS.len() - 1)];
+    lines.push(field(
+        "Relationship",
+        relationship_label(relationship).to_string(),
+        form.field == 2,
+        false,
+    ));
+    lines.push(field(
+        "We read the code",
+        format!(
+            "{}  we read the match code to each other",
+            tick(form.liveness_confirmed)
+        ),
+        form.field == 3,
+        false,
+    ));
+    lines.push(Line::from(""));
+    lines.push(Line::from(format!(
+        "  \"I attest that I verified, by {}, that the person controlling {} presented",
+        method_label(method),
+        row.applicant
+    )));
+    lines.push(Line::from(format!(
+        "  documentation matching the {} above. I did not retain copies of it. I understand",
+        row.required_claims.join(", "),
+    )));
+    lines.push(Line::from(format!(
+        "  this statement is attributable to me within {}.\"",
+        row.community
+    )));
+    lines.push(field(
+        "I attest",
+        format!("{}  sign this statement as me", tick(form.attested)),
+        form.field == 4,
+        false,
+    ));
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "↑/↓: item  ←/→: choose  Space: tick  Enter: sign and send  Esc: cancel",
+    ));
+}
+
+fn tickets(lines: &mut Vec<Line<'static>>, v: &VettingState) {
+    if v.tickets.is_empty() {
+        lines.push(hint("You have no tickets out."));
+        lines.push(Line::from(""));
+        lines.push(hint(
+            "t: hand out a ticket — read the code to someone, or copy it to send them",
+        ));
+        return;
+    }
+    for (i, row) in v.tickets.iter().enumerate() {
+        let selected = i == v.selected;
+        let style = if selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            label()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if selected { "▸ " } else { "  " }, style),
+            Span::styled(
+                row.code.clone(),
+                if row.live {
+                    Style::new().fg(COLOR_SUCCESS).bold()
+                } else {
+                    dim()
+                },
+            ),
+            Span::styled(format!("  {}", row.community), style),
+            Span::styled(
+                if row.live {
+                    format!("  {} left, until {}", row.uses_left, row.expires)
+                } else {
+                    "  spent or expired".to_string()
+                },
+                dim(),
+            ),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "t: new ticket  y: copy code  d: delete  Tab: next tab",
+    ));
+}
+
+fn issued(lines: &mut Vec<Line<'static>>, v: &VettingState) {
+    if v.issued.is_empty() {
+        lines.push(hint("You have not signed any vetting statements."));
+        return;
+    }
+    for (i, row) in v.issued.iter().enumerate() {
+        let selected = i == v.selected;
+        let style = if selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            label()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if selected { "▸ " } else { "  " }, style),
+            Span::styled(row.applicant.clone(), style),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!(
+                    "    {} · {} · {} → {}",
+                    row.community, row.method, row.issued, row.valid_until
+                ),
+                dim(),
+            ),
+            match &row.withdrawal {
+                Some(w) => Span::styled(format!("  {w}"), Style::new().fg(COLOR_ORANGE)),
+                None => Span::styled("", dim()),
+            },
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(hint("w: withdraw  Tab: next tab"));
+}

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -251,6 +251,21 @@ impl Component for MainPage {
                         .send(Action::Credential(CredentialAction::ReasonUpdate(updated)));
                 }
             }
+            MainMenu::Vetting => {
+                if let Some(current) = self
+                    .props
+                    .main_page
+                    .content_panel
+                    .vetting
+                    .mode
+                    .focused_text()
+                {
+                    let updated = format!("{current}{trimmed}");
+                    let _ = self.action_tx.send(Action::Vetting(
+                        crate::state_handler::actions::VettingAction::Input(updated),
+                    ));
+                }
+            }
             MainMenu::Settings => {
                 match &self.props.main_page.content_panel.settings.mode {
                     SettingsMode::EditFriendlyName { input }
@@ -354,6 +369,7 @@ impl MainPage {
             MainMenu::Communities => self.handle_communities_key(key),
             MainMenu::Identity => self.handle_personas_key(key),
             MainMenu::Vta => self.handle_vta_key(key),
+            MainMenu::Vetting => self.handle_vetting_key(key),
             _ => false,
         }
     }
@@ -2210,6 +2226,79 @@ impl MainPage {
 /// the key edits the buffer, or `None` otherwise. Append-only semantics
 /// (printable char appends at the end; Backspace removes the last char) — these
 /// inline editors have no cursor, matching the prior behavior exactly.
+impl MainPage {
+    /// Vetting page keys.
+    ///
+    /// In a list: `Tab` switches tab, `↑/↓` select, and each tab has its own
+    /// verbs (shown in its footer). In a form: `↑/↓`/`Tab` move between fields,
+    /// a text field takes typing, `←/→` cycle a choice, `Space` ticks, `Enter`
+    /// commits and `Esc` leaves.
+    fn handle_vetting_key(&mut self, key: KeyEvent) -> bool {
+        use crate::state_handler::actions::VettingAction as V;
+        use crate::state_handler::main_page::content::{VettingMode, VettingTab};
+
+        let vetting = &self.props.main_page.content_panel.vetting;
+        if !matches!(vetting.mode, VettingMode::List) {
+            let text = vetting.mode.focused_text().map(str::to_string);
+            let confirming = matches!(vetting.mode, VettingMode::ConfirmDecline { .. });
+            let action = match key.code {
+                KeyCode::Esc => Some(V::Back),
+                KeyCode::Enter => Some(V::Submit),
+                KeyCode::Tab | KeyCode::Down => Some(V::NextField),
+                KeyCode::BackTab | KeyCode::Up => Some(V::PrevField),
+                KeyCode::Left => Some(V::Cycle(false)),
+                KeyCode::Right => Some(V::Cycle(true)),
+                code => match text {
+                    Some(current) => edit_text(code, &current).map(V::Input),
+                    None if code == KeyCode::Char('y') && confirming => Some(V::Submit),
+                    None if code == KeyCode::Char('n') && confirming => Some(V::Back),
+                    None if code == KeyCode::Char(' ') => Some(V::Toggle),
+                    None => None,
+                },
+            };
+            return match action {
+                Some(action) => {
+                    let _ = self.action_tx.send(Action::Vetting(action));
+                    true
+                }
+                None => false,
+            };
+        }
+
+        let selected = vetting.selected;
+        let len = vetting.tab_len();
+        let action = match (vetting.tab, key.code) {
+            (_, KeyCode::Tab) => V::SwitchTab,
+            (_, KeyCode::Up) if selected > 0 => V::Select(selected - 1),
+            (_, KeyCode::Down) if selected + 1 < len => V::Select(selected + 1),
+            (VettingTab::Applications, KeyCode::Char('n')) => V::StartApplication,
+            (VettingTab::Applications, KeyCode::Char('i')) => V::EditIdentity,
+            (VettingTab::Applications, KeyCode::Char('r')) => V::RequestVetter,
+            (VettingTab::Applications, KeyCode::Char('m')) => V::RefreshRequirements,
+            (VettingTab::Applications, KeyCode::Char('c') | KeyCode::Enter) => V::ReviewCard,
+            (VettingTab::Desk, KeyCode::Char('o')) => V::OpenSession,
+            (VettingTab::Desk, KeyCode::Char('a') | KeyCode::Enter) => V::StartAttest,
+            (VettingTab::Desk, KeyCode::Char('x')) => V::ArmDecline,
+            (VettingTab::Tickets, KeyCode::Char('t')) => V::NewTicket,
+            (VettingTab::Tickets, KeyCode::Char('d')) => V::DeleteTicket,
+            (VettingTab::Tickets, KeyCode::Char('y')) => {
+                let Some(ticket) = vetting.tickets.get(selected) else {
+                    return true;
+                };
+                let status = match crate::clipboard::copy_to_clipboard(&ticket.code) {
+                    Ok(method) => format!("Ticket code copied via {}.", method.label()),
+                    Err(e) => format!("Could not copy the code: {e}"),
+                };
+                V::Status(status)
+            }
+            (VettingTab::Issued, KeyCode::Char('w')) => V::ArmWithdraw,
+            _ => return false,
+        };
+        let _ = self.action_tx.send(Action::Vetting(action));
+        true
+    }
+}
+
 fn edit_text(code: KeyCode, current: &str) -> Option<String> {
     match code {
         KeyCode::Char(c) => {
@@ -2321,6 +2410,7 @@ fn view_id(page: &MainPageState) -> String {
             SettingsMode::TokenManagement { .. } => "token",
             SettingsMode::WipeConfirm { .. } => "wipe",
         },
+        MainMenu::Vetting => components::vetting_panel::mode_id(&page.content_panel.vetting),
         _ => "",
     };
     format!("{menu:?}:{mode}")
@@ -3199,6 +3289,82 @@ mod key_handler_tests {
             remote_agent_name: None,
             created: String::new(),
         }
+    }
+
+    // ----- Vetting -----------------------------------------------------------
+
+    fn vetting_action(
+        rx: &mut UnboundedReceiver<Action>,
+    ) -> crate::state_handler::actions::VettingAction {
+        match rx.try_recv() {
+            Ok(Action::Vetting(action)) => action,
+            _ => panic!("expected a Vetting action"),
+        }
+    }
+
+    #[test]
+    fn vetting_list_keys_follow_the_tab() {
+        use crate::state_handler::actions::VettingAction as V;
+        use crate::state_handler::main_page::content::VettingTab;
+
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |_| {});
+        page.handle_key_event(press(KeyCode::Char('n')));
+        assert!(matches!(vetting_action(&mut rx), V::StartApplication));
+
+        // The same key means nothing on the desk…
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |s| {
+            s.main_page.content_panel.vetting.tab = VettingTab::Desk;
+        });
+        page.handle_key_event(press(KeyCode::Char('n')));
+        assert!(rx.try_recv().is_err());
+        // …where `x` arms a decline.
+        page.handle_key_event(press(KeyCode::Char('x')));
+        assert!(matches!(vetting_action(&mut rx), V::ArmDecline));
+
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |_| {});
+        page.handle_key_event(press(KeyCode::Tab));
+        assert!(matches!(vetting_action(&mut rx), V::SwitchTab));
+    }
+
+    #[test]
+    fn vetting_forms_take_text_cycle_and_tick() {
+        use crate::state_handler::actions::VettingAction as V;
+        use crate::state_handler::main_page::content::{AttestForm, VettingMode};
+
+        // A focused text field takes typing, spaces included.
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |s| {
+            s.main_page.content_panel.vetting.mode = VettingMode::RequestVetter {
+                application_id: "a1".into(),
+                vetter: "did:key:z".into(),
+                code: String::new(),
+                field: 0,
+            };
+        });
+        page.handle_key_event(press(KeyCode::Char('Q')));
+        assert!(matches!(vetting_action(&mut rx), V::Input(text) if text == "did:key:zQ"));
+
+        // In the checklist, Space ticks and the arrows cycle.
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |s| {
+            s.main_page.content_panel.vetting.mode = VettingMode::Attest {
+                request_id: "r1".into(),
+                form: AttestForm::default(),
+            };
+        });
+        page.handle_key_event(press(KeyCode::Char(' ')));
+        assert!(matches!(vetting_action(&mut rx), V::Toggle));
+        page.handle_key_event(press(KeyCode::Right));
+        assert!(matches!(vetting_action(&mut rx), V::Cycle(true)));
+        page.handle_key_event(press(KeyCode::Enter));
+        assert!(matches!(vetting_action(&mut rx), V::Submit));
+
+        // A decline is confirmed with y, and n keeps the request.
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |s| {
+            s.main_page.content_panel.vetting.mode = VettingMode::ConfirmDecline {
+                request_id: "r1".into(),
+            };
+        });
+        page.handle_key_event(press(KeyCode::Char('n')));
+        assert!(matches!(vetting_action(&mut rx), V::Back));
     }
 
     // ----- Communities -------------------------------------------------------


### PR DESCRIPTION
Stacked on #294.

Adds the **Vetting** menu entry, which drives `openvtc-core::vetting` from the TUI (`docs/design/vetting-process.md` §12). After this PR, someone can apply to a community that vets, and a member can vet them, entirely from the client.

## The page

| Tab | What you do there |
|---|---|
| **Applications** | `n` start an application with a community DID and a persona. `i` enter the identity every vetter is shown. `r` ask a vetter with their ticket code. `c` read the match code together, then sign and send the card. `m` re-read the requirements. The page shows progress against the published requirements, worded as "meets the published requirements", never "approved" (D12). |
| **Vetter desk** | `o` open a session with the person in front of you. `a` check their card and the person against the §9.3 checklist, then attest. `x` decline, with no reason required. |
| **Tickets** | `t` issue a ticket for an active membership, good for one request or a desk queue of 5–25, valid 14 days. `y` copy its code. `d` delete it. |
| **Issued** | `w` withdraw a statement, giving a reason, to the community. |

Forms behave the same way everywhere: `↑/↓` or `Tab` moves between fields, text fields accept typing and bracketed paste, `←/→` cycles a choice, `Space` ticks a box, `Enter` commits and `Esc` leaves.

## What the page guards

- **Identity:** it cannot be changed once any vetter has seen it. Different values on two cards would make the community refer the application.
- **Attesting:** the vetter must tick the attestation. The core adds its own checks: liveness is required except for `priorAcquaintance`, documentation must be named, and every required claim must be verified.
- **Opening a session:** the vetter's client first asks the community which claims it requires, so every vetter asks for the same set. If they try a second time without an answer, it falls back to a legal name and says so.

## How sends work

- **Where the work happens:** signing runs on the loop, since the keys are local. Every send runs as a background job on a new `Vetting` dispatch domain, one at a time.
- **A failed send undoes its step**, so it can be retried:
  - a request is forgotten;
  - a statement is un-issued and the desk goes back to *card received*;
  - a decline or withdrawal is reverted.
- **Inbox tasks** raised by #294 are cleared when the step they asked for is sent.

## Also

- **Pending-join expiry:** a pending join now waits for the community's published `decisionSla` before it expires, instead of the fixed 7 days (§14.1). Commit 1 covers this, with tests in `openvtc-core`.
- **Without a persona:** vetting actions say to create a persona and restart. With no persona the account runs the degraded loop, which has neither a messaging identity nor an inbound arm.

## Tests

- **Key routing** (`ui/pages/main`):
  - list keys differ by tab;
  - forms take text, spaces included;
  - Space ticks, the arrows cycle, and Enter submits;
  - `y` and `n` confirm or cancel a decline.
- **`vetting_actions`:**
  - a failed request is forgotten, and the status says why;
  - the rows are built from the book.
- **Core:**
  - a published SLA replaces the client timeout;
  - the SLA is learned from the manifest.
- **Local runs:** `cargo test -p openvtc` (469) and `-p openvtc-core --lib` (576), plus `cargo clippy --workspace --all-targets -D warnings` and `cargo fmt --check`.

## Not in this PR

- **Card claims:** they are typed in, not read from a persona face.
- **Tickets:** code form only. No QR or scanned secret yet.
- **Directory:** there is no vetter directory (V1).
