### PR TITLE
feat(vetting): the card is read from the persona's face

### DIFF
--- a/openvtc-core/src/persona/disclosure.rs
+++ b/openvtc-core/src/persona/disclosure.rs
@@ -1,18 +1,23 @@
-//! What has actually left — the permanent record of every release.
-//! **Holder-scoped**, and the one read in this module family that deliberately
-//! spans every context at once.
+//! Releasing what a face shows, and the permanent record of every release.
 //!
-//! # Read-only here, and that is the design
+//! # Only when someone asks
 //!
 //! The two writing halves of `persona/disclosure/*` are a preview and the
 //! present it authorises, and they exist to be driven by a verifier's request:
-//! a site asks, a human is shown exactly what would go, and only then is
-//! anything signed. OpenVTC is not a verifier and has nothing asking, so a
-//! "disclose something now" button here would be a request with no requester —
-//! the one shape the two-call gate exists to prevent.
+//! someone asks, a human is shown exactly what would go, and only then does
+//! anything leave. A "disclose something now" button with nobody asking would
+//! be a request with no requester — the one shape the two-call gate exists to
+//! prevent.
 //!
-//! What the TUI can usefully answer is the question asked after the fact: what does
-//! anyone already know, and how did they come to know it. That is this module.
+//! Peer vetting has a requester. A vetter's `vetting/session` names the claim
+//! types they will check against the person in front of them, so [`preview`]
+//! and [`present`] are driven by that session: the verifier is the vetter, the
+//! challenge is the session's, and the holder approves the preview before the
+//! card is signed (`docs/design/vetting-process.md` §9.2).
+//!
+//! [`history`] answers the question asked after the fact: what does anyone
+//! already know, and how did they come to know it. It is **holder-scoped**, and
+//! the one read in this module family that deliberately spans every context.
 //!
 //! # A rung is not a detail
 //!
@@ -146,6 +151,187 @@ fn rung_label(rung: &str) -> &str {
     }
 }
 
+/// The renderer a vetting card is built from: the one that carries provenance.
+pub const RCARD_RENDERER: &str = "rcard";
+
+/// One claim as a disclosure carries it — what the holder is shown in a
+/// preview, and what left in the artifact. The two have the same shape.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReleasedClaim {
+    /// The vocabulary token — `name.legal`.
+    pub claim_type: String,
+    /// Absent when the claim is proved as a predicate: the verifier learns an
+    /// answer, never the value.
+    pub value: Option<Value>,
+    /// Where the value came from: `selfAsserted`, `credentialBacked`, …
+    /// Absent only when the renderer dropped it.
+    pub provenance: Option<String>,
+    /// A credential-backed value that could not be re-derived.
+    pub stale: bool,
+}
+
+impl ReleasedClaim {
+    fn from_wire(value: &Value) -> Self {
+        Self {
+            claim_type: value
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            value: value.get("value").cloned().filter(|v| !v.is_null()),
+            // The preview names the kind; the artifact carries the whole
+            // provenance object. Only the kind travels on.
+            provenance: match value.get("provenance") {
+                Some(Value::String(kind)) => Some(kind.clone()),
+                Some(other) => other
+                    .get("kind")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                None => None,
+            },
+            stale: value.get("stale").and_then(Value::as_bool).unwrap_or(false),
+        }
+    }
+}
+
+/// A preview: what would leave, held by the agent until presented or expired.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Preview {
+    /// Single use; [`present`] consumes it.
+    pub preview_id: String,
+    pub claims: Vec<ReleasedClaim>,
+    pub expires_at: String,
+}
+
+/// Ask what `persona_did`'s face in `context_id` would show `verifier_did`.
+///
+/// Signs nothing and sends nothing. The claims come back so the holder can be
+/// shown them before [`present`] releases them.
+pub async fn preview(
+    client: &VtaClient,
+    context_id: &str,
+    persona_did: &str,
+    verifier_did: &str,
+    requested_claims: Vec<String>,
+    purpose: &str,
+) -> Result<Preview, OpenVTCError> {
+    let value = client
+        .persona_disclosure_preview(
+            context_id,
+            persona_did,
+            verifier_did,
+            requested_claims,
+            Some(purpose),
+            Some(RCARD_RENDERER),
+        )
+        .await
+        .map_err(|e| OpenVTCError::Vta(format!("persona disclosure preview failed: {e}")))?;
+    let preview_id = value
+        .get("previewId")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| OpenVTCError::Vta("the disclosure preview carried no previewId".into()))?
+        .to_string();
+    Ok(Preview {
+        preview_id,
+        claims: value
+            .get("claims")
+            .and_then(Value::as_array)
+            .map(|claims| claims.iter().map(ReleasedClaim::from_wire).collect())
+            .unwrap_or_default(),
+        expires_at: value
+            .get("expiresAt")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    })
+}
+
+/// What a present released.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Presented {
+    pub disclosure_id: String,
+    pub claims: Vec<ReleasedClaim>,
+}
+
+/// Why a present did not release anything.
+#[derive(Debug, thiserror::Error)]
+pub enum PresentError {
+    /// A claim needs a fresh approval. The preview survives: approve on the
+    /// device, then present the same preview again.
+    #[error("a claim in this disclosure needs your approval first")]
+    StepUpRequired,
+    /// Anything else. The preview may be gone.
+    #[error("{0}")]
+    Failed(String),
+}
+
+/// Release what the preview `preview_id` showed, bound to `challenge`.
+///
+/// # Errors
+///
+/// [`PresentError::StepUpRequired`] when the agent wants a fresh approval —
+/// the one refusal that leaves the preview usable.
+pub async fn present(
+    client: &VtaClient,
+    context_id: &str,
+    preview_id: &str,
+    challenge: Option<&str>,
+) -> Result<Presented, PresentError> {
+    let value = client
+        .persona_disclosure_present(context_id, preview_id, challenge, None)
+        .await
+        .map_err(|e| {
+            let message = e.to_string();
+            // `persona/disclosure/present/1.0` refuses with a
+            // specification-extended code the SDK reports as text.
+            if message.contains("stepUpRequired") {
+                PresentError::StepUpRequired
+            } else {
+                PresentError::Failed(format!("persona disclosure present failed: {message}"))
+            }
+        })?;
+    let claims = value
+        .get("artifact")
+        .map(artifact_claims)
+        .transpose()
+        .map_err(PresentError::Failed)?
+        .ok_or_else(|| PresentError::Failed("the disclosure carried no artifact".into()))?;
+    Ok(Presented {
+        disclosure_id: value
+            .get("disclosureId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        claims,
+    })
+}
+
+/// The claims in a rendered artifact, in the order the renderer numbered them.
+///
+/// The artifact travels as a JSON string; an object is accepted too.
+fn artifact_claims(artifact: &Value) -> Result<Vec<ReleasedClaim>, String> {
+    let parsed;
+    let document = match artifact {
+        Value::String(text) => {
+            parsed = serde_json::from_str::<Value>(text)
+                .map_err(|e| format!("the disclosure artifact is not JSON: {e}"))?;
+            &parsed
+        }
+        other => other,
+    };
+    let claims = document
+        .get("claims")
+        .and_then(Value::as_object)
+        .ok_or("the disclosure artifact carries no claims")?;
+    let mut numbered: Vec<(&String, &Value)> = claims.iter().collect();
+    numbered.sort_by(|a, b| a.0.cmp(b.0));
+    Ok(numbered
+        .into_iter()
+        .map(|(_, claim)| ReleasedClaim::from_wire(claim))
+        .collect())
+}
+
 /// Every release, newest first, across every context.
 ///
 /// `limit` caps the read: a history is append-only and unbounded, and a panel
@@ -217,6 +403,47 @@ mod tests {
             "claims": [{ "type": "email.work" }],
         }));
         assert_eq!(row.claims[0].rung, "whole");
+    }
+
+    /// The artifact's claims come back in the renderer's order, with the
+    /// provenance kind lifted out of its object and a predicate left valueless.
+    #[test]
+    fn an_artifact_yields_its_claims_in_order() {
+        let artifact = serde_json::json!({
+            "type": ["VerifiableDataStructure", "RelationshipCard"],
+            "claims": {
+                "0001": { "type": "age.over18", "predicate": { "op": "gte" },
+                          "provenance": { "kind": "credentialBacked", "credentialId": "c1",
+                                          "claimPath": "/age" } },
+                "0000": { "type": "name.legal", "value": "Alice Example",
+                          "provenance": { "kind": "selfAsserted" } },
+            },
+            "unsigned": true,
+        })
+        .to_string();
+        let claims = artifact_claims(&Value::String(artifact)).unwrap();
+        assert_eq!(claims[0].claim_type, "name.legal");
+        assert_eq!(claims[0].value, Some(serde_json::json!("Alice Example")));
+        assert_eq!(claims[0].provenance.as_deref(), Some("selfAsserted"));
+        assert_eq!(claims[1].value, None);
+        assert_eq!(claims[1].provenance.as_deref(), Some("credentialBacked"));
+    }
+
+    /// A preview names provenance by kind alone.
+    #[test]
+    fn a_preview_claim_reads_its_provenance_kind() {
+        let claim = ReleasedClaim::from_wire(&serde_json::json!({
+            "type": "name.legal", "value": "Alice Example",
+            "provenance": "selfAsserted", "rung": "whole", "newToThisVerifier": true,
+        }));
+        assert_eq!(claim.provenance.as_deref(), Some("selfAsserted"));
+        assert!(!claim.stale);
+    }
+
+    #[test]
+    fn an_artifact_without_claims_is_refused() {
+        assert!(artifact_claims(&Value::String("{}".into())).is_err());
+        assert!(artifact_claims(&Value::String("not json".into())).is_err());
     }
 
     /// A release with nothing recorded says so, rather than rendering as a

--- a/openvtc-core/src/vetting/applicant.rs
+++ b/openvtc-core/src/vetting/applicant.rs
@@ -38,6 +38,7 @@ use vta_sdk::vetting::requirements::{
 use vta_sdk::vetting::statement::verify_statement;
 
 use crate::config::account::PersonaId;
+use crate::persona::disclosure::ReleasedClaim;
 
 /// Why an applicant-side step was refused.
 #[derive(Debug, thiserror::Error)]
@@ -60,6 +61,19 @@ pub enum ApplicantError {
     /// The card would lack a claim the session requires.
     #[error("the card needs a `{0}` claim")]
     MissingClaim(String),
+    /// A claim was released without its value — proved as a predicate — and a
+    /// vetter has to read the value to check it against a document.
+    #[error("your face releases `{0}` without its value, and a vetter has to read it")]
+    ValueWithheld(String),
+    /// A credential-backed claim can no longer be proven.
+    #[error("`{0}` can no longer be proven — refresh it under My Identity")]
+    StaleClaim(String),
+    /// The face now shows a value other than the one earlier cards committed to.
+    #[error(
+        "your face now shows a different `{0}` than the cards you already sent — the \
+         community would refer the application"
+    )]
+    IdentityChanged(String),
     /// Building or verifying an artifact failed.
     #[error(transparent)]
     Vetting(#[from] VettingError),
@@ -85,6 +99,12 @@ pub struct Application {
     pub persona: PersonaId,
     /// The DID every card is signed by and every statement names (D13).
     pub join_did: String,
+    /// The VTA context the persona's face for this community is worn in. Set
+    /// the first time a face is chosen or a card is sent, and reused as the
+    /// membership's sub-context when the join goes through, so the face the
+    /// vetters saw is the face the community sees.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
     /// The manifest criterion being gathered for.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub criterion_id: Option<String>,
@@ -97,10 +117,10 @@ pub struct Application {
     /// One salt for the whole application, so every vetter sees the same
     /// identity commitment. Goes to vetters, never to the community.
     pub commitment_salt: String,
-    /// The identity the applicant shows every vetter, entered once. Reusing it
-    /// is what keeps the commitment identical across cards: two cards that
-    /// spell a name differently commit to different identities, and the
-    /// community refers the application.
+    /// The identity vetters have been shown, as the persona's face disclosed
+    /// it. Every later card must show the same values: two cards that spell a
+    /// name differently commit to different identities, and the community
+    /// refers the application.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub identity_claims: Vec<CardClaim>,
     /// Requests to vetters, newest last.
@@ -277,6 +297,7 @@ impl Application {
             community: community.to_string(),
             persona,
             join_did: join_did.to_string(),
+            context_id: None,
             criterion_id: None,
             requirements: None,
             requirements_digest: None,
@@ -518,6 +539,118 @@ impl Application {
         })
     }
 
+    /// The claim types a card for `session_id` asks the face for: required,
+    /// then optional.
+    #[must_use]
+    pub fn requested_claims(&self, session_id: &str) -> Vec<String> {
+        self.session(session_id)
+            .map(|(_, s)| {
+                s.required_claims
+                    .iter()
+                    .chain(&s.optional_claims)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// The card claims for `session_id` from what the face released (or would
+    /// release — a preview has the same shape).
+    ///
+    /// Only the session's claim types are kept. Each needs a readable, current
+    /// value, and a value vetters were already shown must not have changed.
+    ///
+    /// # Errors
+    ///
+    /// No such session, a required claim missing, a value withheld or stale, or
+    /// an identity that differs from the cards already sent.
+    pub fn card_claims(
+        &self,
+        session_id: &str,
+        released: &[ReleasedClaim],
+    ) -> Result<Vec<CardClaim>, ApplicantError> {
+        let (_, session) = self
+            .session(session_id)
+            .ok_or(ApplicantError::NoMatchingRequest)?;
+        let wanted = |t: &str| {
+            session.required_claims.iter().any(|r| r == t)
+                || session.optional_claims.iter().any(|o| o == t)
+        };
+        let mut claims = Vec::new();
+        for claim in released.iter().filter(|c| wanted(&c.claim_type)) {
+            if claim.stale {
+                return Err(ApplicantError::StaleClaim(claim.claim_type.clone()));
+            }
+            let Some(value) = claim.value.clone() else {
+                return Err(ApplicantError::ValueWithheld(claim.claim_type.clone()));
+            };
+            if self
+                .identity_claims
+                .iter()
+                .any(|shown| shown.claim_type == claim.claim_type && shown.value != value)
+            {
+                return Err(ApplicantError::IdentityChanged(claim.claim_type.clone()));
+            }
+            claims.push(CardClaim {
+                claim_type: claim.claim_type.clone(),
+                value,
+                provenance: claim
+                    .provenance
+                    .clone()
+                    .unwrap_or_else(|| "unstated".to_string()),
+            });
+        }
+        if let Some(missing) = session
+            .required_claims
+            .iter()
+            .find(|t| !claims.iter().any(|c| &c.claim_type == *t))
+        {
+            return Err(ApplicantError::MissingClaim(missing.clone()));
+        }
+        Ok(claims)
+    }
+
+    /// Record a card that has been sent into `session_id`, and remember the
+    /// identity it showed so later cards show the same.
+    ///
+    /// # Errors
+    ///
+    /// No such session, or claims that differ from those already shown.
+    pub fn record_sent_card(
+        &mut self,
+        session_id: &str,
+        card: SentCard,
+        claims: &[CardClaim],
+        now: DateTime<Utc>,
+    ) -> Result<(), ApplicantError> {
+        if let Some(changed) = claims.iter().find(|c| {
+            self.identity_claims
+                .iter()
+                .any(|shown| shown.claim_type == c.claim_type && shown.value != c.value)
+        }) {
+            return Err(ApplicantError::IdentityChanged(changed.claim_type.clone()));
+        }
+        let request = self
+            .requests
+            .iter_mut()
+            .find(|r| matches!(&r.state, RequestState::Session { session, .. } if session.id == session_id))
+            .ok_or(ApplicantError::NoMatchingRequest)?;
+        if let RequestState::Session { card: sent, .. } = &mut request.state {
+            *sent = Some(card);
+        }
+        request.updated_at = now;
+        for claim in claims {
+            if !self
+                .identity_claims
+                .iter()
+                .any(|shown| shown.claim_type == claim.claim_type)
+            {
+                self.identity_claims.push(claim.clone());
+            }
+        }
+        Ok(())
+    }
+
     /// The card to sign for `session_id`, from the claims the applicant chose
     /// to disclose. Only the session's required and optional claim types are
     /// kept; the identity commitment covers the required ones.
@@ -568,6 +701,7 @@ impl Application {
 
     /// Record the signed card we are sending into `session_id`. Verifies it the
     /// way the vetter will, so a card that would be refused never leaves.
+    /// Returns what was recorded.
     ///
     /// # Errors
     ///
@@ -578,7 +712,7 @@ impl Application {
         card: &Value,
         resolver: &TrustTaskVmResolver,
         now: DateTime<Utc>,
-    ) -> Result<(), ApplicantError> {
+    ) -> Result<SentCard, ApplicantError> {
         let join_did = self.join_did.clone();
         let community = self.community.clone();
         let request = self
@@ -608,14 +742,15 @@ impl Application {
             resolver,
         )
         .await?;
-        *sent = Some(SentCard {
+        let recorded = SentCard {
             id: verified.card().id.clone(),
             digest_multibase: verified.digest_multibase().to_string(),
             identity_commitment: verified.card().identity_commitment.clone(),
             sent_at: now,
-        });
+        };
+        *sent = Some(recorded.clone());
         request.updated_at = now;
-        Ok(())
+        Ok(recorded)
     }
 
     /// A statement arrived from `vetter`. Verified and bound to this

--- a/openvtc-core/src/vetting/tests.rs
+++ b/openvtc-core/src/vetting/tests.rs
@@ -25,7 +25,7 @@ use vta_sdk::vetting::card::sign_card;
 use vta_sdk::vetting::statement::sign_statement;
 
 use super::VettingBook;
-use super::applicant::{RequestDraft, RequestState};
+use super::applicant::{ApplicantError, RequestDraft, RequestState};
 use super::inbound::{Context, Handled, Notice, handle};
 use super::tickets::{DEFAULT_VALIDITY, Ticket};
 use super::vetter::{Attestation, DeskState};
@@ -34,6 +34,7 @@ use super::wire::{
     tests::{did, secret},
 };
 use crate::config::account::{Account, CommunityRecord, PersonaId};
+use crate::persona::disclosure::ReleasedClaim;
 
 const COMMUNITY: &str = "did:web:vtc.example";
 
@@ -324,6 +325,75 @@ async fn an_applicant_is_vetted_end_to_end() {
             .on_withdrawal_recorded(COMMUNITY, &notice_id, Utc::now())
             .is_some()
     );
+}
+
+/// What the face released, as the disclosure reports it.
+fn released(name: Option<&str>) -> Vec<ReleasedClaim> {
+    vec![
+        ReleasedClaim {
+            claim_type: "name.legal".into(),
+            value: name.map(|n| json!(n)),
+            provenance: Some("selfAsserted".into()),
+            stale: false,
+        },
+        ReleasedClaim {
+            claim_type: "email.work".into(),
+            value: Some(json!("alice@example.com")),
+            provenance: Some("selfAsserted".into()),
+            stale: false,
+        },
+    ]
+}
+
+/// A card's identity comes from the persona's face, and every later card has
+/// to show what the first one did.
+#[tokio::test]
+async fn cards_come_from_the_face_and_keep_showing_the_same_identity() {
+    let (mut applicant, mut vetter, _) = ready().await;
+    let resolver = TrustTaskVmResolver::did_key_only();
+    let (_, session_doc) = in_session(&mut applicant, &mut vetter).await;
+    let message = signed(session_doc, &vetter.secret).await;
+    let handled = applicant.receive(&message, &vetter.did).await;
+    let Some(Notice::SessionOpened { session_id, .. }) = handled.notice else {
+        panic!("the session opens");
+    };
+    let signer = applicant.secret.clone();
+    let app = applicant.application();
+    assert_eq!(app.requested_claims(&session_id), vec!["name.legal"]);
+
+    // Only the session's claim types go on the card, and each needs a value a
+    // vetter can read.
+    let claims = app
+        .card_claims(&session_id, &released(Some("Alice Example")))
+        .unwrap();
+    assert_eq!(claims.len(), 1);
+    assert_eq!(claims[0].value, json!("Alice Example"));
+    assert!(matches!(
+        app.card_claims(&session_id, &released(None)),
+        Err(ApplicantError::ValueWithheld(t)) if t == "name.legal"
+    ));
+    assert!(matches!(
+        app.card_claims(&session_id, &[]),
+        Err(ApplicantError::MissingClaim(_))
+    ));
+
+    let draft = app
+        .card_draft(&session_id, claims.clone(), Utc::now())
+        .unwrap();
+    let card = sign_card(draft, &signer).await.unwrap();
+    let sent = app
+        .record_card(&session_id, &card, &resolver, Utc::now())
+        .await
+        .unwrap();
+    app.record_sent_card(&session_id, sent, &claims, Utc::now())
+        .unwrap();
+    assert_eq!(app.identity_claims, claims);
+
+    // The face has changed since: the next card is refused before it is signed.
+    assert!(matches!(
+        app.card_claims(&session_id, &released(Some("Alicia Example"))),
+        Err(ApplicantError::IdentityChanged(t)) if t == "name.legal"
+    ));
 }
 
 #[tokio::test]

--- a/openvtc-core/src/vetting/wire.rs
+++ b/openvtc-core/src/vetting/wire.rs
@@ -274,6 +274,62 @@ pub(crate) mod tests {
         secret.id.split('#').next().unwrap().to_string()
     }
 
+    /// A persona's assertionMethod key as `Config::regenerate_persona_keys`
+    /// loads it: the secret id is the did:webvh verification method.
+    fn webvh_persona_secret() -> Secret {
+        let mut secret = Secret::generate_ed25519(None, Some(&[7u8; 32]));
+        secret.id = "did:webvh:QmScid:example.com:alice#key-0".to_string();
+        secret
+    }
+
+    /// Vetting documents and cards are signed locally as the persona DID — the
+    /// same path reciprocal VMCs and capabilities take — so the proof names
+    /// the persona's own verification method, not a VTA key or a did:key.
+    #[tokio::test]
+    async fn a_persona_signs_as_its_webvh_verification_method() {
+        let signer = webvh_persona_secret();
+        let persona = "did:webvh:QmScid:example.com:alice";
+        let mut doc = document(
+            VETTING_DECLINE_TYPE,
+            persona,
+            "did:webvh:QmScid:example.com:bob",
+            new_id(),
+            &decline(),
+        )
+        .unwrap();
+        sign(&mut doc, &signer).await.unwrap();
+        let signed = serde_json::to_value(&doc).unwrap();
+        assert_eq!(
+            signed.pointer("/proof/verificationMethod"),
+            Some(&json!("did:webvh:QmScid:example.com:alice#key-0"))
+        );
+
+        let draft = vta_sdk::vetting::card::CardDraft {
+            id: new_id(),
+            publisher: persona.to_string(),
+            audience: "did:webvh:QmScid:example.com:bob".to_string(),
+            community: "did:webvh:QmScid:example.com:vtc".to_string(),
+            challenge: "c".repeat(43),
+            domain: "did:webvh:QmScid:example.com:vtc".to_string(),
+            issued_at: Utc::now(),
+            validity: chrono::Duration::minutes(10),
+            claims: vec![vta_sdk::protocols::vetting::CardClaim {
+                claim_type: "name.legal".into(),
+                value: json!("Alice Example"),
+                provenance: "selfAsserted".into(),
+            }],
+            identity_types: vec!["name.legal".into()],
+            salt: vta_sdk::vetting::card::new_commitment_salt().unwrap(),
+        };
+        let card = vta_sdk::vetting::card::sign_card(draft, &signer)
+            .await
+            .unwrap();
+        assert_eq!(
+            card.pointer("/proof/verificationMethod"),
+            Some(&json!("did:webvh:QmScid:example.com:alice#key-0"))
+        );
+    }
+
     fn decline() -> VettingDeclineBody {
         VettingDeclineBody {
             request_id: "r1".into(),

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -305,7 +305,7 @@ pub enum VettingAction {
     Status(String),
     // ── Applicant ────────────────────────────────────────────────────────
     StartApplication,
-    EditIdentity,
+    ChooseFace,
     RequestVetter,
     RefreshRequirements,
     ReviewCard,

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -1069,28 +1069,39 @@ async fn run_join_sequence(
     // persona pre-existed and is left intact.
     let minted = minted_persona.is_some();
 
-    // 6. Derive the per-community sub-context id (D9, collision-safe).
-    let sub_context_id =
-        match build_sub_context_id(&top_context_id, display_name.as_deref(), &vtc_did, |id| {
+    // 6. Derive the per-community sub-context id (D9, collision-safe). An
+    // application to be vetted already has one — the context its face was worn
+    // in for the vetters — and the membership keeps it, so the community sees
+    // the face the vetters checked.
+    let vetted_context = config
+        .private
+        .vetting
+        .application(&vtc_did, persona_id)
+        .and_then(|a| a.context_id.clone())
+        .filter(|id| {
+            !config
+                .account
+                .memberships()
+                .any(|c| &c.sub_context_id == id)
+        });
+    let derived = match vetted_context {
+        Some(id) => Ok(id),
+        None => build_sub_context_id(&top_context_id, display_name.as_deref(), &vtc_did, |id| {
             config.account.memberships().any(|c| c.sub_context_id == id)
-        }) {
-            Ok(id) => id,
-            Err(e) => {
-                state
-                    .join
-                    .fail(format!("Failed to derive sub-context id: {e}"));
-                if minted {
-                    rollback_minted_persona(
-                        config,
-                        persona_id,
-                        state,
-                        profile,
-                        prior_friendly_name,
-                    );
-                }
-                return;
+        }),
+    };
+    let sub_context_id = match derived {
+        Ok(id) => id,
+        Err(e) => {
+            state
+                .join
+                .fail(format!("Failed to derive sub-context id: {e}"));
+            if minted {
+                rollback_minted_persona(config, persona_id, state, profile, prior_friendly_name);
             }
-        };
+            return;
+        }
+    };
 
     // 7. Register the sub-context at the VTA.
     state

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -1388,6 +1388,9 @@ pub struct VettingState {
     /// Communities a vetter has already asked for requirements this run, so a
     /// second attempt to open a session proceeds instead of asking again.
     pub requirements_requested: Vec<String>,
+    /// The face each application wears, by application id, once read or
+    /// chosen this run.
+    pub worn_faces: std::collections::HashMap<String, String>,
 }
 
 impl VettingState {
@@ -1415,11 +1418,11 @@ pub enum VettingMode {
         persona_index: usize,
         field: usize,
     },
-    /// The identity every vetter is shown, one value per claim type.
-    EditIdentity {
+    /// Choose the face an application shows vetters.
+    ChooseFace {
         application_id: String,
-        claims: Vec<(String, String)>,
-        field: usize,
+        faces: Vec<FaceChoice>,
+        index: usize,
     },
     /// Ask a vetter, with the ticket code they gave us.
     RequestVetter {
@@ -1428,10 +1431,13 @@ pub enum VettingMode {
         code: String,
         field: usize,
     },
-    /// Read the match code with the vetter, then send the card.
+    /// Read the match code with the vetter, preview what the face shows, then
+    /// send the card.
     SendCard {
         application_id: String,
         session_id: String,
+        /// What the card would show, once the VTA has said.
+        preview: Option<CardPreview>,
     },
     /// Hand out a ticket for one of our memberships.
     NewTicket {
@@ -1468,9 +1474,6 @@ impl VettingMode {
                 field: 0,
                 ..
             } => Some(community),
-            VettingMode::EditIdentity { claims, field, .. } => {
-                claims.get(*field).map(|(_, value)| value.as_str())
-            }
             VettingMode::RequestVetter {
                 vetter, field: 0, ..
             } => Some(vetter),
@@ -1478,6 +1481,27 @@ impl VettingMode {
             _ => None,
         }
     }
+}
+
+/// A face an application can wear.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FaceChoice {
+    pub profile_id: String,
+    pub name: String,
+    pub entries: usize,
+    /// Worn in the application's context now.
+    pub worn: bool,
+}
+
+/// What a card would show, as the VTA previewed it. Nothing has left.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CardPreview {
+    /// Single use, and short-lived.
+    pub preview_id: String,
+    /// Claim type and value, as the card would carry them.
+    pub claims: Vec<(String, String)>,
+    /// Why this face cannot make the card, when it cannot.
+    pub problem: Option<String>,
 }
 
 /// The vetter's checklist (design §9.3).

--- a/openvtc/src/state_handler/vetting_actions.rs
+++ b/openvtc/src/state_handler/vetting_actions.rs
@@ -7,19 +7,25 @@
 //! background job. A send that fails puts the book back the way it was, so the
 //! step can simply be tried again.
 
+use std::future::Future;
 use std::sync::Arc;
 
 use affinidi_tdk::didcomm::Message;
+use affinidi_tdk::secrets_resolver::secrets::Secret;
 use chrono::Utc;
 use openvtc_core::config::Config;
 use openvtc_core::config::account::PersonaId;
+use openvtc_core::config::context_path::build_sub_context_id;
 use openvtc_core::didcomm::Messaging;
-use openvtc_core::vetting::applicant::{RequestDraft, RequestState};
+use openvtc_core::persona::disclosure::{self, PresentError};
+use openvtc_core::persona::{binding, profile};
+use openvtc_core::vetting::applicant::{Application, RequestDraft, RequestState, SentCard};
 use openvtc_core::vetting::book::FALLBACK_REQUIRED_CLAIMS;
 use openvtc_core::vetting::tickets::{DEFAULT_VALIDITY, Ticket, normalise_code};
 use openvtc_core::vetting::vetter::{Attestation, DeskState};
 use openvtc_core::vetting::wire::{self, Document};
 use serde_json::Value;
+use vta_sdk::client::VtaClient;
 use vta_sdk::protocols::vetting::{
     CardClaim, TicketPresentation, VETTING_DECLINE_TYPE, VETTING_REQUEST_TYPE,
     VETTING_REVOKE_STATEMENT_TYPE, VETTING_SESSION_RESPONSE_TYPE, VETTING_SESSION_TYPE,
@@ -34,9 +40,10 @@ use crate::state_handler::actions::VettingAction;
 use crate::state_handler::background_dispatch::{self, DispatchDomain, DispatchOutcome, InFlight};
 use crate::state_handler::dispatch_util::{self, Persist, SyncLog};
 use crate::state_handler::main_page::content::{
-    ApplicationRow, AttestForm, DeskRow, DeskStage, IssuedRow, RequestRow, TicketRow,
-    VETTING_METHODS, VETTING_RELATIONSHIPS, VETTING_TICKET_USES, VETTING_WITHDRAWAL_REASONS,
-    VettingMembership, VettingMode, VettingPersona, VettingState, VettingTab, method_label,
+    ApplicationRow, AttestForm, CardPreview, DeskRow, DeskStage, FaceChoice, IssuedRow, RequestRow,
+    TicketRow, VETTING_METHODS, VETTING_RELATIONSHIPS, VETTING_TICKET_USES,
+    VETTING_WITHDRAWAL_REASONS, VettingMembership, VettingMode, VettingPersona, VettingState,
+    VettingTab, method_label,
 };
 use crate::state_handler::main_page::{sanitize_display, shorten_did};
 use crate::state_handler::runtime_actions::ActionCtx;
@@ -403,14 +410,10 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
                 };
             }
         }
-        VettingAction::EditIdentity => {
+        VettingAction::ChooseFace => {
             let v = page(ctx);
             if let Some(row) = v.applications.get(v.selected).cloned() {
-                v.mode = VettingMode::EditIdentity {
-                    application_id: row.id,
-                    claims: row.identity,
-                    field: 0,
-                };
+                list_faces(ctx, &row.id);
             }
         }
         VettingAction::RequestVetter => {
@@ -440,6 +443,7 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
                     v.mode = VettingMode::SendCard {
                         application_id: row.id,
                         session_id,
+                        preview: None,
                     };
                 }
                 None => status(ctx, "No vetter is waiting for your card."),
@@ -535,11 +539,6 @@ fn input(mode: &mut VettingMode, text: String) {
             field: 0,
             ..
         } => *community = text,
-        VettingMode::EditIdentity { claims, field, .. } => {
-            if let Some((_, value)) = claims.get_mut(*field) {
-                *value = text;
-            }
-        }
         VettingMode::RequestVetter {
             vetter, field: 0, ..
         } => *vetter = text,
@@ -563,7 +562,7 @@ fn move_field(v: &mut VettingState, forward: bool) {
         VettingMode::NewApplication { field, .. }
         | VettingMode::RequestVetter { field, .. }
         | VettingMode::NewTicket { field, .. } => step(field, 2),
-        VettingMode::EditIdentity { claims, field, .. } => step(field, claims.len()),
+        VettingMode::ChooseFace { faces, index, .. } => step(index, faces.len()),
         VettingMode::Attest { form, .. } => step(&mut form.field, AttestForm::FIELDS),
         _ => {}
     }
@@ -610,6 +609,7 @@ fn cycle(v: &mut VettingState, forward: bool) {
         VettingMode::Withdraw { reason_index, .. } => {
             turn(reason_index, VETTING_WITHDRAWAL_REASONS.len());
         }
+        VettingMode::ChooseFace { faces, index, .. } => turn(index, faces.len()),
         _ => {}
     }
 }
@@ -622,11 +622,11 @@ async fn submit(ctx: &mut ActionCtx<'_>) {
             persona_index,
             ..
         } => start_application(ctx, community.trim(), persona_index).await,
-        VettingMode::EditIdentity {
+        VettingMode::ChooseFace {
             application_id,
-            claims,
-            ..
-        } => save_identity(ctx, &application_id, claims),
+            faces,
+            index,
+        } => wear_face(ctx, &application_id, faces.get(index).cloned()),
         VettingMode::RequestVetter {
             application_id,
             vetter,
@@ -636,7 +636,8 @@ async fn submit(ctx: &mut ActionCtx<'_>) {
         VettingMode::SendCard {
             application_id,
             session_id,
-        } => send_card(ctx, &application_id, &session_id).await,
+            preview,
+        } => send_card(ctx, &application_id, &session_id, preview).await,
         VettingMode::NewTicket {
             membership_index,
             uses_index,
@@ -787,46 +788,6 @@ async fn start_application(ctx: &mut ActionCtx<'_>, community: &str, persona_ind
     refresh_requirements(ctx, &application_id).await;
 }
 
-fn save_identity(ctx: &mut ActionCtx<'_>, application_id: &str, claims: Vec<(String, String)>) {
-    if claims.iter().any(|(_, value)| value.trim().is_empty()) {
-        return status(
-            ctx,
-            "Fill in every claim — a vetter checks each one against you and your documents.",
-        );
-    }
-    let Some(app) = ctx
-        .config
-        .private
-        .vetting
-        .application_by_id_mut(application_id)
-    else {
-        return;
-    };
-    let shown = app.requests.iter().any(|r| {
-        matches!(
-            &r.state,
-            RequestState::Session { card: Some(_), .. } | RequestState::Attested { .. }
-        )
-    });
-    if shown {
-        return status(
-            ctx,
-            "A vetter has already seen this identity. Changing it now would make your \
-             statements disagree, and the community would refer the application.",
-        );
-    }
-    app.identity_claims = claims
-        .into_iter()
-        .map(|(claim_type, value)| CardClaim {
-            claim_type,
-            value: Value::String(value.trim().to_string()),
-            provenance: "selfAsserted".to_string(),
-        })
-        .collect();
-    page(ctx).mode = VettingMode::List;
-    persist(ctx, "Identity saved — every vetter is shown exactly this.");
-}
-
 async fn request_vetter(ctx: &mut ActionCtx<'_>, application_id: &str, vetter: &str, code: &str) {
     if !vetter.starts_with("did:") {
         return status(ctx, "Enter the vetter's DID (it starts with did:).");
@@ -887,9 +848,135 @@ async fn request_vetter(ctx: &mut ActionCtx<'_>, application_id: &str, vetter: &
     }
 }
 
-async fn send_card(ctx: &mut ActionCtx<'_>, application_id: &str, session_id: &str) {
-    let now = Utc::now();
-    let Some(app) = ctx
+/// What a card's disclosure tells the VTA it is for.
+const VETTING_PURPOSE: &str = "identity vetting";
+
+/// The VTA session, or say why there is none.
+fn admin_client(ctx: &mut ActionCtx<'_>) -> Option<VtaClient> {
+    let client = ctx.admin_vta.cloned();
+    if client.is_none() {
+        status(
+            ctx,
+            "Faces live in your VTA, and it is not connected — try again once it is.",
+        );
+    }
+    client
+}
+
+/// The VTA context an application's face is worn in, and its join DID.
+/// Derived the first time it is needed and kept on the application, so the
+/// membership reuses it when the join goes through.
+fn application_context(
+    config: &mut Config,
+    application_id: &str,
+) -> Result<(String, String), String> {
+    let app = config
+        .private
+        .vetting
+        .applications
+        .iter()
+        .find(|a| a.id == application_id)
+        .ok_or("the application is gone")?;
+    let join_did = app.join_did.clone();
+    if let Some(id) = &app.context_id {
+        return Ok((id.clone(), join_did));
+    }
+    let community = app.community.clone();
+    let name = config.agent_name_for(&community).map(ToString::to_string);
+    let id = build_sub_context_id(
+        &config.account.top_context_id,
+        name.as_deref(),
+        &community,
+        |id| {
+            config.account.memberships().any(|m| m.sub_context_id == id)
+                || config
+                    .private
+                    .vetting
+                    .applications
+                    .iter()
+                    .any(|a| a.context_id.as_deref() == Some(id))
+        },
+    )
+    .map_err(|e| e.to_string())?;
+    if let Some(app) = config.private.vetting.application_by_id_mut(application_id) {
+        app.context_id = Some(id.clone());
+    }
+    Ok((id, join_did))
+}
+
+fn spawn_job(ctx: &mut ActionCtx<'_>, job: impl Future<Output = VettingOutcome> + Send + 'static) {
+    background_dispatch::spawn_dispatch(
+        ctx.dispatch_tx.clone(),
+        DispatchDomain::Vetting,
+        async move { DispatchOutcome::Vetting(job.await) },
+    );
+}
+
+/// Read the holder's faces, and which one the application wears.
+fn list_faces(ctx: &mut ActionCtx<'_>, application_id: &str) {
+    let Some(client) = admin_client(ctx) else {
+        return;
+    };
+    let (context_id, persona_did) = match application_context(ctx.config, application_id) {
+        Ok(found) => found,
+        Err(e) => return status(ctx, format!("Cannot choose a face: {e}")),
+    };
+    if !begin(ctx) {
+        return;
+    }
+    status(ctx, "Reading your faces…");
+    let job = FaceJob::List {
+        client,
+        context_id,
+        persona_did,
+        application_id: application_id.to_string(),
+    };
+    spawn_job(ctx, job.run());
+}
+
+/// Wear `face` in the application's context.
+fn wear_face(ctx: &mut ActionCtx<'_>, application_id: &str, face: Option<FaceChoice>) {
+    let Some(face) = face else {
+        return status(ctx, "Make a face under My Identity first.");
+    };
+    if face.worn {
+        page(ctx).mode = VettingMode::List;
+        return status(
+            ctx,
+            format!("{} is already the face vetters are shown.", face.name),
+        );
+    }
+    let Some(client) = admin_client(ctx) else {
+        return;
+    };
+    let (context_id, persona_did) = match application_context(ctx.config, application_id) {
+        Ok(found) => found,
+        Err(e) => return status(ctx, format!("Cannot wear that face: {e}")),
+    };
+    if !begin(ctx) {
+        return;
+    }
+    page(ctx).mode = VettingMode::List;
+    status(ctx, format!("Wearing {}…", face.name));
+    let job = FaceJob::Wear {
+        client,
+        context_id,
+        persona_did,
+        application_id: application_id.to_string(),
+        face,
+    };
+    spawn_job(ctx, job.run());
+}
+
+/// The card for `session_id`, in two steps: preview what the face would show
+/// the vetter, then — once the holder has seen it — release, sign and send.
+async fn send_card(
+    ctx: &mut ActionCtx<'_>,
+    application_id: &str,
+    session_id: &str,
+    preview: Option<CardPreview>,
+) {
+    let Some(application) = ctx
         .config
         .private
         .vetting
@@ -900,60 +987,70 @@ async fn send_card(ctx: &mut ActionCtx<'_>, application_id: &str, session_id: &s
     else {
         return;
     };
-    if app.identity_claims.is_empty() {
+    let Some((vetter, expires_at)) = application
+        .session(session_id)
+        .map(|(vetter, s)| (vetter.to_string(), s.expires_at))
+    else {
+        return status(ctx, "That session has closed.");
+    };
+    if expires_at <= Utc::now() {
         return status(
             ctx,
-            "First enter the identity you will show vetters (i on the application).",
+            "The session has expired — ask the vetter to open another.",
         );
     }
-    let draft = match app.card_draft(session_id, app.identity_claims.clone(), now) {
-        Ok(draft) => draft,
+    if let Some(problem) = preview.as_ref().and_then(|p| p.problem.clone()) {
+        return status(ctx, problem);
+    }
+    let Some(client) = admin_client(ctx) else {
+        return;
+    };
+    let context_id = match application_context(ctx.config, application_id) {
+        Ok((id, _)) => id,
         Err(e) => return status(ctx, format!("Cannot send a card: {e}")),
     };
     if !begin(ctx) {
         return;
     }
-    let (vetter, join_did) = (draft.audience.clone(), draft.publisher.clone());
-    let keys = match ctx.config.get_persona_keys_for(app.persona, ctx.tdk).await {
-        Ok(keys) => keys,
-        Err(e) => return abandon(ctx, "Could not sign the card", e),
+    let step = match preview {
+        None => {
+            status(ctx, "Asking your VTA what your face shows this vetter…");
+            CardStep::Preview
+        }
+        Some(preview) => {
+            // The card is signed here, as the persona DID, with the persona's
+            // own assertionMethod key — the same path every other document
+            // this client signs takes.
+            let signer = match ctx
+                .config
+                .get_persona_keys_for(application.persona, ctx.tdk)
+                .await
+            {
+                Ok(keys) => keys.signing.secret.clone(),
+                Err(e) => return abandon(ctx, "Could not sign the card", e),
+            };
+            status(ctx, "Releasing and signing your card…");
+            CardStep::Present(Box::new(Presenting {
+                preview_id: preview.preview_id,
+                signer,
+                resolver: resolver(ctx),
+                service: ctx.didcomm_service.clone(),
+                listener_id: openvtc_core::didcomm::listener_id_for_did(
+                    &application.join_did,
+                    ctx.config,
+                ),
+            }))
+        }
     };
-    let card = match sign_card(draft, &keys.signing.secret).await {
-        Ok(card) => card,
-        Err(e) => return abandon(ctx, "Could not sign the card", e),
-    };
-    let resolver = resolver(ctx);
-    let recorded = match ctx
-        .config
-        .private
-        .vetting
-        .application_by_id_mut(application_id)
-    {
-        Some(app) => app.record_card(session_id, &card, &resolver, now).await,
-        None => return abandon(ctx, "Could not send the card", "the application is gone"),
-    };
-    if let Err(e) = recorded {
-        return abandon(ctx, "The card did not verify", e);
-    }
-    let mut document = match wire::document(
-        VETTING_SESSION_RESPONSE_TYPE,
-        &join_did,
-        &vetter,
-        wire::new_id(),
-        &VettingSessionResponseBody { card, ext: None },
-    ) {
-        Ok(d) => d,
-        Err(e) => return abandon(ctx, "Could not send the card", e),
-    };
-    document.thread_id = Some(session_id.to_string());
-    page(ctx).mode = VettingMode::List;
-    persist(ctx, "Sending your card…");
-    let sent = Sent::Card {
+    let job = CardJob {
+        client,
+        context_id,
+        vetter,
+        application,
         session_id: session_id.to_string(),
+        step,
     };
-    if let Err(e) = sign_and_send(ctx, app.persona, document, sent).await {
-        abandon(ctx, "Could not send the card", e);
-    }
+    spawn_job(ctx, job.run());
 }
 
 fn issue_ticket(ctx: &mut ActionCtx<'_>, membership_index: usize, uses_index: usize) {
@@ -1307,9 +1404,6 @@ pub(crate) enum Sent {
         document_id: String,
         vetter: String,
     },
-    Card {
-        session_id: String,
-    },
     Session {
         request_id: String,
     },
@@ -1345,29 +1439,433 @@ impl SendJob {
             &self.to,
         )
         .await;
-        VettingOutcome {
-            sent: self.sent,
+        VettingOutcome::Sent {
+            sent: Box::new(self.sent),
             error: result.err().map(|e| e.to_string()),
         }
     }
 }
 
-/// How a vetting send went. Applied on the loop thread.
-pub(crate) struct VettingOutcome {
-    sent: Sent,
-    error: Option<String>,
+/// Reading or wearing a face. I/O only.
+pub(crate) enum FaceJob {
+    List {
+        client: VtaClient,
+        context_id: String,
+        persona_did: String,
+        application_id: String,
+    },
+    Wear {
+        client: VtaClient,
+        context_id: String,
+        persona_did: String,
+        application_id: String,
+        face: FaceChoice,
+    },
+}
+
+impl FaceJob {
+    pub(crate) async fn run(self) -> VettingOutcome {
+        match self {
+            FaceJob::List {
+                client,
+                context_id,
+                persona_did,
+                application_id,
+            } => {
+                let result = match profile::list(&client).await {
+                    Ok(profiles) => {
+                        // What is worn now is a nicety for the picker; a failed
+                        // read leaves nothing marked rather than failing the list.
+                        let worn = binding::get(&client, &context_id, &persona_did)
+                            .await
+                            .ok()
+                            .filter(|b| b.bound)
+                            .and_then(|b| b.profile_id);
+                        Ok(profiles
+                            .into_iter()
+                            .map(|p| FaceChoice {
+                                worn: worn.as_deref() == Some(p.profile_id.as_str()),
+                                name: sanitize_display(p.display_name(), 128),
+                                entries: p.entry_count,
+                                profile_id: p.profile_id,
+                            })
+                            .collect())
+                    }
+                    Err(e) => Err(e.to_string()),
+                };
+                VettingOutcome::Faces {
+                    application_id,
+                    result,
+                }
+            }
+            FaceJob::Wear {
+                client,
+                context_id,
+                persona_did,
+                application_id,
+                face,
+            } => VettingOutcome::FaceWorn {
+                error: binding::set(&client, &context_id, &persona_did, Some(&face.profile_id))
+                    .await
+                    .err()
+                    .map(|e| e.to_string()),
+                application_id,
+                name: face.name,
+            },
+        }
+    }
+}
+
+/// Which half of the card's two steps a job runs.
+pub(crate) enum CardStep {
+    /// Ask what the face would show. Nothing leaves.
+    Preview,
+    /// Release what the preview showed, then sign, check and send the card.
+    Present(Box<Presenting>),
+}
+
+/// What releasing and sending a card needs.
+pub(crate) struct Presenting {
+    preview_id: String,
+    signer: Secret,
+    resolver: TrustTaskVmResolver,
+    service: Messaging,
+    listener_id: String,
+}
+
+/// One step of sending a card. Works on a copy of the application; the
+/// outcome carries back what the book has to record.
+pub(crate) struct CardJob {
+    client: VtaClient,
+    context_id: String,
+    vetter: String,
+    application: Application,
+    session_id: String,
+    step: CardStep,
+}
+
+/// Why a card did not go.
+pub(crate) enum CardFailure {
+    /// The VTA wants a fresh approval; the preview is still good.
+    StepUp,
+    Failed(String),
+}
+
+fn failed(e: impl std::fmt::Display) -> CardFailure {
+    CardFailure::Failed(e.to_string())
+}
+
+impl CardJob {
+    pub(crate) async fn run(self) -> VettingOutcome {
+        let CardJob {
+            client,
+            context_id,
+            vetter,
+            mut application,
+            session_id,
+            step,
+        } = self;
+        let application_id = application.id.clone();
+        match step {
+            CardStep::Preview => {
+                let requested = application.requested_claims(&session_id);
+                let result = disclosure::preview(
+                    &client,
+                    &context_id,
+                    &application.join_did,
+                    &vetter,
+                    requested,
+                    VETTING_PURPOSE,
+                )
+                .await
+                .map(|preview| CardPreview {
+                    problem: application
+                        .card_claims(&session_id, &preview.claims)
+                        .err()
+                        .map(|e| e.to_string()),
+                    claims: preview
+                        .claims
+                        .iter()
+                        .map(|c| {
+                            (
+                                sanitize_display(&c.claim_type, 64),
+                                match &c.value {
+                                    Some(value) => sanitize_display(&claim_text(value), 256),
+                                    None => "(proved without its value)".to_string(),
+                                },
+                            )
+                        })
+                        .collect(),
+                    preview_id: preview.preview_id,
+                })
+                .map_err(|e| e.to_string());
+                VettingOutcome::Previewed {
+                    application_id,
+                    session_id,
+                    result,
+                }
+            }
+            CardStep::Present(presenting) => {
+                let Presenting {
+                    preview_id,
+                    signer,
+                    resolver,
+                    service,
+                    listener_id,
+                } = *presenting;
+                let result = async {
+                    let challenge = application
+                        .session(&session_id)
+                        .map(|(_, s)| s.challenge.clone())
+                        .ok_or_else(|| failed("the session has closed"))?;
+                    let presented =
+                        disclosure::present(&client, &context_id, &preview_id, Some(&challenge))
+                            .await
+                            .map_err(|e| match e {
+                                PresentError::StepUpRequired => CardFailure::StepUp,
+                                PresentError::Failed(message) => CardFailure::Failed(message),
+                            })?;
+                    let now = Utc::now();
+                    let claims = application
+                        .card_claims(&session_id, &presented.claims)
+                        .map_err(failed)?;
+                    let draft = application
+                        .card_draft(&session_id, claims.clone(), now)
+                        .map_err(failed)?;
+                    let card = sign_card(draft, &signer).await.map_err(failed)?;
+                    let sent = application
+                        .record_card(&session_id, &card, &resolver, now)
+                        .await
+                        .map_err(|e| failed(format!("the card did not verify: {e}")))?;
+                    let mut document = wire::document(
+                        VETTING_SESSION_RESPONSE_TYPE,
+                        &application.join_did,
+                        &vetter,
+                        wire::new_id(),
+                        &VettingSessionResponseBody { card, ext: None },
+                    )
+                    .map_err(failed)?;
+                    document.thread_id = Some(session_id.clone());
+                    wire::sign(&mut document, &signer).await.map_err(failed)?;
+                    let message = wire::to_message(&document).map_err(failed)?;
+                    openvtc_core::didcomm::send_message_via(
+                        &service,
+                        &message,
+                        &listener_id,
+                        &vetter,
+                    )
+                    .await
+                    .map_err(failed)?;
+                    Ok((sent, claims))
+                }
+                .await;
+                VettingOutcome::CardSent {
+                    application_id,
+                    session_id,
+                    result,
+                }
+            }
+        }
+    }
+}
+
+/// How a vetting job went. Applied on the loop thread.
+pub(crate) enum VettingOutcome {
+    /// A document went out, or did not.
+    Sent {
+        /// Boxed: a desk state carries the card, and dwarfs every other outcome.
+        sent: Box<Sent>,
+        error: Option<String>,
+    },
+    /// The holder's faces, for the picker.
+    Faces {
+        application_id: String,
+        result: Result<Vec<FaceChoice>, String>,
+    },
+    /// A face is worn, or is not.
+    FaceWorn {
+        application_id: String,
+        name: String,
+        error: Option<String>,
+    },
+    /// What a card would show.
+    Previewed {
+        application_id: String,
+        session_id: String,
+        result: Result<CardPreview, String>,
+    },
+    /// A card went out — with what it showed — or did not.
+    CardSent {
+        application_id: String,
+        session_id: String,
+        result: Result<(SentCard, Vec<CardClaim>), CardFailure>,
+    },
 }
 
 impl VettingOutcome {
-    /// Report success, clearing the inbox task the step answered; or undo the
-    /// step and say why.
+    /// Fold the result into the book and the page.
     pub(crate) fn apply(self, state: &mut State, config: &mut Config, save: &mut SaveScheduler) {
-        let tasks = &mut config.private.tasks;
-        let book = &mut config.private.vetting;
-        let clear = |tasks: &mut openvtc_core::tasks::Tasks, id: String| {
-            tasks.remove(&Arc::new(id));
+        let v = &mut state.main_page.content_panel.vetting;
+        let (message, persist) = match self {
+            VettingOutcome::Sent { sent, error } => sent_result(*sent, error, config),
+            VettingOutcome::Faces {
+                application_id,
+                result: Ok(faces),
+            } => {
+                if let Some(worn) = faces.iter().find(|f| f.worn) {
+                    v.worn_faces
+                        .insert(application_id.clone(), worn.name.clone());
+                }
+                let message = if faces.is_empty() {
+                    "You have no faces yet — make one under My Identity with the claims the \
+                     community requires, then press f again."
+                } else {
+                    "Choose the face vetters are shown."
+                };
+                if matches!(v.mode, VettingMode::List) && !faces.is_empty() {
+                    let index = faces.iter().position(|f| f.worn).unwrap_or(0);
+                    v.mode = VettingMode::ChooseFace {
+                        application_id,
+                        faces,
+                        index,
+                    };
+                }
+                // The application may have just been given its context.
+                (message.to_string(), true)
+            }
+            VettingOutcome::Faces { result: Err(e), .. } => {
+                (format!("Could not read your faces: {e}"), true)
+            }
+            VettingOutcome::FaceWorn {
+                application_id,
+                name,
+                error: None,
+            } => {
+                v.worn_faces.insert(application_id, name.clone());
+                (
+                    format!(
+                        "Vetters are shown your {name} face, and the community sees the same one \
+                         when you join."
+                    ),
+                    true,
+                )
+            }
+            VettingOutcome::FaceWorn {
+                name,
+                error: Some(e),
+                ..
+            } => (format!("Could not wear {name}: {e}"), true),
+            VettingOutcome::Previewed {
+                application_id,
+                session_id,
+                result: Ok(preview),
+            } => {
+                let message = match &preview.problem {
+                    Some(problem) => format!("This face cannot make the card: {problem}"),
+                    None => "This is what the card shows. Enter approves and sends it.".to_string(),
+                };
+                if let VettingMode::SendCard {
+                    application_id: open_application,
+                    session_id: open,
+                    preview: shown,
+                } = &mut v.mode
+                    && *open == session_id
+                    && *open_application == application_id
+                {
+                    *shown = Some(preview);
+                }
+                (message, true)
+            }
+            VettingOutcome::Previewed { result: Err(e), .. } => {
+                (format!("Could not preview the card: {e}"), true)
+            }
+            VettingOutcome::CardSent {
+                application_id,
+                session_id,
+                result: Ok((card, claims)),
+            } => {
+                if matches!(&v.mode, VettingMode::SendCard { session_id: open, .. } if *open == session_id)
+                {
+                    v.mode = VettingMode::List;
+                }
+                config
+                    .private
+                    .tasks
+                    .remove(&Arc::new(format!("vetting-session-{session_id}")));
+                let recorded = config
+                    .private
+                    .vetting
+                    .application_by_id_mut(&application_id)
+                    .map(|app| app.record_sent_card(&session_id, card, &claims, Utc::now()));
+                match recorded {
+                    Some(Ok(())) => (
+                        "Card sent — the vetter checks it against you and your documents."
+                            .to_string(),
+                        true,
+                    ),
+                    Some(Err(e)) => (
+                        format!("Card sent, but it could not be recorded: {e}"),
+                        true,
+                    ),
+                    None => ("Card sent, but the application is gone.".to_string(), true),
+                }
+            }
+            VettingOutcome::CardSent {
+                result: Err(CardFailure::StepUp),
+                ..
+            } => (
+                "Your VTA wants you to approve this disclosure. Approve it on your device, then \
+                 press Enter again."
+                    .to_string(),
+                false,
+            ),
+            VettingOutcome::CardSent {
+                session_id,
+                result: Err(CardFailure::Failed(e)),
+                ..
+            } => {
+                // The preview may be spent; the next Enter asks for a new one.
+                if let VettingMode::SendCard {
+                    session_id: open,
+                    preview,
+                    ..
+                } = &mut v.mode
+                    && *open == session_id
+                {
+                    *preview = None;
+                }
+                (
+                    format!("Could not send the card: {e}. Enter previews it again."),
+                    true,
+                )
+            }
         };
-        let (message, persist) = match (self.sent, self.error) {
+        dispatch_util::save_and_sync(
+            &mut state.main_page,
+            config,
+            save,
+            if persist {
+                Persist::SaveAndSync
+            } else {
+                Persist::SyncOnly
+            },
+            |mp| &mut mp.content_panel.vetting.status_message,
+            message.clone(),
+            SyncLog::Plain(message),
+        );
+    }
+}
+
+/// Report a send: clear the inbox task the step answered, or undo the step and
+/// say why. Returns the message and whether the book changed.
+fn sent_result(sent: Sent, error: Option<String>, config: &mut Config) -> (String, bool) {
+    let tasks = &mut config.private.tasks;
+    let book = &mut config.private.vetting;
+    let clear = |tasks: &mut openvtc_core::tasks::Tasks, id: String| {
+        tasks.remove(&Arc::new(id));
+    };
+    {
+        match (sent, error) {
             (Sent::Manifest { community }, None) => (
                 format!(
                     "Asked {} for its vetting requirements.",
@@ -1382,13 +1880,6 @@ impl VettingOutcome {
                 ),
                 false,
             ),
-            (Sent::Card { session_id }, None) => {
-                clear(tasks, format!("vetting-session-{session_id}"));
-                (
-                    "Card sent — the vetter checks it against you and your documents.".to_string(),
-                    true,
-                )
-            }
             (Sent::Session { request_id }, None) => {
                 clear(tasks, format!("vetting-request-{request_id}"));
                 ("Session sent — waiting for their card.".to_string(), true)
@@ -1454,23 +1945,10 @@ impl VettingOutcome {
                 }
                 (format!("Could not send the withdrawal: {e}"), true)
             }
-            (Sent::Manifest { .. } | Sent::Card { .. } | Sent::Session { .. }, Some(e)) => {
+            (Sent::Manifest { .. } | Sent::Session { .. }, Some(e)) => {
                 (format!("Could not send — try again: {e}"), false)
             }
-        };
-        dispatch_util::save_and_sync(
-            &mut state.main_page,
-            config,
-            save,
-            if persist {
-                Persist::SaveAndSync
-            } else {
-                Persist::SyncOnly
-            },
-            |mp| &mut mp.content_panel.vetting.status_message,
-            message.clone(),
-            SyncLog::Plain(message),
-        );
+        }
     }
 }
 
@@ -1481,10 +1959,76 @@ mod tests {
     use openvtc_core::vetting::applicant::Application;
 
     fn outcome(sent: Sent, error: Option<&str>) -> VettingOutcome {
-        VettingOutcome {
-            sent,
+        VettingOutcome::Sent {
+            sent: Box::new(sent),
             error: error.map(ToString::to_string),
         }
+    }
+
+    /// A step-up refusal keeps the preview the holder approved, so pressing
+    /// Enter after approving presents the same one; any other failure drops
+    /// it, because the preview may already be spent.
+    #[test]
+    fn a_step_up_keeps_the_preview_and_a_failure_drops_it() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        let preview = CardPreview {
+            preview_id: "01PREVIEW".into(),
+            claims: vec![("name.legal".into(), "Alice Example".into())],
+            problem: None,
+        };
+        state.main_page.content_panel.vetting.mode = VettingMode::SendCard {
+            application_id: "a".into(),
+            session_id: "s".into(),
+            preview: Some(preview.clone()),
+        };
+        let card_sent = |result| VettingOutcome::CardSent {
+            application_id: "a".into(),
+            session_id: "s".into(),
+            result,
+        };
+
+        card_sent(Err(CardFailure::StepUp)).apply(&mut state, &mut config, &mut save);
+        let v = &state.main_page.content_panel.vetting;
+        assert!(matches!(&v.mode, VettingMode::SendCard { preview: Some(p), .. } if *p == preview));
+        assert!(
+            v.status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("approve"))
+        );
+
+        card_sent(Err(CardFailure::Failed("preview expired".into()))).apply(
+            &mut state,
+            &mut config,
+            &mut save,
+        );
+        assert!(matches!(
+            &state.main_page.content_panel.vetting.mode,
+            VettingMode::SendCard { preview: None, .. }
+        ));
+    }
+
+    /// The picker opens on the face already worn, and the page remembers it.
+    #[test]
+    fn the_face_picker_opens_on_the_worn_face() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        let face = |id: &str, worn| FaceChoice {
+            profile_id: id.into(),
+            name: id.to_uppercase(),
+            entries: 2,
+            worn,
+        };
+        VettingOutcome::Faces {
+            application_id: "a".into(),
+            result: Ok(vec![face("home", false), face("work", true)]),
+        }
+        .apply(&mut state, &mut config, &mut save);
+        let v = &state.main_page.content_panel.vetting;
+        assert!(matches!(&v.mode, VettingMode::ChooseFace { index: 1, .. }));
+        assert_eq!(v.worn_faces.get("a").map(String::as_str), Some("WORK"));
     }
 
     /// A request that never left is forgotten, so retrying is not shadowed by

--- a/openvtc/src/ui/pages/main/components/vetting_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vetting_panel.rs
@@ -12,9 +12,9 @@ use crate::colors::{
 };
 use crate::state_handler::{
     main_page::content::{
-        AttestForm, ContentPanelState, DeskStage, VETTING_METHODS, VETTING_RELATIONSHIPS,
-        VETTING_TICKET_USES, VETTING_WITHDRAWAL_REASONS, VettingMode, VettingState, VettingTab,
-        method_label, reason_label, relationship_label,
+        AttestForm, CardPreview, ContentPanelState, DeskStage, VETTING_METHODS,
+        VETTING_RELATIONSHIPS, VETTING_TICKET_USES, VETTING_WITHDRAWAL_REASONS, VettingMode,
+        VettingState, VettingTab, method_label, reason_label, relationship_label,
     },
     state::ConnectionState,
 };
@@ -46,7 +46,7 @@ pub fn mode_id(state: &VettingState) -> &'static str {
         (VettingMode::List, VettingTab::Tickets) => "tickets",
         (VettingMode::List, VettingTab::Issued) => "issued",
         (VettingMode::NewApplication { .. }, _) => "new-application",
-        (VettingMode::EditIdentity { .. }, _) => "identity",
+        (VettingMode::ChooseFace { .. }, _) => "face",
         (VettingMode::RequestVetter { .. }, _) => "request",
         (VettingMode::SendCard { .. }, _) => "card",
         (VettingMode::NewTicket { .. }, _) => "new-ticket",
@@ -171,23 +171,45 @@ pub fn render(v: &VettingState) -> Vec<Line<'static>> {
             lines.push(Line::from(""));
             lines.push(hint("Enter: start  Tab: next field  Esc: cancel"));
         }
-        VettingMode::EditIdentity {
-            claims, field: f, ..
-        } => {
-            lines.push(heading("The identity you show vetters"));
+        VettingMode::ChooseFace { faces, index, .. } => {
+            lines.push(heading("The face vetters are shown"));
             lines.push(Line::from(""));
             lines.push(hint(
-                "Enter it exactly as it appears on the documents you will show. Every vetter sees",
+                "A vetter's card is read from this face, and they check it against your documents.",
             ));
             lines.push(hint(
-                "the same values; a difference between two cards makes the community refer you.",
+                "It is worn in this community's context, so the community sees the same face when",
+            ));
+            lines.push(hint(
+                "you join. Its values must match your documents exactly, and must not change later.",
             ));
             lines.push(Line::from(""));
-            for (i, (claim_type, current)) in claims.iter().enumerate() {
-                lines.push(field(claim_type, current.clone(), i == *f, true));
+            for (i, face) in faces.iter().enumerate() {
+                let chosen = i == *index;
+                let style = if chosen {
+                    Style::new().fg(COLOR_SUCCESS).bold()
+                } else {
+                    label()
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(if chosen { "▸ " } else { "  " }, style),
+                    Span::styled(face.name.clone(), style),
+                    Span::styled(
+                        format!(
+                            "  {} attribute{}",
+                            face.entries,
+                            if face.entries == 1 { "" } else { "s" }
+                        ),
+                        dim(),
+                    ),
+                    Span::styled(
+                        if face.worn { "  worn now" } else { "" },
+                        Style::new().fg(COLOR_SUCCESS),
+                    ),
+                ]));
             }
             lines.push(Line::from(""));
-            lines.push(hint("Enter: save  ↑/↓: field  Esc: cancel"));
+            lines.push(hint("↑/↓: choose  Enter: wear it  Esc: cancel"));
         }
         VettingMode::RequestVetter {
             vetter,
@@ -209,7 +231,8 @@ pub fn render(v: &VettingState) -> Vec<Line<'static>> {
         VettingMode::SendCard {
             application_id,
             session_id,
-        } => send_card(&mut lines, v, application_id, session_id),
+            preview,
+        } => send_card(&mut lines, v, application_id, session_id, preview.as_ref()),
         VettingMode::NewTicket {
             membership_index,
             uses_index,
@@ -406,11 +429,21 @@ fn applications(lines: &mut Vec<Line<'static>>, v: &VettingState) {
     }
     lines.push(Line::from(""));
     lines.push(Line::from(" Identity shown to vetters").fg(COLOR_SUCCESS));
+    lines.push(Line::from(vec![
+        Span::styled(format!("  {:<20}", "face"), label()),
+        match v.worn_faces.get(&app.id) {
+            Some(face) => Span::styled(face.clone(), value()),
+            None => Span::styled("f shows or changes it", dim()),
+        },
+    ]));
     for (claim_type, shown) in &app.identity {
         lines.push(Line::from(vec![
             Span::styled(format!("  {claim_type:<20}"), label()),
             if shown.is_empty() {
-                Span::styled("not set — press i", Style::new().fg(COLOR_ORANGE))
+                Span::styled(
+                    "not shown yet — read from the face with your first card",
+                    dim(),
+                )
             } else {
                 Span::styled(shown.clone(), value())
             },
@@ -442,7 +475,7 @@ fn applications(lines: &mut Vec<Line<'static>>, v: &VettingState) {
     }
     lines.push(Line::from(""));
     lines.push(hint(
-        "n: new  i: identity  r: ask a vetter  c: send card  m: refresh requirements  Tab: next tab",
+        "n: new  f: face  r: ask a vetter  c: send card  m: refresh requirements  Tab: next tab",
     ));
 }
 
@@ -451,6 +484,7 @@ fn send_card(
     v: &VettingState,
     application_id: &str,
     session_id: &str,
+    preview: Option<&CardPreview>,
 ) {
     lines.push(heading("Send your card"));
     lines.push(Line::from(""));
@@ -486,26 +520,48 @@ fn send_card(
         }
     }
     lines.push(Line::from(""));
-    lines.push(Line::from(" The card shows").fg(COLOR_SUCCESS));
-    for (claim_type, shown) in &app.identity {
+    let face = v
+        .worn_faces
+        .get(application_id)
+        .cloned()
+        .unwrap_or_else(|| "the face this persona wears in the community".to_string());
+    let Some(preview) = preview else {
+        lines.push(Line::from(vec![
+            Span::styled("The card is read from  ", label()),
+            Span::styled(face, value()),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(hint(
+            "Enter asks your VTA what that face would show this vetter. Nothing leaves until you",
+        ));
+        lines.push(hint("have seen it and pressed Enter again."));
+        lines.push(Line::from(""));
+        lines.push(hint(
+            "Enter: preview  Esc: not now (f on the application changes the face)",
+        ));
+        return;
+    };
+    lines.push(Line::from(" The card will show").fg(COLOR_SUCCESS));
+    for (claim_type, shown) in &preview.claims {
         lines.push(Line::from(vec![
             Span::styled(format!("  {claim_type:<20}"), label()),
-            if shown.is_empty() {
-                Span::styled(
-                    "not set — Esc, then i",
-                    Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
-                )
-            } else {
-                Span::styled(shown.clone(), value())
-            },
+            Span::styled(shown.clone(), value()),
         ]));
     }
     lines.push(Line::from(""));
+    if let Some(problem) = &preview.problem {
+        lines.push(Line::from(problem.clone()).fg(COLOR_WARNING_ACCESSIBLE_RED));
+        lines.push(Line::from(""));
+        lines.push(hint(
+            "Esc, fix the face under My Identity (or choose another with f), then preview again.",
+        ));
+        return;
+    }
     lines.push(hint(
         "No document numbers or images are sent: the vetter looks at your document, not a copy.",
     ));
     lines.push(Line::from(""));
-    lines.push(hint("Enter: sign and send  Esc: not now"));
+    lines.push(hint("Enter: approve, sign and send  Esc: not now"));
 }
 
 fn desk(lines: &mut Vec<Line<'static>>, v: &VettingState) {

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2272,7 +2272,7 @@ impl MainPage {
             (_, KeyCode::Up) if selected > 0 => V::Select(selected - 1),
             (_, KeyCode::Down) if selected + 1 < len => V::Select(selected + 1),
             (VettingTab::Applications, KeyCode::Char('n')) => V::StartApplication,
-            (VettingTab::Applications, KeyCode::Char('i')) => V::EditIdentity,
+            (VettingTab::Applications, KeyCode::Char('f')) => V::ChooseFace,
             (VettingTab::Applications, KeyCode::Char('r')) => V::RequestVetter,
             (VettingTab::Applications, KeyCode::Char('m')) => V::RefreshRequirements,
             (VettingTab::Applications, KeyCode::Char('c') | KeyCode::Enter) => V::ReviewCard,


### PR DESCRIPTION
Stacked on #295. With this PR, the identity on a Vetting Card is read from the join persona's **face** through persona disclosure, instead of being typed into OpenVTC (`docs/design/vetting-process.md` §9.2, D2, D19).

## What changes

**Applicant flow**
- `f` on an application lists the holder's faces (`persona/profile/list`) and shows which one is worn. Enter wears the chosen face in the application's VTA context (`persona/binding/set`).
- `c` on an open session sends the card in two steps:
  1. **Preview.** `persona/disclosure/preview/1.0` runs with `verifierDid` set to the vetter and `requestedClaims` set to the session's required and optional claim types. The TUI shows exactly what the card would carry, and nothing leaves yet.
  2. **Present and send.** On a second Enter, `persona/disclosure/present/1.0` runs with renderer `rcard` and the session's challenge. The card is then built from the released claims, signed **as the join persona DID** (its assertionMethod key, the same path VMCs and capability grants use), and verified the way the vetter will verify it. It is then sent. This runs as a background job; the book is updated when the outcome is applied.
- A `stepUpRequired` refusal keeps the preview. The applicant approves on their device and presses Enter again. Any other failure drops the preview, because it may already be spent.
- Typed identity entry (`i`) is removed.

**Context**
- An application gets its VTA context (`build_sub_context_id`) the first time a face is chosen or a card is sent.
- `join_flow` reuses that context for the membership, so the community sees the face the vetters checked.

**Core (`openvtc-core`)**
- `persona::disclosure::{preview, present}`, which return `ReleasedClaim`s parsed from the preview or the rendered artifact.
- `Application::{requested_claims, card_claims, record_sent_card}` and `Application.context_id`. `card_claims` refuses:
  - a missing required claim;
  - a claim released without its value (a predicate) — `ValueWithheld`;
  - a stale credential-backed claim — `StaleClaim`;
  - a value that differs from one an earlier card showed — `IdentityChanged`, because the identity commitments would diverge and the community would refer the application.
- `record_card` now returns the `SentCard` it recorded.

**Docs:** D19, D2, §9.2, §9.4 and §11.3 are corrected on #292 and merged up the stack. OpenVTC signs as the persona DID; the only thing that path gives up is a VTA-side step-up gate on the signature.

## Notes for review
- Step-up is detected from the SDK's error text (`stepUpRequired`), because vta-sdk reports specification-extended Trust Task codes as `VtaError::Protocol` text.
- `vta::create_sub_context` is still a stub. The application's context behaves exactly like a membership's does today.
- A released claim with no provenance (a renderer that drops it; `rcard` doesn't) is carried as `unstated`, not guessed.
- The disclosure `purpose` is `identity vetting`.
- The new service calls (profile list, binding get/set, disclosure preview/present) all go through `VtaClient` Trust Tasks with the persona task timeout (R1.2). `../design-docs/` isn't in this checkout, so the stack guide checklist isn't pasted.

## Tests
- `openvtc-core`:
  - disclosure artifact and preview parsing;
  - a card read from a face, including withheld values and a changed identity;
  - a document and a card signed with a `did:webvh:…#key-0` secret name that verification method in the proof.
- `openvtc`:
  - a step-up keeps the preview and a failure drops it;
  - the face picker opens on the worn face.

Run locally (stacked PRs get no CI): `cargo test -p openvtc-core --lib` 581 passed; `cargo test -p openvtc --bins` 471 passed; `cargo clippy -p openvtc -p openvtc-core --all-targets -- -D warnings` clean.
