### PR TITLE
feat(communities): each community can live in a VTA context of its own

### DIFF
--- a/openvtc-core/src/config/account.rs
+++ b/openvtc-core/src/config/account.rs
@@ -89,7 +89,11 @@ pub struct PersonaRecord {
     pub key_refs: Vec<KeyRef>,
     /// Mediator DID; defaults to the VTA mediator, optional override at mint (D7).
     pub mediator_did: Option<String>,
-    /// The sub-context the persona was minted under — provenance only (D6).
+    /// The VTA context the persona's keys and DID were minted in. A persona can
+    /// only be presented from here, so joining a community with it shares this
+    /// context ([`crate::config::community_context`]). Empty for a persona
+    /// minted before per-community contexts, whose keys are in the account's
+    /// top context.
     pub origin_context_id: String,
     /// When the persona was created.
     pub created_at: DateTime<Utc>,

--- a/openvtc-core/src/config/community_context.rs
+++ b/openvtc-core/src/config/community_context.rs
@@ -1,0 +1,434 @@
+//! Which VTA context a community lives in.
+//!
+//! Every community a person joins can get its own sub-context under the
+//! account's top context (`<top>/<slug>`). A sub-context has its own branch of
+//! the key hierarchy and its own ACL scope, and the persona's faces for that
+//! community are worn in it, so nothing a community is shown, and no key its
+//! persona signs with, is shared with another community unless the person
+//! chooses to share it.
+//!
+//! The choice is the person's, made when they join (or start a vetting
+//! application): a new sub-context, a context they already use, or the top
+//! context. One constraint shapes the options: a persona's keys and DID live in
+//! exactly one context, the one it was minted in. A persona minted into a
+//! sub-context can only be presented from that context; picking it means
+//! sharing that context. A persona minted before per-community contexts has its
+//! keys in the top context, so any context can hold its faces, but none of them
+//! isolates its keys.
+//!
+//! OpenVTC holds admin of the top context, which covers every sub-context
+//! beneath it. Isolation is therefore between communities, not from OpenVTC
+//! itself.
+
+use vta_sdk::client::{CreateContextRequest, VtaClient};
+use vta_sdk::error::VtaError;
+
+use super::account::{Account, CommunityRecord, PersonaRecord};
+use super::context_path::{SEPARATOR, child_path, parse_sub_context_id, validate_context_path};
+use crate::errors::OpenVTCError;
+
+/// The context `persona`'s keys and DID live in. Personas minted before
+/// per-community contexts record none, and theirs are in the top context.
+#[must_use]
+pub fn persona_context<'a>(persona: &'a PersonaRecord, top_context_id: &'a str) -> &'a str {
+    if persona.origin_context_id.is_empty() {
+        top_context_id
+    } else {
+        &persona.origin_context_id
+    }
+}
+
+/// Whether `context_id` is a sub-context of `top_context_id` (strictly below it).
+#[must_use]
+pub fn is_sub_context(context_id: &str, top_context_id: &str) -> bool {
+    context_id
+        .strip_prefix(top_context_id)
+        .is_some_and(|rest| rest.starts_with(SEPARATOR) && rest.len() > 1)
+}
+
+/// What kind of context an option is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ContextKind {
+    /// A new sub-context, for this community alone.
+    New,
+    /// A context the account already uses.
+    Existing,
+    /// The account's top context.
+    Top,
+}
+
+/// One context a join or an application can use.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContextOption {
+    /// The full context path.
+    pub context_id: String,
+    pub kind: ContextKind,
+    /// The communities already in it, by VTC DID.
+    pub communities: Vec<String>,
+    /// The persona being presented has its keys here, so this is the only
+    /// context it can be presented from.
+    pub holds_persona_keys: bool,
+}
+
+/// The contexts available for presenting `persona` — `None` for a persona not
+/// yet minted — to a community, with `suggested_new` as the new sub-context.
+///
+/// A persona whose keys live in a sub-context has one option: that context.
+/// Everyone else may choose a new sub-context (first, the default), any
+/// sub-context the account already uses, or the top context.
+#[must_use]
+pub fn context_options(
+    account: &Account,
+    persona: Option<&PersonaRecord>,
+    suggested_new: &str,
+) -> Vec<ContextOption> {
+    let top = account.top_context_id.as_str();
+    let in_context = |context_id: &str| -> Vec<String> {
+        let mut communities: Vec<String> = account
+            .memberships()
+            .filter(|m| m.sub_context_id == context_id)
+            .map(|m| m.vtc_did.clone())
+            .collect();
+        communities.sort();
+        communities.dedup();
+        communities
+    };
+
+    if let Some(persona) = persona {
+        let home = persona_context(persona, top);
+        if is_sub_context(home, top) {
+            return vec![ContextOption {
+                context_id: home.to_string(),
+                kind: ContextKind::Existing,
+                communities: in_context(home),
+                holds_persona_keys: true,
+            }];
+        }
+    }
+
+    let mut existing: Vec<String> = account
+        .memberships()
+        .map(|m| m.sub_context_id.clone())
+        .chain(
+            account
+                .personas
+                .values()
+                .map(|p| p.origin_context_id.clone()),
+        )
+        .filter(|c| is_sub_context(c, top) && c != suggested_new)
+        .collect();
+    existing.sort();
+    existing.dedup();
+
+    let mut options = vec![ContextOption {
+        context_id: suggested_new.to_string(),
+        kind: ContextKind::New,
+        communities: Vec::new(),
+        holds_persona_keys: false,
+    }];
+    options.extend(existing.into_iter().map(|context_id| ContextOption {
+        communities: in_context(&context_id),
+        context_id,
+        kind: ContextKind::Existing,
+        holds_persona_keys: false,
+    }));
+    options.push(ContextOption {
+        context_id: top.to_string(),
+        kind: ContextKind::Top,
+        communities: in_context(top),
+        holds_persona_keys: persona.is_some(),
+    });
+    options
+}
+
+/// Whether `context_id` is already used by the account — by a membership or a
+/// persona's keys.
+#[must_use]
+pub fn context_in_use(account: &Account, context_id: &str) -> bool {
+    account
+        .memberships()
+        .any(|m| m.sub_context_id == context_id)
+        || account
+            .personas
+            .values()
+            .any(|p| p.origin_context_id == context_id)
+}
+
+/// The new sub-context `<top>/<slug>` for a slug the person typed.
+///
+/// # Errors
+///
+/// A slug that is not a valid path segment, a path too deep, or one already in
+/// use — a new context is new, and choosing an existing one is a different
+/// option.
+pub fn new_context_id(
+    top_context_id: &str,
+    slug: &str,
+    taken: impl Fn(&str) -> bool,
+) -> Result<String, OpenVTCError> {
+    let id = child_path(top_context_id, slug.trim())?;
+    if taken(&id) {
+        return Err(OpenVTCError::Config(format!(
+            "{id} is already in use — choose it from the list to share it, or pick another name"
+        )));
+    }
+    Ok(id)
+}
+
+/// How far a membership is kept apart from the account's other communities.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Isolation {
+    /// Its own sub-context, holding its persona's keys.
+    Isolated,
+    /// A sub-context that holds its persona's keys, shared with `n` other
+    /// memberships.
+    Shared(usize),
+    /// Its own sub-context for faces, but the persona's keys live elsewhere —
+    /// a persona minted before per-community contexts, or one shown to several.
+    KeysElsewhere,
+    /// The account's top context.
+    Top,
+}
+
+impl Isolation {
+    /// One line for the communities panel.
+    #[must_use]
+    pub fn describe(self) -> String {
+        match self {
+            Isolation::Isolated => "own context — kept apart from your other communities".into(),
+            Isolation::Shared(1) => "shared with 1 other community".into(),
+            Isolation::Shared(n) => format!("shared with {n} other communities"),
+            Isolation::KeysElsewhere => {
+                "own context for faces — this persona's keys live in another context".into()
+            }
+            Isolation::Top => "top context — not kept apart".into(),
+        }
+    }
+}
+
+/// How `membership` is kept apart, given the account it belongs to.
+#[must_use]
+pub fn isolation(account: &Account, membership: &CommunityRecord) -> Isolation {
+    let top = account.top_context_id.as_str();
+    let context = membership.sub_context_id.as_str();
+    if context.is_empty() || !is_sub_context(context, top) {
+        return Isolation::Top;
+    }
+    let keys_here = account
+        .personas
+        .get(&membership.persona_ref)
+        .is_some_and(|p| persona_context(p, top) == context);
+    if !keys_here {
+        return Isolation::KeysElsewhere;
+    }
+    let others = account
+        .memberships()
+        .filter(|m| m.sub_context_id == context)
+        .count()
+        .saturating_sub(1);
+    match others {
+        0 => Isolation::Isolated,
+        n => Isolation::Shared(n),
+    }
+}
+
+/// Make sure `context_id` exists at the VTA, creating it — and any missing
+/// ancestor — beneath the account's top context. Returns whether anything was
+/// created. The top context itself is never created here; it exists from setup.
+///
+/// Looked up before it is created, and a create that races another one
+/// (`Conflict`) counts as existing, so a retried join reuses what an
+/// interrupted one left behind.
+///
+/// # Errors
+///
+/// A path outside the account's top context, or a VTA that refuses.
+pub async fn ensure_context(
+    client: &VtaClient,
+    top_context_id: &str,
+    context_id: &str,
+    name: &str,
+) -> Result<bool, OpenVTCError> {
+    if context_id == top_context_id {
+        return Ok(false);
+    }
+    validate_context_path(context_id)?;
+    if !is_sub_context(context_id, top_context_id) {
+        return Err(OpenVTCError::Config(format!(
+            "{context_id} is not inside this account's context {top_context_id}"
+        )));
+    }
+    let mut created = false;
+    let mut chain = Vec::new();
+    let mut current = context_id;
+    while current != top_context_id {
+        chain.push(current);
+        match parse_sub_context_id(current) {
+            Some((parent, _)) => current = parent,
+            None => break,
+        }
+    }
+    for path in chain.into_iter().rev() {
+        match client.get_context(path).await {
+            Ok(_) => continue,
+            Err(VtaError::NotFound(_)) => {}
+            Err(e) => {
+                return Err(OpenVTCError::Vta(format!(
+                    "could not look up context {path}: {e}"
+                )));
+            }
+        }
+        let Some((parent, slug)) = parse_sub_context_id(path) else {
+            continue;
+        };
+        let label = if path == context_id { name } else { slug };
+        match client
+            .create_context(
+                CreateContextRequest::new(slug, label)
+                    .description("A community context, created by OpenVTC")
+                    .parent(parent),
+            )
+            .await
+        {
+            Ok(_) => created = true,
+            Err(VtaError::Conflict(_)) => {}
+            Err(e) => {
+                return Err(OpenVTCError::Vta(format!(
+                    "could not create context {path}: {e}"
+                )));
+            }
+        }
+    }
+    Ok(created)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::account::PersonaId;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    const TOP: &str = "openvtc";
+
+    fn persona(origin: &str) -> PersonaRecord {
+        let persona_id = PersonaId::new();
+        PersonaRecord {
+            extra: serde_json::Map::new(),
+            persona_id,
+            did: format!("did:webvh:scid:example.com:{persona_id}"),
+            did_document: None,
+            key_refs: vec![],
+            mediator_did: None,
+            origin_context_id: origin.to_string(),
+            created_at: Utc::now(),
+            label: None,
+        }
+    }
+
+    fn account() -> Account {
+        Account {
+            top_context_id: TOP.into(),
+            ..Account::default()
+        }
+    }
+
+    fn join(account: &mut Account, persona: &PersonaRecord, community: &str, context: &str) {
+        account.personas.insert(persona.persona_id, persona.clone());
+        account.add_membership(CommunityRecord::new_pending(
+            community.into(),
+            None,
+            context.into(),
+            persona.persona_id,
+            Uuid::new_v4(),
+            Utc::now(),
+        ));
+    }
+
+    #[test]
+    fn a_sub_context_is_strictly_below_the_top() {
+        assert!(is_sub_context("openvtc/kernel", TOP));
+        assert!(is_sub_context("openvtc/work/kernel", TOP));
+        assert!(!is_sub_context("openvtc", TOP));
+        assert!(!is_sub_context("openvtc-evil/kernel", TOP));
+        assert!(!is_sub_context("openvtc/", TOP));
+    }
+
+    /// A new persona may go anywhere: a new sub-context first, then the ones in
+    /// use, then the top context.
+    #[test]
+    fn a_new_persona_is_offered_new_existing_and_top() {
+        let mut account = account();
+        let work = persona("openvtc/work");
+        join(&mut account, &work, "did:webvh:a", "openvtc/work");
+        let options = context_options(&account, None, "openvtc/kernel");
+        let kinds: Vec<_> = options.iter().map(|o| o.kind).collect();
+        assert_eq!(
+            kinds,
+            [ContextKind::New, ContextKind::Existing, ContextKind::Top]
+        );
+        assert_eq!(options[1].context_id, "openvtc/work");
+        assert_eq!(options[1].communities, ["did:webvh:a"]);
+        assert!(options.iter().all(|o| !o.holds_persona_keys));
+    }
+
+    /// A persona's keys live in one context, so a persona minted into a
+    /// sub-context can only be presented from it.
+    #[test]
+    fn a_persona_with_keys_in_a_sub_context_has_one_option() {
+        let mut account = account();
+        let work = persona("openvtc/work");
+        join(&mut account, &work, "did:webvh:a", "openvtc/work");
+        let options = context_options(&account, Some(&work), "openvtc/kernel");
+        assert_eq!(options.len(), 1);
+        assert_eq!(options[0].context_id, "openvtc/work");
+        assert!(options[0].holds_persona_keys);
+    }
+
+    /// A persona from before per-community contexts keeps its keys in the top
+    /// context; its faces can still go in a context of its own.
+    #[test]
+    fn a_legacy_persona_can_still_choose_where_its_faces_go() {
+        let mut account = account();
+        let legacy = persona("");
+        join(&mut account, &legacy, "did:webvh:a", "openvtc/a");
+        let options = context_options(&account, Some(&legacy), "openvtc/b");
+        assert_eq!(options[0].kind, ContextKind::New);
+        assert!(options.last().unwrap().holds_persona_keys);
+        assert_eq!(options.last().unwrap().kind, ContextKind::Top);
+    }
+
+    #[test]
+    fn isolation_reads_where_the_keys_are_and_who_shares() {
+        let mut account = account();
+        let alone = persona("openvtc/kernel");
+        join(&mut account, &alone, "did:webvh:k", "openvtc/kernel");
+        let shared = persona("openvtc/work");
+        join(&mut account, &shared, "did:webvh:w1", "openvtc/work");
+        join(&mut account, &shared, "did:webvh:w2", "openvtc/work");
+        let legacy = persona("");
+        join(&mut account, &legacy, "did:webvh:l", "openvtc/legacy");
+        join(&mut account, &legacy, "did:webvh:t", TOP);
+
+        let of = |vtc: &str| {
+            let m = account.memberships().find(|m| m.vtc_did == vtc).unwrap();
+            isolation(&account, m)
+        };
+        assert_eq!(of("did:webvh:k"), Isolation::Isolated);
+        assert_eq!(of("did:webvh:w1"), Isolation::Shared(1));
+        assert_eq!(of("did:webvh:l"), Isolation::KeysElsewhere);
+        assert_eq!(of("did:webvh:t"), Isolation::Top);
+    }
+
+    #[test]
+    fn a_new_context_must_be_new_and_well_formed() {
+        let taken = |id: &str| id == "openvtc/work";
+        assert_eq!(
+            new_context_id(TOP, "kernel", taken).unwrap(),
+            "openvtc/kernel"
+        );
+        assert!(new_context_id(TOP, "work", taken).is_err());
+        assert!(new_context_id(TOP, "a/b", taken).is_err());
+        assert!(new_context_id(TOP, "", taken).is_err());
+    }
+}

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -29,6 +29,7 @@ use std::{
 };
 
 pub mod account;
+pub mod community_context;
 pub mod context_path;
 pub mod did;
 pub mod integrity;

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -390,6 +390,15 @@ pub enum Action {
     /// selection (or mint).
     JoinInvitationChoose,
 
+    /// Move the context-choice highlight to this row.
+    JoinContextSelect(usize),
+
+    /// Replace the name typed for a new sub-context.
+    JoinContextSlug(String),
+
+    /// Commit the highlighted context and launch the join in it.
+    JoinContextChoose,
+
     /// Issue this Active membership's reciprocal VMC (member → community) and
     /// send it to the community's VTC over DIDComm (`members/vmc/1.0`). Indexed
     /// into the Communities display list.

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -112,6 +112,9 @@ pub(crate) enum DispatchDomain {
     /// A vetting send: a request, session, card, statement, decline,
     /// withdrawal or requirements fetch. One at a time, like every peer send.
     Vetting,
+    /// Registering the contexts memberships already name at the VTA — the ids
+    /// joins recorded before OpenVTC created them. Read-then-create, off the loop.
+    CommunityContexts,
 }
 
 impl DispatchDomain {
@@ -133,6 +136,7 @@ impl DispatchDomain {
             DispatchDomain::PersonaManage => "Identity request",
             DispatchDomain::Vic => "Invitation credential refresh",
             DispatchDomain::Vetting => "Vetting send",
+            DispatchDomain::CommunityContexts => "Community context registration",
         }
     }
 }
@@ -255,6 +259,9 @@ pub(crate) enum DispatchOutcome {
     Panicked(DispatchDomain),
     /// A vetting send finished (or failed, and was undone).
     Vetting(crate::state_handler::vetting_actions::VettingOutcome),
+    /// Membership contexts were checked at the VTA: each context id, and
+    /// whether it had to be created or why it could not be.
+    CommunityContexts(Vec<(String, Result<bool, String>)>),
 }
 
 impl DispatchOutcome {
@@ -280,6 +287,7 @@ impl DispatchOutcome {
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::VicMutation(_) => DispatchDomain::Vic,
             DispatchOutcome::Vetting(_) => DispatchDomain::Vetting,
+            DispatchOutcome::CommunityContexts(_) => DispatchDomain::CommunityContexts,
             DispatchOutcome::Panicked(domain) => *domain,
         }
     }
@@ -483,6 +491,21 @@ pub(crate) fn apply_outcome(
                 .extend(results);
         }
         DispatchOutcome::PersonaManage(outcome) => outcome.apply(state),
+        // Log-only: nothing on screen depends on a context existing, and a
+        // failure is retried on the next launch.
+        DispatchOutcome::CommunityContexts(results) => {
+            for (context_id, result) in results {
+                match result {
+                    Ok(true) => state.main_page.log(format!(
+                        "Registered community context {context_id} at the VTA."
+                    )),
+                    Ok(false) => {}
+                    Err(e) => state.main_page.log(format!(
+                        "Could not register community context {context_id}: {e}"
+                    )),
+                }
+            }
+        }
         DispatchOutcome::Vic(outcome) => outcome.apply(state, config),
         DispatchOutcome::VicMutation(outcome) => outcome.apply(state),
         // Handled above, before the domain is finished. Listed because the

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -8,6 +8,7 @@
 //! `State.setup`; this struct only tracks the join-specific surface.
 
 use openvtc_core::config::account::{CommunityRecord, PersonaId};
+use openvtc_core::config::community_context::{ContextKind, ContextOption};
 use serde_json::Value;
 
 use crate::state_handler::setup_sequence::{Completion, MessageType};
@@ -28,8 +29,21 @@ pub enum JoinPage {
     /// Choose the identity to present (R-B-3 / D1): reuse an existing persona or
     /// mint a fresh one. Skipped when the account has no personas yet.
     IdentityChoice,
+    /// Choose the VTA context the community lives in: a new sub-context of its
+    /// own, one already in use, or the top context. Skipped when the identity
+    /// allows only one.
+    ContextChoice,
     /// Automated mint + join sequence progress / result.
     Progress,
+}
+
+/// The identity a join presents, once chosen.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdentityPick {
+    /// A new persona, minted into the chosen context.
+    Mint,
+    /// An existing persona.
+    Reuse(PersonaId),
 }
 
 /// Summary of the invitation credential (VIC) actually presented with a join,
@@ -164,6 +178,16 @@ pub struct JoinState {
     /// submits an open request. Set when the invitation choice is made, or
     /// directly (false) on paths with no available invitation.
     pub present_invitation: bool,
+    /// The identity the context step is choosing for.
+    pub picked_identity: Option<IdentityPick>,
+    /// Contexts offered on the context-choice page, the default first.
+    pub context_options: Vec<ContextOption>,
+    /// Highlighted row on the context-choice page.
+    pub context_selected: usize,
+    /// The name typed for a new sub-context: its last path segment.
+    pub context_slug: String,
+    /// Display names for the communities listed under each context, by VTC DID.
+    pub context_community_names: Vec<(String, String)>,
 }
 
 impl JoinState {
@@ -194,6 +218,21 @@ impl JoinState {
     /// It is also the clamp ceiling for `invitation_use_selected`.
     pub fn invitation_without_row(&self) -> usize {
         self.invitation_options.len() + 1
+    }
+
+    /// Whether the highlighted context row is the new sub-context.
+    pub fn new_context_selected(&self) -> bool {
+        self.context_options
+            .get(self.context_selected)
+            .is_some_and(|o| o.kind == ContextKind::New)
+    }
+
+    /// The display name for a community listed under a context.
+    pub fn community_name<'a>(&'a self, vtc_did: &'a str) -> &'a str {
+        self.context_community_names
+            .iter()
+            .find(|(did, _)| did == vtc_did)
+            .map_or(vtc_did, |(_, name)| name.as_str())
     }
 
     /// Append an info message to the progress log.
@@ -249,6 +288,29 @@ mod tests {
         assert!(!js.mint_row_selected());
         js.identity_selected = 2;
         assert!(js.mint_row_selected());
+    }
+
+    #[test]
+    fn only_the_new_row_takes_a_typed_name() {
+        let option = |context_id: &str, kind| ContextOption {
+            context_id: context_id.to_string(),
+            kind,
+            communities: Vec::new(),
+            holds_persona_keys: false,
+        };
+        let mut js = JoinState {
+            context_options: vec![
+                option("openvtc/kernel", ContextKind::New),
+                option("openvtc/work", ContextKind::Existing),
+                option("openvtc", ContextKind::Top),
+            ],
+            ..JoinState::default()
+        };
+        assert!(js.new_context_selected());
+        js.context_selected = 1;
+        assert!(!js.new_context_selected());
+        js.context_selected = 2;
+        assert!(!js.new_context_selected());
     }
 
     #[test]

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -20,7 +20,8 @@ use chrono::Utc;
 use openvtc_core::config::{
     Config,
     account::{CommunityRecord, PersonaId, VtcDid},
-    context_path::build_sub_context_id,
+    community_context::{self, ContextKind},
+    context_path::{build_sub_context_id, parse_sub_context_id},
 };
 use openvtc_core::didcomm::Messaging;
 use openvtc_core::logs::LogFamily;
@@ -33,22 +34,15 @@ use crate::{
     state_handler::{
         StateHandler,
         actions::Action,
-        join::{AvailableVic, JoinPage, JoinState, PersonaOption, PresentedInvitation},
+        join::{
+            AvailableVic, IdentityPick, JoinPage, JoinState, PersonaOption, PresentedInvitation,
+        },
         main_page::content::{VicLifecycle, VicSummary},
         main_page::{sanitize_display, shorten_did},
         setup_sequence::{Completion, MessageType, config::ConfigExtension, vta},
         state::{ActivePage, State},
     },
 };
-
-/// Which identity to present to the community being joined (R-B-3 / D1).
-#[derive(Clone, Debug)]
-enum JoinIdentityChoice {
-    /// Mint a fresh, self-contained `did:webvh` persona (D6).
-    Mint,
-    /// Reuse an existing account persona (links the user across communities).
-    Reuse(PersonaId),
-}
 
 /// The persona + community of a just-completed join, handed back to the runtime
 /// loop so it can bring a live session up immediately (R-B-5 / D11) rather than
@@ -224,19 +218,23 @@ impl StateHandler {
                                 // A new persona can't hold an existing invitation.
                                 state.invitation_credential = None;
                                 state.join.present_invitation = false;
-                                if let Some(interrupted) = self
-                                    .launch_join_sequence(
-                                        JoinIdentityChoice::Mint,
-                                        vtc_did,
-                                        interrupt_rx,
-                                        state,
-                                        tdk,
-                                        config,
-                                        admin_vta,
-                                        profile,
-                                        messaging,
-                                    )
-                                    .await
+                                state.join.pending_vtc = Some(vtc_did.clone());
+                                if let Some(context_id) =
+                                    offer_contexts(state, config, IdentityPick::Mint, &vtc_did)
+                                    && let Some(interrupted) = self
+                                        .launch_join_sequence(
+                                            IdentityPick::Mint,
+                                            vtc_did,
+                                            context_id,
+                                            interrupt_rx,
+                                            state,
+                                            tdk,
+                                            config,
+                                            admin_vta,
+                                            profile,
+                                            messaging,
+                                        )
+                                        .await
                                 {
                                     return Ok(JoinExit::Exit(interrupted));
                                 }
@@ -264,19 +262,22 @@ impl StateHandler {
                                 // A freshly minted persona holds no invitation.
                                 state.invitation_credential = None;
                                 state.join.present_invitation = false;
-                                if let Some(interrupted) = self
-                                    .launch_join_sequence(
-                                        JoinIdentityChoice::Mint,
-                                        vtc_did,
-                                        interrupt_rx,
-                                        state,
-                                        tdk,
-                                        config,
-                                        admin_vta,
-                                        profile,
-                                        messaging,
-                                    )
-                                    .await
+                                if let Some(context_id) =
+                                    offer_contexts(state, config, IdentityPick::Mint, &vtc_did)
+                                    && let Some(interrupted) = self
+                                        .launch_join_sequence(
+                                            IdentityPick::Mint,
+                                            vtc_did,
+                                            context_id,
+                                            interrupt_rx,
+                                            state,
+                                            tdk,
+                                            config,
+                                            admin_vta,
+                                            profile,
+                                            messaging,
+                                        )
+                                        .await
                                 {
                                     return Ok(JoinExit::Exit(interrupted));
                                 }
@@ -395,10 +396,74 @@ impl StateHandler {
                                 state.invitation_credential = None;
                                 state.join.present_invitation = false;
                             }
+                            let pick = IdentityPick::Reuse(persona_id);
+                            if let Some(context_id) = offer_contexts(state, config, pick, &vtc_did)
+                                && let Some(interrupted) = self
+                                    .launch_join_sequence(
+                                        pick,
+                                        vtc_did,
+                                        context_id,
+                                        interrupt_rx,
+                                        state,
+                                        tdk,
+                                        config,
+                                        admin_vta,
+                                        profile,
+                                        messaging,
+                                    )
+                                    .await
+                            {
+                                return Ok(JoinExit::Exit(interrupted));
+                            }
+                        }
+                        Action::JoinContextSelect(i) => {
+                            let last = state.join.context_options.len().saturating_sub(1);
+                            state.join.context_selected = i.min(last);
+                            state.join.messages.clear();
+                        }
+                        Action::JoinContextSlug(slug) => {
+                            state.join.context_slug = slug;
+                            state.join.messages.clear();
+                        }
+                        Action::JoinContextChoose => {
+                            let (Some(vtc_did), Some(pick)) =
+                                (state.join.pending_vtc.clone(), state.join.picked_identity)
+                            else {
+                                continue;
+                            };
+                            let Some(option) = state
+                                .join
+                                .context_options
+                                .get(state.join.context_selected)
+                                .cloned()
+                            else {
+                                continue;
+                            };
+                            let context_id = if option.kind == ContextKind::New {
+                                match community_context::new_context_id(
+                                    &config.account.top_context_id,
+                                    &state.join.context_slug,
+                                    |id| context_taken(config, id),
+                                ) {
+                                    Ok(id) => id,
+                                    Err(e) => {
+                                        state.join.messages.clear();
+                                        state
+                                            .join
+                                            .messages
+                                            .push(MessageType::Error(e.to_string()));
+                                        let _ = self.state_tx.send(state.clone());
+                                        continue;
+                                    }
+                                }
+                            } else {
+                                option.context_id
+                            };
                             if let Some(interrupted) = self
                                 .launch_join_sequence(
-                                    JoinIdentityChoice::Reuse(persona_id),
+                                    pick,
                                     vtc_did,
+                                    context_id,
                                     interrupt_rx,
                                     state,
                                     tdk,
@@ -430,8 +495,9 @@ impl StateHandler {
     #[allow(clippy::too_many_arguments)]
     async fn launch_join_sequence(
         &self,
-        choice: JoinIdentityChoice,
+        choice: IdentityPick,
         vtc_did: String,
+        context_id: String,
         interrupt_rx: &mut broadcast::Receiver<Interrupted>,
         state: &mut State,
         tdk: &TDK,
@@ -477,6 +543,7 @@ impl StateHandler {
             profile,
             vtc_did,
             choice,
+            context_id,
             &mut minted_persona,
             &prior_friendly_name,
             messaging,
@@ -507,6 +574,85 @@ impl StateHandler {
         let _ = self.state_tx.send(state.clone());
         None
     }
+}
+
+/// Whether `context_id` is already claimed: by a membership, a persona's keys,
+/// or a vetting application's face.
+pub(crate) fn context_taken(config: &Config, context_id: &str) -> bool {
+    community_context::context_in_use(&config.account, context_id)
+        || config
+            .private
+            .vetting
+            .applications
+            .iter()
+            .any(|a| a.context_id.as_deref() == Some(context_id))
+}
+
+/// The new sub-context to suggest for `vtc_did`: named after the community,
+/// and not yet claimed.
+pub(crate) fn suggested_context(config: &Config, vtc_did: &str) -> String {
+    let top = &config.account.top_context_id;
+    let taken = |id: &str| context_taken(config, id);
+    build_sub_context_id(top, config.agent_name_for(vtc_did), vtc_did, taken)
+        .or_else(|_| build_sub_context_id(top, Some("community"), vtc_did, taken))
+        .unwrap_or_else(|_| top.clone())
+}
+
+/// Offer the contexts `pick` can join `vtc_did` in.
+///
+/// Returns the context when there is nothing to ask — a persona whose keys
+/// live in a sub-context, or one whose vetting application already chose where
+/// its face is worn — and otherwise opens the context-choice page and returns
+/// `None`.
+fn offer_contexts(
+    state: &mut State,
+    config: &Config,
+    pick: IdentityPick,
+    vtc_did: &str,
+) -> Option<String> {
+    let persona = match pick {
+        IdentityPick::Reuse(id) => {
+            if let Some(context) = config
+                .private
+                .vetting
+                .application(vtc_did, id)
+                .and_then(|a| a.context_id.clone())
+            {
+                return Some(context);
+            }
+            config.account.personas.get(&id)
+        }
+        IdentityPick::Mint => None,
+    };
+    let suggested = suggested_context(config, vtc_did);
+    let options = community_context::context_options(&config.account, persona, &suggested);
+    if options.len() == 1 {
+        return options.into_iter().next().map(|o| o.context_id);
+    }
+    state.join.context_slug = parse_sub_context_id(&suggested)
+        .map(|(_, slug)| slug.to_string())
+        .unwrap_or_default();
+    state.join.context_community_names = options
+        .iter()
+        .flat_map(|o| o.communities.iter())
+        .map(|did| {
+            let display = config
+                .account
+                .memberships()
+                .find(|m| &m.vtc_did == did)
+                .and_then(|m| m.display_name.as_deref());
+            (
+                did.clone(),
+                crate::state_handler::community_label(config, did, display, 40),
+            )
+        })
+        .collect();
+    state.join.context_options = options;
+    state.join.context_selected = 0;
+    state.join.picked_identity = Some(pick);
+    state.join.messages.clear();
+    state.join.page = JoinPage::ContextChoice;
+    None
 }
 
 /// Build the reuse options for the identity-choice page (R-B-3): every existing
@@ -853,7 +999,8 @@ async fn run_join_sequence(
     admin_vta: Option<&VtaClient>,
     profile: &str,
     vtc_did: String,
-    choice: JoinIdentityChoice,
+    choice: IdentityPick,
+    context_id: String,
     minted_persona: &mut Option<PersonaId>,
     prior_friendly_name: &str,
     messaging: Option<&Messaging>,
@@ -909,12 +1056,31 @@ async fn run_join_sequence(
 
     let top_context_id = config.account.top_context_id.clone();
 
+    // 4. The community's context exists before anything is minted into it. A
+    // retried join reuses a context an interrupted one left behind.
+    let context_name = display_name
+        .clone()
+        .unwrap_or_else(|| shorten_did(&vtc_did, 48));
+    match community_context::ensure_context(admin_vta, &top_context_id, &context_id, &context_name)
+        .await
+    {
+        Ok(true) => state.join.info(format!("Created context {context_id}.")),
+        Ok(false) => state.join.info(format!("Using context {context_id}.")),
+        Err(e) => {
+            state.join.fail(format!(
+                "Could not prepare context {context_id}: {e}. Nothing was created."
+            ));
+            return;
+        }
+    }
+    let _ = handler.state_tx.send(state.clone());
+
     // Resolve the persona to present: reuse an existing account persona (R-B-3)
     // or mint a fresh, self-contained one (D6). Only a *minted* persona is
     // recorded in `minted_persona` for rollback — a reused persona pre-exists and
     // must never be rolled back.
     let (persona_id, persona_did) = match choice {
-        JoinIdentityChoice::Reuse(persona_id) => match config.identities.get(&persona_id) {
+        IdentityPick::Reuse(persona_id) => match config.identities.get(&persona_id) {
             Some(ident) => {
                 // Per-persona idempotency (R-B-9): block a second live membership
                 // as the *same* persona, while still allowing other personas.
@@ -923,6 +1089,19 @@ async fn run_join_sequence(
                         "Already a member of (or have a pending request for) this community as this persona.",
                     );
                     return;
+                }
+                // A persona's keys live in one context; one minted into a
+                // sub-context is only ever presented from it.
+                if let Some(record) = config.account.personas.get(&persona_id) {
+                    let home = community_context::persona_context(record, &top_context_id);
+                    if community_context::is_sub_context(home, &top_context_id)
+                        && home != context_id
+                    {
+                        state.join.fail(format!(
+                            "This persona's keys live in {home}, so it can only join from there."
+                        ));
+                        return;
+                    }
                 }
                 let did = ident.persona_did().to_string();
                 state.join.info(format!("Reusing persona {did}…"));
@@ -936,14 +1115,14 @@ async fn run_join_sequence(
                 return;
             }
         },
-        JoinIdentityChoice::Mint => {
-            // 4. Mint a fresh persona into `state.setup` (reusing the setup helpers).
-            // Persona signing/auth/encryption keys.
+        IdentityPick::Mint => {
+            // 5. Mint a fresh persona into `state.setup` (reusing the setup
+            // helpers), with every key and the DID in the community's context.
             state
                 .join
                 .info("Creating persona keys (signing, authentication, encryption)…");
             let _ = handler.state_tx.send(state.clone());
-            match vta::create_persona_keys(admin_vta, Some(&top_context_id)).await {
+            match vta::create_persona_keys(admin_vta, Some(&context_id)).await {
                 Ok(keys) => state.setup.did_keys = Some(keys),
                 Err(e) => {
                     state
@@ -955,7 +1134,7 @@ async fn run_join_sequence(
             // WebVH update keys.
             state.join.info("Creating DID update keys…");
             let _ = handler.state_tx.send(state.clone());
-            match vta::create_update_keys(admin_vta, Some(&top_context_id)).await {
+            match vta::create_update_keys(admin_vta, Some(&context_id)).await {
                 Ok((update, next_update)) => {
                     state.setup.vta.update_secret = Some(update);
                     state.setup.vta.next_update_secret = Some(next_update);
@@ -997,7 +1176,7 @@ async fn run_join_sequence(
             match vta::create_did_via_server(
                 admin_vta,
                 tdk,
-                &top_context_id,
+                &context_id,
                 &server_id,
                 WebvhPathMode::AutoAssign,
             )
@@ -1059,6 +1238,10 @@ async fn run_join_sequence(
                     }
                 };
             *minted_persona = Some(persona_id);
+            // Where its keys live, which decides every context it can join from.
+            if let Some(record) = config.account.personas.get_mut(&persona_id) {
+                record.origin_context_id = context_id.clone();
+            }
             let persona_did = state.setup.webvh_address.did.clone();
             state.join.info(format!("Persona created: {persona_did}"));
             let _ = handler.state_tx.send(state.clone());
@@ -1069,54 +1252,10 @@ async fn run_join_sequence(
     // persona pre-existed and is left intact.
     let minted = minted_persona.is_some();
 
-    // 6. Derive the per-community sub-context id (D9, collision-safe). An
-    // application to be vetted already has one — the context its face was worn
-    // in for the vetters — and the membership keeps it, so the community sees
-    // the face the vetters checked.
-    let vetted_context = config
-        .private
-        .vetting
-        .application(&vtc_did, persona_id)
-        .and_then(|a| a.context_id.clone())
-        .filter(|id| {
-            !config
-                .account
-                .memberships()
-                .any(|c| &c.sub_context_id == id)
-        });
-    let derived = match vetted_context {
-        Some(id) => Ok(id),
-        None => build_sub_context_id(&top_context_id, display_name.as_deref(), &vtc_did, |id| {
-            config.account.memberships().any(|c| c.sub_context_id == id)
-        }),
-    };
-    let sub_context_id = match derived {
-        Ok(id) => id,
-        Err(e) => {
-            state
-                .join
-                .fail(format!("Failed to derive sub-context id: {e}"));
-            if minted {
-                rollback_minted_persona(config, persona_id, state, profile, prior_friendly_name);
-            }
-            return;
-        }
-    };
-
-    // 7. Register the sub-context at the VTA.
-    state
-        .join
-        .info(format!("Creating sub-context {sub_context_id}…"));
-    let _ = handler.state_tx.send(state.clone());
-    if let Err(e) = vta::create_sub_context(admin_vta, &top_context_id, &sub_context_id).await {
-        state
-            .join
-            .fail(format!("Failed to create sub-context: {e}"));
-        if minted {
-            rollback_minted_persona(config, persona_id, state, profile, prior_friendly_name);
-        }
-        return;
-    }
+    // 6. The membership lives in the context chosen for it, prepared at step 4.
+    // A vetting application's context was offered as the only choice, so the
+    // community sees the face the vetters checked.
+    let sub_context_id = context_id;
 
     // 8. Submit the join request to the VTC over DIDComm. The persona is
     // the authcrypt sender (the VTC reads the applicant from the
@@ -1692,6 +1831,53 @@ mod tests {
     use tokio::sync::broadcast;
 
     // ---- Pure-decision tests (peeled out of the join sequence) ----
+
+    /// A persona whose keys live in a sub-context is presented from it, so
+    /// nothing is asked; a new persona is asked, with a context of its own
+    /// offered first.
+    #[test]
+    fn a_persona_bound_to_a_context_skips_the_choice_and_a_new_one_is_asked() {
+        use super::offer_contexts;
+        use crate::state_handler::join::{IdentityPick, JoinPage};
+        use openvtc_core::config::account::PersonaRecord;
+        use openvtc_core::config::community_context::ContextKind;
+
+        let mut config = test_config();
+        config.account.top_context_id = "openvtc".into();
+        let persona_id = PersonaId::new();
+        config.account.personas.insert(
+            persona_id,
+            PersonaRecord {
+                extra: serde_json::Map::new(),
+                persona_id,
+                did: "did:webvh:scid:example.com:alice".into(),
+                did_document: None,
+                key_refs: vec![],
+                mediator_did: None,
+                origin_context_id: "openvtc/work".into(),
+                created_at: chrono::Utc::now(),
+                label: None,
+            },
+        );
+        let vtc = "did:webvh:QmCommunityScid:vtc.example.com";
+        let mut state = State::default();
+
+        assert_eq!(
+            offer_contexts(&mut state, &config, IdentityPick::Reuse(persona_id), vtc).as_deref(),
+            Some("openvtc/work")
+        );
+        assert_ne!(state.join.page, JoinPage::ContextChoice);
+
+        assert!(offer_contexts(&mut state, &config, IdentityPick::Mint, vtc).is_none());
+        assert_eq!(state.join.page, JoinPage::ContextChoice);
+        let kinds: Vec<_> = state.join.context_options.iter().map(|o| o.kind).collect();
+        assert_eq!(
+            kinds,
+            [ContextKind::New, ContextKind::Existing, ContextKind::Top]
+        );
+        assert!(!state.join.context_slug.is_empty());
+        assert_eq!(state.join.picked_identity, Some(IdentityPick::Mint));
+    }
 
     /// `validate_join_input` trims and rejects empties; otherwise returns the
     /// cleaned DID. Table-driven over (raw input, expected).

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use dtg_credentials::DTGCredential;
 use openvtc_core::config::account::PersonaId;
+use openvtc_core::config::community_context::ContextOption;
 use vta_sdk::protocols::vetting::{DeclaredRelationship, RevocationReason, VettingMethod};
 
 /// Lazily-rendered raw credential JSON for credential detail views.
@@ -393,6 +394,8 @@ pub struct CommunitySummary {
     pub vtc_agent_name: Option<String>,
     /// The per-community sub-context id (troubleshooting detail).
     pub sub_context_id: String,
+    /// How far that context keeps this community apart from the others.
+    pub context_note: String,
     /// The join request id while `Pending`; empty otherwise.
     pub request_id: String,
     /// Whether the membership credential (VMC) has been received + stored.
@@ -1416,6 +1419,9 @@ pub enum VettingMode {
     NewApplication {
         community: String,
         persona_index: usize,
+        /// Where the application's face is worn, and the membership lives.
+        context_options: Vec<ContextOption>,
+        context_index: usize,
         field: usize,
     },
     /// Choose the face an application shows vetters.

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -616,6 +616,11 @@ impl MainPageState {
                     .agent_name_for(&c.vtc_did)
                     .map(|n| sanitize_display(n, 256)),
                 sub_context_id: c.sub_context_id.clone(),
+                context_note: openvtc_core::config::community_context::isolation(
+                    &config.account,
+                    c,
+                )
+                .describe(),
                 request_id,
                 has_membership_credential: c
                     .credentials

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1026,6 +1026,10 @@ impl StateHandler {
         let (dispatch_tx, mut dispatch_rx) =
             mpsc::unbounded_channel::<background_dispatch::DispatchOutcome>();
         let mut in_flight = background_dispatch::InFlight::default();
+        // Membership contexts already checked at the VTA this run. A failure is
+        // logged and retried on the next launch rather than every tick.
+        let mut contexts_checked: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         // Coalesced + offloaded config persistence (R11). Mutation sites mark the
         // config dirty on the loop thread instead of saving inline; the
@@ -1693,6 +1697,56 @@ impl StateHandler {
                         );
                     }
 
+                    // Register the contexts memberships name. Joins before
+                    // per-community contexts recorded an id without creating it;
+                    // faces worn there worked only because nothing checked.
+                    let top_context_id = config.account.top_context_id.clone();
+                    let unchecked: Vec<String> = config
+                        .account
+                        .memberships()
+                        .map(|c| c.sub_context_id.clone())
+                        .filter(|id| {
+                            openvtc_core::config::community_context::is_sub_context(
+                                id,
+                                &top_context_id,
+                            ) && !contexts_checked.contains(id)
+                        })
+                        .collect::<std::collections::BTreeSet<_>>()
+                        .into_iter()
+                        .collect();
+                    if !unchecked.is_empty()
+                        && let Some(client) = admin_vta.as_ref()
+                        && in_flight
+                            .try_begin(background_dispatch::DispatchDomain::CommunityContexts)
+                    {
+                        contexts_checked.extend(unchecked.iter().cloned());
+                        let client = client.clone();
+                        background_dispatch::spawn_dispatch(
+                            dispatch_tx.clone(),
+                            background_dispatch::DispatchDomain::CommunityContexts,
+                            async move {
+                                let mut results = Vec::with_capacity(unchecked.len());
+                                for context_id in unchecked {
+                                    let name = openvtc_core::config::context_path::parse_sub_context_id(
+                                        &context_id,
+                                    )
+                                    .map_or(context_id.clone(), |(_, slug)| slug.to_string());
+                                    let result =
+                                        openvtc_core::config::community_context::ensure_context(
+                                            &client,
+                                            &top_context_id,
+                                            &context_id,
+                                            &name,
+                                        )
+                                        .await
+                                        .map_err(|e| e.to_string());
+                                    results.push((context_id, result));
+                                }
+                                background_dispatch::DispatchOutcome::CommunityContexts(results)
+                            },
+                        );
+                    }
+
                     // Probe what transports the VTA advertises, for the VTA
                     // panel. Runs on this tick rather than its own so the loop
                     // gains no extra timer. Re-probed only while the answer is
@@ -2294,6 +2348,8 @@ impl StateHandler {
                     Action::JoinIdentitySelect(..) | Action::JoinIdentityChoose |
                     Action::JoinReuseConfirm | Action::JoinReuseCancel |
                     Action::JoinInvitationSelect(..) | Action::JoinInvitationChoose |
+                    Action::JoinContextSelect(..) | Action::JoinContextSlug(..) |
+                    Action::JoinContextChoose |
                     Action::JoinCancel | Action::JoinPasteVic(..) | Action::JoinPasteFromClipboard |
                     Action::JoinClearVic | Action::ImportConfig(..) | Action::SetProtection(..) |
                     Action::VtaSubmitDid(..) | Action::VtaStartProvision(..) |

--- a/openvtc/src/state_handler/runtime_actions.rs
+++ b/openvtc/src/state_handler/runtime_actions.rs
@@ -1155,6 +1155,9 @@ pub(crate) async fn handle_action(ctx: &mut ActionCtx<'_>, action: Action) -> Ha
         | Action::JoinReuseCancel
         | Action::JoinInvitationSelect(..)
         | Action::JoinInvitationChoose
+        | Action::JoinContextSelect(..)
+        | Action::JoinContextSlug(..)
+        | Action::JoinContextChoose
         | Action::JoinCancel
         | Action::JoinPasteVic(..)
         | Action::JoinPasteFromClipboard

--- a/openvtc/src/state_handler/setup_sequence/vta.rs
+++ b/openvtc/src/state_handler/setup_sequence/vta.rs
@@ -445,27 +445,6 @@ pub async fn create_did_via_server(
     Ok((persona_keys, did, resolved.doc, mnemonic))
 }
 
-// ── State-B join seams (R-A-5 Stage 4) ──────────────────────────────────────
-//
-// Stubbed async seams: they carry the final signatures (so the real VTA/VTC
-// calls are a body swap with no call-site churn) but do not hit the network yet.
-
-/// Create the per-community sub-context under the account's top context (D9).
-///
-/// The id is already derived client-side via
-/// [`context_path::build_sub_context_id`](openvtc_core::config::context_path::build_sub_context_id);
-/// this seam is where the VTA registration call will go. STUB: echoes the id
-/// back. `parent_id` is the account's `top_context_id`.
-#[allow(clippy::unused_async)]
-pub async fn create_sub_context(
-    client: &VtaClient,
-    parent_id: &str,
-    sub_context_id: &str,
-) -> Result<String> {
-    let _ = (client, parent_id);
-    Ok(sub_context_id.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/openvtc/src/state_handler/vetting_actions.rs
+++ b/openvtc/src/state_handler/vetting_actions.rs
@@ -15,7 +15,8 @@ use affinidi_tdk::secrets_resolver::secrets::Secret;
 use chrono::Utc;
 use openvtc_core::config::Config;
 use openvtc_core::config::account::PersonaId;
-use openvtc_core::config::context_path::build_sub_context_id;
+use openvtc_core::config::community_context::{self, ContextKind, ContextOption};
+use openvtc_core::config::context_path::parse_sub_context_id;
 use openvtc_core::didcomm::Messaging;
 use openvtc_core::persona::disclosure::{self, PresentError};
 use openvtc_core::persona::{binding, profile};
@@ -41,6 +42,7 @@ use vta_sdk::vetting::statement::sign_statement;
 use crate::state_handler::actions::VettingAction;
 use crate::state_handler::background_dispatch::{self, DispatchDomain, DispatchOutcome, InFlight};
 use crate::state_handler::dispatch_util::{self, Persist, SyncLog};
+use crate::state_handler::join_flow;
 use crate::state_handler::main_page::content::{
     ApplicationRow, AttestForm, CardPreview, DeskRow, DeskStage, FaceChoice, IssuedRow, RequestRow,
     TicketRow, VETTING_METHODS, VETTING_RELATIONSHIPS, VETTING_TICKET_USES,
@@ -414,10 +416,16 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
         }
         VettingAction::Back => page(ctx).mode = VettingMode::List,
         VettingAction::Status(message) => status(ctx, message),
-        VettingAction::Input(text) => input(&mut page(ctx).mode, text),
+        VettingAction::Input(text) => {
+            input(&mut page(ctx).mode, text);
+            refresh_application_contexts(ctx);
+        }
         VettingAction::NextField => move_field(page(ctx), true),
         VettingAction::PrevField => move_field(page(ctx), false),
-        VettingAction::Cycle(forward) => cycle(page(ctx), forward),
+        VettingAction::Cycle(forward) => {
+            cycle(page(ctx), forward);
+            refresh_application_contexts(ctx);
+        }
         VettingAction::Toggle => {
             if let VettingMode::Attest { form, .. } = &mut page(ctx).mode {
                 match form.field {
@@ -437,8 +445,11 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
                 page(ctx).mode = VettingMode::NewApplication {
                     community: String::new(),
                     persona_index: 0,
+                    context_options: Vec::new(),
+                    context_index: 0,
                     field: 0,
                 };
+                refresh_application_contexts(ctx);
             }
         }
         VettingAction::ChooseFace => {
@@ -591,9 +602,10 @@ fn move_field(v: &mut VettingState, forward: bool) {
         };
     };
     match &mut v.mode {
-        VettingMode::NewApplication { field, .. }
-        | VettingMode::RequestVetter { field, .. }
-        | VettingMode::NewTicket { field, .. } => step(field, 2),
+        VettingMode::NewApplication { field, .. } => step(field, 3),
+        VettingMode::RequestVetter { field, .. } | VettingMode::NewTicket { field, .. } => {
+            step(field, 2);
+        }
         VettingMode::ChooseFace { faces, index, .. } => step(index, faces.len()),
         VettingMode::Attest { form, .. } => step(&mut form.field, AttestForm::FIELDS),
         _ => {}
@@ -619,6 +631,12 @@ fn cycle(v: &mut VettingState, forward: bool) {
             field: 1,
             ..
         } => turn(persona_index, personas),
+        VettingMode::NewApplication {
+            context_options,
+            context_index,
+            field: 2,
+            ..
+        } => turn(context_index, context_options.len()),
         VettingMode::NewTicket {
             membership_index,
             field: 0,
@@ -652,8 +670,15 @@ async fn submit(ctx: &mut ActionCtx<'_>) {
         VettingMode::NewApplication {
             community,
             persona_index,
+            context_options,
+            context_index,
             ..
-        } => start_application(ctx, community.trim(), persona_index).await,
+        } => {
+            let context = context_options
+                .get(context_index)
+                .map(|o| o.context_id.clone());
+            start_application(ctx, community.trim(), persona_index, context).await;
+        }
         VettingMode::ChooseFace {
             application_id,
             faces,
@@ -788,7 +813,60 @@ async fn refresh_requirements(ctx: &mut ActionCtx<'_>, application_id: &str) {
     }
 }
 
-async fn start_application(ctx: &mut ActionCtx<'_>, community: &str, persona_index: usize) {
+/// Recompute the contexts a new application can use, for the community and
+/// persona on the form. An application that already exists keeps its own.
+fn refresh_application_contexts(ctx: &mut ActionCtx<'_>) {
+    let (community, persona) = {
+        let v = page(ctx);
+        let VettingMode::NewApplication {
+            community,
+            persona_index,
+            ..
+        } = &v.mode
+        else {
+            return;
+        };
+        (
+            community.trim().to_string(),
+            v.personas.get(*persona_index).map(|p| p.persona),
+        )
+    };
+    let config: &Config = ctx.config;
+    let existing = persona
+        .and_then(|p| config.private.vetting.application(&community, p))
+        .and_then(|a| a.context_id.clone());
+    let options = match existing {
+        Some(context_id) => vec![ContextOption {
+            context_id,
+            kind: ContextKind::Existing,
+            communities: Vec::new(),
+            holds_persona_keys: false,
+        }],
+        None => {
+            let record = persona.and_then(|p| config.account.personas.get(&p));
+            let suggested = join_flow::suggested_context(config, &community);
+            community_context::context_options(&config.account, record, &suggested)
+        }
+    };
+    if let VettingMode::NewApplication {
+        context_options,
+        context_index,
+        ..
+    } = &mut page(ctx).mode
+    {
+        if *context_options != options {
+            *context_index = 0;
+        }
+        *context_options = options;
+    }
+}
+
+async fn start_application(
+    ctx: &mut ActionCtx<'_>,
+    community: &str,
+    persona_index: usize,
+    context: Option<String>,
+) {
     if !community.starts_with("did:") {
         return status(ctx, "Enter the community's DID (it starts with did:).");
     }
@@ -801,7 +879,12 @@ async fn start_application(ctx: &mut ActionCtx<'_>, community: &str, persona_ind
         &persona.did,
         Utc::now(),
     ) {
-        Ok(app) => app.id.clone(),
+        Ok(app) => {
+            if app.context_id.is_none() {
+                app.context_id = context;
+            }
+            app.id.clone()
+        }
         Err(e) => return status(ctx, format!("Could not start the application: {e}")),
     };
     {
@@ -913,23 +996,19 @@ fn application_context(
     if let Some(id) = &app.context_id {
         return Ok((id.clone(), join_did));
     }
-    let community = app.community.clone();
-    let name = config.agent_name_for(&community).map(ToString::to_string);
-    let id = build_sub_context_id(
-        &config.account.top_context_id,
-        name.as_deref(),
-        &community,
-        |id| {
-            config.account.memberships().any(|m| m.sub_context_id == id)
-                || config
-                    .private
-                    .vetting
-                    .applications
-                    .iter()
-                    .any(|a| a.context_id.as_deref() == Some(id))
-        },
-    )
-    .map_err(|e| e.to_string())?;
+    // A persona whose keys live in a sub-context is presented from it;
+    // otherwise the community gets a context of its own.
+    let top = config.account.top_context_id.as_str();
+    let id = match config
+        .account
+        .personas
+        .get(&app.persona)
+        .map(|p| community_context::persona_context(p, top))
+        .filter(|home| community_context::is_sub_context(home, top))
+    {
+        Some(home) => home.to_string(),
+        None => join_flow::suggested_context(config, &app.community.clone()),
+    };
     if let Some(app) = config.private.vetting.application_by_id_mut(application_id) {
         app.context_id = Some(id.clone());
     }
@@ -992,6 +1071,7 @@ fn wear_face(ctx: &mut ActionCtx<'_>, application_id: &str, face: Option<FaceCho
     status(ctx, format!("Wearing {}…", face.name));
     let job = FaceJob::Wear {
         client,
+        top_context_id: ctx.config.account.top_context_id.clone(),
         context_id,
         persona_did,
         application_id: application_id.to_string(),
@@ -1488,6 +1568,7 @@ pub(crate) enum FaceJob {
     },
     Wear {
         client: VtaClient,
+        top_context_id: String,
         context_id: String,
         persona_did: String,
         application_id: String,
@@ -1532,18 +1613,37 @@ impl FaceJob {
             }
             FaceJob::Wear {
                 client,
+                top_context_id,
                 context_id,
                 persona_did,
                 application_id,
                 face,
-            } => VettingOutcome::FaceWorn {
-                error: binding::set(&client, &context_id, &persona_did, Some(&face.profile_id))
-                    .await
-                    .err()
-                    .map(|e| e.to_string()),
-                application_id,
-                name: face.name,
-            },
+            } => {
+                // The context exists before a face is worn in it.
+                let slug =
+                    parse_sub_context_id(&context_id).map_or(context_id.as_str(), |(_, slug)| slug);
+                let error = match community_context::ensure_context(
+                    &client,
+                    &top_context_id,
+                    &context_id,
+                    slug,
+                )
+                .await
+                {
+                    Err(e) => Some(e.to_string()),
+                    Ok(_) => {
+                        binding::set(&client, &context_id, &persona_did, Some(&face.profile_id))
+                            .await
+                            .err()
+                            .map(|e| e.to_string())
+                    }
+                };
+                VettingOutcome::FaceWorn {
+                    error,
+                    application_id,
+                    name: face.name,
+                }
+            }
         }
     }
 }

--- a/openvtc/src/ui/pages/join_flow/context_choice.rs
+++ b/openvtc/src/ui/pages/join_flow/context_choice.rs
@@ -1,0 +1,239 @@
+//! Join flow — where the community lives at the VTA.
+//!
+//! A context keeps its keys, faces and access grants apart from every other
+//! context. The default is a new sub-context for this community alone; the
+//! person may instead share a context they already use, or use the account's
+//! top context. The new sub-context's name is typed in place on its row.
+
+use crate::colors::{
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
+    COLOR_WARNING_ACCESSIBLE_RED,
+};
+use crossterm::event::{KeyCode, KeyEvent};
+use openvtc_core::config::community_context::{ContextKind, ContextOption};
+use openvtc_core::config::context_path::parse_sub_context_id;
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Layout, Margin,
+    },
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+
+use crate::{
+    state_handler::{
+        actions::Action,
+        join::{IdentityPick, JoinState},
+        setup_sequence::MessageType,
+    },
+    ui::pages::join_flow::JoinFlow,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct ContextChoice;
+
+impl ContextChoice {
+    pub fn handle_key_event(state: &mut JoinFlow, key: KeyEvent) {
+        if state.props.state.processing {
+            return;
+        }
+        let js = &state.props.state;
+        let selected = js.context_selected;
+        let last = js.context_options.len().saturating_sub(1);
+        let action = match key.code {
+            KeyCode::F(10) => Action::Exit,
+            KeyCode::Up => Action::JoinContextSelect(selected.saturating_sub(1)),
+            KeyCode::Down => Action::JoinContextSelect((selected + 1).min(last)),
+            KeyCode::Enter => Action::JoinContextChoose,
+            KeyCode::Esc => Action::JoinCancel,
+            KeyCode::Char(c) if js.new_context_selected() => {
+                let mut slug = js.context_slug.clone();
+                slug.push(c);
+                Action::JoinContextSlug(slug)
+            }
+            KeyCode::Backspace if js.new_context_selected() => {
+                let mut slug = js.context_slug.clone();
+                slug.pop();
+                Action::JoinContextSlug(slug)
+            }
+            _ => return,
+        };
+        let _ = state.action_tx.send(action);
+    }
+
+    pub fn render(&self, state: &JoinState, frame: &mut Frame<'_>) {
+        let [middle, bottom] = Layout::vertical([Min(0), Length(3)]).areas(frame.area());
+        frame.render_widget(
+            Block::bordered()
+                .fg(COLOR_BORDER)
+                .padding(Padding::proportional(1))
+                .title(" Where should this community live? "),
+            middle,
+        );
+        let inner = middle.inner(Margin::new(3, 2));
+
+        let minting = state.picked_identity == Some(IdentityPick::Mint);
+        let mut lines = vec![
+            Line::styled(
+                "Your VTA keeps each context's keys, faces and access apart.",
+                Style::new().fg(COLOR_BORDER).bold(),
+            ),
+            Line::styled(
+                "A community in a context of its own shares none of them with your other communities.",
+                Style::new().fg(COLOR_DARK_GRAY),
+            ),
+            Line::default(),
+        ];
+        for (i, option) in state.context_options.iter().enumerate() {
+            let selected = i == state.context_selected;
+            let marker = if selected { "▸ " } else { "  " };
+            let style = if selected {
+                Style::new().fg(COLOR_SUCCESS).bold()
+            } else if option.kind == ContextKind::New {
+                Style::new().fg(COLOR_SOFT_PURPLE)
+            } else {
+                Style::new().fg(COLOR_TEXT_DEFAULT)
+            };
+            let (title, detail) = describe(state, option, minting);
+            let mut spans = vec![Span::styled(format!("{marker}{title}"), style)];
+            if selected && option.kind == ContextKind::New {
+                spans.push(Span::styled("▎", Style::new().fg(COLOR_SUCCESS)));
+            }
+            lines.push(Line::from(spans));
+            lines.push(Line::styled(
+                format!("    {detail}"),
+                Style::new().fg(COLOR_DARK_GRAY),
+            ));
+        }
+        for message in &state.messages {
+            if let MessageType::Error(text) = message {
+                lines.push(Line::default());
+                lines.push(Line::styled(
+                    text.clone(),
+                    Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
+                ));
+            }
+        }
+        lines.push(Line::default());
+        lines.push(Line::from(vec![
+            Span::styled("[↑/↓]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" select   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[type]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(
+                " name the new context   ",
+                Style::new().fg(COLOR_TEXT_DEFAULT),
+            ),
+            Span::styled("[ENTER]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" join   ", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            Span::styled("[ESC]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" cancel", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]));
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+
+        let bottom_line = Line::from(vec![
+            Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+            Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+        ]);
+        frame.render_widget(
+            Paragraph::new(bottom_line).block(Block::new().padding(Padding::new(2, 0, 1, 0))),
+            bottom,
+        );
+    }
+}
+
+/// A row's title and the line beneath it.
+fn describe(state: &JoinState, option: &ContextOption, minting: bool) -> (String, String) {
+    match option.kind {
+        ContextKind::New => {
+            let parent = parse_sub_context_id(&option.context_id)
+                .map_or(option.context_id.as_str(), |(parent, _)| parent);
+            (
+                format!("✦ A context of its own   {parent}/{}", state.context_slug),
+                if minting {
+                    "A new persona is made here — nothing is shared with your other communities"
+                        .to_string()
+                } else {
+                    "This community's faces are kept here; the persona's keys stay where they are"
+                        .to_string()
+                },
+            )
+        }
+        ContextKind::Existing => {
+            let detail = if option.holds_persona_keys {
+                "This persona's keys live here, so the community joins this context".to_string()
+            } else if option.communities.is_empty() {
+                "In use, with no communities yet".to_string()
+            } else {
+                let names: Vec<&str> = option
+                    .communities
+                    .iter()
+                    .map(|did| state.community_name(did))
+                    .collect();
+                format!("Shared with {}", names.join(", "))
+            };
+            (option.context_id.clone(), detail)
+        }
+        ContextKind::Top => (
+            format!("{} (your account's top context)", option.context_id),
+            "Nothing is kept apart from your other communities".to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::{join::JoinPage, state::State};
+    use crate::ui::component::Component;
+    use crossterm::event::KeyModifiers;
+    use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+    fn flow(selected: usize) -> (JoinFlow, UnboundedReceiver<Action>) {
+        let (tx, rx) = unbounded_channel();
+        let mut state = State::default();
+        state.join.page = JoinPage::ContextChoice;
+        state.join.picked_identity = Some(IdentityPick::Mint);
+        state.join.context_slug = "kerne".to_string();
+        state.join.context_options = vec![
+            ContextOption {
+                context_id: "openvtc/kernel".into(),
+                kind: ContextKind::New,
+                communities: vec![],
+                holds_persona_keys: false,
+            },
+            ContextOption {
+                context_id: "openvtc".into(),
+                kind: ContextKind::Top,
+                communities: vec![],
+                holds_persona_keys: false,
+            },
+        ];
+        state.join.context_selected = selected;
+        (JoinFlow::new(&state, tx), rx)
+    }
+
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn typing_on_the_new_row_names_the_context() {
+        let (mut flow, mut rx) = flow(0);
+        ContextChoice::handle_key_event(&mut flow, press(KeyCode::Char('l')));
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinContextSlug(s)) if s == "kernel"));
+    }
+
+    #[test]
+    fn typing_elsewhere_does_nothing_and_enter_joins() {
+        let (mut flow, mut rx) = flow(1);
+        ContextChoice::handle_key_event(&mut flow, press(KeyCode::Char('x')));
+        assert!(rx.try_recv().is_err());
+        ContextChoice::handle_key_event(&mut flow, press(KeyCode::Enter));
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinContextChoose)));
+        ContextChoice::handle_key_event(&mut flow, press(KeyCode::Up));
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinContextSelect(0))));
+    }
+}

--- a/openvtc/src/ui/pages/join_flow/mod.rs
+++ b/openvtc/src/ui/pages/join_flow/mod.rs
@@ -18,8 +18,9 @@ use crate::{
     ui::{
         component::{Component, ComponentRender},
         pages::join_flow::{
-            identity_choice::IdentityChoice, invitation_choice::InvitationChoice,
-            join_progress::JoinProgress, vtc_enter_did::VtcEnterDid,
+            context_choice::ContextChoice, identity_choice::IdentityChoice,
+            invitation_choice::InvitationChoice, join_progress::JoinProgress,
+            vtc_enter_did::VtcEnterDid,
         },
     },
 };
@@ -28,6 +29,7 @@ use ratatui::Frame;
 use tokio::sync::mpsc::UnboundedSender;
 use tui_input::Input;
 
+pub mod context_choice;
 pub mod identity_choice;
 pub mod invitation_choice;
 pub mod join_progress;
@@ -54,6 +56,7 @@ pub struct JoinFlow {
     pub vtc_enter_did: VtcEnterDid,
     pub invitation_choice: InvitationChoice,
     pub identity_choice: IdentityChoice,
+    pub context_choice: ContextChoice,
     pub join_progress: JoinProgress,
 
     /// State-mapped join props.
@@ -115,6 +118,7 @@ impl Component for JoinFlow {
             vtc_enter_did: VtcEnterDid,
             invitation_choice: InvitationChoice,
             identity_choice: IdentityChoice,
+            context_choice: ContextChoice,
             join_progress: JoinProgress,
             props: Props::from(state),
         }
@@ -141,6 +145,7 @@ impl Component for JoinFlow {
             JoinPage::EnterDid => VtcEnterDid::handle_key_event(self, key),
             JoinPage::InvitationChoice => InvitationChoice::handle_key_event(self, key),
             JoinPage::IdentityChoice => IdentityChoice::handle_key_event(self, key),
+            JoinPage::ContextChoice => ContextChoice::handle_key_event(self, key),
             JoinPage::Progress => JoinProgress::handle_key_event(self, key),
         }
     }
@@ -176,7 +181,13 @@ impl Component for JoinFlow {
                     .action_tx
                     .send(Action::JoinPasteVic(trimmed.to_string()));
             }
-            JoinPage::IdentityChoice | JoinPage::Progress => {}
+            // A pasted name lands in the new sub-context's name.
+            JoinPage::ContextChoice if self.props.state.new_context_selected() => {
+                let mut slug = self.props.state.context_slug.clone();
+                slug.push_str(trimmed);
+                let _ = self.action_tx.send(Action::JoinContextSlug(slug));
+            }
+            JoinPage::IdentityChoice | JoinPage::ContextChoice | JoinPage::Progress => {}
         }
     }
 }
@@ -190,6 +201,7 @@ impl ComponentRender<()> for JoinFlow {
             }
             JoinPage::InvitationChoice => self.invitation_choice.render(&self.props.state, frame),
             JoinPage::IdentityChoice => self.identity_choice.render(&self.props.state, frame),
+            JoinPage::ContextChoice => self.context_choice.render(&self.props.state, frame),
             JoinPage::Progress => self.join_progress.render(&self.props.state, frame),
         }
     }

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -211,7 +211,10 @@ pub fn render(
                 .into_owned(),
             ));
             if !c.sub_context_id.is_empty() {
-                lines.push(kv("Sub-context:", c.sub_context_id.clone()));
+                lines.push(kv(
+                    "Context:",
+                    format!("{}  ({})", c.sub_context_id, c.context_note),
+                ));
             }
             if !c.request_id.is_empty() {
                 lines.push(kv("Request ID:", c.request_id.clone()));
@@ -421,6 +424,7 @@ mod key_hint_tests {
             vtc_did: String::new(),
             vtc_agent_name: None,
             sub_context_id: String::new(),
+            context_note: String::new(),
             request_id: String::new(),
             has_membership_credential: false,
             has_role_credential: false,

--- a/openvtc/src/ui/pages/main/components/vetting_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vetting_panel.rs
@@ -18,6 +18,7 @@ use crate::state_handler::{
     },
     state::ConnectionState,
 };
+use openvtc_core::config::community_context::{ContextKind, ContextOption};
 use openvtc_core::display::display_identifier;
 use ratatui::{
     style::{Style, Stylize},
@@ -96,6 +97,23 @@ fn field(name: &str, shown: String, focused: bool, text: bool) -> Line<'static> 
     Line::from(spans)
 }
 
+/// A context choice, in a line.
+fn context_label(option: &ContextOption) -> String {
+    let id = &option.context_id;
+    match option.kind {
+        ContextKind::New => format!("{id}  (a context of its own)"),
+        ContextKind::Existing if option.holds_persona_keys => {
+            format!("{id}  (this persona's context)")
+        }
+        ContextKind::Existing => match option.communities.len() {
+            0 => format!("{id}  (in use)"),
+            1 => format!("{id}  (shared with 1 community)"),
+            n => format!("{id}  (shared with {n} communities)"),
+        },
+        ContextKind::Top => format!("{id}  (top context — nothing kept apart)"),
+    }
+}
+
 fn tick(on: bool) -> String {
     if on { "[x]" } else { "[ ]" }.to_string()
 }
@@ -150,6 +168,8 @@ pub fn render(v: &VettingState) -> Vec<Line<'static>> {
         VettingMode::NewApplication {
             community,
             persona_index,
+            context_options,
+            context_index,
             field: f,
         } => {
             lines.push(heading("Apply to be vetted"));
@@ -168,8 +188,21 @@ pub fn render(v: &VettingState) -> Vec<Line<'static>> {
                 .map(|p| format!("{}  ({})", p.label, p.did))
                 .unwrap_or_else(|| "no personas".to_string());
             lines.push(field("Join as", persona, *f == 1, false));
+            let context = context_options
+                .get(*context_index)
+                .map_or_else(|| "—".to_string(), context_label);
+            lines.push(field("Context", context, *f == 2, false));
             lines.push(Line::from(""));
-            lines.push(hint("Enter: start  Tab: next field  Esc: cancel"));
+            lines.push(hint(
+                "The context keeps this community's faces apart from your other communities. A",
+            ));
+            lines.push(hint(
+                "persona minted into a context can only be presented from it.",
+            ));
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "Enter: start  Tab: next field  ←/→: choose  Esc: cancel",
+            ));
         }
         VettingMode::ChooseFace { faces, index, .. } => {
             lines.push(heading("The face vetters are shown"));

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -3229,6 +3229,7 @@ mod key_handler_tests {
             vtc_did: format!("did:example:{name}"),
             vtc_agent_name: None,
             sub_context_id: format!("top/{name}"),
+            context_note: String::new(),
             request_id: String::new(),
             has_membership_credential: false,
             has_role_credential: false,


### PR DESCRIPTION
Stacked on #297. With this PR, each community a person joins can live in its own VTA sub-context, and the person chooses which context to use.

## Why
The VTA already supports nested contexts (VTI #258–#260):
- `contexts/create/1.0` takes a `parent`;
- an admin of a parent may create children;
- keys in a child are derived beneath the parent's key path;
- ACL scope covers a subtree but not its siblings.

OpenVTC only half-used this:
- It derived a `<top>/<slug>` id for each membership but never created it; `create_sub_context` was a stub.
- Faces worn in those ids worked only because persona tasks don't check that the context exists.
- Every persona's keys and DID were minted in the top context, so communities shared one key hierarchy and were isolated in name only.

## What changes

**Choosing the context at join.** After the identity choice, a new page asks where the community lives:
1. **A context of its own (default).** `<top>/<slug>`, named after the community; the name can be edited in place.
2. **A context already in use.** It shows the communities already in it.
3. **The top context.** Nothing is kept apart.

The page is skipped when there is only one answer:
- The persona's keys live in a sub-context. A persona's keys live in exactly one context, so it can only be presented from there, and joining shares that context.
- A vetting application for the community already chose where its face is worn. The membership keeps that context, so the community sees the face the vetters checked.

**Minting into the context.**
- The join makes sure the context exists first, creating any missing ancestor. A context that already exists, or a create that races another (`Conflict`), counts as existing, so a retried join reuses what an interrupted one left behind.
- It then mints the new persona's keys, update keys and DID **in that context**, and records the context on the persona (`origin_context_id`, which now means where its keys live).
- A reused persona whose keys live in a different sub-context is refused.

**Vetting applications.** The new-application form has a **Context** field with the same options. Wearing a face makes sure its context exists before the binding is set.

**Existing memberships.** A background job registers the sub-context ids that older joins recorded but never created, using the exact same paths, so faces and bindings keep working. Their keys stay where they were minted, because keys can't move.

**Communities panel.** The detail now reads `Context: openvtc/kernel (own context — kept apart from your other communities)`. The other readings are:
- shared with *n* other communities;
- own context for faces, with the persona's keys in another context;
- top context, not kept apart.

## Notes for review
- **Scope of isolation.** OpenVTC holds admin of the top context, which covers every sub-context beneath it. Isolation is between communities, not from OpenVTC itself; the module docs say so.
- **Leaving a community** keeps its context. Deleting it (the VTA supports cascade) should be a separate, explicit action, not a side effect of leaving.
- **Standalone personas** created under My Identity are still minted in the top context. Offering a context there is a natural follow-up.
- **Registration results** are log-only and don't block anything. A failure is retried on the next launch rather than on every tick.
- **Stub removed.** `vta::create_sub_context` is gone; `openvtc_core::config::community_context::ensure_context` replaces it.

## Tests
- **openvtc-core:**
  - context options for a new persona, a persona bound to a sub-context, and a legacy persona;
  - the isolation reading;
  - new-context naming rules;
  - the segment-aware sub-context check (`openvtc-evil/…` is not under `openvtc`).
- **openvtc:**
  - the join offers a bound persona's context without asking, and asks for a new persona with a context of its own first;
  - the context page's key routing;
  - only the new-context row takes a typed name.

Run locally (stacked PRs get no CI):
- `cargo test -p openvtc-core --lib`: 591 passed
- `cargo test -p openvtc --bins`: 475 passed
- `cargo clippy -p openvtc -p openvtc-core --all-targets -- -D warnings`: clean
