### PR TITLE
feat(tui): live theme switching, auto light/dark, accessible themes, NO_COLOR and export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6120,6 +6120,7 @@ dependencies = [
  "ed25519-dalek-bip32",
  "hex",
  "keyring-core",
+ "libc",
  "linux-keyutils-keyring-store",
  "multibase",
  "openpgp-card",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,10 @@ didwebvh-rs = "0.6"
 ed25519-dalek-bip32 = "0.3"
 hkdf = "0.13"
 hex = "0.4"
+# poll(2) with a timeout, for asking the terminal its background colour
+# (`openvtc::theme::terminal`). Already in the graph beneath crossterm and
+# console; named directly because neither exposes a timed read.
+libc = "0.2"
 # keyring split: the library API is now in keyring-core 1.0; platform
 # backends ship as separate keyring-store crates that each binary registers
 # at startup via keyring_core::set_default_store.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -2,7 +2,8 @@
 
 The OpenVTC TUI can be drawn in any theme: one of those built in, one you make,
 one of Omarchy's, or one imported from Neovim, base16/base24, Alacritty, Kitty
-or Ghostty.
+or Ghostty. A theme can follow your terminal's background, and one you make can
+be exported for your terminal, editor or desktop.
 
 ## Choosing a theme
 
@@ -15,15 +16,107 @@ The choice is kept in `~/.config/openvtc/tui.toml` (or under
 `OPENVTC_CONFIG_PATH`). It belongs to you rather than to a profile, so every
 profile uses it, and no unlock is needed to change it.
 
+A running TUI notices within a second when the theme changes, and redraws —
+see [Changes while the TUI runs](#changes-while-the-tui-runs).
+
+### Following your terminal: `auto`
+
+```sh
+openvtc theme set auto                                   # openvtc when dark, catppuccin-latte when light
+openvtc theme set auto --dark nord --light high-contrast-light
+```
+
+With `auto`, OpenVTC asks the terminal for its background colour as it starts
+(the OSC 11 query most terminals answer), then draws with one theme on a dark
+background and another on a light one. A terminal that does not answer within
+half a second is judged by `COLORFGBG`, and failing that taken to be dark. The
+two themes live in `tui.toml`:
+
+```toml
+theme = "auto"
+auto_dark = "nord"
+auto_light = "high-contrast-light"
+```
+
+The terminal can only be asked before the TUI starts, because its answer arrives
+as input. If you choose Auto in the picker of a TUI that did not start with it,
+Auto goes by `COLORFGBG` (or dark) until the next start.
+
+### For one session: `OPENVTC_THEME`
+
+```sh
+OPENVTC_THEME=high-contrast-dark openvtc
+```
+
+`OPENVTC_THEME=<id>` draws that session in a theme other than the one chosen,
+without changing `tui.toml`. An id that cannot be loaded is reported, and the
+chosen theme used instead. Choosing a theme while that session runs — in its
+picker, or with `openvtc theme set` — still takes effect.
+
+### Without colour: `NO_COLOR`
+
+When `NO_COLOR` is set to anything but an empty string
+([no-color.org](https://no-color.org)), OpenVTC draws in your terminal's own
+colours, and keeps the roles apart with text attributes instead:
+
+| Role | Drawn as |
+|------|----------|
+| accent | **bold** |
+| danger | **bold**, underlined |
+| warning | underlined |
+| success (and selected rows) | reversed |
+| highlight | *italic* |
+| muted | dim |
+| text | plain |
+
+Anything drawn on a role's colour as a background is reversed too. The
+command-line output printed before the TUI starts, and the prompts, are
+uncoloured as well.
+
 ## Where themes come from
 
 | Id | Source |
 |----|--------|
+| `auto` | follows your terminal's background (see above) |
 | `openvtc` | OpenVTC's own colours (the default) |
 | `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `gruvbox-dark`, `nord`, `tokyo-night` | built in |
+| `high-contrast-dark`, `high-contrast-light`, `colourblind-dark`, `colourblind-light` | built in, for accessibility |
 | `user/<name>` | your theme files, in `~/.config/openvtc/themes/<name>.toml` |
 | `omarchy/current` | whichever Omarchy theme is current, followed as you switch |
 | `omarchy/<name>` | an Omarchy theme, read in place from `~/.config/omarchy/themes` or `/usr/share/omarchy/themes` |
+
+### Accessibility themes
+
+- **High Contrast Dark** and **High Contrast Light** hold every colour to at
+  least 7:1 against the background (WCAG AAA for body text).
+- **Colourblind Safe Dark** and **Colourblind Safe Light** colour the roles in
+  the hues of the [Okabe–Ito palette](https://jfly.uni-koeln.de/color/), which
+  stay distinct under the common colour-vision deficiencies. The dark theme uses
+  Okabe–Ito's own colours; on white those are too pale to read, so the light
+  theme darkens each hue until it reaches 4.5:1. Every colour in both is at
+  least 4.5:1 against its background (WCAG AA).
+
+A test measures the contrast of every built-in theme's text against its
+background, and of every colour in these four.
+
+## Changes while the TUI runs
+
+About once a second the TUI checks — by modification time, size and link
+target, never by reading files that have not changed — for:
+
+- **Another theme chosen:** `tui.toml` changing, for example by
+  `openvtc theme set` in another terminal.
+- **The theme in use changing where it is read from:**
+  - your theme file, `themes/<name>.toml`, saved after an edit;
+  - Omarchy switching theme, for `omarchy/current` — current releases record
+    the name in `~/.local/state/omarchy/current/theme.name`, earlier ones
+    repoint the `~/.config/omarchy/current/theme` link;
+  - an Omarchy theme's `colors.toml` (or `alacritty.toml`) edited;
+  - under `auto`, `auto_dark` or `auto_light` changing.
+
+A file caught half-saved keeps the theme on screen until it is saved whole.
+While the picker is open nothing is redrawn under your preview; a change made
+meanwhile is picked up once the picker closes.
 
 ## Making your own
 
@@ -34,8 +127,8 @@ openvtc theme new "My Theme" --from nord
 ```
 
 Or press **c** in Settings → Theme to copy the highlighted theme. The copy lands
-in your themes directory. Edit it, then press **r** in the picker to see your
-changes.
+in your themes directory. Edit it, save, and a TUI using it redraws; in the
+picker, press **r** to see your changes to a theme you are previewing.
 
 A theme file names seven roles, plus an optional background:
 
@@ -71,7 +164,7 @@ openvtc theme import nvim:tokyonight-storm --use     # a Neovim colorscheme
 
 An import writes an OpenVTC theme file into your themes directory, so you can
 edit it afterwards. Add `--name` to name it, and `--use` to choose it straight
-away.
+away. An import whose text is under 4.5:1 against its background says so.
 
 ### Neovim
 
@@ -94,12 +187,52 @@ configuration, which limits the choice to the colorschemes Neovim bundles. Set
 | highlight | `base0E` | `magenta` | magenta (5) | `Keyword` |
 | background | `base00` | `background` | background | `Normal` background |
 
+## Exporting
+
+A theme — one you made, or any other — can be written out for another tool:
+
+```sh
+openvtc theme export user/my-theme --format kitty > ~/.config/kitty/current-theme.conf
+openvtc theme export user/my-theme --format alacritty -o ~/.config/alacritty/my-theme.toml
+openvtc theme export user/my-theme --format omarchy -o ~/.config/omarchy/themes/my-theme
+openvtc theme export nord --format base16 -o nord.yaml
+```
+
+| `--format` | Writes |
+|------------|--------|
+| `openvtc` (the default) | an OpenVTC theme file |
+| `base16` | a base16 scheme (YAML) |
+| `omarchy` | with `-o`, an Omarchy theme directory: `colors.toml`, and `light.mode` for a light theme (or just the file, if the path ends in `.toml`) |
+| `alacritty` | an Alacritty colour file |
+| `kitty` | a Kitty colour file |
+
+Without `--output` the theme is printed, bare, to be piped or redirected.
+
+The roles go where the table above reads them from, so an exported theme
+imports back as the same theme — tests check this for every format. The other
+colours a format expects are derived from the roles: black and white from the
+background and text, cyan from accent and success, bright colours a step toward
+the text, and base16's in-between shades from blends of background, muted and
+text. A theme drawn on your terminal's own background is exported on black
+(dark) or white (light).
+
 ## For contributors
 
 Panels draw with the `COLOR_*` role constants in `openvtc/src/colors.rs` and
 need know nothing about themes. After each frame, `theme::paint` swaps each role
-for the active theme's colour. Keep using the roles, and a new panel is themed
-for free.
+for the active theme's colour — or, under `NO_COLOR`, for the terminal's own and
+a text attribute. Keep using the roles, and a new panel is themed for free.
 
-The command-line output printed before the TUI starts (prompts and errors) uses
-the terminal's own colours and is not themed.
+Command-line output printed outside the TUI styles by role too:
+`style(..).themed(CLI_INFO)` (or `CLI_ERROR`, `CLI_CAUTION`, `CLI_EXAMPLE`), which
+uses the active theme's colour, in 24-bit where `COLORTERM` says the terminal
+draws it and the nearest of 256 colours otherwise. `theme::init` loads the theme
+at the top of `main`, before anything is printed.
+
+`theme::live::Watcher` does the checking described above. The UI loop runs it on
+a blocking thread once a second and only takes what it found when the picker is
+closed, so the render loop never waits on the file system.
+
+The active theme is process-wide. A test that sets it restores the default
+before it ends, and tests that need a particular theme on screen belong in one
+test rather than several running in parallel.

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -131,6 +131,10 @@ linux-keyutils-keyring-store.workspace = true
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store.workspace = true
 
+# Asking the terminal its background colour for the `auto` theme.
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 # `test-util` enables tokio's paused clock (`start_paused`) used by the R11
 # save-coalescing debounce tests; test-only, not pulled into the binary build.

--- a/openvtc/src/cli.rs
+++ b/openvtc/src/cli.rs
@@ -160,6 +160,64 @@ mod tests {
     }
 
     #[test]
+    fn theme_set_auto_and_export_are_accepted() {
+        let matches = cli()
+            .try_get_matches_from([
+                "openvtc", "theme", "set", "auto", "--dark", "nord", "--light", "dracula",
+            ])
+            .expect("`theme set auto --dark --light` is valid");
+        let (_, theme) = matches.subcommand().expect("theme");
+        let (_, set) = theme.subcommand().expect("set");
+        assert_eq!(
+            set.get_one::<String>("dark").map(String::as_str),
+            Some("nord")
+        );
+        assert_eq!(
+            set.get_one::<String>("light").map(String::as_str),
+            Some("dracula")
+        );
+
+        let matches = cli()
+            .try_get_matches_from([
+                "openvtc",
+                "theme",
+                "export",
+                "nord",
+                "--format",
+                "kitty",
+                "-o",
+                "nord.conf",
+            ])
+            .expect("`theme export` is valid");
+        let (_, theme) = matches.subcommand().expect("theme");
+        let (_, export) = theme.subcommand().expect("export");
+        assert_eq!(
+            export.get_one::<String>("format").map(String::as_str),
+            Some("kitty")
+        );
+        assert_eq!(
+            export.get_one::<String>("output").map(String::as_str),
+            Some("nord.conf")
+        );
+
+        let matches = cli()
+            .try_get_matches_from(["openvtc", "theme", "export", "nord"])
+            .expect("the format defaults");
+        let (_, theme) = matches.subcommand().expect("theme");
+        let (_, export) = theme.subcommand().expect("export");
+        assert_eq!(
+            export.get_one::<String>("format").map(String::as_str),
+            Some("openvtc")
+        );
+        assert!(
+            cli()
+                .try_get_matches_from(["openvtc", "theme", "export", "nord", "--format", "vim"])
+                .is_err(),
+            "an unknown format is refused"
+        );
+    }
+
+    #[test]
     fn no_subcommand_is_accepted() {
         // Bare `openvtc` (launch the TUI) must still parse cleanly.
         cli()

--- a/openvtc/src/colors.rs
+++ b/openvtc/src/colors.rs
@@ -1,11 +1,82 @@
+use console::StyledObject;
 use ratatui::style::Color;
 
-// Basic Terminal Colors
-// CLI Color codes (used by the pre-TUI startup output)
-pub const CLI_BLUE: u8 = 69; // Use for general information
-pub const CLI_RED: u8 = 9; // Use for Error messages
-pub const CLI_ORANGE: u8 = 214; // Use for cautionary data
-pub const CLI_PURPLE: u8 = 165; // Use for Example data
+use crate::theme::{self, Role};
+
+// Command-line colours
+//
+// What `openvtc` prints outside the TUI — before it starts, and from its
+// subcommands — is coloured by role too, in the active theme's colours:
+// `crate::theme::init` chooses the theme before anything is printed. Style with
+// `.themed(CLI_*)` rather than a literal colour.
+
+/// General information.
+pub const CLI_INFO: Role = Role::Accent;
+/// Error messages.
+pub const CLI_ERROR: Role = Role::Danger;
+/// Cautionary data.
+pub const CLI_CAUTION: Role = Role::Warning;
+/// Example data and values.
+pub const CLI_EXAMPLE: Role = Role::Highlight;
+
+/// Colour command-line output by role.
+pub trait Themed {
+    /// Draw in the active theme's colour for `role`: 24-bit where the terminal
+    /// says it draws 24-bit colour, else the nearest of the 256 colours, and in
+    /// no colour at all under `NO_COLOR`.
+    #[must_use]
+    fn themed(self, role: Role) -> Self;
+}
+
+impl<D> Themed for StyledObject<D> {
+    fn themed(self, role: Role) -> Self {
+        if theme::no_color() {
+            return self;
+        }
+        match theme::active_palette().get(role) {
+            Color::Rgb(r, g, b) if theme::terminal::truecolor() => self.true_color(r, g, b),
+            Color::Rgb(r, g, b) => self.color256(nearest_256((r, g, b))),
+            Color::Indexed(n) => self.color256(n),
+            named => match theme::ansi_index(named) {
+                Some(n) => self.color256(n),
+                None => self,
+            },
+        }
+    }
+}
+
+/// The xterm 256-colour index nearest `rgb`: from the 6×6×6 colour cube or the
+/// grey ramp, whichever is closer.
+fn nearest_256((r, g, b): (u8, u8, u8)) -> u8 {
+    const LEVELS: [i32; 6] = [0, 95, 135, 175, 215, 255];
+    let step = |v: u8| -> usize {
+        match v {
+            0..48 => 0,
+            48..115 => 1,
+            _ => usize::from((v - 35) / 40),
+        }
+    };
+    let distance = |(x, y, z): (i32, i32, i32)| {
+        let (dr, dg, db) = (x - i32::from(r), y - i32::from(g), z - i32::from(b));
+        dr * dr + dg * dg + db * db
+    };
+    let (qr, qg, qb) = (step(r), step(g), step(b));
+    let cube = (LEVELS[qr], LEVELS[qg], LEVELS[qb]);
+    let cube_index = 16 + 36 * qr + 6 * qg + qb;
+
+    let average = (i32::from(r) + i32::from(g) + i32::from(b)) / 3;
+    let grey_step = if average > 238 {
+        23
+    } else {
+        (average - 3).max(0) / 10
+    };
+    let grey = 8 + 10 * grey_step;
+    if distance((grey, grey, grey)) < distance(cube) {
+        u8::try_from(232 + grey_step).unwrap_or(255)
+    } else {
+        u8::try_from(cube_index).unwrap_or(255)
+    }
+}
 
 // ****************************************************************************
 
@@ -37,3 +108,20 @@ pub const COLOR_DARK_GRAY: Color = Color::DarkGray;
 /// Copy/Export actions and sensitive data shortcuts (\[C\], \[C1\], \[C2\], \[C3\])
 /// Soft Purple to distinguish special operations
 pub const COLOR_SOFT_PURPLE: Color = Color::Rgb(189, 147, 249); // #BD93F9
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The 256-colour fallback lands on the colours OpenVTC used before
+    /// command-line output was themed.
+    #[test]
+    fn rgb_falls_back_to_the_nearest_of_256() {
+        assert_eq!(nearest_256((95, 135, 255)), 69);
+        assert_eq!(nearest_256((255, 0, 0)), 196);
+        assert_eq!(nearest_256((128, 128, 128)), 244);
+        assert_eq!(nearest_256((0, 0, 0)), 16);
+        assert_eq!(nearest_256((255, 255, 255)), 231);
+        assert_eq!(nearest_256((0x61, 0xaf, 0xef)), 75);
+    }
+}

--- a/openvtc/src/health_cmd.rs
+++ b/openvtc/src/health_cmd.rs
@@ -20,7 +20,7 @@ use openvtc_core::health::{
     build_report_with_progress,
 };
 
-use crate::colors::{CLI_BLUE, CLI_ORANGE, CLI_PURPLE, CLI_RED};
+use crate::colors::{CLI_CAUTION, CLI_ERROR, CLI_EXAMPLE, CLI_INFO, Themed};
 
 /// Build the subject list and render the report.
 ///
@@ -81,7 +81,7 @@ pub async fn run(
             Some(config) => report_recoverability(config).await,
             None => eprintln!(
                 "{}",
-                style("--recoverable needs a loadable account; skipping.").color256(CLI_ORANGE)
+                style("--recoverable needs a loadable account; skipping.").themed(CLI_CAUTION)
             ),
         }
     }
@@ -111,7 +111,7 @@ pub async fn run(
                     "\nNo network checks ran: no account could be loaded and no --vtc was \
                      given. Pass --vtc <did> to check a community directly."
                 )
-                .color256(CLI_ORANGE)
+                .themed(CLI_CAUTION)
             );
         }
         if local.is_healthy() {
@@ -236,7 +236,7 @@ impl LocalReport {
 
     fn render(&self) {
         use openvtc_core::secure_store::EntryStatus;
-        println!("{}", style("Local configuration").color256(CLI_BLUE).bold());
+        println!("{}", style("Local configuration").themed(CLI_INFO).bold());
         println!("  profile          {}", self.profile);
         if let Some(path) = &self.config_path {
             let mark = if path.exists() { "present" } else { "MISSING" };
@@ -250,7 +250,7 @@ impl LocalReport {
             EntryStatus::Present => {
                 println!(
                     "  credential       {} ({})",
-                    style("present").color256(CLI_PURPLE),
+                    style("present").themed(CLI_EXAMPLE),
                     self.probe.durability.lifetime_phrase()
                 );
                 if let Some(path) = &self.probe.path {
@@ -263,20 +263,20 @@ impl LocalReport {
                             "WARNING: this profile's keys are NOT written to disk and will be \
                              lost. Export a backup: Settings -> Export config."
                         )
-                        .color256(CLI_ORANGE)
+                        .themed(CLI_CAUTION)
                     );
                 }
             }
             EntryStatus::Missing => {
                 println!(
                     "  credential       {}",
-                    style("NOT FOUND").color256(CLI_RED)
+                    style("NOT FOUND").themed(CLI_ERROR)
                 );
             }
             EntryStatus::Unavailable(e) => {
                 println!(
                     "  credential       {} ({e})",
-                    style("store unavailable").color256(CLI_RED)
+                    style("store unavailable").themed(CLI_ERROR)
                 );
             }
         }
@@ -368,7 +368,7 @@ impl VtaAccess {
     }
 
     fn render(&self) {
-        println!("{}", style("VTA access").color256(CLI_BLUE).bold());
+        println!("{}", style("VTA access").themed(CLI_INFO).bold());
         println!("  VTA              {}", self.vta_did);
         println!("  context          {}", self.context_id);
         println!("  transport        {}", self.transport());
@@ -383,7 +383,7 @@ impl VtaAccess {
         // as the TUI panel must, for width — would make it useless here.
         println!(
             "  authenticates as {}",
-            style(&self.credential_did).color256(CLI_PURPLE)
+            style(&self.credential_did).themed(CLI_EXAMPLE)
         );
         println!();
         println!("  The VTA's ACL is keyed on that last DID: it is what to name when reading");
@@ -391,7 +391,7 @@ impl VtaAccess {
         println!();
         println!(
             "    {}",
-            style(format!("pnm acl get {}", self.credential_did)).color256(CLI_ORANGE)
+            style(format!("pnm acl get {}", self.credential_did)).themed(CLI_CAUTION)
         );
         println!(
             "    {}",
@@ -399,7 +399,7 @@ impl VtaAccess {
                 "pnm acl update {} --capabilities persona-holder",
                 self.credential_did
             ))
-            .color256(CLI_ORANGE)
+            .themed(CLI_CAUTION)
         );
         println!();
         // `--capabilities` narrows everywhere else it appears, and someone
@@ -456,15 +456,13 @@ fn trace(step: &Step) {
             elapsed,
         } => {
             let transports = if transports.is_empty() {
-                style("no known transport").color256(CLI_ORANGE).to_string()
+                style("no known transport").themed(CLI_CAUTION).to_string()
             } else {
-                style(protocols(transports))
-                    .color256(CLI_PURPLE)
-                    .to_string()
+                style(protocols(transports)).themed(CLI_EXAMPLE).to_string()
             };
             eprintln!(
                 "    {} {label} — {services} service{}, {transports} {}",
-                style("✓").color256(CLI_BLUE),
+                style("✓").themed(CLI_INFO),
                 if *services == 1 { "" } else { "s" },
                 dim(secs(elapsed)),
             );
@@ -476,7 +474,7 @@ fn trace(step: &Step) {
         } => {
             eprintln!(
                 "    {} {label} — {error} {}",
-                style("✗").color256(CLI_RED).bold(),
+                style("✗").themed(CLI_ERROR).bold(),
                 dim(secs(elapsed)),
             );
         }
@@ -498,19 +496,19 @@ fn trace(step: &Step) {
             Probe::Reachable { url, http_status } => {
                 let (word, colour) = probe_words(probe);
                 let mark = if probe.grade() == Some(ProbeGrade::ServerError) {
-                    style("!").color256(CLI_ORANGE).bold()
+                    style("!").themed(CLI_CAUTION).bold()
                 } else {
-                    style("✓").color256(CLI_BLUE)
+                    style("✓").themed(CLI_INFO)
                 };
                 eprintln!(
                     "    {mark} {url} — {} (HTTP {http_status}) {}",
-                    style(word).color256(colour),
+                    style(word).themed(colour),
                     dim(secs(elapsed)),
                 );
             }
             Probe::Unreachable { url, error } => eprintln!(
                 "    {} {url} — {error} {}",
-                style("✗").color256(CLI_RED).bold(),
+                style("✗").themed(CLI_ERROR).bold(),
                 dim(secs(elapsed)),
             ),
         },
@@ -564,22 +562,19 @@ fn render(report: &HealthReport, config_missing: bool) {
                 "No account loaded — reporting only the DIDs given with --vtc. \
                  Persona, VTA and mediator legs are not covered."
             )
-            .color256(CLI_ORANGE)
+            .themed(CLI_CAUTION)
         );
         println!();
     }
 
-    println!("{}", style("PARTIES").color256(CLI_BLUE).bold());
+    println!("{}", style("PARTIES").themed(CLI_INFO).bold());
     for party in &report.parties {
         render_party(party);
     }
 
     if !report.links.is_empty() {
         println!();
-        println!(
-            "{}",
-            style("NEGOTIATED TRANSPORT").color256(CLI_BLUE).bold()
-        );
+        println!("{}", style("NEGOTIATED TRANSPORT").themed(CLI_INFO).bold());
         for link in &report.links {
             let arrow = format!("  {} → {}", link.from, link.to);
             match &link.outcome {
@@ -588,18 +583,18 @@ fn render(report: &HealthReport, config_missing: bool) {
                     peer_endpoint,
                 } => println!(
                     "{arrow}: {} via {}",
-                    style(protocol.as_str()).color256(CLI_PURPLE).bold(),
-                    style(peer_endpoint).color256(CLI_PURPLE),
+                    style(protocol.as_str()).themed(CLI_EXAMPLE).bold(),
+                    style(peer_endpoint).themed(CLI_EXAMPLE),
                 ),
                 LinkOutcome::NoCommonProtocol { ours, theirs } => println!(
                     "{arrow}: {} (we offer [{}], they offer [{}])",
-                    style("no shared transport").color256(CLI_RED).bold(),
+                    style("no shared transport").themed(CLI_ERROR).bold(),
                     protocols(ours),
                     protocols(theirs),
                 ),
                 LinkOutcome::Unknown { reason } => println!(
                     "{arrow}: {} ({reason})",
-                    style("unknown").color256(CLI_ORANGE)
+                    style("unknown").themed(CLI_CAUTION)
                 ),
             }
         }
@@ -609,10 +604,10 @@ fn render(report: &HealthReport, config_missing: bool) {
     if report.notes.is_empty() {
         println!(
             "{}",
-            style("No problems found in the messaging chain.").color256(CLI_BLUE)
+            style("No problems found in the messaging chain.").themed(CLI_INFO)
         );
     } else {
-        println!("{}", style("FINDINGS").color256(CLI_ORANGE).bold());
+        println!("{}", style("FINDINGS").themed(CLI_CAUTION).bold());
         for note in &report.notes {
             println!("  • {note}");
         }
@@ -623,22 +618,22 @@ fn render_party(party: &Party) {
     println!();
     println!(
         "  {} {}",
-        style(format!("[{}]", party.role.as_str())).color256(CLI_PURPLE),
+        style(format!("[{}]", party.role.as_str())).themed(CLI_EXAMPLE),
         style(&party.label).bold(),
     );
-    println!("    did: {}", style(&party.did).color256(CLI_PURPLE));
+    println!("    did: {}", style(&party.did).themed(CLI_EXAMPLE));
 
     let Some(resolved) = &party.resolved else {
         println!(
             "    {}: {}",
-            style("UNRESOLVED").color256(CLI_RED).bold(),
+            style("UNRESOLVED").themed(CLI_ERROR).bold(),
             party.error.as_deref().unwrap_or("unknown error"),
         );
         return;
     };
 
     if resolved.services.is_empty() {
-        println!("    services: {}", style("none").color256(CLI_RED));
+        println!("    services: {}", style("none").themed(CLI_ERROR));
     } else {
         println!("    services:");
         for service in &resolved.services {
@@ -653,7 +648,7 @@ fn render_party(party: &Party) {
             println!(
                 "      {:<28} {:<22} → {}",
                 fragment(&service.id),
-                style(types).color256(CLI_BLUE),
+                style(types).themed(CLI_INFO),
                 service.endpoint,
             );
         }
@@ -665,12 +660,12 @@ fn render_party(party: &Party) {
                 let (word, colour) = probe_words(probe);
                 println!(
                     "    probe {url} → {} (HTTP {http_status})",
-                    style(word).color256(colour),
+                    style(word).themed(colour),
                 );
             }
             Probe::Unreachable { url, error } => println!(
                 "    probe {url} → {} ({error})",
-                style("unreachable").color256(CLI_RED).bold(),
+                style("unreachable").themed(CLI_ERROR).bold(),
             ),
         }
     }
@@ -683,12 +678,12 @@ fn render_party(party: &Party) {
 /// now carries the grade, so a mediator base path answering 404 says
 /// "responding", which is exactly what it is: the host is there and that path
 /// does not serve GETs.
-fn probe_words(probe: &Probe) -> (&'static str, u8) {
+fn probe_words(probe: &Probe) -> (&'static str, crate::theme::Role) {
     match probe.grade() {
-        Some(ProbeGrade::Ok) => ("ok", CLI_BLUE),
-        Some(ProbeGrade::Responding) => ("responding", CLI_BLUE),
-        Some(ProbeGrade::ServerError) => ("server error", CLI_ORANGE),
-        None => ("unreachable", CLI_RED),
+        Some(ProbeGrade::Ok) => ("ok", CLI_INFO),
+        Some(ProbeGrade::Responding) => ("responding", CLI_INFO),
+        Some(ProbeGrade::ServerError) => ("server error", CLI_CAUTION),
+        None => ("unreachable", CLI_ERROR),
     }
 }
 
@@ -728,7 +723,7 @@ fn protocols(list: &[vta_sdk::protocol::matching::Protocol]) -> String {
 async fn report_recoverability(config: &Config) {
     use openvtc_core::config::KeyBackend;
 
-    println!("{}", style("Recoverability").color256(CLI_BLUE).bold());
+    println!("{}", style("Recoverability").themed(CLI_INFO).bold());
 
     let KeyBackend::Vta { .. } = &config.key_backend else {
         println!("  This profile does not use a VTA, so there is nothing to rebuild from.\n");
@@ -816,7 +811,7 @@ async fn report_recoverability(config: &Config) {
                 "NOT RECOVERABLE: the VTA holds identities, but none of their keys could \
                  be matched to them, so a rebuilt account could not sign or receive."
             )
-            .color256(CLI_RED)
+            .themed(CLI_ERROR)
         );
         println!(
             "  {}",
@@ -825,18 +820,18 @@ async fn report_recoverability(config: &Config) {
                  method of the persona's DID. This deployment appears to label them some \
                  other way, so recovery would need a different mapping."
             )
-            .color256(CLI_ORANGE)
+            .themed(CLI_CAUTION)
         );
     } else if rebuilt.account.personas.is_empty() {
         println!(
             "\n  {}",
-            style("Nothing to recover: this context holds no identities.").color256(CLI_ORANGE)
+            style("Nothing to recover: this context holds no identities.").themed(CLI_CAUTION)
         );
     } else if rebuilt.skipped.is_empty() {
         println!(
             "\n  {}",
             style("RECOVERABLE: every identity in this context maps to its keys.")
-                .color256(CLI_PURPLE)
+                .themed(CLI_EXAMPLE)
         );
     } else {
         println!(
@@ -846,7 +841,7 @@ async fn report_recoverability(config: &Config) {
                 rebuilt.account.personas.len(),
                 plan.personas.len()
             ))
-            .color256(CLI_ORANGE)
+            .themed(CLI_CAUTION)
         );
     }
 
@@ -861,7 +856,7 @@ async fn report_recoverability(config: &Config) {
                  on connect — then re-run this.",
                 held_locally - rebuilt.account.memberships().count()
             ))
-            .color256(CLI_ORANGE)
+            .themed(CLI_CAUTION)
         );
     }
 
@@ -878,7 +873,7 @@ async fn report_recoverability(config: &Config) {
 
     println!(
         "\n  {}",
-        style("Not restored by a rebuild, whatever the outcome above:").color256(CLI_BLUE)
+        style("Not restored by a rebuild, whatever the outcome above:").themed(CLI_INFO)
     );
     for gap in openvtc_core::rebuild::RebuildPlan::known_gaps() {
         println!("    - {gap}");

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "openpgp-card")]
 use crate::cli::get_user_pin;
-use crate::colors::{CLI_BLUE, CLI_ORANGE, CLI_PURPLE, CLI_RED};
+use crate::colors::{CLI_CAUTION, CLI_ERROR, CLI_EXAMPLE, CLI_INFO, Themed};
 use crate::{
     cli::cli,
     state_handler::{DeferredLoad, StartingMode, StateHandler},
@@ -50,7 +50,7 @@ async fn load_config_for_health(profile: &str, unlock_code_arg: Option<&str>) ->
         Err(e) => {
             eprintln!(
                 "{} {}",
-                style("Account not loaded:").color256(CLI_ORANGE),
+                style("Account not loaded:").themed(CLI_CAUTION),
                 redact_paths(&e.to_string()),
             );
             return None;
@@ -70,7 +70,7 @@ async fn load_config_for_health(profile: &str, unlock_code_arg: Option<&str>) ->
         Err(e) => {
             eprintln!(
                 "{} {e}",
-                style("Account not loaded (TDK init failed):").color256(CLI_ORANGE)
+                style("Account not loaded (TDK init failed):").themed(CLI_CAUTION)
             );
             return None;
         }
@@ -108,7 +108,7 @@ async fn load_config_for_health(profile: &str, unlock_code_arg: Option<&str>) ->
         Err(e) => {
             eprintln!(
                 "{} {}",
-                style("Account not loaded:").color256(CLI_ORANGE),
+                style("Account not loaded:").themed(CLI_CAUTION),
                 redact_paths(&e.to_string()),
             );
             None
@@ -239,7 +239,7 @@ fn init_default_keyring_store(profile: &str) -> Result<()> {
                      only so you can recover an older profile: export a backup now \
                      (Settings -> Export Config), then restart without the variable set."
                 )
-                .color256(CLI_ORANGE)
+                .themed(CLI_CAUTION)
             );
             Ok(())
         }
@@ -350,11 +350,17 @@ async fn main() -> Result<()> {
     // the unlock-code passed into `load_fast`). Unknown subcommands and
     // `--help`/`--version` are handled here by clap (process exits).
     let matches = cli().get_matches();
+    // The theme colours everything printed from here on — prompts and errors
+    // as well as the TUI — so it is chosen first. Under `auto` this asks the
+    // terminal for its background, which only works before the TUI starts.
+    let theme_roots = theme::catalog::Roots::from_env();
+    let theme_in_use = theme::init(&theme_roots);
     // `theme` needs no profile: how the TUI looks is the person's, not an
     // account's, so it runs before any profile is resolved or opened.
     if let Some(("theme", theme_args)) = matches.subcommand() {
         return theme_cmd::run(theme_args);
     }
+    let theme_watcher = theme::live::Watcher::new(theme_roots, &theme_in_use);
     let cli_profile = matches
         .get_one::<String>("profile")
         .cloned()
@@ -387,20 +393,20 @@ async fn main() -> Result<()> {
         // ENV Profile will override the CLI Argument
         if cli_profile != "default" && cli_profile != env_profile {
             println!("{}", 
-                style("WARNING: Using both ENV OPENVTC_CONFIG_PROFILE and CLI profile! These do not match!").color256(CLI_ORANGE)
+                style("WARNING: Using both ENV OPENVTC_CONFIG_PROFILE and CLI profile! These do not match!").themed(CLI_CAUTION)
             );
             println!(
                 "{} {}",
-                style("WARNING: Using CLI Profile:").color256(CLI_ORANGE),
-                style(&cli_profile).color256(CLI_PURPLE)
+                style("WARNING: Using CLI Profile:").themed(CLI_CAUTION),
+                style(&cli_profile).themed(CLI_EXAMPLE)
             );
             cli_profile
         } else {
             println!(
                 "{}{}{}",
-                style("Using profile (").color256(CLI_BLUE),
-                style(&env_profile).color256(CLI_PURPLE),
-                style(") from OPENVTC_CONFIG_PROFILE ENV variable").color256(CLI_BLUE)
+                style("Using profile (").themed(CLI_INFO),
+                style(&env_profile).themed(CLI_EXAMPLE),
+                style(") from OPENVTC_CONFIG_PROFILE ENV variable").themed(CLI_INFO)
             );
             env_profile
         }
@@ -419,8 +425,8 @@ async fn main() -> Result<()> {
     {
         eprintln!(
             "{} {}",
-            style("ERROR: Invalid profile name:").color256(CLI_RED),
-            style(&profile).color256(CLI_ORANGE)
+            style("ERROR: Invalid profile name:").themed(CLI_ERROR),
+            style(&profile).themed(CLI_CAUTION)
         );
         bail!("Profile name may only contain [A-Za-z0-9._-] and must not contain '..'");
     }
@@ -479,7 +485,7 @@ async fn main() -> Result<()> {
                          this version of OpenVTC (format v{expected}) and cannot be upgraded \
                          automatically."
                     ))
-                    .color256(CLI_ORANGE)
+                    .themed(CLI_CAUTION)
                 );
                 eprintln!(
                     "{}",
@@ -487,7 +493,7 @@ async fn main() -> Result<()> {
                         "Continuing will DELETE the existing configuration and its stored \
                          credentials, then start a fresh setup. This cannot be undone."
                     )
-                    .color256(CLI_RED)
+                    .themed(CLI_ERROR)
                 );
                 let confirmed = Confirm::with_theme(&ColorfulTheme::default())
                     .with_prompt("Delete the incompatible configuration and reset?")
@@ -503,7 +509,7 @@ async fn main() -> Result<()> {
                 for warning in &summary.warnings {
                     eprintln!(
                         "{}",
-                        style(format!("warning during reset: {warning}")).color256(CLI_ORANGE)
+                        style(format!("warning during reset: {warning}")).themed(CLI_CAUTION)
                     );
                 }
                 starting_mode = StartingMode::SetupWizard;
@@ -519,17 +525,17 @@ async fn main() -> Result<()> {
                 };
                 eprintln!(
                     "{} {}",
-                    style("ERROR: Couldn't reach the VTA! Reason:").color256(CLI_RED),
-                    style(redact_paths(&e.to_string())).color256(CLI_ORANGE)
+                    style("ERROR: Couldn't reach the VTA! Reason:").themed(CLI_ERROR),
+                    style(redact_paths(&e.to_string())).themed(CLI_CAUTION)
                 );
-                eprintln!("{}", style(hint).color256(CLI_ORANGE));
+                eprintln!("{}", style(hint).themed(CLI_CAUTION));
                 bail!("VTA Connection Error");
             }
             Err(e) => {
                 eprintln!(
                     "{} {}",
-                    style("ERROR: Couldn't load configuration! Reason:").color256(CLI_RED),
-                    style(redact_paths(&e.to_string())).color256(CLI_ORANGE)
+                    style("ERROR: Couldn't load configuration! Reason:").themed(CLI_ERROR),
+                    style(redact_paths(&e.to_string())).themed(CLI_CAUTION)
                 );
                 bail!("Configuration Error");
             }
@@ -541,16 +547,11 @@ async fn main() -> Result<()> {
         bail!("Starting mode not set correctly!");
     }
 
-    // The chosen theme, before the first frame is drawn.
-    theme::set_active(&theme::catalog::load_selected(
-        &theme::catalog::Roots::from_env(),
-    ));
-
     // Setup the initial state
     let (terminator, mut interrupt_rx) = create_termination();
     let (mut state, state_rx) = StateHandler::new(&profile, starting_mode);
     state.set_invitation_credential(invitation_credential);
-    let (ui_manager, action_rx) = UiManager::new();
+    let (ui_manager, action_rx) = UiManager::new(theme_watcher);
 
     tokio::try_join!(
         state.main_loop(terminator, action_rx, interrupt_rx.resubscribe()),
@@ -685,7 +686,7 @@ fn load_fast(profile: &str, unlock_code_arg: Option<&str>) -> Result<DeferredLoa
                         "WARNING: --unlock-code exposes the passphrase in the process list; \
                          prefer the interactive prompt on shared systems."
                     )
-                    .color256(CLI_ORANGE)
+                    .themed(CLI_CAUTION)
                 );
                 Some(UnlockCode::from_string(passphrase)?)
             } else {

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -707,6 +707,7 @@ use crate::state_handler::main_page::content::ThemeRow;
 use crate::theme::{
     self, Theme,
     catalog::{self, Roots},
+    terminal,
 };
 
 fn theme_rows(roots: &Roots) -> Vec<ThemeRow> {
@@ -770,8 +771,19 @@ fn handle_theme_apply(state: &mut State, roots: &Roots) {
         Ok(theme) => {
             theme::set_active(&theme);
             settings.mode = SettingsMode::View;
-            settings.status_message = Some(format!("Theme set to {}.", theme.name));
-            state.main_page.log(format!("Theme set to {}", theme.name));
+            let shown = theme::display_name(&theme.id, &theme.name);
+            let mut message = format!("Theme set to {shown}.");
+            let (mode, learned) = terminal::mode();
+            if theme.id == catalog::AUTO_ID && learned != terminal::Source::Asked {
+                // The terminal can only be asked before the TUI starts.
+                message.push_str(&format!(
+                    " OpenVTC asks your terminal for its background when it starts; \
+                     until then, Auto takes it to be {}.",
+                    mode.as_str()
+                ));
+            }
+            settings.status_message = Some(message);
+            state.main_page.log(format!("Theme set to {shown}"));
         }
         Err(e) => settings.status_message = Some(format!("Could not use that theme: {e}")),
     }
@@ -978,7 +990,10 @@ mod tests {
         assert_eq!(theme::active_theme().0, "nord", "moving previews");
         handle_theme_cancel(&mut state, &roots);
         assert_eq!(theme::active_theme().0, "openvtc", "cancel puts it back");
-        assert_eq!(catalog::selected(&roots), None, "and remembers nothing");
+        assert!(
+            !roots.settings_file().unwrap().exists(),
+            "and remembers nothing"
+        );
 
         handle_theme_open(&mut state, &roots);
         handle_theme_select(&mut state, &roots, nord);
@@ -997,8 +1012,27 @@ mod tests {
             state.main_page.content_panel.settings.mode,
             SettingsMode::View
         ));
-        assert_eq!(catalog::selected(&roots).as_deref(), Some("user/nord-mine"));
+        assert_eq!(catalog::choice(&roots).theme, "user/nord-mine");
         assert_eq!(theme::active_theme().1, "Nord (mine)");
+
+        // Auto is listed first, and kept by its own id.
+        handle_theme_open(&mut state, &roots);
+        let SettingsMode::ThemePicker { rows, .. } = &state.main_page.content_panel.settings.mode
+        else {
+            panic!("the picker opens again");
+        };
+        assert_eq!(rows[0].id, catalog::AUTO_ID);
+        handle_theme_select(&mut state, &roots, 0);
+        assert_eq!(theme::active_theme().0, catalog::AUTO_ID, "auto previews");
+        handle_theme_apply(&mut state, &roots);
+        assert_eq!(catalog::choice(&roots).theme, catalog::AUTO_ID);
+        let message = state
+            .main_page
+            .content_panel
+            .settings
+            .status_message
+            .clone();
+        assert!(message.is_some_and(|m| m.starts_with("Theme set to Auto — ")));
 
         theme::set_active(&Theme::default_theme());
         let _ = std::fs::remove_dir_all(base);

--- a/openvtc/src/theme/builtin.rs
+++ b/openvtc/src/theme/builtin.rs
@@ -1,8 +1,16 @@
 //! Themes that ship with OpenVTC.
 //!
-//! OpenVTC's own colours, and a few widely used open palettes mapped onto
-//! OpenVTC's roles. The colour values are those the palettes publish; their
-//! projects are credited by name.
+//! OpenVTC's own colours, a few widely used open palettes mapped onto OpenVTC's
+//! roles, and four made for accessibility. The open palettes' colour values are
+//! those they publish; their projects are credited by name.
+//!
+//! The accessibility themes:
+//! - **High contrast**, dark and light: every role at least 7:1 against the
+//!   background (WCAG AAA for body text).
+//! - **Colourblind safe**, dark and light: roles in the hues of the Okabe–Ito
+//!   palette, which stay distinct under the common colour-vision deficiencies.
+//!   The dark theme uses Okabe–Ito's own colours; on white those are too pale to
+//!   read, so the light theme darkens each hue until it reaches 4.5:1.
 
 use ratatui::style::Color;
 
@@ -102,8 +110,53 @@ pub fn all() -> Vec<Theme> {
                 0x7aa2f7, 0x9ece6a, 0xff9e64, 0xf7768e, 0xc0caf5, 0x565f89, 0xbb9af7, 0x1a1b26,
             ],
         ),
+        theme(
+            "high-contrast-dark",
+            "High Contrast Dark",
+            Mode::Dark,
+            [
+                0x00d7ff, 0x00ff87, 0xffd700, 0xff6b6b, 0xffffff, 0xc6c6c6, 0xff87ff, 0x000000,
+            ],
+        ),
+        theme(
+            "high-contrast-light",
+            "High Contrast Light",
+            Mode::Light,
+            [
+                0x0033b3, 0x005c1a, 0x8a4600, 0xb3001b, 0x000000, 0x3d3d3d, 0x7a1fa2, 0xffffff,
+            ],
+        ),
+        // Okabe–Ito: sky blue, bluish green, yellow, vermillion, reddish purple.
+        theme(
+            "colourblind-dark",
+            "Colourblind Safe Dark",
+            Mode::Dark,
+            [
+                0x56b4e9, 0x009e73, 0xf0e442, 0xd55e00, 0xf0f0f0, 0xb0b0b0, 0xcc79a7, 0x101010,
+            ],
+        ),
+        // Okabe–Ito's blue, then its bluish green, yellow, vermillion and
+        // reddish purple darkened to read on white.
+        theme(
+            "colourblind-light",
+            "Colourblind Safe Light",
+            Mode::Light,
+            [
+                0x0072b2, 0x007a5a, 0x736b00, 0xb34e00, 0x000000, 0x595959, 0xa6497f, 0xffffff,
+            ],
+        ),
     ]
 }
+
+/// The ids of the themes made for accessibility, and the contrast every one
+/// of their roles reaches against the background.
+#[cfg(test)]
+const ACCESSIBLE: [(&str, f64); 4] = [
+    ("high-contrast-dark", 7.0),
+    ("high-contrast-light", 7.0),
+    ("colourblind-dark", 4.5),
+    ("colourblind-light", 4.5),
+];
 
 /// The built-in theme with `id`.
 #[must_use]
@@ -123,6 +176,61 @@ mod tests {
         ids.sort_unstable();
         ids.dedup();
         assert_eq!(ids.len(), themes.len());
+    }
+
+    /// Every built-in theme's text reads on its background (4.5:1, WCAG AA),
+    /// and the accessibility themes hold every role to their own bar. A theme
+    /// drawn on the terminal's background is measured on black or white.
+    #[test]
+    fn text_is_readable_on_every_built_in_background() {
+        use crate::theme::{Role, contrast, rgb};
+
+        let roles = [
+            Role::Accent,
+            Role::Success,
+            Role::Warning,
+            Role::Danger,
+            Role::Text,
+            Role::Muted,
+            Role::Highlight,
+        ];
+        let themes = all();
+        for theme in &themes {
+            let background = theme
+                .palette
+                .background
+                .and_then(rgb)
+                .unwrap_or(match theme.mode {
+                    Mode::Dark => (0, 0, 0),
+                    Mode::Light => (255, 255, 255),
+                });
+            let ratio = |role: Role| {
+                let colour = rgb(theme.palette.get(role)).expect("a solid colour");
+                contrast(colour, background)
+            };
+            assert!(
+                ratio(Role::Text) >= 4.5,
+                "{}: text is {:.2}:1 on its background",
+                theme.id,
+                ratio(Role::Text)
+            );
+            let bar = ACCESSIBLE
+                .iter()
+                .find_map(|(id, bar)| (*id == theme.id).then_some(*bar));
+            if let Some(bar) = bar {
+                for role in roles {
+                    assert!(
+                        ratio(role) >= bar,
+                        "{}: {role:?} is {:.2}:1, under {bar}:1",
+                        theme.id,
+                        ratio(role)
+                    );
+                }
+            }
+        }
+        for (id, _) in ACCESSIBLE {
+            assert!(themes.iter().any(|t| t.id == id), "{id} is built in");
+        }
     }
 
     #[test]

--- a/openvtc/src/theme/catalog.rs
+++ b/openvtc/src/theme/catalog.rs
@@ -2,26 +2,54 @@
 //!
 //! | Id                  | Where it comes from                                         |
 //! |---------------------|-------------------------------------------------------------|
+//! | `auto`              | follows the terminal's background: `auto_dark` or `auto_light` |
 //! | `openvtc`, `nord`…  | built in ([`super::builtin`])                               |
 //! | `user/<name>`       | `<config>/themes/<name>.toml`, an OpenVTC theme file        |
 //! | `omarchy/current`   | whichever Omarchy theme is current, followed as it changes  |
 //! | `omarchy/<name>`    | an Omarchy theme directory, read in place                   |
 //!
 //! `<config>` is `OPENVTC_CONFIG_PATH`, else `~/.config/openvtc` (the
-//! platform's config directory on Windows). The chosen id is kept in
+//! platform's config directory on Windows). The choice is kept in
 //! `<config>/tui.toml`, shared by every profile: how the TUI looks is the
 //! person's, not the account's.
+//!
+//! ```toml
+//! theme = "auto"
+//! auto_dark = "openvtc"            # under auto, on a dark terminal
+//! auto_light = "catppuccin-latte"  # and on a light one
+//! ```
 
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 
-use super::{Theme, builtin, import};
+use super::{Mode, Theme, builtin, import, terminal};
+
+/// The id that follows the terminal's background.
+pub const AUTO_ID: &str = "auto";
+
+/// Under `auto`, the theme for a light terminal when `tui.toml` names none.
+const AUTO_LIGHT_DEFAULT: &str = "catppuccin-latte";
+
+/// Where current Omarchy releases record the current theme's name, under home.
+const OMARCHY_CURRENT_NAME: &str = ".local/state/omarchy/current/theme.name";
+
+/// Where earlier Omarchy releases linked the current theme's directory.
+const OMARCHY_CURRENT_LINK: &str = ".config/omarchy/current/theme";
+
+/// The files an Omarchy theme directory is read from.
+const OMARCHY_THEME_FILES: [&str; 4] =
+    ["colors.toml", "alacritty.toml", "kitty.conf", "light.mode"];
 
 /// Where a listed theme comes from.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Source {
+    /// Follows the terminal, between these two ids.
+    Auto {
+        dark: String,
+        light: String,
+    },
     Builtin,
     User(PathBuf),
     Omarchy(PathBuf),
@@ -29,14 +57,17 @@ pub enum Source {
 }
 
 impl Source {
-    /// A word for a list.
+    /// A few words for a list.
     #[must_use]
-    pub fn label(&self) -> &'static str {
+    pub fn label(&self) -> String {
         match self {
-            Source::Builtin => "built in",
-            Source::User(_) => "yours",
-            Source::Omarchy(_) => "Omarchy",
-            Source::OmarchyCurrent => "Omarchy, follows the current theme",
+            Source::Auto { dark, light } => {
+                format!("{dark} on a dark terminal, {light} on a light one")
+            }
+            Source::Builtin => "built in".to_string(),
+            Source::User(_) => "yours".to_string(),
+            Source::Omarchy(_) => "Omarchy".to_string(),
+            Source::OmarchyCurrent => "Omarchy, follows the current theme".to_string(),
         }
     }
 }
@@ -47,6 +78,38 @@ pub struct Entry {
     pub id: String,
     pub name: String,
     pub source: Source,
+}
+
+/// What `tui.toml` says to draw with.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Choice {
+    /// The theme chosen: an id, or `auto`.
+    pub theme: String,
+    /// Under `auto`, the theme for a dark terminal.
+    pub auto_dark: String,
+    /// Under `auto`, the theme for a light terminal.
+    pub auto_light: String,
+}
+
+impl Default for Choice {
+    fn default() -> Self {
+        Choice {
+            theme: builtin::DEFAULT_ID.to_string(),
+            auto_dark: builtin::DEFAULT_ID.to_string(),
+            auto_light: AUTO_LIGHT_DEFAULT.to_string(),
+        }
+    }
+}
+
+impl Choice {
+    /// The theme `auto` draws with on a terminal in `mode`.
+    #[must_use]
+    pub fn for_mode(&self, mode: Mode) -> &str {
+        match mode {
+            Mode::Dark => &self.auto_dark,
+            Mode::Light => &self.auto_light,
+        }
+    }
 }
 
 /// The places themes live.
@@ -90,7 +153,9 @@ impl Roots {
         self.config.as_ref().map(|c| c.join("themes"))
     }
 
-    fn settings_file(&self) -> Option<PathBuf> {
+    /// `tui.toml`, where the choice is kept.
+    #[must_use]
+    pub fn settings_file(&self) -> Option<PathBuf> {
         self.config.as_ref().map(|c| c.join("tui.toml"))
     }
 
@@ -117,13 +182,13 @@ impl Roots {
     fn omarchy_current(&self) -> Option<PathBuf> {
         let home = self.home.as_ref()?;
         // Current releases record the theme's name.
-        if let Ok(name) = fs::read_to_string(home.join(".local/state/omarchy/current/theme.name"))
+        if let Ok(name) = fs::read_to_string(home.join(OMARCHY_CURRENT_NAME))
             && let Some(dir) = self.omarchy_theme(name.trim())
         {
             return Some(dir);
         }
         // Earlier ones link to its directory.
-        fs::canonicalize(home.join(".config/omarchy/current/theme"))
+        fs::canonicalize(home.join(OMARCHY_CURRENT_LINK))
             .ok()
             .filter(|d| is_omarchy_theme(d))
     }
@@ -142,17 +207,24 @@ fn valid_segment(segment: &str) -> bool {
         && !segment.starts_with('.')
 }
 
-/// Every theme that can be chosen: built in, the person's own, then Omarchy's.
+/// Every theme that can be chosen: auto, built in, the person's own, then
+/// Omarchy's.
 #[must_use]
 pub fn list(roots: &Roots) -> Vec<Entry> {
-    let mut entries: Vec<Entry> = builtin::all()
-        .into_iter()
-        .map(|t| Entry {
-            id: t.id,
-            name: t.name,
-            source: Source::Builtin,
-        })
-        .collect();
+    let choice = choice(roots);
+    let mut entries = vec![Entry {
+        id: AUTO_ID.to_string(),
+        name: "Auto (follow terminal)".to_string(),
+        source: Source::Auto {
+            dark: choice.auto_dark,
+            light: choice.auto_light,
+        },
+    }];
+    entries.extend(builtin::all().into_iter().map(|t| Entry {
+        id: t.id,
+        name: t.name,
+        source: Source::Builtin,
+    }));
 
     if let Some(dir) = roots.themes_dir()
         && let Ok(files) = fs::read_dir(&dir)
@@ -221,12 +293,20 @@ pub fn list(roots: &Roots) -> Vec<Entry> {
     entries
 }
 
-/// The theme with `id`.
+/// The theme with `id`. `auto` loads the theme for the terminal's background,
+/// keeping `auto` as its id.
 ///
 /// # Errors
 ///
 /// An unknown id, or a theme file that cannot be read.
 pub fn load(roots: &Roots, id: &str) -> Result<Theme> {
+    if id == AUTO_ID {
+        let target = resolve(roots, id);
+        let mut theme = load(roots, &target)
+            .with_context(|| format!("auto's theme for this terminal, `{target}`"))?;
+        theme.id = AUTO_ID.to_string();
+        return Ok(theme);
+    }
     let mut theme = if let Some(theme) = builtin::find(id) {
         theme
     } else if let Some(name) = id.strip_prefix("user/") {
@@ -261,15 +341,86 @@ pub fn load(roots: &Roots, id: &str) -> Result<Theme> {
     Ok(theme)
 }
 
-/// The id of the chosen theme, if one was chosen.
+/// The id of the theme `id` draws with: under `auto`, the one for the
+/// terminal's background as [`terminal::mode`] knows it; any other id is itself.
 #[must_use]
-pub fn selected(roots: &Roots) -> Option<String> {
-    let text = fs::read_to_string(roots.settings_file()?).ok()?;
-    let table: toml::Table = toml::from_str(&text).ok()?;
-    table
-        .get("theme")
-        .and_then(toml::Value::as_str)
-        .map(str::to_string)
+pub fn resolve(roots: &Roots, id: &str) -> String {
+    if id == AUTO_ID {
+        choice(roots).for_mode(terminal::mode().0).to_string()
+    } else {
+        id.to_string()
+    }
+}
+
+/// The files theme `id` is read from, whether or not they exist yet, so a
+/// change to any of them can be noticed. Built-in themes have none; `auto` is
+/// resolved by the caller, which knows the choice it is following.
+#[must_use]
+pub fn sources(roots: &Roots, id: &str) -> Vec<PathBuf> {
+    let theme_files = |dir: PathBuf| OMARCHY_THEME_FILES.map(|f| dir.join(f)).to_vec();
+    if let Some(name) = id.strip_prefix("user/") {
+        return roots
+            .themes_dir()
+            .filter(|_| valid_segment(name))
+            .map(|dir| vec![dir.join(format!("{name}.toml"))])
+            .unwrap_or_default();
+    }
+    if id == "omarchy/current" {
+        let mut files = Vec::new();
+        if let Some(home) = &roots.home {
+            files.push(home.join(OMARCHY_CURRENT_NAME));
+            files.push(home.join(OMARCHY_CURRENT_LINK));
+        }
+        files.extend(roots.omarchy_current().map(theme_files).unwrap_or_default());
+        return files;
+    }
+    if let Some(name) = id.strip_prefix("omarchy/")
+        && valid_segment(name)
+        && let Some(dir) = roots.omarchy_theme(name)
+    {
+        return theme_files(dir);
+    }
+    Vec::new()
+}
+
+/// `tui.toml` as a table: empty when there is none, `None` when it is there but
+/// is not TOML.
+fn settings(roots: &Roots) -> Option<toml::Table> {
+    let Some(text) = roots
+        .settings_file()
+        .and_then(|path| fs::read_to_string(path).ok())
+    else {
+        return Some(toml::Table::new());
+    };
+    toml::from_str(&text).ok()
+}
+
+/// What `tui.toml` says to draw with, or `None` while it cannot be read as TOML
+/// — half-written, or mid-edit.
+#[must_use]
+pub fn read_choice(roots: &Roots) -> Option<Choice> {
+    let table = settings(roots)?;
+    let default = Choice::default();
+    let id = |key: &str, fallback: String, auto_allowed: bool| {
+        table
+            .get(key)
+            .and_then(toml::Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty() && (auto_allowed || *id != AUTO_ID))
+            .map_or(fallback, str::to_string)
+    };
+    Some(Choice {
+        theme: id("theme", default.theme, true),
+        // `auto` cannot pick itself.
+        auto_dark: id("auto_dark", default.auto_dark, false),
+        auto_light: id("auto_light", default.auto_light, false),
+    })
+}
+
+/// What `tui.toml` says to draw with, OpenVTC's own theme when it says nothing.
+#[must_use]
+pub fn choice(roots: &Roots) -> Choice {
+    read_choice(roots).unwrap_or_default()
 }
 
 /// Remember `id` as the chosen theme, keeping anything else `tui.toml` holds.
@@ -278,33 +429,42 @@ pub fn selected(roots: &Roots) -> Option<String> {
 ///
 /// A configuration directory that cannot be written.
 pub fn remember(roots: &Roots, id: &str) -> Result<()> {
+    store(roots, &[("theme", id)])
+}
+
+/// Choose `auto`, and with `dark` or `light`, the theme it draws with on a dark
+/// or light terminal.
+///
+/// # Errors
+///
+/// A configuration directory that cannot be written.
+pub fn remember_auto(roots: &Roots, dark: Option<&str>, light: Option<&str>) -> Result<()> {
+    let mut entries = vec![("theme", AUTO_ID)];
+    entries.extend(dark.map(|id| ("auto_dark", id)));
+    entries.extend(light.map(|id| ("auto_light", id)));
+    store(roots, &entries)
+}
+
+/// Set `entries` in `tui.toml`. Written to a temporary file and renamed into
+/// place, so a running TUI never reads it half-written.
+fn store(roots: &Roots, entries: &[(&str, &str)]) -> Result<()> {
     let path = roots
         .settings_file()
         .ok_or_else(|| anyhow!("no configuration directory to remember the theme in"))?;
-    let mut table: toml::Table = fs::read_to_string(&path)
-        .ok()
-        .and_then(|text| toml::from_str(&text).ok())
-        .unwrap_or_default();
-    table.insert("theme".to_string(), toml::Value::String(id.to_string()));
+    let mut table = settings(roots).unwrap_or_default();
+    for (key, value) in entries {
+        table.insert(
+            (*key).to_string(),
+            toml::Value::String((*value).to_string()),
+        );
+    }
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(&path, toml::to_string(&table)?)
+    let partial = path.with_extension("toml.partial");
+    fs::write(&partial, toml::to_string(&table)?)
+        .and_then(|()| fs::rename(&partial, &path))
         .with_context(|| format!("could not write {}", path.display()))
-}
-
-/// The chosen theme, or OpenVTC's own when none was chosen or it cannot be read.
-#[must_use]
-pub fn load_selected(roots: &Roots) -> Theme {
-    selected(roots)
-        .and_then(|id| match load(roots, &id) {
-            Ok(theme) => Some(theme),
-            Err(e) => {
-                tracing::warn!(theme = %id, error = %e, "chosen theme could not be loaded; using the default");
-                None
-            }
-        })
-        .unwrap_or_else(Theme::default_theme)
 }
 
 /// Write `theme` into the person's themes directory, under a file name no
@@ -375,10 +535,14 @@ mod tests {
         );
 
         remember(&roots, &id).unwrap();
-        let chosen = load_selected(&roots);
+        let chosen = load(&roots, &choice(&roots).theme).unwrap();
         assert_eq!(chosen.id, "user/my-nord");
         assert_eq!(chosen.palette, theme.palette);
         assert!(list(&roots).iter().any(|e| e.id == "user/my-nord"));
+        assert_eq!(
+            sources(&roots, &id),
+            [roots.themes_dir().unwrap().join("my-nord.toml")]
+        );
         let _ = fs::remove_dir_all(base);
     }
 
@@ -423,17 +587,58 @@ mod tests {
         let current = load(&roots, "omarchy/current").unwrap();
         assert_eq!(current.id, "omarchy/current");
         assert_eq!(current.mode, Mode::Light);
+
+        let watched = sources(&roots, "omarchy/current");
+        assert!(watched.contains(&state.join("theme.name")));
+        assert!(watched.contains(&roots.system_omarchy.unwrap().join("white/colors.toml")));
         let _ = fs::remove_dir_all(base);
     }
 
     #[test]
-    fn nothing_chosen_or_something_unreadable_falls_back_to_openvtc() {
+    fn nothing_chosen_or_something_unreadable() {
         let (base, roots) = roots("fallback");
-        assert_eq!(load_selected(&roots).id, builtin::DEFAULT_ID);
+        assert_eq!(choice(&roots), Choice::default());
         remember(&roots, "user/missing").unwrap();
-        assert_eq!(load_selected(&roots).id, builtin::DEFAULT_ID);
+        assert_eq!(choice(&roots).theme, "user/missing");
+        assert!(load(&roots, "user/missing").is_err());
         assert!(load(&roots, "user/../../etc/passwd").is_err());
         assert!(load(&roots, "omarchy/../x").is_err());
+        assert!(sources(&roots, "user/../x").is_empty());
+
+        fs::write(roots.settings_file().unwrap(), "theme = \"nord").unwrap();
+        assert_eq!(read_choice(&roots), None, "half-written is not a choice");
+        assert_eq!(choice(&roots), Choice::default());
+        let _ = fs::remove_dir_all(base);
+    }
+
+    /// `auto` keeps its own id, draws with the theme for the terminal, and can
+    /// never be told to pick itself.
+    #[test]
+    fn auto_picks_between_two_themes() {
+        let (base, roots) = roots("auto");
+        let entries = list(&roots);
+        assert_eq!(entries[0].id, AUTO_ID, "auto comes first");
+
+        remember(&roots, "dracula").unwrap();
+        remember_auto(&roots, Some("nord"), None).unwrap();
+        let chosen = choice(&roots);
+        assert_eq!(chosen.theme, AUTO_ID);
+        assert_eq!(chosen.for_mode(Mode::Dark), "nord");
+        assert_eq!(chosen.for_mode(Mode::Light), AUTO_LIGHT_DEFAULT);
+
+        let theme = load(&roots, AUTO_ID).unwrap();
+        assert_eq!(theme.id, AUTO_ID);
+        let expected = builtin::find(chosen.for_mode(terminal::mode().0)).unwrap();
+        assert_eq!(theme.palette, expected.palette);
+        assert_eq!(theme.name, expected.name);
+
+        fs::write(
+            roots.settings_file().unwrap(),
+            "theme = \"auto\"\nauto_dark = \"auto\"\nauto_light = \"auto\"\n",
+        )
+        .unwrap();
+        assert_eq!(choice(&roots).auto_dark, builtin::DEFAULT_ID);
+        assert!(load(&roots, AUTO_ID).is_ok());
         let _ = fs::remove_dir_all(base);
     }
 }

--- a/openvtc/src/theme/export.rs
+++ b/openvtc/src/theme/export.rs
@@ -1,0 +1,465 @@
+//! Writing a theme out for other tools, so a theme made in OpenVTC can colour
+//! them too.
+//!
+//! Each format carries OpenVTC's seven roles and background where
+//! [`super::import`] reads them back, so an exported theme imports as the same
+//! theme. What else a format expects is derived from the roles:
+//!
+//! | Format            | Derived                                                                |
+//! |-------------------|------------------------------------------------------------------------|
+//! | base16            | `base01`/`base02`/`base04` blend background and text; `base06`/`base07` run past the text; `base0A` is the warning colour, `base0C` blends accent and success, `base0F` danger and warning |
+//! | Omarchy           | the background and foreground shades, `selection`, `cyan`, `brown` and the `bright_*` colours |
+//! | Alacritty, Kitty  | black and white from background and text, cyan, and the bright colours |
+//!
+//! A theme drawn on the terminal's own background is exported on black (dark)
+//! or white (light), and named terminal colours as xterm draws them.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use ratatui::style::Color;
+
+use super::{Mode, Theme, import, rgb};
+
+type Rgb = (u8, u8, u8);
+
+const BLACK: Rgb = (0, 0, 0);
+const WHITE: Rgb = (255, 255, 255);
+
+/// A format a theme can be written in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Format {
+    /// An OpenVTC theme file.
+    Openvtc,
+    /// A base16 scheme (YAML).
+    Base16,
+    /// An Omarchy `colors.toml`, or a theme directory holding one.
+    Omarchy,
+    /// An Alacritty colour file (TOML).
+    Alacritty,
+    /// A Kitty colour file.
+    Kitty,
+}
+
+impl Format {
+    /// Every format's name, as `--format` takes it.
+    pub const NAMES: [&'static str; 5] = ["openvtc", "base16", "omarchy", "alacritty", "kitty"];
+
+    /// The format named `name`.
+    #[must_use]
+    pub fn parse(name: &str) -> Option<Self> {
+        Some(match name {
+            "openvtc" => Format::Openvtc,
+            "base16" => Format::Base16,
+            "omarchy" => Format::Omarchy,
+            "alacritty" => Format::Alacritty,
+            "kitty" => Format::Kitty,
+            _ => return None,
+        })
+    }
+}
+
+/// `theme` in `format`.
+#[must_use]
+pub fn render(theme: &Theme, format: Format) -> String {
+    match format {
+        Format::Openvtc => import::to_toml(theme),
+        Format::Base16 => base16(theme),
+        Format::Omarchy => omarchy(theme),
+        Format::Alacritty => alacritty(theme),
+        Format::Kitty => kitty(theme),
+    }
+}
+
+/// Write `theme` to `output` in `format`, and return the file written.
+///
+/// An Omarchy export to a path not ending in `.toml` makes a theme directory
+/// Omarchy can use: `colors.toml`, and `light.mode` for a light theme.
+///
+/// # Errors
+///
+/// A path that cannot be written.
+pub fn write(theme: &Theme, format: Format, output: &Path) -> Result<PathBuf> {
+    let file = if format == Format::Omarchy && output.extension().is_none_or(|e| e != "toml") {
+        fs::create_dir_all(output)
+            .with_context(|| format!("could not create {}", output.display()))?;
+        let light = output.join("light.mode");
+        match theme.mode {
+            Mode::Light => fs::write(&light, "")?,
+            Mode::Dark if light.exists() => fs::remove_file(&light)?,
+            Mode::Dark => {}
+        }
+        output.join("colors.toml")
+    } else {
+        if let Some(parent) = output.parent().filter(|p| !p.as_os_str().is_empty()) {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("could not create {}", parent.display()))?;
+        }
+        output.to_path_buf()
+    };
+    fs::write(&file, render(theme, format))
+        .with_context(|| format!("could not write {}", file.display()))?;
+    Ok(file)
+}
+
+/// A theme's colours, every one of them a definite colour.
+struct Solid {
+    name: String,
+    mode: Mode,
+    background: Rgb,
+    text: Rgb,
+    muted: Rgb,
+    accent: Rgb,
+    success: Rgb,
+    warning: Rgb,
+    danger: Rgb,
+    highlight: Rgb,
+}
+
+impl Solid {
+    fn of(theme: &Theme) -> Self {
+        let p = &theme.palette;
+        let (dark, light) = match theme.mode {
+            Mode::Dark => (BLACK, WHITE),
+            Mode::Light => (WHITE, BLACK),
+        };
+        let text = rgb(p.text).unwrap_or(light);
+        let solid = |color: Color| rgb(color).unwrap_or(text);
+        Solid {
+            // Names end up inside quotes and comments.
+            name: theme
+                .name
+                .chars()
+                .map(|c| match c {
+                    '"' | '\\' => '\'',
+                    c if c.is_control() => ' ',
+                    c => c,
+                })
+                .collect(),
+            mode: theme.mode,
+            background: p.background.and_then(rgb).unwrap_or(dark),
+            text,
+            muted: solid(p.muted),
+            accent: solid(p.accent),
+            success: solid(p.success),
+            warning: solid(p.warning),
+            danger: solid(p.danger),
+            highlight: solid(p.highlight),
+        }
+    }
+
+    /// From the background toward the text, by `t`.
+    fn shade(&self, t: f64) -> Rgb {
+        mix(self.background, self.text, t)
+    }
+
+    /// Past the text, further from the background, by `t`.
+    fn beyond_text(&self, t: f64) -> Rgb {
+        let far = match self.mode {
+            Mode::Dark => WHITE,
+            Mode::Light => BLACK,
+        };
+        mix(self.text, far, t)
+    }
+
+    fn cyan(&self) -> Rgb {
+        mix(self.accent, self.success, 0.5)
+    }
+
+    fn selection(&self) -> Rgb {
+        mix(self.background, self.accent, 0.3)
+    }
+
+    /// A colour's bright variant: a step toward the text.
+    fn bright(&self, color: Rgb) -> Rgb {
+        mix(color, self.text, 0.25)
+    }
+
+    /// The sixteen terminal colours, black to bright white.
+    fn ansi(&self) -> [Rgb; 16] {
+        let (black, white, bright_white) = match self.mode {
+            Mode::Dark => (self.shade(0.15), self.text, self.beyond_text(0.5)),
+            Mode::Light => (
+                self.text,
+                self.shade(0.15),
+                mix(self.background, WHITE, 0.5),
+            ),
+        };
+        let cyan = self.cyan();
+        [
+            black,
+            self.danger,
+            self.success,
+            self.warning,
+            self.accent,
+            self.highlight,
+            cyan,
+            white,
+            self.muted,
+            self.bright(self.danger),
+            self.bright(self.success),
+            self.bright(self.warning),
+            self.bright(self.accent),
+            self.bright(self.highlight),
+            self.bright(cyan),
+            bright_white,
+        ]
+    }
+
+    fn header(&self) -> String {
+        format!("# {}, exported from OpenVTC\n", self.name)
+    }
+}
+
+fn mix(from: Rgb, to: Rgb, t: f64) -> Rgb {
+    let channel = |a: u8, b: u8| {
+        (f64::from(a) + (f64::from(b) - f64::from(a)) * t)
+            .round()
+            .clamp(0.0, 255.0) as u8
+    };
+    (
+        channel(from.0, to.0),
+        channel(from.1, to.1),
+        channel(from.2, to.2),
+    )
+}
+
+fn hex((r, g, b): Rgb) -> String {
+    format!("#{r:02x}{g:02x}{b:02x}")
+}
+
+fn base16(theme: &Theme) -> String {
+    let c = Solid::of(theme);
+    let colours = [
+        c.background,
+        c.shade(0.08),
+        c.shade(0.16),
+        c.muted,
+        mix(c.muted, c.text, 0.5),
+        c.text,
+        c.beyond_text(0.35),
+        c.beyond_text(0.7),
+        c.danger,
+        c.warning,
+        c.warning,
+        c.success,
+        c.cyan(),
+        c.accent,
+        c.highlight,
+        mix(c.danger, c.warning, 0.5),
+    ];
+    let mut out = c.header();
+    out.push_str(&format!(
+        "system: \"base16\"\nname: \"{}\"\nauthor: \"OpenVTC\"\nvariant: \"{}\"\npalette:\n",
+        c.name,
+        c.mode.as_str()
+    ));
+    for (i, colour) in colours.iter().enumerate() {
+        out.push_str(&format!("  base{i:02X}: \"{}\"\n", hex(*colour)));
+    }
+    out
+}
+
+fn omarchy(theme: &Theme) -> String {
+    let c = Solid::of(theme);
+    let cyan = c.cyan();
+    let groups: [&[(&str, Rgb)]; 5] = [
+        &[
+            ("accent", c.accent),
+            ("selection", c.selection()),
+            ("muted", c.muted),
+        ],
+        &[
+            ("background", c.background),
+            ("dark_background", mix(c.background, BLACK, 0.25)),
+            ("darker_background", mix(c.background, BLACK, 0.45)),
+            ("lighter_background", mix(c.background, WHITE, 0.08)),
+        ],
+        &[
+            ("foreground", c.text),
+            ("dark_foreground", c.muted),
+            ("light_foreground", c.beyond_text(0.2)),
+            ("bright_foreground", c.beyond_text(0.4)),
+        ],
+        &[
+            ("red", c.danger),
+            ("yellow", c.warning),
+            ("orange", c.warning),
+            ("green", c.success),
+            ("cyan", cyan),
+            ("blue", c.accent),
+            ("magenta", c.highlight),
+            ("brown", mix(c.danger, c.background, 0.45)),
+        ],
+        &[
+            ("bright_red", c.bright(c.danger)),
+            ("bright_yellow", c.bright(c.warning)),
+            ("bright_green", c.bright(c.success)),
+            ("bright_cyan", c.bright(cyan)),
+            ("bright_blue", c.bright(c.accent)),
+            ("bright_magenta", c.bright(c.highlight)),
+        ],
+    ];
+    let mut out = c.header();
+    out.push_str(&format!("mode = \"{}\"\n", c.mode.as_str()));
+    for group in groups {
+        out.push('\n');
+        for (key, colour) in group {
+            out.push_str(&format!("{key} = \"{}\"\n", hex(*colour)));
+        }
+    }
+    out
+}
+
+const ANSI_NAMES: [&str; 8] = [
+    "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+];
+
+fn alacritty(theme: &Theme) -> String {
+    let c = Solid::of(theme);
+    let ansi = c.ansi();
+    let mut out = c.header();
+    out.push_str(&format!(
+        "\n[colors.primary]\nbackground = \"{}\"\nforeground = \"{}\"\n\
+         \n[colors.cursor]\ntext = \"{}\"\ncursor = \"{}\"\n\
+         \n[colors.selection]\ntext = \"{}\"\nbackground = \"{}\"\n",
+        hex(c.background),
+        hex(c.text),
+        hex(c.background),
+        hex(c.accent),
+        hex(c.text),
+        hex(c.selection()),
+    ));
+    for (table, colours) in [("normal", &ansi[..8]), ("bright", &ansi[8..])] {
+        out.push_str(&format!("\n[colors.{table}]\n"));
+        for (name, colour) in ANSI_NAMES.iter().zip(colours) {
+            out.push_str(&format!("{name} = \"{}\"\n", hex(*colour)));
+        }
+    }
+    out
+}
+
+fn kitty(theme: &Theme) -> String {
+    let c = Solid::of(theme);
+    let mut out = c.header();
+    for (key, colour) in [
+        ("foreground", c.text),
+        ("background", c.background),
+        ("selection_foreground", c.text),
+        ("selection_background", c.selection()),
+        ("cursor", c.accent),
+        ("cursor_text_color", c.background),
+        ("url_color", c.accent),
+        ("active_border_color", c.accent),
+        ("inactive_border_color", c.muted),
+    ] {
+        out.push_str(&format!("{key} {}\n", hex(colour)));
+    }
+    for (n, colour) in c.ansi().iter().enumerate() {
+        out.push_str(&format!("color{n} {}\n", hex(*colour)));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::builtin;
+
+    fn same(exported: &Theme, back: &Theme, format: &str) {
+        assert_eq!(
+            back.palette, exported.palette,
+            "{} through {format}",
+            exported.id
+        );
+        assert_eq!(back.mode, exported.mode, "{} through {format}", exported.id);
+    }
+
+    /// Every built-in theme written out in every format imports as itself.
+    #[test]
+    fn every_format_reads_back_as_the_same_theme() {
+        for theme in builtin::all()
+            .into_iter()
+            .filter(|t| t.palette.background.is_some())
+        {
+            let back = import::from_toml(&render(&theme, Format::Openvtc), "x").unwrap();
+            same(&theme, &back, "openvtc");
+            assert_eq!(back.name, theme.name);
+
+            let back = import::from_base16(&render(&theme, Format::Base16), "x").unwrap();
+            same(&theme, &back, "base16");
+            assert_eq!(back.name, theme.name);
+
+            let text = render(&theme, Format::Omarchy);
+            same(
+                &theme,
+                &import::from_omarchy_colors(&text, "x", None).unwrap(),
+                "omarchy",
+            );
+            let text = render(&theme, Format::Alacritty);
+            same(
+                &theme,
+                &import::from_alacritty(&text, "x", None).unwrap(),
+                "alacritty",
+            );
+            let text = render(&theme, Format::Kitty);
+            same(
+                &theme,
+                &import::from_kitty(&text, "x", None).unwrap(),
+                "kitty",
+            );
+        }
+    }
+
+    /// Written to disk, each export is recognised by what it is, and an
+    /// Omarchy export is a theme directory Omarchy — and OpenVTC — can read.
+    #[test]
+    fn exports_written_to_disk_are_recognised() {
+        let dir = std::env::temp_dir().join(format!("openvtc-export-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let latte = builtin::find("catppuccin-latte").unwrap();
+        for (format, name) in [
+            (Format::Openvtc, "latte.toml"),
+            (Format::Base16, "latte.yaml"),
+            (Format::Alacritty, "alacritty.toml"),
+            (Format::Kitty, "latte.conf"),
+            (Format::Omarchy, "latte-export"),
+        ] {
+            let file = write(&latte, format, &dir.join(name)).unwrap();
+            let back = import::from_path(&dir.join(name)).unwrap();
+            same(&latte, &back, name);
+            assert!(file.is_file());
+        }
+        let omarchy = dir.join("latte-export");
+        assert!(omarchy.join("colors.toml").is_file());
+        assert!(omarchy.join("light.mode").is_file());
+        assert_eq!(import::from_path(&omarchy).unwrap().name, "Latte Export");
+
+        // Exporting a dark theme over it leaves no light.mode behind.
+        let nord = builtin::find("nord").unwrap();
+        write(&nord, Format::Omarchy, &omarchy).unwrap();
+        assert!(!omarchy.join("light.mode").exists());
+        assert_eq!(import::from_path(&omarchy).unwrap().mode, Mode::Dark);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// OpenVTC's own theme names terminal colours and has no background; it is
+    /// exported in the colours xterm draws, on black.
+    #[test]
+    fn a_theme_on_the_terminals_background_exports_on_black() {
+        let theme = Theme::default_theme();
+        let back = import::from_base16(&render(&theme, Format::Base16), "x").unwrap();
+        assert_eq!(back.palette.background, Some(Color::Rgb(0, 0, 0)));
+        assert_eq!(back.palette.text, Color::Rgb(255, 255, 255));
+        assert_eq!(back.palette.accent, theme.palette.accent);
+    }
+
+    #[test]
+    fn format_names_parse() {
+        for name in Format::NAMES {
+            assert!(Format::parse(name).is_some(), "{name}");
+        }
+        assert_eq!(Format::parse("vim"), None);
+    }
+}

--- a/openvtc/src/theme/import.rs
+++ b/openvtc/src/theme/import.rs
@@ -120,7 +120,7 @@ impl Roles {
         if self.is_empty() {
             bail!("no colours found");
         }
-        let mode = mode.unwrap_or_else(|| mode_of(self.background));
+        let mode = mode.unwrap_or_else(|| Mode::of_background(self.background));
         let default = Palette::DEFAULT;
         // Text a theme did not set must still be readable on the background it did.
         let text = self.text.unwrap_or(match (self.background, mode) {
@@ -142,18 +142,6 @@ impl Roles {
                 background: self.background,
             },
         })
-    }
-}
-
-/// Light when the background is.
-fn mode_of(background: Option<Color>) -> Mode {
-    match background {
-        Some(Color::Rgb(r, g, b))
-            if 0.2126 * f64::from(r) + 0.7152 * f64::from(g) + 0.0722 * f64::from(b) > 140.0 =>
-        {
-            Mode::Light
-        }
-        _ => Mode::Dark,
     }
 }
 

--- a/openvtc/src/theme/live.rs
+++ b/openvtc/src/theme/live.rs
@@ -1,0 +1,302 @@
+//! Following theme changes while the TUI runs.
+//!
+//! A theme can change under a running TUI in two ways: another theme is chosen
+//! (`openvtc theme set` in another terminal rewrites `tui.toml`), or the theme
+//! in use changes where it is read from (a theme file is edited, Omarchy
+//! switches its current theme, an Omarchy theme's colours are edited).
+//!
+//! [`Watcher::check`] looks for both by comparing modification times, sizes and
+//! link targets of a handful of files — cheap enough to do every second, and
+//! the same on every platform, without a file-watching dependency. It changes
+//! nothing itself: the UI loop runs it off the render thread and decides
+//! whether to take what it found, so a theme being previewed in the picker is
+//! never replaced from under the person previewing it.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use super::catalog::{self, AUTO_ID, Choice, Roots};
+use super::{Theme, terminal};
+
+/// How often the UI loop checks.
+pub const POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// What a file looked like when last checked.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Stamp {
+    path: PathBuf,
+    modified: Option<SystemTime>,
+    len: Option<u64>,
+    /// Where it links to, when it is a link.
+    target: Option<PathBuf>,
+}
+
+impl Stamp {
+    fn of(path: &Path) -> Self {
+        let metadata = fs::metadata(path).ok();
+        Stamp {
+            path: path.to_path_buf(),
+            modified: metadata.as_ref().and_then(|m| m.modified().ok()),
+            len: metadata.map(|m| m.len()),
+            target: fs::read_link(path).ok(),
+        }
+    }
+}
+
+/// Follows the theme in use and `tui.toml` for changes.
+#[derive(Clone, Debug)]
+pub struct Watcher {
+    roots: Roots,
+    settings: Option<Stamp>,
+    choice: Choice,
+    /// The id of the theme being drawn with, which may not be `tui.toml`'s
+    /// choice: `OPENVTC_THEME` can choose another for the session.
+    following: String,
+    sources: Vec<Stamp>,
+}
+
+/// What [`Watcher::check`] found: the watcher as it would be once it has seen
+/// the change, and the theme to draw with, if that changed.
+#[derive(Debug)]
+pub struct Update {
+    watcher: Watcher,
+    theme: Option<Theme>,
+}
+
+impl Watcher {
+    /// Follow the theme `following`, the one being drawn with now.
+    #[must_use]
+    pub fn new(roots: Roots, following: &str) -> Self {
+        let mut watcher = Watcher {
+            settings: roots.settings_file().map(|p| Stamp::of(&p)),
+            choice: catalog::choice(&roots),
+            following: following.to_string(),
+            sources: Vec::new(),
+            roots,
+        };
+        watcher.sources = watcher.stamp_sources();
+        watcher
+    }
+
+    /// The files the followed theme is read from, as they are now.
+    fn stamp_sources(&self) -> Vec<Stamp> {
+        let id = if self.following == AUTO_ID {
+            self.choice.for_mode(terminal::mode().0)
+        } else {
+            &self.following
+        };
+        catalog::sources(&self.roots, id)
+            .iter()
+            .map(|path| Stamp::of(path))
+            .collect()
+    }
+
+    /// Look for a change since this watcher last saw one. `None` when nothing
+    /// has changed. Touches the file system, so keep it off the render thread.
+    #[must_use]
+    pub fn check(&self) -> Option<Update> {
+        let mut next = self.clone();
+        let mut reload = false;
+        next.settings = self.roots.settings_file().map(|p| Stamp::of(&p));
+        if next.settings != self.settings
+            && let Some(choice) = catalog::read_choice(&self.roots)
+        {
+            if choice.theme != self.choice.theme {
+                // A theme chosen while the TUI runs — here or with `openvtc
+                // theme set` — replaces the one in use, even one
+                // OPENVTC_THEME chose for the session.
+                next.following.clone_from(&choice.theme);
+                reload = true;
+            } else if choice != self.choice && self.following == AUTO_ID {
+                reload = true;
+            }
+            next.choice = choice;
+        }
+        next.sources = next.stamp_sources();
+        reload |= next.sources != self.sources;
+
+        if !reload {
+            return (next.settings != self.settings).then_some(Update {
+                watcher: next,
+                theme: None,
+            });
+        }
+        let theme = match catalog::load(&self.roots, &next.following) {
+            Ok(theme) => Some(theme),
+            Err(e) => {
+                // Most likely a file caught mid-edit; the next save is checked again.
+                tracing::warn!(theme = %next.following, error = %e, "changed theme could not be loaded; keeping the one in use");
+                None
+            }
+        };
+        Some(Update {
+            watcher: next,
+            theme,
+        })
+    }
+
+    /// Take `update` as seen. Returns the theme to draw with now, if it changed.
+    pub fn accept(&mut self, update: Update) -> Option<Theme> {
+        *self = update.watcher;
+        update.theme
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::Color;
+
+    fn roots(tag: &str) -> (PathBuf, Roots) {
+        let base = std::env::temp_dir().join(format!("openvtc-live-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(base.join("config/themes")).unwrap();
+        let roots = Roots {
+            config: Some(base.join("config")),
+            home: Some(base.join("home")),
+            system_omarchy: None,
+        };
+        (base, roots)
+    }
+
+    fn omarchy_theme(roots: &Roots, name: &str, background: &str) -> PathBuf {
+        let dir = roots
+            .home
+            .as_ref()
+            .unwrap()
+            .join(".config/omarchy/themes")
+            .join(name);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("colors.toml"),
+            format!("background = \"{background}\"\nforeground = \"#dddddd\"\n"),
+        )
+        .unwrap();
+        dir
+    }
+
+    /// Run a check and take what it found, as the UI loop does.
+    fn step(watcher: &mut Watcher) -> Option<Option<Theme>> {
+        let update = watcher.check()?;
+        Some(watcher.accept(update))
+    }
+
+    #[test]
+    fn an_edited_theme_file_is_redrawn() {
+        let (base, roots) = roots("edit");
+        let file = roots.themes_dir().unwrap().join("mine.toml");
+        fs::write(&file, "[colors]\naccent = \"#ff0000\"\n").unwrap();
+        let mut watcher = Watcher::new(roots, "user/mine");
+        assert!(watcher.check().is_none(), "nothing has changed");
+
+        fs::write(
+            &file,
+            "[colors]\naccent = \"#00ff00\"\ntext = \"#ffffff\"\n",
+        )
+        .unwrap();
+        let theme = step(&mut watcher).flatten().expect("the edit is drawn");
+        assert_eq!(theme.id, "user/mine");
+        assert_eq!(theme.palette.accent, Color::Rgb(0, 255, 0));
+        assert!(watcher.check().is_none(), "and seen once");
+
+        // A file caught half-written keeps the theme in use, and is seen
+        // again when it is saved whole.
+        fs::write(&file, "[colors]\naccent = \"#00").unwrap();
+        assert_eq!(step(&mut watcher), Some(None));
+        fs::write(&file, "[colors]\naccent = \"#0000ff\"\n").unwrap();
+        let theme = step(&mut watcher).flatten().unwrap();
+        assert_eq!(theme.palette.accent, Color::Rgb(0, 0, 255));
+        let _ = fs::remove_dir_all(base);
+    }
+
+    /// A theme chosen elsewhere replaces the one in use, even one chosen for
+    /// the session; other changes to `tui.toml` redraw nothing.
+    #[test]
+    fn a_theme_chosen_elsewhere_is_drawn() {
+        let (base, roots) = roots("chosen");
+        catalog::remember(&roots, "nord").unwrap();
+        // As if OPENVTC_THEME=dracula.
+        let mut watcher = Watcher::new(roots.clone(), "dracula");
+        assert!(watcher.check().is_none());
+
+        let settings = roots.settings_file().unwrap();
+        fs::write(&settings, "theme = \"nord\"\nsomething_else = \"x\"\n").unwrap();
+        assert_eq!(
+            step(&mut watcher),
+            Some(None),
+            "still nord: nothing to draw"
+        );
+
+        catalog::remember(&roots, "gruvbox-dark").unwrap();
+        let theme = step(&mut watcher).flatten().expect("the new choice");
+        assert_eq!(theme.id, "gruvbox-dark");
+        assert!(watcher.check().is_none());
+        let _ = fs::remove_dir_all(base);
+    }
+
+    /// Under `auto`, changing the theme it picks for this terminal redraws.
+    #[test]
+    fn auto_follows_its_own_themes() {
+        let (base, roots) = roots("auto");
+        catalog::remember_auto(&roots, Some("nord"), Some("nord")).unwrap();
+        let mut watcher = Watcher::new(roots.clone(), AUTO_ID);
+        catalog::remember_auto(&roots, Some("dracula"), Some("dracula")).unwrap();
+        let theme = step(&mut watcher).flatten().expect("auto's theme changed");
+        assert_eq!(theme.id, AUTO_ID);
+        assert_eq!(theme.name, "Dracula");
+        let _ = fs::remove_dir_all(base);
+    }
+
+    /// Omarchy switching its current theme, and an edit to the current theme's
+    /// colours, are both followed.
+    #[test]
+    fn omarchy_switching_themes_is_followed() {
+        let (base, roots) = roots("omarchy");
+        omarchy_theme(&roots, "one", "#111111");
+        let two = omarchy_theme(&roots, "two", "#222222");
+        let state = roots
+            .home
+            .as_ref()
+            .unwrap()
+            .join(".local/state/omarchy/current");
+        fs::create_dir_all(&state).unwrap();
+        fs::write(state.join("theme.name"), "one\n").unwrap();
+        let mut watcher = Watcher::new(roots, "omarchy/current");
+        assert!(watcher.check().is_none());
+
+        fs::write(state.join("theme.name"), "two\n").unwrap();
+        let theme = step(&mut watcher).flatten().expect("the switch");
+        assert_eq!(theme.id, "omarchy/current");
+        assert_eq!(theme.palette.background, Some(Color::Rgb(0x22, 0x22, 0x22)));
+
+        fs::write(
+            two.join("colors.toml"),
+            "background = \"#333333\"\nforeground = \"#eeeeee\"\n",
+        )
+        .unwrap();
+        let theme = step(&mut watcher).flatten().expect("the edit");
+        assert_eq!(theme.palette.background, Some(Color::Rgb(0x33, 0x33, 0x33)));
+        let _ = fs::remove_dir_all(base);
+    }
+
+    /// Earlier Omarchy releases switch by repointing a link.
+    #[cfg(unix)]
+    #[test]
+    fn the_older_omarchy_link_is_followed() {
+        let (base, roots) = roots("link");
+        let one = omarchy_theme(&roots, "one", "#111111");
+        let two = omarchy_theme(&roots, "two", "#222222");
+        let current = roots.home.as_ref().unwrap().join(".config/omarchy/current");
+        fs::create_dir_all(&current).unwrap();
+        std::os::unix::fs::symlink(&one, current.join("theme")).unwrap();
+        let mut watcher = Watcher::new(roots, "omarchy/current");
+        assert!(watcher.check().is_none());
+
+        fs::remove_file(current.join("theme")).unwrap();
+        std::os::unix::fs::symlink(&two, current.join("theme")).unwrap();
+        let theme = step(&mut watcher).flatten().expect("the new link");
+        assert_eq!(theme.palette.background, Some(Color::Rgb(0x22, 0x22, 0x22)));
+        let _ = fs::remove_dir_all(base);
+    }
+}

--- a/openvtc/src/theme/mod.rs
+++ b/openvtc/src/theme/mod.rs
@@ -13,29 +13,43 @@
 //! written today is themed without knowing themes exist.
 //!
 //! Where themes come from:
-//! - [`builtin`] — a handful of well-known open palettes, plus OpenVTC's own;
+//! - [`builtin`] — a handful of well-known open palettes, OpenVTC's own, and
+//!   high-contrast and colourblind-safe ones;
 //! - the user's themes directory — OpenVTC theme files, written by hand, copied
 //!   from another theme, or produced by [`import`];
 //! - Omarchy's themes, read in place, including whichever is current;
 //! - [`import`] converts base16/base24 schemes, Omarchy themes, Alacritty and
 //!   Kitty colour files, and [`nvim`] reads any colorscheme Neovim can load.
 //!
-//! [`catalog`] lists and loads all of them, and remembers the one chosen.
+//! [`catalog`] lists and loads all of them, remembers the one chosen, and
+//! resolves `auto` with what [`terminal`] learns of the terminal's background.
+//! [`live`] notices a theme changing while the TUI runs, and [`export`] writes a
+//! theme out for other tools.
+//!
+//! With `NO_COLOR` set, [`paint`] draws in the terminal's own colours and keeps
+//! the roles apart with bold, underline and the like instead.
 
 pub mod builtin;
 pub mod catalog;
+pub mod export;
 pub mod import;
+pub mod live;
 pub mod nvim;
+pub mod terminal;
 
-use std::sync::{PoisonError, RwLock};
+use std::sync::{OnceLock, PoisonError, RwLock};
 
 use ratatui::buffer::Buffer;
-use ratatui::style::Color;
+use ratatui::style::{Color, Modifier};
 
 use crate::colors::{
-    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
-    COLOR_TEXT_DEFAULT, COLOR_WARNING_ACCESSIBLE_RED,
+    CLI_CAUTION, COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
+    COLOR_TEXT_DEFAULT, COLOR_WARNING_ACCESSIBLE_RED, Themed,
 };
+use catalog::Roots;
+
+/// Environment variable that chooses a theme for one session, over `tui.toml`.
+pub const OVERRIDE_ENV: &str = "OPENVTC_THEME";
 
 /// Whether a theme is meant for a dark or a light background.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -62,6 +76,65 @@ impl Mode {
             Mode::Light
         } else {
             Mode::Dark
+        }
+    }
+
+    /// Light when `background` is; dark when it is dark or unknown.
+    #[must_use]
+    pub fn of_background(background: Option<Color>) -> Self {
+        match background.and_then(rgb) {
+            Some((r, g, b))
+                if 0.2126 * f64::from(r) + 0.7152 * f64::from(g) + 0.0722 * f64::from(b)
+                    > 140.0 =>
+            {
+                Mode::Light
+            }
+            _ => Mode::Dark,
+        }
+    }
+}
+
+/// One of the seven colour roles panels draw with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Role {
+    Accent,
+    Success,
+    Warning,
+    Danger,
+    Text,
+    Muted,
+    Highlight,
+}
+
+impl Role {
+    /// The role OpenVTC's own colour `color` stands for, if it stands for one.
+    #[must_use]
+    fn of(color: Color) -> Option<Role> {
+        [
+            (COLOR_BORDER, Role::Accent),
+            (COLOR_SUCCESS, Role::Success),
+            (COLOR_ORANGE, Role::Warning),
+            (COLOR_WARNING_ACCESSIBLE_RED, Role::Danger),
+            (COLOR_TEXT_DEFAULT, Role::Text),
+            (COLOR_DARK_GRAY, Role::Muted),
+            (COLOR_SOFT_PURPLE, Role::Highlight),
+        ]
+        .into_iter()
+        .find_map(|(own, role)| (own == color).then_some(role))
+    }
+
+    /// How the role stands apart when drawn without colour. Success is what
+    /// selected rows are drawn in, so it is reversed, as a selection bar.
+    #[must_use]
+    fn without_colour(self) -> Modifier {
+        match self {
+            Role::Accent => Modifier::BOLD,
+            Role::Success => Modifier::REVERSED,
+            Role::Warning => Modifier::UNDERLINED,
+            Role::Danger => Modifier::BOLD | Modifier::UNDERLINED,
+            Role::Text => Modifier::empty(),
+            Role::Muted => Modifier::DIM,
+            Role::Highlight => Modifier::ITALIC,
         }
     }
 }
@@ -100,26 +173,24 @@ impl Palette {
         background: None,
     };
 
+    /// The colour `role` is drawn in.
+    #[must_use]
+    pub fn get(&self, role: Role) -> Color {
+        match role {
+            Role::Accent => self.accent,
+            Role::Success => self.success,
+            Role::Warning => self.warning,
+            Role::Danger => self.danger,
+            Role::Text => self.text,
+            Role::Muted => self.muted,
+            Role::Highlight => self.highlight,
+        }
+    }
+
     /// The colour role `color` stands for, or `color` itself when it is not a role.
     #[must_use]
     fn role(&self, color: Color) -> Color {
-        if color == COLOR_BORDER {
-            self.accent
-        } else if color == COLOR_SUCCESS {
-            self.success
-        } else if color == COLOR_ORANGE {
-            self.warning
-        } else if color == COLOR_WARNING_ACCESSIBLE_RED {
-            self.danger
-        } else if color == COLOR_TEXT_DEFAULT {
-            self.text
-        } else if color == COLOR_DARK_GRAY {
-            self.muted
-        } else if color == COLOR_SOFT_PURPLE {
-            self.highlight
-        } else {
-            color
-        }
+        Role::of(color).map_or(color, |role| self.get(role))
     }
 }
 
@@ -127,7 +198,7 @@ impl Palette {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Theme {
     /// How [`catalog`] finds it again: `catppuccin-mocha`, `user/mine`,
-    /// `omarchy/tokyo-night`, `omarchy/current`.
+    /// `omarchy/tokyo-night`, `omarchy/current`, `auto`.
     pub id: String,
     pub name: String,
     pub mode: Mode,
@@ -145,6 +216,100 @@ impl Theme {
             palette: Palette::DEFAULT,
         }
     }
+}
+
+/// The red, green and blue `color` is drawn in, taking named and indexed
+/// colours as xterm draws them by default. `None` for `Reset`, which is
+/// whatever the terminal's own colour is.
+#[must_use]
+pub fn rgb(color: Color) -> Option<(u8, u8, u8)> {
+    const ANSI: [(u8, u8, u8); 16] = [
+        (0, 0, 0),
+        (205, 0, 0),
+        (0, 205, 0),
+        (205, 205, 0),
+        (0, 0, 238),
+        (205, 0, 205),
+        (0, 205, 205),
+        (229, 229, 229),
+        (127, 127, 127),
+        (255, 0, 0),
+        (0, 255, 0),
+        (255, 255, 0),
+        (92, 92, 255),
+        (255, 0, 255),
+        (0, 255, 255),
+        (255, 255, 255),
+    ];
+    let index = match color {
+        Color::Reset => return None,
+        Color::Rgb(r, g, b) => return Some((r, g, b)),
+        Color::Indexed(n) => n,
+        named => ansi_index(named)?,
+    };
+    Some(match index {
+        0..=15 => ANSI[usize::from(index)],
+        16..=231 => {
+            let n = index - 16;
+            let level = |v: u8| if v == 0 { 0 } else { 55 + v * 40 };
+            (level(n / 36), level(n / 6 % 6), level(n % 6))
+        }
+        _ => {
+            let grey = 8 + (index - 232) * 10;
+            (grey, grey, grey)
+        }
+    })
+}
+
+/// The ANSI colour number (0–15) of a named colour.
+#[must_use]
+pub fn ansi_index(color: Color) -> Option<u8> {
+    Some(match color {
+        Color::Black => 0,
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Yellow => 3,
+        Color::Blue => 4,
+        Color::Magenta => 5,
+        Color::Cyan => 6,
+        Color::Gray => 7,
+        Color::DarkGray => 8,
+        Color::LightRed => 9,
+        Color::LightGreen => 10,
+        Color::LightYellow => 11,
+        Color::LightBlue => 12,
+        Color::LightMagenta => 13,
+        Color::LightCyan => 14,
+        Color::White => 15,
+        _ => return None,
+    })
+}
+
+/// The WCAG contrast ratio of two colours: 1 for none, 21 for black on white.
+/// Body text wants at least 4.5.
+#[must_use]
+pub fn contrast(a: (u8, u8, u8), b: (u8, u8, u8)) -> f64 {
+    fn luminance((r, g, b): (u8, u8, u8)) -> f64 {
+        let channel = |c: u8| {
+            let c = f64::from(c) / 255.0;
+            if c <= 0.040_45 {
+                c / 12.92
+            } else {
+                ((c + 0.055) / 1.055).powf(2.4)
+            }
+        };
+        0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+    }
+    let (a, b) = (luminance(a), luminance(b));
+    (a.max(b) + 0.05) / (a.min(b) + 0.05)
+}
+
+/// Whether to draw without colour: `NO_COLOR` is set and not empty
+/// (<https://no-color.org>). Read once; it cannot change under a running TUI.
+#[must_use]
+pub fn no_color() -> bool {
+    static NO_COLOR: OnceLock<bool> = OnceLock::new();
+    *NO_COLOR.get_or_init(|| std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()))
 }
 
 /// The theme being drawn with, as a name and a palette.
@@ -188,9 +353,82 @@ pub fn active_theme() -> (String, String) {
         )
 }
 
+/// How a theme is named on screen: `auto` shows the theme it picked.
+#[must_use]
+pub fn display_name(id: &str, name: &str) -> String {
+    if id == catalog::AUTO_ID {
+        format!("Auto — {name}")
+    } else {
+        name.to_string()
+    }
+}
+
+/// Choose this process's theme, before anything is printed: the one
+/// `OPENVTC_THEME` names, else the one chosen in `tui.toml`, else OpenVTC's
+/// own. Returns the id of the theme in use, for [`live::Watcher`] to follow.
+///
+/// Under `auto` this asks the terminal for its background, so it must run
+/// before the TUI takes the terminal over.
+pub fn init(roots: &Roots) -> String {
+    if no_color() {
+        // Prompts and messages printed through `console` and `dialoguer` too.
+        console::set_colors_enabled(false);
+        console::set_colors_enabled_stderr(false);
+    }
+    let chosen = catalog::choice(roots).theme;
+    let requested = std::env::var(OVERRIDE_ENV)
+        .ok()
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty());
+    if let Some(id) = requested {
+        match load_for_session(roots, &id) {
+            Ok(theme) => {
+                set_active(&theme);
+                return theme.id;
+            }
+            Err(e) => {
+                let theme = load_or_default(roots, &chosen);
+                set_active(&theme);
+                eprintln!(
+                    "{}",
+                    console::style(format!(
+                        "{OVERRIDE_ENV}={id} was ignored ({e:#}); using {}.",
+                        display_name(&theme.id, &theme.name)
+                    ))
+                    .themed(CLI_CAUTION)
+                );
+                return theme.id;
+            }
+        }
+    }
+    let theme = load_or_default(roots, &chosen);
+    set_active(&theme);
+    theme.id
+}
+
+/// Load `id`, asking the terminal for its background first when `id` is `auto`.
+fn load_for_session(roots: &Roots, id: &str) -> anyhow::Result<Theme> {
+    if id == catalog::AUTO_ID && !no_color() {
+        terminal::detect();
+    }
+    catalog::load(roots, id)
+}
+
+/// Theme `id`, or OpenVTC's own when it cannot be loaded.
+fn load_or_default(roots: &Roots, id: &str) -> Theme {
+    load_for_session(roots, id).unwrap_or_else(|e| {
+        tracing::warn!(theme = %id, error = %e, "chosen theme could not be loaded; using the default");
+        Theme::default_theme()
+    })
+}
+
 /// Theme a finished frame: call at the end of every `Terminal::draw`.
 pub fn paint(buffer: &mut Buffer) {
-    paint_with(buffer, &active_palette());
+    if no_color() {
+        paint_without_colour(buffer);
+    } else {
+        paint_with(buffer, &active_palette());
+    }
 }
 
 /// [`paint`] with an explicit palette.
@@ -211,6 +449,22 @@ pub fn paint_with(buffer: &mut Buffer, palette: &Palette) {
             (Color::Reset, Some(background)) => background,
             (color, _) => palette.role(color),
         };
+    }
+}
+
+/// [`paint`] for `NO_COLOR`: every colour becomes the terminal's own, and each
+/// role keeps a modifier of its own so it still reads as that role. A role used
+/// as a background marks a selection, so it is reversed.
+pub fn paint_without_colour(buffer: &mut Buffer) {
+    for cell in &mut buffer.content {
+        if let Some(role) = Role::of(cell.fg) {
+            cell.modifier |= role.without_colour();
+        }
+        if Role::of(cell.bg).is_some() {
+            cell.modifier |= Modifier::REVERSED;
+        }
+        cell.fg = Color::Reset;
+        cell.bg = Color::Reset;
     }
 }
 
@@ -277,5 +531,72 @@ mod tests {
         let before = buffer.clone();
         paint_with(&mut buffer, &Palette::DEFAULT);
         assert_eq!(buffer, before);
+    }
+
+    /// Without colour, nothing is coloured, and the roles stay apart.
+    #[test]
+    fn without_colour_roles_are_told_apart_by_modifiers() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 6, 1));
+        buffer.set_string(0, 0, "a", Style::new().fg(COLOR_BORDER));
+        buffer.set_string(1, 0, "d", Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED));
+        buffer.set_string(2, 0, "m", Style::new().fg(COLOR_DARK_GRAY));
+        buffer.set_string(
+            3,
+            0,
+            "s",
+            Style::new().fg(COLOR_TEXT_DEFAULT).bg(COLOR_BORDER),
+        );
+        buffer.set_string(4, 0, "x", Style::new().fg(Color::Rgb(1, 2, 3)).bold());
+        paint_without_colour(&mut buffer);
+
+        for x in 0..6 {
+            assert_eq!(buffer[(x, 0)].fg, Color::Reset);
+            assert_eq!(buffer[(x, 0)].bg, Color::Reset);
+        }
+        assert_eq!(buffer[(0, 0)].modifier, Modifier::BOLD);
+        assert_eq!(
+            buffer[(1, 0)].modifier,
+            Modifier::BOLD | Modifier::UNDERLINED
+        );
+        assert_eq!(buffer[(2, 0)].modifier, Modifier::DIM);
+        assert_eq!(buffer[(3, 0)].modifier, Modifier::REVERSED, "a selection");
+        assert_eq!(
+            buffer[(4, 0)].modifier,
+            Modifier::BOLD,
+            "a panel's own modifiers stay"
+        );
+        assert_eq!(buffer[(5, 0)].modifier, Modifier::empty());
+    }
+
+    #[test]
+    fn named_and_indexed_colours_have_rgb() {
+        assert_eq!(rgb(Color::White), Some((255, 255, 255)));
+        assert_eq!(rgb(Color::Indexed(16)), Some((0, 0, 0)));
+        assert_eq!(rgb(Color::Indexed(69)), Some((95, 135, 255)));
+        assert_eq!(rgb(Color::Indexed(244)), Some((128, 128, 128)));
+        assert_eq!(rgb(Color::Reset), None);
+    }
+
+    /// The figures WCAG publishes.
+    #[test]
+    fn contrast_is_measured_as_wcag_does() {
+        assert!((contrast((0, 0, 0), (255, 255, 255)) - 21.0).abs() < 1e-9);
+        assert!((contrast((255, 255, 255), (255, 255, 255)) - 1.0).abs() < 1e-9);
+        let grey = contrast((0x76, 0x76, 0x76), (255, 255, 255));
+        assert!((4.5..4.6).contains(&grey), "#767676 on white is 4.54:1");
+    }
+
+    #[test]
+    fn a_background_sets_the_mode() {
+        assert_eq!(
+            Mode::of_background(Some(Color::Rgb(0xef, 0xf1, 0xf5))),
+            Mode::Light
+        );
+        assert_eq!(
+            Mode::of_background(Some(Color::Rgb(0x1a, 0x1b, 0x26))),
+            Mode::Dark
+        );
+        assert_eq!(Mode::of_background(Some(Color::White)), Mode::Light);
+        assert_eq!(Mode::of_background(None), Mode::Dark);
     }
 }

--- a/openvtc/src/theme/terminal.rs
+++ b/openvtc/src/theme/terminal.rs
@@ -1,0 +1,236 @@
+//! What OpenVTC learns about the terminal: whether its background is dark or
+//! light, for the `auto` theme, and whether it draws 24-bit colour.
+//!
+//! The background is asked for with OSC 11, which most terminals answer with
+//! their background colour. The answer arrives as input, so the question is put
+//! once, before the TUI starts reading keys; after that the answer is only
+//! looked up. A terminal that does not answer is judged by `COLORFGBG`, and
+//! failing that taken to be dark.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use ratatui::style::Color;
+
+use super::Mode;
+
+/// How long to wait for the terminal's answer. Most answer within milliseconds,
+/// and a device-attributes query sent straight after the background query ends
+/// the wait as soon as the terminal has answered that — so only a terminal that
+/// answers neither waits this long. Long enough not to leave a slow SSH link's
+/// late answer to be read as typing.
+#[cfg_attr(not(unix), allow(dead_code))]
+const QUERY_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Background colour query (OSC 11), then primary device attributes (DA1),
+/// which virtually every terminal answers.
+#[cfg_attr(not(unix), allow(dead_code))]
+const QUERY: &[u8] = b"\x1b]11;?\x07\x1b[c";
+
+/// How the terminal's background was learned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Source {
+    /// The terminal said.
+    Asked,
+    /// `COLORFGBG` said.
+    ColorFgBg,
+    /// Nothing said; dark was assumed.
+    Assumed,
+}
+
+static DETECTED: OnceLock<(Mode, Source)> = OnceLock::new();
+
+/// Ask the terminal for its background, once per process, and remember the
+/// answer. Only call this before the TUI takes the terminal over: the answer
+/// arrives as input, which the TUI would read as keys.
+pub fn detect() -> (Mode, Source) {
+    *DETECTED.get_or_init(|| match query_background(QUERY_TIMEOUT) {
+        Some(rgb) => (
+            Mode::of_background(Some(Color::Rgb(rgb.0, rgb.1, rgb.2))),
+            Source::Asked,
+        ),
+        None => fallback(),
+    })
+}
+
+/// The terminal's background as [`detect`] found it, or — when it was never
+/// asked — as `COLORFGBG` suggests, else dark. Never asks the terminal.
+#[must_use]
+pub fn mode() -> (Mode, Source) {
+    DETECTED.get().copied().unwrap_or_else(fallback)
+}
+
+fn fallback() -> (Mode, Source) {
+    std::env::var("COLORFGBG")
+        .ok()
+        .and_then(|value| mode_from_colorfgbg(&value))
+        .map_or((Mode::Dark, Source::Assumed), |mode| {
+            (mode, Source::ColorFgBg)
+        })
+}
+
+/// `COLORFGBG` is `fg;bg`, or `fg;default;bg`, in ANSI colour numbers. By
+/// rxvt's convention, which the terminals that set it follow, a background of
+/// 7 or 9–15 is light.
+fn mode_from_colorfgbg(value: &str) -> Option<Mode> {
+    let background: u8 = value.rsplit(';').next()?.trim().parse().ok()?;
+    Some(if background == 7 || (9..=15).contains(&background) {
+        Mode::Light
+    } else {
+        Mode::Dark
+    })
+}
+
+/// Whether the terminal draws 24-bit colour, as `COLORTERM` declares.
+#[must_use]
+pub fn truecolor() -> bool {
+    std::env::var("COLORTERM").is_ok_and(|v| v == "truecolor" || v == "24bit")
+}
+
+/// Ask the terminal on `/dev/tty` for its background colour.
+#[cfg(unix)]
+fn query_background(timeout: Duration) -> Option<(u8, u8, u8)> {
+    use crossterm::terminal;
+    use std::io::{IsTerminal, Write};
+
+    if !std::io::stdin().is_terminal()
+        || !std::io::stdout().is_terminal()
+        || std::env::var("TERM").is_ok_and(|t| t == "dumb")
+    {
+        return None;
+    }
+    let mut tty = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
+    // Raw, so the answer is neither echoed nor held back for a newline.
+    let was_raw = terminal::is_raw_mode_enabled().unwrap_or(false);
+    if !was_raw {
+        terminal::enable_raw_mode().ok()?;
+    }
+    let reply = tty
+        .write_all(QUERY)
+        .and_then(|()| tty.flush())
+        .ok()
+        .map(|()| read_reply(&tty, timeout));
+    if !was_raw {
+        let _ = terminal::disable_raw_mode();
+    }
+    parse_background(&reply?)
+}
+
+#[cfg(not(unix))]
+fn query_background(_timeout: Duration) -> Option<(u8, u8, u8)> {
+    None
+}
+
+/// Read what the terminal sends until it has answered the device-attributes
+/// query, or `timeout` passes.
+#[cfg(unix)]
+fn read_reply(tty: &std::fs::File, timeout: Duration) -> Vec<u8> {
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::time::Instant;
+
+    let deadline = Instant::now() + timeout;
+    let mut reply = Vec::new();
+    let mut chunk = [0u8; 256];
+    while !answered(&reply) {
+        let left = deadline.saturating_duration_since(Instant::now());
+        if left.is_zero() {
+            break;
+        }
+        let mut fd = libc::pollfd {
+            fd: tty.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let millis = libc::c_int::try_from(left.as_millis().max(1)).unwrap_or(libc::c_int::MAX);
+        // SAFETY: one initialised pollfd, for a descriptor `tty` keeps open
+        // for the whole call.
+        if unsafe { libc::poll(&raw mut fd, 1, millis) } <= 0 {
+            break;
+        }
+        match (&*tty).read(&mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => reply.extend_from_slice(&chunk[..n]),
+        }
+    }
+    reply
+}
+
+/// Whether `reply` holds the answer to the device-attributes query:
+/// `ESC [ ? <digits and semicolons> c`.
+#[cfg_attr(not(unix), allow(dead_code))]
+fn answered(reply: &[u8]) -> bool {
+    reply.windows(3).enumerate().any(|(i, window)| {
+        window == b"\x1b[?"
+            && reply[i + 3..]
+                .iter()
+                .find(|b| !(b.is_ascii_digit() || **b == b';'))
+                == Some(&b'c')
+    })
+}
+
+/// The colour in an OSC 11 answer: `ESC ] 11 ; rgb:RRRR/GGGG/BBBB`, ended by
+/// BEL or ST, with one to four hex digits a channel.
+#[cfg_attr(not(unix), allow(dead_code))]
+fn parse_background(reply: &[u8]) -> Option<(u8, u8, u8)> {
+    let text = String::from_utf8_lossy(reply);
+    let body = &text[text.find("]11;")? + 4..];
+    let spec = &body[..body.find(['\x07', '\x1b']).unwrap_or(body.len())];
+    let channels = spec
+        .strip_prefix("rgb:")
+        .or_else(|| spec.strip_prefix("rgba:"))?;
+    let mut parts = channels.split('/').map(|hex| {
+        if hex.is_empty() || hex.len() > 4 {
+            return None;
+        }
+        let value = u32::from_str_radix(hex, 16).ok()?;
+        let max = (1u32 << (4 * hex.len())) - 1;
+        u8::try_from((value * 255 + max / 2) / max).ok()
+    });
+    Some((parts.next()??, parts.next()??, parts.next()??))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_background_answer_is_read_in_the_forms_terminals_send() {
+        // xterm, with ST, then its device attributes.
+        let xterm = b"\x1b]11;rgb:eeee/f1f1/f5f5\x1b\\\x1b[?64;1;2;6;9;15;18;21;22c";
+        assert_eq!(parse_background(xterm), Some((0xee, 0xf1, 0xf5)));
+        assert!(answered(xterm));
+        // BEL-terminated, two digits a channel.
+        assert_eq!(
+            parse_background(b"\x1b]11;rgb:1a/1b/26\x07"),
+            Some((0x1a, 0x1b, 0x26))
+        );
+        // One digit a channel is scaled, not truncated.
+        assert_eq!(
+            parse_background(b"\x1b]11;rgb:f/0/8\x07"),
+            Some((255, 0, 136))
+        );
+        assert_eq!(parse_background(b"\x1b[?62;22c"), None, "no answer");
+        assert_eq!(parse_background(b"\x1b]11;rgb:zz/00/00\x07"), None);
+    }
+
+    #[test]
+    fn device_attributes_end_the_wait() {
+        assert!(answered(b"\x1b[?62;22c"));
+        assert!(!answered(b"\x1b]11;rgb:0000/0000/0000\x07"));
+        assert!(!answered(b"\x1b[?62;22"), "not finished yet");
+    }
+
+    #[test]
+    fn colorfgbg_names_the_background_last() {
+        assert_eq!(mode_from_colorfgbg("15;0"), Some(Mode::Dark));
+        assert_eq!(mode_from_colorfgbg("0;15"), Some(Mode::Light));
+        assert_eq!(mode_from_colorfgbg("0;default;7"), Some(Mode::Light));
+        assert_eq!(mode_from_colorfgbg("12;8"), Some(Mode::Dark));
+        assert_eq!(mode_from_colorfgbg("default;default"), None);
+    }
+}

--- a/openvtc/src/theme_cmd.rs
+++ b/openvtc/src/theme_cmd.rs
@@ -1,30 +1,34 @@
-//! `openvtc theme`: list, choose, import and create themes for the TUI.
+//! `openvtc theme`: list, choose, import, create and export themes for the TUI.
 //!
 //! Runs before any profile is opened: how the TUI looks belongs to the person,
 //! not to an account, so no unlock is needed to change it.
 
 use std::path::Path;
 
-use anyhow::{Result, bail};
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command, builder::PossibleValuesParser};
 use console::style;
 
-use crate::colors::{CLI_BLUE, CLI_ORANGE, CLI_PURPLE};
-use crate::theme::catalog::{self, Roots};
-use crate::theme::{builtin, import, nvim};
+use crate::colors::{CLI_CAUTION, CLI_EXAMPLE, CLI_INFO, Themed};
+use crate::theme::catalog::{self, AUTO_ID, Roots};
+use crate::theme::export::{self, Format};
+use crate::theme::{OVERRIDE_ENV, Theme, contrast, import, nvim, rgb};
 
 /// The `theme` subcommand's definition.
 pub fn command() -> Command {
     Command::new("theme")
-        .about("List, choose, import and create themes for the TUI")
+        .about("List, choose, import, create and export themes for the TUI")
         .long_about(
             "Themes colour the TUI. Choose one here or under Settings → Theme, where \
-             moving through the list previews each one.\n\n\
+             moving through the list previews each one. A running TUI picks up a new \
+             choice, or an edit to the theme in use, within a second.\n\n\
              Themes come from four places: those built in; your own OpenVTC theme files; \
              Omarchy's themes, read in place (omarchy/current follows whichever is \
              current); and anything you import — a base16 or base24 scheme, an Omarchy \
              theme directory, an Alacritty, Kitty or Ghostty colour file, or a Neovim \
-             colorscheme (nvim:<name>).",
+             colorscheme (nvim:<name>). `auto` follows your terminal's background.\n\n\
+             OPENVTC_THEME=<id> chooses a theme for one session, and NO_COLOR draws \
+             without colour.",
         )
         .subcommand_required(true)
         .arg_required_else_help(true)
@@ -32,11 +36,25 @@ pub fn command() -> Command {
         .subcommand(
             Command::new("set")
                 .about("Choose the theme the TUI uses")
-                .arg(
+                .long_about(
+                    "Choose the theme the TUI uses.\n\n\
+                     `auto` follows your terminal's background: OpenVTC asks the terminal \
+                     when it starts, and draws with one theme on a dark background and \
+                     another on a light one. --dark and --light choose those two.",
+                )
+                .args([
                     Arg::new("id")
                         .required(true)
-                        .help("A theme id from `openvtc theme list`"),
-                ),
+                        .help("A theme id from `openvtc theme list`, or auto"),
+                    Arg::new("dark")
+                        .long("dark")
+                        .value_name("ID")
+                        .help("With auto, the theme for a dark terminal (default: openvtc)"),
+                    Arg::new("light")
+                        .long("light")
+                        .value_name("ID")
+                        .help("With auto, the theme for a light terminal (default: catppuccin-latte)"),
+                ]),
         )
         .subcommand(
             Command::new("import")
@@ -77,7 +95,40 @@ pub fn command() -> Command {
                     Arg::new("from")
                         .long("from")
                         .value_name("ID")
-                        .help("The theme to start from (default: the one in use)"),
+                        .help("The theme to start from (default: the one chosen)"),
+                ]),
+        )
+        .subcommand(
+            Command::new("export")
+                .about("Write a theme out for another tool")
+                .long_about(
+                    "Write a theme out in another tool's format, so a theme made in OpenVTC \
+                     can colour your terminal, editor or desktop too. Prints it unless \
+                     --output is given.\n\n\
+                     FORMAT is one of:\n  \
+                     openvtc    an OpenVTC theme file\n  \
+                     base16     a base16 scheme (.yaml)\n  \
+                     omarchy    an Omarchy theme: with --output, a theme directory \
+                     (colors.toml, and light.mode for a light theme), unless the path ends \
+                     in .toml\n  \
+                     alacritty  an Alacritty colour file (.toml)\n  \
+                     kitty      a Kitty colour file (.conf)",
+                )
+                .args([
+                    Arg::new("id")
+                        .required(true)
+                        .help("A theme id from `openvtc theme list`"),
+                    Arg::new("format")
+                        .long("format")
+                        .value_name("FORMAT")
+                        .value_parser(PossibleValuesParser::new(Format::NAMES))
+                        .default_value("openvtc")
+                        .help("The format to write"),
+                    Arg::new("output")
+                        .long("output")
+                        .short('o')
+                        .value_name("PATH")
+                        .help("Write to PATH instead of printing"),
                 ]),
         )
 }
@@ -94,35 +145,92 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
             list(&roots);
             Ok(())
         }
-        Some(("set", args)) => {
-            let id = args.get_one::<String>("id").map_or("", String::as_str);
-            let theme = catalog::load(&roots, id)?;
-            catalog::remember(&roots, &theme.id)?;
-            println!(
-                "{} {}",
-                style("The TUI now uses").color256(CLI_BLUE),
-                style(&theme.name).color256(CLI_PURPLE)
-            );
-            Ok(())
-        }
+        Some(("set", args)) => set(&roots, args),
         Some(("import", args)) => import_theme(&roots, args),
         Some(("new", args)) => new_theme(&roots, args),
-        _ => bail!("choose one of: list, set, import, new"),
+        Some(("export", args)) => export_theme(&roots, args),
+        _ => bail!("choose one of: list, set, import, new, export"),
     }
 }
 
+/// `OPENVTC_THEME` as set in this shell, if it is.
+fn session_override() -> Option<String> {
+    std::env::var(OVERRIDE_ENV)
+        .ok()
+        .filter(|id| !id.trim().is_empty())
+}
+
+/// Tell the person when this shell's `OPENVTC_THEME` will outrank their choice.
+fn note_override() {
+    if let Some(id) = session_override() {
+        println!(
+            "{}",
+            style(format!(
+                "{OVERRIDE_ENV}={id} is set in this shell, so a TUI started from it uses that \
+                 theme instead."
+            ))
+            .themed(CLI_CAUTION)
+        );
+    }
+}
+
+fn set(roots: &Roots, args: &ArgMatches) -> Result<()> {
+    let id = args.get_one::<String>("id").map_or("", String::as_str);
+    let dark = args.get_one::<String>("dark").map(String::as_str);
+    let light = args.get_one::<String>("light").map(String::as_str);
+    if id != AUTO_ID {
+        if dark.is_some() || light.is_some() {
+            bail!(
+                "--dark and --light choose the themes auto picks between: \
+                 `openvtc theme set auto --dark <id> --light <id>`"
+            );
+        }
+        let theme = catalog::load(roots, id)?;
+        catalog::remember(roots, &theme.id)?;
+        println!(
+            "{} {}",
+            style("The TUI now uses").themed(CLI_INFO),
+            style(&theme.name).themed(CLI_EXAMPLE)
+        );
+        note_override();
+        return Ok(());
+    }
+
+    for (flag, chosen) in [("--dark", dark), ("--light", light)] {
+        if let Some(chosen) = chosen {
+            if chosen == AUTO_ID {
+                bail!("{flag} needs a theme of its own, not auto");
+            }
+            catalog::load(roots, chosen).with_context(|| format!("{flag} {chosen}"))?;
+        }
+    }
+    catalog::remember_auto(roots, dark, light)?;
+    let choice = catalog::choice(roots);
+    let name = |id: &str| catalog::load(roots, id).map_or_else(|_| id.to_string(), |t| t.name);
+    println!(
+        "{} {} {} {} {}",
+        style("The TUI now follows your terminal:").themed(CLI_INFO),
+        style(name(&choice.auto_dark)).themed(CLI_EXAMPLE),
+        style("on a dark background,").themed(CLI_INFO),
+        style(name(&choice.auto_light)).themed(CLI_EXAMPLE),
+        style("on a light one.").themed(CLI_INFO)
+    );
+    note_override();
+    Ok(())
+}
+
 fn list(roots: &Roots) {
-    let in_use = catalog::selected(roots).unwrap_or_else(|| builtin::DEFAULT_ID.to_string());
+    let in_use = catalog::choice(roots).theme;
     println!(
         "{}",
         style("Themes — choose with `openvtc theme set <id>` or under Settings → Theme")
-            .color256(CLI_BLUE)
+            .themed(CLI_INFO)
     );
     for entry in catalog::list(roots) {
         let mark = if entry.id == in_use { "✓" } else { " " };
         println!(
             "  {mark} {:<28} {:<34} {}",
-            style(&entry.id).color256(CLI_PURPLE),
+            style(&entry.id).themed(CLI_EXAMPLE),
             entry.name,
             style(entry.source.label()).dim()
         );
@@ -130,10 +238,23 @@ fn list(roots: &Roots) {
     if let Some(dir) = roots.themes_dir() {
         println!(
             "{} {}",
-            style("Your themes live in").color256(CLI_BLUE),
+            style("Your themes live in").themed(CLI_INFO),
             dir.display()
         );
     }
+    note_override();
+}
+
+/// A warning for a theme whose text is hard to read on its own background.
+fn readability(theme: &Theme) -> Option<String> {
+    let background = rgb(theme.palette.background?)?;
+    let ratio = contrast(rgb(theme.palette.text)?, background);
+    (ratio < 4.5).then(|| {
+        format!(
+            "Its text is {ratio:.1}:1 against its background, under the 4.5:1 that reads \
+             comfortably; consider a lighter or darker text colour."
+        )
+    })
 }
 
 fn import_theme(roots: &Roots, args: &ArgMatches) -> Result<()> {
@@ -148,22 +269,26 @@ fn import_theme(roots: &Roots, args: &ArgMatches) -> Result<()> {
     let (id, path) = catalog::install(roots, &theme)?;
     println!(
         "{} {} {} {}",
-        style("Imported").color256(CLI_BLUE),
-        style(&theme.name).color256(CLI_PURPLE),
-        style("as").color256(CLI_BLUE),
-        style(&id).color256(CLI_PURPLE)
+        style("Imported").themed(CLI_INFO),
+        style(&theme.name).themed(CLI_EXAMPLE),
+        style("as").themed(CLI_INFO),
+        style(&id).themed(CLI_EXAMPLE)
     );
     println!("  {}", path.display());
+    if let Some(warning) = readability(&theme) {
+        println!("{}", style(warning).themed(CLI_CAUTION));
+    }
     if args.get_flag("use") {
         catalog::remember(roots, &id)?;
-        println!("{}", style("and chose it for the TUI.").color256(CLI_BLUE));
+        println!("{}", style("and chose it for the TUI.").themed(CLI_INFO));
+        note_override();
     } else {
         println!(
             "{}",
             style(format!(
                 "Edit the file to adjust it, and choose it with `openvtc theme set {id}`."
             ))
-            .color256(CLI_ORANGE)
+            .themed(CLI_CAUTION)
         );
     }
     Ok(())
@@ -174,16 +299,15 @@ fn new_theme(roots: &Roots, args: &ArgMatches) -> Result<()> {
     let from = args
         .get_one::<String>("from")
         .cloned()
-        .or_else(|| catalog::selected(roots))
-        .unwrap_or_else(|| builtin::DEFAULT_ID.to_string());
+        .unwrap_or_else(|| catalog::choice(roots).theme);
     let mut theme = catalog::load(roots, &from)?;
     theme.name = name.to_string();
     let (id, path) = catalog::install(roots, &theme)?;
     println!(
         "{} {} {}",
-        style("Started").color256(CLI_BLUE),
-        style(&id).color256(CLI_PURPLE),
-        style(format!("from {from}:")).color256(CLI_BLUE)
+        style("Started").themed(CLI_INFO),
+        style(&id).themed(CLI_EXAMPLE),
+        style(format!("from {from}:")).themed(CLI_INFO)
     );
     println!("  {}", path.display());
     println!(
@@ -192,7 +316,31 @@ fn new_theme(roots: &Roots, args: &ArgMatches) -> Result<()> {
             "Edit its colours, then choose it with `openvtc theme set {id}` — or under \
              Settings → Theme, where r reloads after an edit."
         ))
-        .color256(CLI_ORANGE)
+        .themed(CLI_CAUTION)
     );
+    Ok(())
+}
+
+fn export_theme(roots: &Roots, args: &ArgMatches) -> Result<()> {
+    let id = args.get_one::<String>("id").map_or("", String::as_str);
+    let format = args
+        .get_one::<String>("format")
+        .and_then(|name| Format::parse(name))
+        .unwrap_or(Format::Openvtc);
+    let theme = catalog::load(roots, id)?;
+    match args.get_one::<String>("output") {
+        // Printed bare, so it can be piped or redirected as it is.
+        None => print!("{}", export::render(&theme, format)),
+        Some(output) => {
+            let file = export::write(&theme, format, Path::new(output))?;
+            println!(
+                "{} {} {} {}",
+                style("Exported").themed(CLI_INFO),
+                style(&theme.name).themed(CLI_EXAMPLE),
+                style("to").themed(CLI_INFO),
+                file.display()
+            );
+        }
+    }
     Ok(())
 }

--- a/openvtc/src/ui/mod.rs
+++ b/openvtc/src/ui/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     Interrupted,
-    state_handler::{actions::Action, state::State},
+    state_handler::{actions::Action, main_page::content::SettingsMode, state::State},
+    theme::{self, live},
     ui::{
         component::{Component, ComponentRender},
         pages::AppRouter,
@@ -15,6 +16,7 @@ use crossterm::{
 use ratatui::{Terminal, prelude::CrosstermBackend};
 use std::io::{self, Stdout};
 use tokio::sync::{broadcast, mpsc, mpsc::UnboundedReceiver, watch};
+use tokio::time::MissedTickBehavior;
 use tokio_stream::StreamExt;
 
 pub mod component;
@@ -22,13 +24,21 @@ pub mod pages;
 
 pub struct UiManager {
     action_tx: mpsc::UnboundedSender<Action>,
+    /// Follows the theme in use, so a change to it is drawn without a restart.
+    theme_watcher: live::Watcher,
 }
 
 impl UiManager {
-    pub fn new() -> (Self, UnboundedReceiver<Action>) {
+    pub fn new(theme_watcher: live::Watcher) -> (Self, UnboundedReceiver<Action>) {
         let (action_tx, action_rx) = mpsc::unbounded_channel();
 
-        (Self { action_tx }, action_rx)
+        (
+            Self {
+                action_tx,
+                theme_watcher,
+            },
+            action_rx,
+        )
     }
 
     pub async fn main_loop(
@@ -36,29 +46,48 @@ impl UiManager {
         mut state_rx: watch::Receiver<State>,
         mut interrupt_rx: broadcast::Receiver<Interrupted>,
     ) -> Result<Interrupted> {
+        let Self {
+            action_tx,
+            mut theme_watcher,
+        } = self;
         let mut terminal = setup_terminal()?;
 
         let mut crossterm_events = EventStream::new();
         // let mut ticker = tokio::time::interval(Duration::from_millis(250));
 
+        // Theme changes are looked for on a blocking thread — the check stats
+        // files, which a slow home directory could stall — and come back here.
+        let (theme_tx, mut theme_rx) = mpsc::unbounded_channel();
+        let mut theme_poll = tokio::time::interval(live::POLL_INTERVAL);
+        theme_poll.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let mut theme_checking = false;
+        // Counts states that arrive with the theme picker open. A check that
+        // ran while this moved may have raced a preview or a choice, so what it
+        // found is left to be found again.
+        let mut picker_epoch: u64 = 0;
+        let mut check_epoch: u64 = 0;
+
         // consume the first state to initialize the ui app
         let mut app_router = {
             let state = state_rx.borrow_and_update().clone();
-            AppRouter::new(&state, self.action_tx.clone())
+            AppRouter::new(&state, action_tx.clone())
         };
 
+        let mut redraw = true;
         let result: anyhow::Result<Interrupted> = loop {
-            if let Err(err) = terminal
-                .draw(|frame| {
-                    app_router.render(frame, ());
-                    // Every panel draws with colour roles; the active theme
-                    // colours the finished frame (docs/themes.md).
-                    crate::theme::paint(frame.buffer_mut());
-                })
-                .context("could not render to the terminal")
+            if redraw
+                && let Err(err) = terminal
+                    .draw(|frame| {
+                        app_router.render(frame, ());
+                        // Every panel draws with colour roles; the active theme
+                        // colours the finished frame (docs/themes.md).
+                        theme::paint(frame.buffer_mut());
+                    })
+                    .context("could not render to the terminal")
             {
                 break Err(err);
             }
+            redraw = true;
 
             tokio::select! {
                 // Tick to terminate the select every N milliseconds
@@ -77,7 +106,41 @@ impl UiManager {
                 // Handle state updates
                 Ok(()) = state_rx.changed() => {
                     let state = state_rx.borrow_and_update().clone();
+                    if theme_picker_open(&state) {
+                        picker_epoch += 1;
+                    }
                     app_router = app_router.move_with_state(&state);
+                },
+                // Look for a theme change, unless a look is already under way
+                // or the picker is open.
+                _ = theme_poll.tick() => {
+                    redraw = false;
+                    let picker_open = theme_picker_open(&state_rx.borrow());
+                    if !theme_checking && !picker_open {
+                        theme_checking = true;
+                        check_epoch = picker_epoch;
+                        let watcher = theme_watcher.clone();
+                        let theme_tx = theme_tx.clone();
+                        tokio::task::spawn_blocking(move || {
+                            let _ = theme_tx.send(watcher.check());
+                        });
+                    }
+                },
+                // Draw a theme change, unless the picker opened meanwhile: its
+                // preview is the person's, and the change is seen again once
+                // the picker closes.
+                Some(found) = theme_rx.recv() => {
+                    theme_checking = false;
+                    redraw = false;
+                    let picker_open = theme_picker_open(&state_rx.borrow());
+                    if let Some(update) = found
+                        && check_epoch == picker_epoch
+                        && !picker_open
+                        && let Some(changed) = theme_watcher.accept(update)
+                    {
+                        theme::set_active(&changed);
+                        redraw = true;
+                    }
                 },
                 // Catch and handle interrupt signal to gracefully shutdown
                 Ok(interrupted) = interrupt_rx.recv() => {
@@ -90,6 +153,14 @@ impl UiManager {
 
         result
     }
+}
+
+/// Whether the theme picker is open, previewing themes.
+fn theme_picker_open(state: &State) -> bool {
+    matches!(
+        state.main_page.content_panel.settings.mode,
+        SettingsMode::ThemePicker { .. }
+    )
 }
 
 fn setup_terminal() -> anyhow::Result<Terminal<CrosstermBackend<Stdout>>> {

--- a/openvtc/src/ui/pages/main/components/settings_panel.rs
+++ b/openvtc/src/ui/pages/main/components/settings_panel.rs
@@ -87,6 +87,12 @@ fn render_theme_picker(
         Line::from("Moving through the list previews each theme. Enter keeps it; Esc puts back the one you had.")
             .fg(COLOR_DARK_GRAY),
     );
+    if crate::theme::no_color() {
+        lines.push(
+            Line::from("NO_COLOR is set, so themes are not drawn. The one you choose is kept for when it is not.")
+                .fg(COLOR_ORANGE),
+        );
+    }
     lines.push(Line::from(""));
     for (i, row) in rows.iter().enumerate() {
         let is_selected = i == selected;
@@ -358,11 +364,14 @@ fn render_view(state: &SettingsState) -> Vec<Line<'static>> {
     } else {
         Style::new().fg(COLOR_TEXT_DEFAULT)
     };
-    let (_, theme_name) = crate::theme::active_theme();
+    let (theme_id, theme_name) = crate::theme::active_theme();
     lines.push(Line::from(vec![
         Span::styled(if theme_selected { "▸ " } else { "  " }, theme_style),
         Span::styled("Theme: ", theme_style),
-        Span::styled(theme_name, Style::new().fg(COLOR_SOFT_PURPLE)),
+        Span::styled(
+            crate::theme::display_name(&theme_id, &theme_name),
+            Style::new().fg(COLOR_SOFT_PURPLE),
+        ),
         Span::styled(
             if theme_selected {
                 " [Enter to change]"


### PR DESCRIPTION
Builds on #299. A running TUI now picks up theme changes live. It adds an `auto` theme that follows the terminal's background, four accessibility themes, `NO_COLOR` support, themed command-line output, and `openvtc theme export`.

## What
- **Live switching.** A running TUI redraws within about a second when any of these change:
  - `tui.toml` (for example, `openvtc theme set` run in another terminal);
  - the `user/` theme file in use;
  - Omarchy's current theme (`~/.local/state/omarchy/current/theme.name`, or the older `~/.config/omarchy/current/theme` link);
  - the in-use Omarchy theme's `colors.toml`.
- **`auto`.** Follows the terminal's background. OpenVTC asks the terminal with OSC 11 before the alternate screen is entered, then falls back to `COLORFGBG`, then to dark.
  - `openvtc theme set auto [--dark <id>] [--light <id>]` sets the two themes. They are kept in `tui.toml` as `auto_dark` / `auto_light` (defaults `openvtc` and `catppuccin-latte`).
  - The picker lists **Auto (follow terminal)** first. Settings shows `Theme: Auto — <theme>`.
- **Accessibility built-ins:**
  - `high-contrast-dark` and `high-contrast-light`: every colour ≥ 7:1 against the background.
  - `colourblind-dark` and `colourblind-light`, in Okabe–Ito hues: every colour ≥ 4.5:1. The light variant darkens each hue until it reads on white.
- **`NO_COLOR`** (set and non-empty). Every role and the background become the terminal default. Roles stay apart through modifiers:

  | Role | Modifier |
  |------|----------|
  | accent | bold |
  | danger | bold + underline |
  | warning | underline |
  | success and selections | reversed |
  | highlight | italic |
  | muted | dim |

  `console`/`dialoguer` output is uncoloured too, and the picker says themes are not being drawn.
- **`OPENVTC_THEME=<id>`** chooses a theme for one session. An id that can't be loaded is reported, and the chosen theme is used instead.
- **Themed pre-TUI output.** `style(..).color256(CLI_*)` becomes `style(..).themed(CLI_INFO | CLI_ERROR | CLI_CAUTION | CLI_EXAMPLE)` across `main.rs`, `health_cmd.rs` and `theme_cmd.rs`.
  - It uses the active theme's role colour: 24-bit when `COLORTERM` is `truecolor`/`24bit`, otherwise the nearest xterm-256 index. The default theme's accent maps back to 69, the old `CLI_BLUE`.
  - `theme::init` runs straight after argument parsing, before anything is printed.
- **Export.** `openvtc theme export <id> --format openvtc|base16|omarchy|alacritty|kitty [--output <path>]`.
  - It prints bare to stdout by default.
  - Omarchy with `-o` writes a theme directory (`colors.toml`, plus `light.mode` for light themes), unless the path ends in `.toml`.
  - Omarchy output uses the key set of Omarchy's current `colors.toml` (checked against `basecamp/omarchy` `themes/tokyo-night`).
  - Colours a format needs that OpenVTC doesn't have (the ANSI 16, base16 shades) are derived from the roles.
- **Import warning.** `theme import` now warns when a theme's text is under 4.5:1 against its background.
- **Docs.** `docs/themes.md` covers all of the above.

## How
- **`theme/live.rs`.** `Watcher::check(&self) -> Option<Update>` stamps `tui.toml` and the files the followed theme is read from (mtime, size, link target), and loads the theme only when something differs. It mutates nothing; `accept` commits the update.
  - The UI loop (`ui/mod.rs`) runs `check` on `spawn_blocking` from a one-second `interval` and gets the result back over a channel. The render loop never touches the file system.
  - The loop skips checks while `SettingsMode::ThemePicker` is open. It also drops results from any check that overlapped the picker being open (a picker-epoch counter), so a preview is never overridden and the change is found again once the picker closes.
  - The loop now redraws only when something happened (poll ticks do not redraw). The harness confirms zero bytes are written while idle.
- **Choice semantics.** A theme chosen while running (in the picker, or via `theme set`) replaces the session's theme, including one chosen by `OPENVTC_THEME`. Other edits to `tui.toml` redraw nothing. Under `auto`, changing `auto_dark`/`auto_light` redraws.
- **Atomic `tui.toml` writes.** `tui.toml` is now written via a temp file and rename. `catalog::read_choice` returns `None` for unparseable TOML, so a half-saved file never flips the theme. A half-saved theme file keeps the current theme until it is saved whole.
- **`theme/terminal.rs`.** Opens `/dev/tty`, enters crossterm raw mode, and writes `OSC 11 ?` followed by DA1 (`ESC [ c`). It reads with `poll(2)` until the DA1 reply arrives, capped at 500 ms. It parses `rgb:` with 1–4 hex digits per channel. On non-Unix it returns nothing and falls back to `COLORFGBG`.
- **`theme/export.rs`.** `render` / `write`.
- **`theme/mod.rs`.**
  - `Role`, `Palette::get`, and `Mode::of_background` (moved from `import.rs`; it now also handles named colours).
  - `rgb` (xterm values for named and indexed colours) and WCAG `contrast`.
  - `no_color`, `paint_without_colour`, `display_name`, `init`.
- **`catalog.rs`.** `AUTO_ID`, `Choice` (`theme`, `auto_dark`, `auto_light`; `auto` can't pick itself), `read_choice` / `choice`, `remember_auto`, `resolve`, and `sources`. `load("auto")` loads the resolved theme under the id `auto`. `load_selected` and `selected` are gone; `theme::init` covers them.

## Notes for review
- **Dependency.** Adds `libc = "0.2"` as a Unix-only direct dependency, for `poll(2)` with a timeout. It was already in `Cargo.lock` beneath crossterm and console, so the only lock change is the edge. There is no file-watcher dependency: polling stats a handful of files.
- **When the terminal is asked.** Only when `auto` is the choice in effect at startup, and never under `NO_COLOR` or when stdin/stdout isn't a terminal.
  - This keeps a startup delay, and a slow link's late reply landing in the passphrase prompt, away from people who don't use `auto`.
  - The trade-off: choosing Auto in the picker of a session that didn't start with it uses `COLORFGBG`/dark until restart, and the status message says so.
  - The terminal can't be asked mid-session, because crossterm's event reader would take the reply as keys.
  - The DA1 sentinel means terminals that answer return within milliseconds. Only a terminal answering neither query waits the full 500 ms.
- **`NO_COLOR` and `success`.** Success is reversed because success + bold is this codebase's selected-row style. The trade-off is that success text elsewhere (e.g. the picker's "Theme" heading) is also reversed.
- **CLI colours on light themes.** Pre-TUI output uses the theme's role colours on the terminal's own background. A light theme's accent may be darker than ideal on a dark terminal. `auto` avoids the mismatch.
- **Crossterm and `NO_COLOR`.** Crossterm independently drops colour when `NO_COLOR` is non-empty. Our paint does the modifier mapping, so both agree.
- **Scope.** No service calls are added or changed, so the networking rules (R1.2/R1.4/R6.4) don't apply.

## Tests
- **Painting.** `theme::tests`: `NO_COLOR` modifiers per role (panels' own modifiers are kept), `rgb` for named and indexed colours, WCAG figures, mode from background.
- **Contrast.** `builtin::tests::text_is_readable_on_every_built_in_background`: text ≥ 4.5:1 for every built-in; every colour ≥ 7:1 (high contrast) or ≥ 4.5:1 (colourblind).
- **Terminal.** `terminal::tests`: OSC 11 replies with ST, BEL, and 1- and 2-digit channels; DA1 detection; `COLORFGBG` forms.
- **Catalogue.** `catalog::tests`: `auto` resolves and keeps its id, `auto` can't pick itself, `sources` for user and Omarchy themes, half-written `tui.toml`.
- **Live.** `live::tests`:
  - a user file edit, including a half-saved file;
  - a theme chosen elsewhere replacing an `OPENVTC_THEME` session, while unrelated `tui.toml` edits redraw nothing;
  - `auto_dark`/`auto_light` changes;
  - Omarchy switching via `theme.name`, and via the legacy symlink (Unix);
  - edits to Omarchy's `colors.toml`.
- **Export.** `export::tests`:
  - every built-in with a background round-trips through `openvtc`, `base16`, `omarchy`, `alacritty` and `kitty` via the importers (same palette and mode);
  - files written to disk are recognised by `import::from_path`;
  - an Omarchy dir gets `light.mode`, and it is removed when overwritten with a dark theme;
  - the default theme exports on black.
- **Settings picker.** The picker test now also checks Auto is listed first, previews under the id `auto`, and is remembered.
- **CLI.** `set auto --dark --light`, `export --format -o`, the default format, an unknown format refused.
- **Colours.** Nearest-256 mapping (`#5f87ff` → 69, `#61afef` → 75).

Local results, matching `.github/workflows/ci.yml`:
- `cargo fmt --all --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test --workspace`: openvtc 505 passed, 1 ignored (needs Neovim); openvtc-core 551; did-git-sign 5.
- `cargo test --workspace --no-default-features`: pass.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`: clean.

**CLI smoke test, `OPENVTC_CONFIG_PATH` in a scratch directory:**
- `theme set auto --dark nord --light high-contrast-light` writes `theme`/`auto_dark`/`auto_light`.
- `set nord --dark …` and `--dark nosuch` are refused with a clear message.
- `theme list` shows Auto first and the four new built-ins.
- `OPENVTC_THEME=bogus` reports it was ignored, and `list` notes the override.
- `export high-contrast-dark` to all five formats, then `theme import` of each file, gives five identical palettes.
- A low-contrast Alacritty import warns (1.3:1).
- `NO_COLOR=1 CLICOLOR_FORCE=1` emits no escapes. `COLORTERM=truecolor` emits `38;2;…`; without it, `38;5;110`.

**TUI end-to-end, a Python pty harness driving the real binary (13/13):**
- `auto` sends OSC 11; answering white draws High Contrast Light's `#ffffff`.
- No bytes are written while idle.
- `openvtc theme set dracula` from outside redraws in Dracula.
- A `user/` theme chosen from outside is drawn, and an edit to its file is drawn.
- Non-auto themes never query the terminal.
- `omarchy/current` draws Omarchy's current theme, and rewriting `theme.name` switches it.
- `OPENVTC_THEME=nord` overrides the choice.
- `NO_COLOR=1` emits no 24-bit colour but does emit bold/reverse; an empty `NO_COLOR` still draws colour.
