### PR TITLE
feat(vetting): vetters are named by their community's role credential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9616,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "vta-audit"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9633,7 +9633,7 @@ dependencies = [
 [[package]]
 name = "vta-backup"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -9660,7 +9660,7 @@ dependencies = [
 [[package]]
 name = "vta-cli-common"
 version = "0.15.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9687,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "vta-config"
 version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "vta-keys"
 version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9736,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "vta-keyspaces"
 version = "0.2.7"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "vti-common",
 ]
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "vta-persona"
 version = "0.3.2"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "vta-policy"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "hex",
  "multibase",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.36.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "vta-service"
 version = "0.25.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9931,7 +9931,7 @@ dependencies = [
 [[package]]
 name = "vta-support"
 version = "0.3.5"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9951,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "vta-sweepers"
 version = "0.3.4"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9965,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "vta-vault"
 version = "0.5.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9996,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "vta-webvh"
 version = "0.2.7"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10014,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "vtc-client"
 version = "0.6.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "vti-common"
 version = "0.18.3"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "vti-rooms"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -10097,7 +10097,7 @@ dependencies = [
 [[package]]
 name = "vti-rooms-dtg"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10114,7 +10114,7 @@ dependencies = [
 [[package]]
 name = "vti-secrets"
 version = "0.3.5"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "hex",
  "serde",
@@ -10127,7 +10127,7 @@ dependencies = [
 [[package]]
 name = "vti-webauthn"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetting-revocation#477cd78597056ad31e31b4b3ec02f7dfb3885354"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?branch=feat%2Fvtc-vetter-role-vec#68e3fb456c224ceed053aeeb0b5f25e09b30f39f"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,7 +384,7 @@ strip = "symbols"
 # `cargo tree`, not only the two named in a manifest: a crate left on crates.io
 # would pull its own `vti-common` beside the patched one.
 #
-# The branch is the top of the VTI vetting stack (#1425–#1428), not `main`:
+# The branch is the top of the VTI vetting stack (#1425–#1429), not `main`:
 # `vta-sdk`'s `vetting` feature, which this workspace enables, exists only there
 # until that stack merges. Once it has, point these back at `main`, and remove
 # them with the release that follows.
@@ -401,23 +401,23 @@ strip = "symbols"
 did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
 vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
 
-vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-config = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-keys = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-keyspaces = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-persona = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-policy = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-support = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-sweepers = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-vault = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vta-webvh = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vtc-client = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vti-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vti-rooms = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vti-rooms-dtg = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vti-secrets = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
-vti-webauthn = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetting-revocation" }
+vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-config = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-keys = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-keyspaces = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-persona = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-policy = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-support = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-sweepers = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-vault = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vta-webvh = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vtc-client = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vti-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vti-rooms = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vti-rooms-dtg = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vti-secrets = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }
+vti-webauthn = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", branch = "feat/vtc-vetter-role-vec" }

--- a/openvtc-core/src/vetting/applicant.rs
+++ b/openvtc-core/src/vetting/applicant.rs
@@ -22,7 +22,7 @@ use serde_json::{Value, json};
 use uuid::Uuid;
 use vta_sdk::protocols::join_requests::JoinRequestManifestResponseBody;
 use vta_sdk::protocols::vetting::{
-    CardClaim, DeclaredRelationship, DeclineCode, ShapeError, TicketPresentation,
+    CardClaim, DeclaredRelationship, DeclineCode, ShapeError, TicketPresentation, VETTER_ROLE,
     VettingDeclineBody, VettingMethod, VettingRequestAcceptedBody, VettingRequestBody,
     VettingRequirements, VettingSessionBody,
 };
@@ -136,6 +136,33 @@ pub struct Application {
     pub extra: serde_json::Map<String, Value>,
 }
 
+/// What an applicant could establish about a vetter from the eligibility
+/// presentation that came with their acceptance.
+///
+/// Advisory, like the checklist: the community checks the vetter again when
+/// it decides, and does not count a statement from one it has not named.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum VetterEligibility {
+    /// The community's vetter role credential for this vetter verified, bound
+    /// to our request. Whether the community has since revoked it is not
+    /// checked here.
+    Shown {
+        /// The role credential's `id`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        credential_id: Option<String>,
+        /// Its `validUntil`.
+        valid_until: DateTime<Utc>,
+    },
+    /// The vetter presented nothing.
+    NotShown,
+    /// What they presented did not verify.
+    Failed {
+        /// Why.
+        reason: String,
+    },
+}
+
 /// One request to one vetter.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OutboundRequest {
@@ -145,6 +172,9 @@ pub struct OutboundRequest {
     pub vetter: String,
     /// Where it stands.
     pub state: RequestState,
+    /// What the vetter's acceptance showed of their eligibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eligibility: Option<VetterEligibility>,
     /// When we sent it.
     pub sent_at: DateTime<Utc>,
     /// When it last moved.
@@ -380,6 +410,7 @@ impl Application {
             document_id: document_id.to_string(),
             vetter: vetter.to_string(),
             state: RequestState::Sent,
+            eligibility: None,
             sent_at: now,
             updated_at: now,
         });
@@ -432,8 +463,18 @@ impl Application {
             .ok_or(ApplicantError::NoMatchingRequest)
     }
 
+    /// The role a vetter must hold: the requirements' `eligibleVetters.role`,
+    /// or `vetter` while they are unknown.
+    #[must_use]
+    pub fn vetter_role(&self) -> &str {
+        self.requirements
+            .as_ref()
+            .map_or(VETTER_ROLE, |r| r.eligible_vetters.role.as_str())
+    }
+
     /// The vetter accepted (`vetting/request#response`, threaded on our
-    /// request). A repeat of the same acceptance is harmless.
+    /// request), and `eligibility` is what its presentation showed. A repeat
+    /// of the same acceptance is harmless.
     ///
     /// # Errors
     ///
@@ -444,6 +485,7 @@ impl Application {
         thread: &str,
         vetter: &str,
         body: VettingRequestAcceptedBody,
+        eligibility: VetterEligibility,
         now: DateTime<Utc>,
     ) -> Result<(), ApplicantError> {
         body.check_shape()?;
@@ -453,6 +495,7 @@ impl Application {
             RequestState::Accepted { request_id, .. } if *request_id == body.request_id => {}
             _ => return Err(ApplicantError::WrongState("be accepted")),
         }
+        request.eligibility = Some(eligibility);
         request.state = RequestState::Accepted {
             request_id: body.request_id,
             accepts_documentation: body.accepts_documentation,

--- a/openvtc-core/src/vetting/book.rs
+++ b/openvtc-core/src/vetting/book.rs
@@ -92,6 +92,36 @@ pub struct KnownCriterion {
     pub fetched_at: DateTime<Utc>,
 }
 
+/// A community naming one of our personas a vetter: the role credential it
+/// issued through `vtc/vetting/vetters/grant` (design §10.3). Presented to
+/// applicants with every acceptance, and needed to hand out tickets.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct VetterGrant {
+    /// The community that issued it.
+    pub community: String,
+    /// Our persona it names.
+    pub persona: PersonaId,
+    /// The credential's `id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credential_id: Option<String>,
+    /// Its `validUntil`. A grant without one is never treated as live.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<DateTime<Utc>>,
+    /// When it arrived.
+    pub received_at: DateTime<Utc>,
+    /// The signed credential, exactly as delivered.
+    pub credential: serde_json::Value,
+}
+
+impl VetterGrant {
+    /// Unexpired at `now`. Revocation is the community's to apply: a revoked
+    /// grant stops the vetter's statements counting there.
+    #[must_use]
+    pub fn is_live(&self, now: DateTime<Utc>) -> bool {
+        self.valid_until.is_some_and(|until| until > now)
+    }
+}
+
 /// All vetting state, for both sides.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct VettingBook {
@@ -116,6 +146,9 @@ pub struct VettingBook {
     /// Our rules as a vetter.
     #[serde(default, skip_serializing_if = "VetterPolicy::is_default")]
     pub policy: VetterPolicy,
+    /// Communities that named one of our personas a vetter.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vetter_grants: Vec<VetterGrant>,
     /// Fields written by a newer build, preserved verbatim (D19).
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, serde_json::Value>,
@@ -132,7 +165,36 @@ impl VettingBook {
             && self.throttle.is_empty()
             && self.criteria.is_empty()
             && self.policy.is_default()
+            && self.vetter_grants.is_empty()
             && self.extra.is_empty()
+    }
+
+    /// Keep `grant`, replacing an earlier one from the same community for the
+    /// same persona. Returns whether anything changed.
+    pub fn keep_vetter_grant(&mut self, grant: VetterGrant) -> bool {
+        let same = |g: &VetterGrant| g.community == grant.community && g.persona == grant.persona;
+        if let Some(existing) = self.vetter_grants.iter_mut().find(|g| same(g)) {
+            if existing.credential == grant.credential {
+                return false;
+            }
+            *existing = grant;
+        } else {
+            self.vetter_grants.push(grant);
+        }
+        true
+    }
+
+    /// `persona`'s live vetter grant from `community`.
+    #[must_use]
+    pub fn vetter_grant(
+        &self,
+        community: &str,
+        persona: PersonaId,
+        now: DateTime<Utc>,
+    ) -> Option<&VetterGrant> {
+        self.vetter_grants
+            .iter()
+            .find(|g| g.community == community && g.persona == persona && g.is_live(now))
     }
 
     /// Remember `community`'s vetting criteria from its manifest, replacing

--- a/openvtc-core/src/vetting/inbound.rs
+++ b/openvtc-core/src/vetting/inbound.rs
@@ -4,10 +4,12 @@
 //! everything else, so the caller's existing routing is untouched. Two message
 //! types are shared, and those are claimed only when they are vetting's:
 //!
-//! - `credential-exchange/issue` carries both a community's membership
-//!   credential and a vetter's statement. Only an identity-vetting statement
-//!   is claimed ([`wire::delivered_statement`]); a membership credential still
-//!   reaches the join handler, which would refuse a vetter as its issuer.
+//! - `credential-exchange/issue` carries a community's membership and role
+//!   credentials, a community's vetter grant, and a vetter's statement. Only
+//!   the last two are claimed: a vetter grant, which would otherwise take the
+//!   member's role credential's place, and an identity-vetting statement
+//!   ([`wire::delivered_statement`]). Everything else still reaches the join
+//!   handler.
 //! - `trust-task-error` answers any Trust Task. Only one threaded on a request
 //!   or withdrawal of ours is claimed.
 //!
@@ -28,14 +30,18 @@ use vta_sdk::protocols::join_requests::{
     JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, JoinRequestManifestResponseBody,
 };
 use vta_sdk::protocols::vetting::{
-    RevokeStatementResponseBody, VETTING_DECLINE_TYPE, VETTING_REQUEST_RESPONSE_TYPE,
+    RevokeStatementResponseBody, VETTER_ROLE, VETTING_DECLINE_TYPE, VETTING_REQUEST_RESPONSE_TYPE,
     VETTING_REQUEST_TYPE, VETTING_REVOKE_STATEMENT_RESPONSE_TYPE, VETTING_SESSION_RESPONSE_TYPE,
     VETTING_SESSION_TYPE, VettingDeclineBody, VettingRequestAcceptedBody, VettingRequestBody,
-    VettingSessionBody, VettingSessionResponseBody,
+    VettingSessionBody, VettingSessionResponseBody, role_matches,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+use vta_sdk::vetting::eligibility::{
+    EligibilityExpectations, community_role, verify_eligibility_vp,
+};
 
-use super::book::VettingBook;
+use super::applicant::VetterEligibility;
+use super::book::{VetterGrant, VettingBook};
 use super::vetter::{IncomingRequest, Intake};
 use super::wire;
 use crate::config::account::{Account, PersonaId};
@@ -72,6 +78,21 @@ pub struct Reply {
     pub persona: PersonaId,
     /// The unsigned document.
     pub document: TrustTask<Value>,
+    /// A presentation to attach as `eligibilityVp` before signing
+    /// ([`wire::send_reply`]).
+    pub eligibility: Option<EligibilityPresentation>,
+}
+
+/// The vetter role credential to present with an acceptance, bound to the
+/// request it answers (`vetting/request/0.1` rule 5).
+#[derive(Debug, Clone)]
+pub struct EligibilityPresentation {
+    /// The community's role credentials.
+    pub credentials: Vec<Value>,
+    /// The `id` of the request being answered.
+    pub nonce: String,
+    /// The applicant's `joinDid`.
+    pub domain: String,
 }
 
 /// Something that happened that a person should know about. The ones marked
@@ -93,6 +114,15 @@ pub enum Notice {
         application_id: String,
         /// The vetter.
         vetter: String,
+        /// Their presentation showed the community named them a vetter.
+        shown_eligible: bool,
+    },
+    /// Vetter: a community named us a vetter.
+    VetterGranted {
+        /// The community.
+        community: String,
+        /// Until when.
+        valid_until: Option<DateTime<Utc>>,
     },
     /// Applicant: a vetter refused our request.
     VetterRefused {
@@ -168,9 +198,25 @@ impl Notice {
                     "Vetting request from {applicant} accepted — open a session when you are together."
                 )
             }
-            Notice::VetterAccepted { vetter, .. } => {
-                format!("{vetter} accepted your vetting request.")
-            }
+            Notice::VetterAccepted {
+                vetter,
+                shown_eligible: true,
+                ..
+            } => format!("{vetter} accepted your vetting request."),
+            Notice::VetterAccepted { vetter, .. } => format!(
+                "{vetter} accepted your vetting request, but did not show that the community \
+                 named them a vetter — their statement may not count."
+            ),
+            Notice::VetterGranted {
+                community,
+                valid_until,
+            } => match valid_until {
+                Some(until) => format!(
+                    "{community} named you a vetter until {}. You can hand out tickets.",
+                    until.format("%Y-%m-%d")
+                ),
+                None => format!("{community} named you a vetter."),
+            },
             Notice::VetterRefused { vetter, code, .. } => {
                 format!("{vetter} refused your vetting request [{code}].")
             }
@@ -330,10 +376,14 @@ async fn take_request(
         return Handled::default();
     };
     let community = opened.payload.community.clone();
-    let is_member = ctx
-        .account
-        .membership(&community, persona)
-        .is_some_and(|m| m.status.is_active());
+    // A vetter is who the community named: an active member holding its live
+    // role credential (design §10.3). The community checks again.
+    let grant = book.vetter_grant(&community, persona, ctx.now).cloned();
+    let eligible = grant.is_some()
+        && ctx
+            .account
+            .membership(&community, persona)
+            .is_some_and(|m| m.status.is_active());
     let throttle = book.throttle.clone();
     let intake = book.take_request(
         IncomingRequest {
@@ -341,7 +391,7 @@ async fn take_request(
             sender,
             persona,
             body: opened.payload,
-            is_member,
+            eligible,
         },
         ctx.now,
     );
@@ -349,11 +399,20 @@ async fn take_request(
     match intake {
         Intake::Accepted(body) => {
             let request_id = body.request_id.clone();
+            let eligibility = grant.map(|g| EligibilityPresentation {
+                credentials: vec![g.credential],
+                nonce: opened.document.id.clone(),
+                domain: sender.to_string(),
+            });
             Handled {
                 changed: true,
                 reply: wire::response(&opened.document, &body)
                     .ok()
-                    .map(|document| Reply { persona, document }),
+                    .map(|document| Reply {
+                        persona,
+                        document,
+                        eligibility,
+                    }),
                 notice: Some(Notice::RequestAccepted {
                     request_id,
                     applicant: sender.to_string(),
@@ -367,7 +426,11 @@ async fn take_request(
                 changed: throttled,
                 reply: wire::refusal(&opened.document, code, None)
                     .ok()
-                    .map(|document| Reply { persona, document }),
+                    .map(|document| Reply {
+                        persona,
+                        document,
+                        eligibility: None,
+                    }),
                 notice: None,
             }
         }
@@ -398,12 +461,41 @@ async fn accepted(
         warn!(%sender, "vetting acceptance for no request of ours");
         return Handled::default();
     };
-    match application.on_accepted(thread, sender, opened.payload, ctx.now) {
+    // Bound to our request by `nonce` and to us by `domain`, so a presentation
+    // made for someone else, or before the vetter lost the role, does not pass.
+    let eligibility = match &opened.payload.eligibility_vp {
+        None => VetterEligibility::NotShown,
+        Some(vp) => {
+            let expect = EligibilityExpectations {
+                vetter: sender,
+                community: &application.community,
+                role: application.vetter_role(),
+                challenge: thread,
+                domain: &application.join_did,
+                now: ctx.now,
+            };
+            match verify_eligibility_vp(vp, &expect, ctx.resolver).await {
+                Ok(verified) => VetterEligibility::Shown {
+                    credential_id: verified.credential_id().map(str::to_string),
+                    valid_until: verified.valid_until(),
+                },
+                Err(e) => {
+                    warn!(%sender, error = %e, "vetter eligibility presentation did not verify");
+                    VetterEligibility::Failed {
+                        reason: e.to_string(),
+                    }
+                }
+            }
+        }
+    };
+    let shown_eligible = matches!(eligibility, VetterEligibility::Shown { .. });
+    match application.on_accepted(thread, sender, opened.payload, eligibility, ctx.now) {
         Ok(()) => Handled {
             changed: true,
             notice: Some(Notice::VetterAccepted {
                 application_id: application.id.clone(),
                 vetter: sender.to_string(),
+                shown_eligible,
             }),
             ..Handled::default()
         },
@@ -524,6 +616,12 @@ async fn statement(
     message: &Message,
     sender: &str,
 ) -> Option<Handled> {
+    if let Some(credential) = message.body.pointer("/credential_response/credential")
+        && let Some((community, role)) = community_role(credential)
+        && role_matches(&role, VETTER_ROLE)
+    {
+        return Some(vetter_grant(book, ctx, credential, community, sender));
+    }
     let credential = wire::delivered_statement(&message.body)?;
     let Some((persona, _)) = ctx.recipient else {
         return Some(Handled::default());
@@ -552,6 +650,63 @@ async fn statement(
         }
     }
     Some(Handled::default())
+}
+
+/// A community's vetter role credential for one of our personas.
+///
+/// Kept when the community that it names issued it, sent it (authcrypt
+/// authenticates the sender), and named the persona it was addressed to, which
+/// must hold a membership there. Its proof is not checked here: it proves
+/// nothing to us that the authenticated sender does not, and every applicant
+/// it is presented to verifies it.
+fn vetter_grant(
+    book: &mut VettingBook,
+    ctx: &Context<'_>,
+    credential: &Value,
+    community: String,
+    sender: &str,
+) -> Handled {
+    let Some((persona, our_did)) = ctx.recipient else {
+        return Handled::default();
+    };
+    let issuer = credential
+        .get("issuer")
+        .and_then(|i| i.as_str().or_else(|| i.get("id").and_then(Value::as_str)));
+    let subject = credential
+        .pointer("/credentialSubject/id")
+        .and_then(Value::as_str);
+    if community != sender || issuer != Some(sender) || subject != Some(our_did) {
+        warn!(%sender, %community, "vetter role credential not from its community, or not for us — ignored");
+        return Handled::default();
+    }
+    if ctx.account.membership(&community, persona).is_none() {
+        warn!(%community, "vetter role credential from a community we are not a member of — ignored");
+        return Handled::default();
+    }
+    let valid_until = credential
+        .get("validUntil")
+        .and_then(Value::as_str)
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.with_timezone(&Utc));
+    let changed = book.keep_vetter_grant(VetterGrant {
+        community: community.clone(),
+        persona,
+        credential_id: credential
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        valid_until,
+        received_at: ctx.now,
+        credential: credential.clone(),
+    });
+    Handled {
+        changed,
+        notice: changed.then_some(Notice::VetterGranted {
+            community,
+            valid_until,
+        }),
+        ..Handled::default()
+    }
 }
 
 fn refused(

--- a/openvtc-core/src/vetting/tests.rs
+++ b/openvtc-core/src/vetting/tests.rs
@@ -8,6 +8,7 @@
 use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::secrets_resolver::secrets::Secret;
 use chrono::Utc;
+use dtg_credentials::DTGCredential;
 use serde_json::{Value, json};
 use trust_tasks_rs::TrustTask;
 use uuid::Uuid;
@@ -15,18 +16,19 @@ use vta_sdk::protocols::join_requests::{
     JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, JoinRequestManifestResponseBody, ManifestCriterion,
 };
 use vta_sdk::protocols::vetting::{
-    CardClaim, DeclaredRelationship, DeclineCode, IDENTITY_VETTING_ENDORSEMENT_TYPE,
-    RevocationReason, TicketPresentation, VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_INVALID_TICKET,
-    VETTING_REQUEST_ERR_NOT_ELIGIBLE, VETTING_REQUEST_TYPE, VETTING_SESSION_TYPE, VettingMethod,
-    VettingRequirements, VettingSessionResponseBody,
+    COMMUNITY_ROLE_ENDORSEMENT_TYPE, CardClaim, DeclaredRelationship, DeclineCode,
+    IDENTITY_VETTING_ENDORSEMENT_TYPE, RevocationReason, TicketPresentation, VETTER_ROLE,
+    VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_INVALID_TICKET, VETTING_REQUEST_ERR_NOT_ELIGIBLE,
+    VETTING_REQUEST_TYPE, VETTING_SESSION_TYPE, VettingMethod, VettingRequirements,
+    VettingSessionResponseBody,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::card::sign_card;
 use vta_sdk::vetting::statement::sign_statement;
 
 use super::VettingBook;
-use super::applicant::{ApplicantError, RequestDraft, RequestState};
-use super::inbound::{Context, Handled, Notice, handle};
+use super::applicant::{ApplicantError, RequestDraft, RequestState, VetterEligibility};
+use super::inbound::{Context, Handled, Notice, Reply, handle};
 use super::tickets::{DEFAULT_VALIDITY, Ticket};
 use super::vetter::{Attestation, DeskState};
 use super::wire::{
@@ -36,7 +38,56 @@ use super::wire::{
 use crate::config::account::{Account, CommunityRecord, PersonaId};
 use crate::persona::disclosure::ReleasedClaim;
 
-const COMMUNITY: &str = "did:web:vtc.example";
+/// The community is a `did:key` too, so the role credentials it signs verify
+/// offline. [`the_community_is_its_key`] holds the two together.
+const COMMUNITY: &str = "did:key:z6MkkckEJvRiDoUSv2KFGPFuUoNjJbWTZUvWThqshF7g1u4p";
+const COMMUNITY_SEED: u8 = 0xC0;
+
+#[test]
+fn the_community_is_its_key() {
+    assert_eq!(did(&secret(COMMUNITY_SEED)), COMMUNITY);
+}
+
+/// A community role credential, signed by `issuer`.
+async fn role_credential(issuer: &Secret, community: &str, subject: &str, role: &str) -> Value {
+    let now = Utc::now();
+    let mut credential = DTGCredential::new_vec(
+        did(issuer),
+        subject.to_string(),
+        now - chrono::Duration::minutes(1),
+        Some(now + chrono::Duration::days(365)),
+        json!({
+            "type": COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+            "role": role,
+            "communityDid": community,
+        }),
+    )
+    .with_id(wire::new_id());
+    credential.sign(issuer, None).await.unwrap();
+    serde_json::to_value(&credential).unwrap()
+}
+
+/// `credential-exchange/issue` from `from`, as a community delivers.
+fn delivery(credential: &Value, from: &str) -> Message {
+    Message::build(
+        wire::new_id(),
+        vta_sdk::protocols::credential_exchange::ISSUE.to_string(),
+        json!({ "credential_response": { "credential": credential } }),
+    )
+    .from(from.to_string())
+    .finalize()
+}
+
+/// Sign a reply the way `wire::send_reply` does: presentation first.
+async fn signed_reply(reply: Reply, signer: &Secret) -> Message {
+    let mut document = reply.document;
+    if let Some(eligibility) = reply.eligibility {
+        wire::attach_eligibility(&mut document, signer, eligibility)
+            .await
+            .unwrap();
+    }
+    signed(document, signer).await
+}
 
 struct Party {
     secret: Secret,
@@ -70,6 +121,21 @@ impl Party {
         record.activate(Utc::now());
         self.account.add_membership(record);
         self
+    }
+
+    /// The community names this party a vetter, and delivers the credential.
+    async fn named_vetter(&mut self) {
+        let credential = role_credential(
+            &secret(COMMUNITY_SEED),
+            COMMUNITY,
+            &self.did.clone(),
+            VETTER_ROLE,
+        )
+        .await;
+        let handled = self
+            .receive(&delivery(&credential, COMMUNITY), COMMUNITY)
+            .await;
+        assert!(matches!(handled.notice, Some(Notice::VetterGranted { .. })));
     }
 
     async fn receive(&mut self, message: &Message, sender: &str) -> Handled {
@@ -136,6 +202,7 @@ fn manifest_reply() -> Message {
 async fn ready() -> (Party, Party, TicketPresentation) {
     let mut applicant = Party::new(1);
     let mut vetter = Party::new(2).member_of(COMMUNITY);
+    vetter.named_vetter().await;
     let now = Utc::now();
     applicant
         .book
@@ -179,11 +246,23 @@ async fn in_session(applicant: &mut Party, vetter: &mut Party) -> (String, Trust
         panic!("the request is accepted");
     };
     let reply = handled.reply.expect("an accepted request is answered");
-    let message = signed(reply.document, &vetter.secret).await;
+    assert!(
+        reply.eligibility.is_some(),
+        "a named vetter presents the grant"
+    );
+    let message = signed_reply(reply, &vetter.secret).await;
     let handled = applicant.receive(&message, &vetter.did).await;
     assert!(matches!(
         handled.notice,
-        Some(Notice::VetterAccepted { .. })
+        Some(Notice::VetterAccepted {
+            shown_eligible: true,
+            ..
+        })
+    ));
+    let accepted = applicant.application().requests.last().unwrap().clone();
+    assert!(matches!(
+        accepted.eligibility,
+        Some(VetterEligibility::Shown { .. })
     ));
 
     let session_id = wire::new_id();
@@ -459,6 +538,115 @@ async fn someone_who_is_not_a_member_cannot_vet() {
     assert_eq!(
         handled.reply.unwrap().document.payload["code"],
         VETTING_REQUEST_ERR_NOT_ELIGIBLE
+    );
+}
+
+/// Membership is not enough: the community has to have named the member a
+/// vetter, or requests are refused before anything is recorded.
+#[tokio::test]
+async fn a_member_the_community_has_not_named_cannot_vet() {
+    let (mut applicant, _, _) = ready().await;
+    let mut member = Party::new(4).member_of(COMMUNITY);
+    let ticket = Ticket::issue(
+        COMMUNITY,
+        member.persona,
+        vec![],
+        1,
+        DEFAULT_VALIDITY,
+        Utc::now(),
+    );
+    let presented = ticket.code_presentation();
+    member.book.tickets.push(ticket);
+    let message = request(&mut applicant, &member, presented).await;
+    let handled = member.receive(&message, &applicant.did).await;
+    assert_eq!(
+        handled.reply.unwrap().document.payload["code"],
+        VETTING_REQUEST_ERR_NOT_ELIGIBLE
+    );
+    assert!(member.book.desk.is_empty());
+}
+
+/// Only the community a grant names can deliver it, and only to the persona
+/// it names. A member's ordinary role credential is left for the join handler,
+/// so it keeps its place.
+#[tokio::test]
+async fn a_vetter_grant_is_kept_only_from_its_community() {
+    let mut member = Party::new(5).member_of(COMMUNITY);
+    let impostor = secret(0xC1);
+    let forged = role_credential(&impostor, COMMUNITY, &member.did.clone(), VETTER_ROLE).await;
+    let handled = member
+        .receive(&delivery(&forged, &did(&impostor)), &did(&impostor))
+        .await;
+    assert!(handled.notice.is_none() && member.book.vetter_grants.is_empty());
+
+    let for_someone_else = role_credential(
+        &secret(COMMUNITY_SEED),
+        COMMUNITY,
+        "did:key:zSomeoneElse",
+        VETTER_ROLE,
+    )
+    .await;
+    let handled = member
+        .receive(&delivery(&for_someone_else, COMMUNITY), COMMUNITY)
+        .await;
+    assert!(handled.notice.is_none() && member.book.vetter_grants.is_empty());
+
+    let ordinary = role_credential(
+        &secret(COMMUNITY_SEED),
+        COMMUNITY,
+        &member.did.clone(),
+        "member",
+    )
+    .await;
+    let resolver = TrustTaskVmResolver::did_key_only();
+    let ctx = Context {
+        account: &member.account,
+        resolver: &resolver,
+        recipient: Some((member.persona, &member.did)),
+        now: Utc::now(),
+    };
+    assert!(
+        handle(
+            &mut member.book,
+            &ctx,
+            &delivery(&ordinary, COMMUNITY),
+            COMMUNITY
+        )
+        .await
+        .is_none(),
+        "an ordinary role credential is not vetting's"
+    );
+
+    member.named_vetter().await;
+    assert!(
+        member
+            .book
+            .vetter_grant(COMMUNITY, member.persona, Utc::now())
+            .is_some()
+    );
+}
+
+/// An acceptance that shows nothing is still an acceptance — the check is
+/// advisory — but the applicant is told.
+#[tokio::test]
+async fn an_acceptance_without_a_grant_shown_is_recorded_as_such() {
+    let (mut applicant, mut vetter, ticket) = ready().await;
+    let message = request(&mut applicant, &vetter, ticket).await;
+    let handled = vetter.receive(&message, &applicant.did).await;
+    let mut reply = handled.reply.unwrap();
+    reply.eligibility = None;
+    let message = signed_reply(reply, &vetter.secret).await;
+    let handled = applicant.receive(&message, &vetter.did).await;
+    assert!(matches!(
+        handled.notice,
+        Some(Notice::VetterAccepted {
+            shown_eligible: false,
+            ..
+        })
+    ));
+    assert_eq!(
+        applicant.application().requests[0].eligibility,
+        Some(VetterEligibility::NotShown)
     );
 }
 

--- a/openvtc-core/src/vetting/vetter.rs
+++ b/openvtc-core/src/vetting/vetter.rs
@@ -227,8 +227,9 @@ pub struct IncomingRequest<'a> {
     pub persona: PersonaId,
     /// The payload.
     pub body: VettingRequestBody,
-    /// `persona` is an active member of `body.community`.
-    pub is_member: bool,
+    /// `persona` is an active member of `body.community` and holds its live
+    /// vetter role credential.
+    pub eligible: bool,
 }
 
 /// What an inbound request earns.
@@ -326,7 +327,7 @@ impl VettingBook {
             sender,
             persona,
             body,
-            is_member,
+            eligible,
         } = incoming;
         if body.check_shape(sender).is_err() {
             return Intake::Silent;
@@ -367,7 +368,7 @@ impl VettingBook {
         {
             return Intake::Refused(VETTING_REQUEST_ERR_METHOD_UNAVAILABLE);
         }
-        if !is_member {
+        if !eligible {
             return Intake::Refused(VETTING_REQUEST_ERR_NOT_ELIGIBLE);
         }
         if self.open_requests(persona) >= self.policy.max_open_requests {

--- a/openvtc-core/src/vetting/wire.rs
+++ b/openvtc-core/src/vetting/wire.rs
@@ -212,9 +212,65 @@ pub async fn sign_and_send(
     tdk: &affinidi_tdk::TDK,
     service: &crate::didcomm::Messaging,
     persona: crate::config::account::PersonaId,
-    mut document: TrustTask<Value>,
+    document: TrustTask<Value>,
 ) -> Result<String, OpenVTCError> {
-    let keys = config.get_persona_keys_for(persona, tdk).await?;
+    send_reply(
+        config,
+        tdk,
+        service,
+        super::inbound::Reply {
+            persona,
+            document,
+            eligibility: None,
+        },
+    )
+    .await
+}
+
+/// Present the role credentials `eligibility` names as the acceptance's
+/// `eligibilityVp`, signed by `holder` for `authentication`. Done before the
+/// document itself is signed, so its proof covers the presentation.
+///
+/// # Errors
+///
+/// A payload that is not an object, or a presentation that cannot be signed.
+pub async fn attach_eligibility(
+    document: &mut TrustTask<Value>,
+    holder: &Secret,
+    eligibility: super::inbound::EligibilityPresentation,
+) -> Result<(), OpenVTCError> {
+    let vp = vta_sdk::vetting::eligibility::build_eligibility_vp(
+        holder,
+        eligibility.credentials,
+        &eligibility.nonce,
+        &eligibility.domain,
+    )
+    .await
+    .map_err(|e| config_error("eligibility presentation", e))?;
+    document
+        .payload
+        .as_object_mut()
+        .ok_or_else(|| OpenVTCError::Config("vetting reply payload is not an object".into()))?
+        .insert("eligibilityVp".into(), vp);
+    Ok(())
+}
+
+/// Sign a reply from [`super::inbound::handle`] as its persona — presenting
+/// the role credential it asks for with the persona's authentication key —
+/// and send it over DIDComm. Returns the document id.
+///
+/// `Ok` means handed to the transport, not delivered (R1.1).
+pub async fn send_reply(
+    config: &crate::config::Config,
+    tdk: &affinidi_tdk::TDK,
+    service: &crate::didcomm::Messaging,
+    reply: super::inbound::Reply,
+) -> Result<String, OpenVTCError> {
+    let keys = config.get_persona_keys_for(reply.persona, tdk).await?;
+    let mut document = reply.document;
+    if let Some(eligibility) = reply.eligibility {
+        attach_eligibility(&mut document, &keys.authentication.secret, eligibility).await?;
+    }
     sign(&mut document, &keys.signing.secret).await?;
     let message = to_message(&document)?;
     let (from, to) = (

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -1549,6 +1549,9 @@ pub struct RequestRow {
     pub match_code: Option<String>,
     /// The open session still waiting for our card.
     pub card_session: Option<String>,
+    /// What their acceptance showed of their eligibility, and whether that is
+    /// good news.
+    pub eligibility: Option<(bool, String)>,
 }
 
 /// Where a desk request is, for choosing what the keys do.

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -236,14 +236,8 @@ pub async fn process_inbound_message(
         .await
         {
             if let Some(reply) = handled.reply
-                && let Err(e) = openvtc_core::vetting::wire::sign_and_send(
-                    config,
-                    tdk,
-                    service,
-                    reply.persona,
-                    reply.document,
-                )
-                .await
+                && let Err(e) =
+                    openvtc_core::vetting::wire::send_reply(config, tdk, service, reply).await
             {
                 warn!(to = %from_did, error = %e, "could not send vetting reply");
             }

--- a/openvtc/src/state_handler/vetting_actions.rs
+++ b/openvtc/src/state_handler/vetting_actions.rs
@@ -19,7 +19,9 @@ use openvtc_core::config::context_path::build_sub_context_id;
 use openvtc_core::didcomm::Messaging;
 use openvtc_core::persona::disclosure::{self, PresentError};
 use openvtc_core::persona::{binding, profile};
-use openvtc_core::vetting::applicant::{Application, RequestDraft, RequestState, SentCard};
+use openvtc_core::vetting::applicant::{
+    Application, RequestDraft, RequestState, SentCard, VetterEligibility,
+};
 use openvtc_core::vetting::book::FALLBACK_REQUIRED_CLAIMS;
 use openvtc_core::vetting::tickets::{DEFAULT_VALIDITY, Ticket, normalise_code};
 use openvtc_core::vetting::vetter::{Attestation, DeskState};
@@ -82,6 +84,9 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
         .account
         .memberships()
         .filter(|m| m.status.is_active())
+        // Tickets are for communities that named us a vetter: a request made
+        // with one to anyone else would be refused as not eligible.
+        .filter(|m| book.vetter_grant(&m.vtc_did, m.persona_ref, now).is_some())
         .map(|m| VettingMembership {
             community: m.vtc_did.clone(),
             name: m
@@ -188,6 +193,7 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
                             state,
                             match_code,
                             card_session,
+                            eligibility: r.eligibility.as_ref().map(eligibility_line),
                         }
                     })
                     .collect(),
@@ -298,6 +304,31 @@ fn claim_text(value: &Value) -> String {
     match value {
         Value::String(s) => s.clone(),
         other => other.to_string(),
+    }
+}
+
+/// What a vetter's acceptance showed, in a line, and whether it is good news.
+fn eligibility_line(eligibility: &VetterEligibility) -> (bool, String) {
+    match eligibility {
+        VetterEligibility::Shown { valid_until, .. } => (
+            true,
+            format!(
+                "named a vetter by the community until {}",
+                valid_until.format("%Y-%m-%d")
+            ),
+        ),
+        VetterEligibility::NotShown => (
+            false,
+            "did not show that the community named them a vetter — their statement may not count"
+                .to_string(),
+        ),
+        VetterEligibility::Failed { reason } => (
+            false,
+            format!(
+                "their vetter credential did not verify ({}) — their statement may not count",
+                sanitize_display(reason, 160)
+            ),
+        ),
     }
 }
 
@@ -453,7 +484,8 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
             if page(ctx).memberships.is_empty() {
                 status(
                     ctx,
-                    "You can hand out tickets once you are an active member of a community.",
+                    "You can hand out tickets once a community you belong to has named you a \
+                     vetter — ask its admins for the vetter role.",
                 );
             } else {
                 page(ctx).mode = VettingMode::NewTicket {

--- a/openvtc/src/ui/pages/main/components/vetting_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vetting_panel.rs
@@ -472,6 +472,16 @@ fn applications(lines: &mut Vec<Line<'static>>, v: &VettingState) {
             ));
         }
         lines.push(Line::from(state));
+        if let Some((good, line)) = &request.eligibility {
+            lines.push(Line::from(Span::styled(
+                format!("    {line}"),
+                if *good {
+                    Style::new().fg(COLOR_SUCCESS)
+                } else {
+                    Style::new().fg(COLOR_ORANGE)
+                },
+            )));
+        }
     }
     lines.push(Line::from(""));
     lines.push(hint(


### PR DESCRIPTION
Stacked on #296. OpenVTC now treats vetters as **named by their community with a revocable role credential**, not by an ACL role. This is the client side of OpenVTC/verifiable-trust-infrastructure#1429 and trustoverip/dtgwg-trust-tasks-tf#452 (`docs/design/vetting-process.md` §10.2–§10.3, D5, D20, D24).

## What changes

**Vetter**
- **Keeping the grant.** OpenVTC stores the community's `CommunityRole: vetter` credential in the vetting book (`VettingBook::vetter_grants`) when the community delivers it (`credential-exchange/issue`).
  - It is claimed before the join handler, which files every `EndorsementCredential` in the membership's single Role slot. Without that, a grant would replace the member's ordinary role credential.
  - It is kept only if the community it names sent and issued it, it names the persona it was addressed to, and that persona is a member.
  - An ordinary role credential (for example `member`) is left to the join handler, as before.
- **Refusing requests.** A request is refused with `notEligible` unless the persona is an active member **and** holds a live grant for that community.
- **Presenting the grant.** Each acceptance now carries `eligibilityVp`: the grant presented with the persona's authentication key, with `nonce` = the request document `id` and `domain` = the applicant's `joinDid` (#452 rule 5). `wire::send_reply` attaches it before the document is signed, so the document proof covers it.
- **Tickets.** The Tickets tab only offers communities that have named us a vetter. Without a grant, it tells the member to ask the community's admins.

**Applicant**
- **Checking the vetter.** The applicant verifies `eligibilityVp` with `vta_sdk::vetting::eligibility::verify_eligibility_vp`, against the requirements' `eligibleVetters.role`, the request id and its own join DID. The result is recorded on the request as `Shown`, `NotShown` or `Failed`.
- **Showing the result.** Under each vetter, the page shows "named a vetter by the community until …". Otherwise it warns, in orange, that their statement may not count.
- **Advisory only.** The acceptance still goes ahead either way: the community checks again, and it does not count statements from vetters it hasn't named.

**Dependencies:** the VTI patches now point at `feat/vtc-vetter-role-vec` (#1429).

## Notes for review
- **Revocation isn't checked by either side here.** The applicant would need a status-list fetch. A revoked grant stops the vetter's statements counting at the community, and that is the check that decides admission.
- **The grant's own proof isn't verified when it is stored.** The authenticated sender already proves as much to us as the proof would, and every applicant it is shown to verifies it.
- **Test community DID.** In the core tests the community is now a `did:key`, so role credentials verify offline. A test pins that key to its seed.

## Tests
New core tests:
- the end-to-end flow now carries a real grant, and the applicant records it as `Shown`;
- a member the community hasn't named can't vet;
- a grant is kept only from its community and for us, and an ordinary role credential is left to the join handler;
- an acceptance without a presentation is recorded as `NotShown`.

Results, run locally (stacked PRs get no CI):
- `cargo test -p openvtc-core --lib`: 585 passed
- `cargo test -p openvtc --bins`: 471 passed
- `cargo clippy -p openvtc -p openvtc-core --all-targets -- -D warnings`: clean
