### PR TITLE
fix(health): probe only public HTTPS transport endpoints, and never follow a redirect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6161,6 +6161,7 @@ dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-did-web",
  "affinidi-messaging-core",
  "affinidi-messaging-delivery",
  "affinidi-messaging-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,11 @@ agent-names = "0.1.3"
 affinidi-did-resolver-cache-sdk = { version = "0.8.34", features = [
   "agent-names",
 ] }
+# The SSRF guard the resolver above already applies to did:web fetches, taken
+# directly so `health` can put the same connect-time check on its own probe
+# client (`guarded_dns_resolver`). Not a new crate: the resolver pulls in this
+# exact version on the same `reqwest` line, so the types unify.
+affinidi-did-web = "0.1.4"
 anyhow = "1.0"
 # Structure-aware fuzzing support (issue #124). Only pulled in when a crate
 # enables its own `arbitrary` feature; the `derive` feature provides the

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -35,6 +35,9 @@ affinidi-did-resolver-cache-sdk.workspace = true
 # document is fetchable, not that the transport host behind it answers, and the
 # two fail independently.
 reqwest = { workspace = true }
+# Those transport URLs come from DID documents anyone can publish, so the probe
+# client installs the resolver's own DNS guard rather than dialling them as-is.
+affinidi-did-web.workspace = true
 # `CancellationToken`, for `start_service`'s shutdown hook.
 tokio-util = { workspace = true }
 # The delivery layer this module now runs on (#189): `-delivery` is the durable

--- a/openvtc-core/src/health.rs
+++ b/openvtc-core/src/health.rs
@@ -22,6 +22,10 @@
 //!
 //! Deliberately read-only: it resolves, negotiates and probes. It never sends a
 //! message, so it is safe to run against production while a join is stuck.
+//!
+//! The probed URLs come from DID documents, which anyone can publish. By default
+//! only public HTTPS endpoints are dialled, redirects are never followed, and
+//! the rest are listed as not probed; see [`ProbePolicy`].
 
 use std::collections::BTreeSet;
 use std::time::Duration;
@@ -91,6 +95,35 @@ pub enum Probe {
     Reachable { url: String, http_status: u16 },
     /// No answer: DNS, TLS, connection or timeout.
     Unreachable { url: String, error: String },
+    /// Not dialled: under the run's [`ProbePolicy`] this is a URL a probe must
+    /// not follow — plaintext, carrying credentials, or naming a loopback,
+    /// private or link-local host (literally, or through what its name
+    /// resolves to).
+    ///
+    /// The URL comes from a DID document, which anyone can publish. Probing it
+    /// as written would let that document aim this machine at services on its
+    /// own network and read back whether they answer. An endpoint like that is
+    /// also no route a real peer could take, so it is reported, not hidden.
+    Blocked { url: String, reason: String },
+}
+
+/// Which transport URLs [`build_report_with_progress`] is willing to dial.
+///
+/// Mirrors `affinidi_did_web::HostPolicy`, which guards DID resolution the same
+/// way. The probe URLs come out of the documents that resolution returned, so
+/// without a policy of their own they would reopen what the resolver closes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProbePolicy {
+    /// HTTPS only, no userinfo, and never a loopback, private, carrier-grade
+    /// NAT or link-local host — refused both when the URL names one literally
+    /// and when its hostname resolves to one. The default.
+    #[default]
+    PublicOnly,
+    /// Dial any `http(s)` URL, plaintext and non-routable ones included. For a
+    /// development stack on loopback or a private network, where the DIDs
+    /// being checked are the operator's own. It reopens the exposure
+    /// [`ProbePolicy::PublicOnly`] closes.
+    AllowPrivate,
 }
 
 /// How to read a probe's status code.
@@ -106,7 +139,8 @@ pub enum ProbeGrade {
 }
 
 impl Probe {
-    /// Classify a reachable probe's status; `None` when nothing answered.
+    /// Classify a reachable probe's status; `None` when nothing answered or
+    /// nothing was asked.
     #[must_use]
     pub fn grade(&self) -> Option<ProbeGrade> {
         match self {
@@ -115,7 +149,7 @@ impl Probe {
                 400..=499 => ProbeGrade::Responding,
                 _ => ProbeGrade::ServerError,
             }),
-            Probe::Unreachable { .. } => None,
+            Probe::Unreachable { .. } | Probe::Blocked { .. } => None,
         }
     }
 }
@@ -303,17 +337,21 @@ impl Subject {
 /// party uses is a property of its document, and taking it from local config
 /// would report what we believe rather than what is published. That difference
 /// is one of the things this command exists to expose.
+///
+/// Probes only public HTTPS endpoints ([`ProbePolicy::PublicOnly`]).
 pub async fn build_report(subjects: &[Subject]) -> HealthReport {
-    build_report_with_progress(subjects, &|_| {}).await
+    build_report_with_progress(subjects, &|_| {}, ProbePolicy::PublicOnly).await
 }
 
-/// [`build_report`], reporting each step to `progress` as it happens.
+/// [`build_report`], reporting each step to `progress` as it happens, and
+/// probing transport URLs under an explicit [`ProbePolicy`].
 ///
 /// The work is almost entirely network waits, so a caller that shows nothing
 /// until the end shows nothing for most of the run. See [`Step`].
 pub async fn build_report_with_progress(
     subjects: &[Subject],
     progress: ProgressFn<'_>,
+    policy: ProbePolicy,
 ) -> HealthReport {
     let started = std::time::Instant::now();
     progress(Step::ResolverStarting);
@@ -335,10 +373,7 @@ pub async fn build_report_with_progress(
         }
     };
 
-    let http = reqwest::Client::builder()
-        .timeout(STEP_TIMEOUT)
-        .build()
-        .ok();
+    let http = probe_client(policy);
 
     let mut parties: Vec<Party> = Vec::new();
     for subject in subjects {
@@ -348,7 +383,7 @@ pub async fn build_report_with_progress(
         if parties.iter().any(|p| p.did == subject.did) {
             continue;
         }
-        parties.push(resolve_party(&resolver, http.as_ref(), subject, progress).await);
+        parties.push(resolve_party(&resolver, http.as_ref(), policy, subject, progress).await);
     }
 
     // Second pass: every mediator any resolved party routes through, resolved
@@ -365,7 +400,7 @@ pub async fn build_report_with_progress(
     progress(Step::FollowingMediators { count: fresh.len() });
     for (did, users) in fresh {
         let subject = Subject::new(Role::Mediator, format!("mediator of {users}"), did);
-        parties.push(resolve_party(&resolver, http.as_ref(), &subject, progress).await);
+        parties.push(resolve_party(&resolver, http.as_ref(), policy, &subject, progress).await);
     }
 
     let links = negotiate_links(&parties);
@@ -432,6 +467,7 @@ fn mediator_references(parties: &[Party]) -> std::collections::BTreeMap<String, 
 async fn resolve_party(
     resolver: &DIDCacheClient,
     http: Option<&reqwest::Client>,
+    policy: ProbePolicy,
     subject: &Subject,
     progress: ProgressFn<'_>,
 ) -> Party {
@@ -500,7 +536,7 @@ async fn resolve_party(
                 url: url.to_string(),
             });
             let probe_started = std::time::Instant::now();
-            let result = probe(client, url).await;
+            let result = probe(client, url, policy).await;
             progress(Step::Probed {
                 probe: result.clone(),
                 elapsed: probe_started.elapsed(),
@@ -600,18 +636,120 @@ fn endpoint_uri(endpoint: &Value) -> Option<String> {
     }
 }
 
+/// The client transport probes are sent with.
+///
+/// Built like `affinidi_did_web`'s own resolver client, because it dials URLs
+/// out of the same untrusted documents:
+///
+/// - **No redirects.** Any 3xx already proves the host answers, and following
+///   one would let a public endpoint hand the probe on to an internal one.
+/// - **No proxy.** A proxy resolves the name itself, out of reach of the DNS
+///   guard below.
+/// - **Guarded DNS** under [`ProbePolicy::PublicOnly`]. A hostname that
+///   resolves to a non-routable address is refused, and the connection goes to
+///   the addresses that were checked, so the answer cannot change in between.
+///   `reqwest` never consults a resolver for an IP-literal host, which is why
+///   [`probe`] also vets the URL itself.
+fn probe_client(policy: ProbePolicy) -> Option<reqwest::Client> {
+    let mut builder = reqwest::Client::builder()
+        .timeout(STEP_TIMEOUT)
+        .connect_timeout(STEP_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy();
+    if policy == ProbePolicy::PublicOnly {
+        builder = builder.dns_resolver(affinidi_did_web::guarded_dns_resolver());
+    }
+    builder.build().ok()
+}
+
 /// A bounded GET. Any HTTP answer is reachability — see [`Probe::Reachable`].
-async fn probe(client: &reqwest::Client, url: &str) -> Probe {
-    match client.get(url).send().await {
+///
+/// The URL is vetted before any I/O ([`vet_probe_url`]), and what is sent is
+/// the parsed form that was vetted, never the string re-parsed.
+async fn probe(client: &reqwest::Client, url: &str, policy: ProbePolicy) -> Probe {
+    let parsed = match vet_probe_url(url, policy) {
+        Ok(parsed) => parsed,
+        Err(reason) => {
+            return Probe::Blocked {
+                url: url.to_string(),
+                reason,
+            };
+        }
+    };
+    match client.get(parsed).send().await {
         Ok(response) => Probe::Reachable {
             url: url.to_string(),
             http_status: response.status().as_u16(),
         },
-        Err(e) => Probe::Unreachable {
+        Err(e) => send_failure(url, &e),
+    }
+}
+
+/// Parse `url` and say why a probe must not dial it under `policy`, if it
+/// must not.
+///
+/// This is the literal half of the guard: the host is classified as the URL
+/// names it, after WHATWG canonicalisation, so `https://2130706433/` is
+/// `127.0.0.1` here too. A hostname is left to the probe client's DNS guard.
+fn vet_probe_url(url: &str, policy: ProbePolicy) -> Result<reqwest::Url, String> {
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("unparseable URL: {e}"))?;
+    match (parsed.scheme(), policy) {
+        ("https", _) | ("http", ProbePolicy::AllowPrivate) => {}
+        ("http", ProbePolicy::PublicOnly) => {
+            return Err("plaintext http".to_string());
+        }
+        (other, _) => return Err(format!("{other} scheme")),
+    }
+    // Credentials embedded in a URL someone else published are not ours to
+    // send, under either policy.
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("URL carries userinfo".to_string());
+    }
+    if policy == ProbePolicy::PublicOnly
+        && let Some(host) = parsed.host_str()
+        && crate::net_guard::is_blocked_host(host)
+    {
+        return Err(format!("non-public host {host}"));
+    }
+    Ok(parsed)
+}
+
+/// A send that failed: [`Probe::Blocked`] when the probe client's DNS guard
+/// refused the name, [`Probe::Unreachable`] for anything else.
+fn send_failure(url: &str, error: &reqwest::Error) -> Probe {
+    match dns_refusal_in_chain(error) {
+        Some(reason) => Probe::Blocked {
             url: url.to_string(),
-            error: e.to_string(),
+            reason,
+        },
+        None => Probe::Unreachable {
+            url: url.to_string(),
+            error: error.to_string(),
         },
     }
+}
+
+/// The refusal `affinidi_did_web::guarded_dns_resolver` raised, if one is
+/// anywhere in `error`'s source chain.
+///
+/// That crate keeps its error type private, so the refusal is recognised by the
+/// message it renders (`"<host> resolves to non-routable <addr>"`), walking the
+/// chain the way the crate does internally. The innermost match wins, since
+/// wrappers may repeat it with their own prefix.
+/// `probe_client_dns_guard_refuses_localhost_name` pins the text, so an upstream
+/// change to it fails a test rather than quietly turning refusals back into
+/// "unreachable".
+fn dns_refusal_in_chain(error: &(dyn std::error::Error + 'static)) -> Option<String> {
+    let mut found = None;
+    let mut next = Some(error);
+    while let Some(e) = next {
+        let message = e.to_string();
+        if message.contains(" resolves to non-routable ") {
+            found = Some(message);
+        }
+        next = e.source();
+    }
+    found
 }
 
 /// Negotiate the pairs that decide whether a join can complete: each persona
@@ -709,6 +847,17 @@ fn collect_notes(parties: &[Party], links: &[Link]) -> Vec<String> {
                     ));
                 }
                 Probe::Reachable { .. } => {}
+                // A transport on plaintext or on a loopback/private address is
+                // no route a real peer could take, and it is exactly what a
+                // document aimed at this machine's own network would publish.
+                // Stated, but not a fault: `is_healthy` does not change.
+                Probe::Blocked { url, reason } => {
+                    notes.push(format!(
+                        "{}: {url} not probed ({reason}) — a DID document advertising a \
+                         plaintext or non-public endpoint is itself worth a look.",
+                        party.label
+                    ));
+                }
             }
         }
     }
@@ -1276,6 +1425,333 @@ mod tests {
         assert!(
             !notes.iter().any(|n| n.contains("cannot be messaged")),
             "a mediator publishing a transport URL is healthy: {notes:?}"
+        );
+    }
+
+    // ---- Probe egress policy -------------------------------------------------
+    //
+    // Probe URLs come from DID documents anyone can publish. These pin that a
+    // document cannot point the probe at this machine's own network.
+
+    /// A loopback listener standing in for an internal service.
+    async fn loopback_listener() -> (tokio::net::TcpListener, u16) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind a loopback listener");
+        let port = listener.local_addr().expect("listener address").port();
+        (listener, port)
+    }
+
+    /// Nothing connected to `listener`. A refused probe must refuse before any
+    /// I/O, not after a connection it then discards.
+    async fn assert_never_dialled(listener: &tokio::net::TcpListener) {
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), listener.accept())
+                .await
+                .is_err(),
+            "something connected to the stand-in internal service"
+        );
+    }
+
+    fn public_client() -> reqwest::Client {
+        probe_client(ProbePolicy::PublicOnly).expect("the probe client builds")
+    }
+
+    #[tokio::test]
+    async fn probe_refuses_loopback_literal_without_dialing() {
+        let (listener, port) = loopback_listener().await;
+        let url = format!("https://127.0.0.1:{port}/latest/meta-data/");
+
+        let result = probe(&public_client(), &url, ProbePolicy::PublicOnly).await;
+
+        assert!(
+            matches!(&result, Probe::Blocked { url: u, reason } if *u == url && reason.contains("127.0.0.1")),
+            "a loopback literal must be refused by name: {result:?}"
+        );
+        assert_eq!(result.grade(), None, "nothing was asked, so nothing grades");
+        assert_never_dialled(&listener).await;
+    }
+
+    #[tokio::test]
+    async fn probe_refuses_plain_http() {
+        let (listener, port) = loopback_listener().await;
+        let url = format!("http://127.0.0.1:{port}/latest/meta-data/");
+
+        let result = probe(&public_client(), &url, ProbePolicy::PublicOnly).await;
+
+        assert!(
+            matches!(&result, Probe::Blocked { reason, .. } if reason.contains("plaintext")),
+            "a plaintext endpoint is listed, not dialled: {result:?}"
+        );
+        assert_never_dialled(&listener).await;
+    }
+
+    /// The connect-time half. `reqwest` never asks a resolver about an IP
+    /// literal, so the literal check above cannot be the whole guard; this goes
+    /// straight to the client, past `vet_probe_url`, to prove the DNS guard is
+    /// installed. `localhost` resolves to loopback everywhere without a network.
+    #[tokio::test]
+    async fn probe_client_dns_guard_refuses_localhost_name() {
+        let (listener, port) = loopback_listener().await;
+        let url = format!("https://localhost:{port}/");
+
+        let error = public_client()
+            .get(&url)
+            .send()
+            .await
+            .expect_err("the guarded resolver must refuse a name resolving to loopback");
+
+        let refusal = dns_refusal_in_chain(&error);
+        assert!(
+            refusal
+                .as_deref()
+                .is_some_and(|r| r.contains("localhost resolves to non-routable")),
+            "affinidi-did-web's refusal must be recoverable from the error chain: {error:?}"
+        );
+        assert!(
+            matches!(send_failure(&url, &error), Probe::Blocked { .. }),
+            "a DNS refusal is a block, not an unreachable host"
+        );
+        assert_never_dialled(&listener).await;
+    }
+
+    /// A 3xx proves the host answers; following it would let a public endpoint
+    /// hand the probe on to an internal one. `AllowPrivate` only so the first
+    /// hop (a local mock) is dialled at all.
+    #[tokio::test]
+    async fn probe_does_not_follow_redirects() {
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let target = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&target)
+            .await;
+
+        let redirector = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("Location", format!("{}/latest/meta-data/", target.uri())),
+            )
+            .mount(&redirector)
+            .await;
+
+        let client = probe_client(ProbePolicy::AllowPrivate).expect("the probe client builds");
+        let result = probe(&client, &redirector.uri(), ProbePolicy::AllowPrivate).await;
+
+        assert_eq!(
+            result,
+            Probe::Reachable {
+                url: redirector.uri(),
+                http_status: 302,
+            }
+        );
+        assert!(
+            target
+                .received_requests()
+                .await
+                .expect("request recording is on")
+                .is_empty(),
+            "the redirect target must never be requested"
+        );
+    }
+
+    /// The end-to-end case: a `did:peer:2` carries its service inline and
+    /// resolves offline, so a DID alone is enough to name an internal endpoint.
+    /// Both a plaintext and an HTTPS form must come back not probed, with a
+    /// finding each and no connection made.
+    #[tokio::test]
+    async fn health_report_blocks_did_peer_inline_internal_service() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let (listener, port) = loopback_listener().await;
+        let did_with_service = |endpoint: String| {
+            let service = json!({ "t": "dm", "s": endpoint }).to_string();
+            format!(
+                "did:peer:2.Vz6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK.S{}",
+                URL_SAFE_NO_PAD.encode(service)
+            )
+        };
+
+        let report = build_report(&[
+            Subject::new(
+                Role::Vtc,
+                "plaintext",
+                did_with_service(format!("http://127.0.0.1:{port}/latest/meta-data/")),
+            ),
+            Subject::new(
+                Role::Vtc,
+                "https",
+                did_with_service(format!("https://127.0.0.1:{port}/latest/meta-data/")),
+            ),
+        ])
+        .await;
+
+        assert_eq!(report.parties.len(), 2, "{report:#?}");
+        for party in &report.parties {
+            let resolved = party
+                .resolved
+                .as_ref()
+                .unwrap_or_else(|| panic!("did:peer resolves offline: {party:#?}"));
+            assert!(
+                matches!(resolved.probes.as_slice(), [Probe::Blocked { .. }]),
+                "{}: the inline internal endpoint must be blocked: {:?}",
+                party.label,
+                resolved.probes
+            );
+        }
+        assert_eq!(
+            report
+                .notes
+                .iter()
+                .filter(|n| n.contains("not probed"))
+                .count(),
+            2,
+            "each blocked endpoint is a finding: {:?}",
+            report.notes
+        );
+        assert_never_dialled(&listener).await;
+    }
+
+    /// The literal half runs on the canonical URL, so the alternate spellings of
+    /// an internal address are caught too. Every vector is refused before any
+    /// I/O, so none of this touches the network.
+    #[test]
+    fn probe_urls_are_vetted_after_canonicalisation() {
+        for url in [
+            // Alternate IPv4 encodings of loopback.
+            "https://2130706433/",
+            "https://0x7f000001/",
+            "https://017700000001/",
+            "https://0177.0.0.1/",
+            "https://0x7f.0.0.1/",
+            "https://127.1/",
+            "https://127.0.1/",
+            "https://0/",
+            "https://%31%32%37.0.0.1/",
+            // Metadata, CGNAT, IPv6 forms.
+            "https://169.254.169.254./",
+            "https://100.100.100.200/",
+            "https://[::ffff:127.0.0.1]/",
+            "https://[0:0:0:0:0:ffff:7f00:1]/",
+            "https://[::1]:8443/",
+            "https://[fd00:ec2::254]/",
+            // Names.
+            "https://localhost/",
+            "https://LOCALHOST./",
+            "https://svc.localhost/",
+            "https://printer.local/",
+            "https://kube-dns.kube-system.svc.cluster.local/",
+            // Userinfo, including the confusable forms.
+            "https://example.com@127.0.0.1/",
+            "https://127.0.0.1\\@example.com/",
+            "https://user:pass@example.com/",
+            // Invalid.
+            "https://0x100000000/",
+            "https://1.2.3.4.5/",
+            "https://[fe80::1%25en0]/",
+            "not a url",
+            // Schemes.
+            "http://example.com/",
+            "ws://example.com/",
+            "ftp://example.com/",
+            "file:///etc/passwd",
+            "gopher://example.com/",
+            "data:text/plain,x",
+            "javascript:alert(1)",
+            "blob:https://x/y",
+        ] {
+            assert!(
+                vet_probe_url(url, ProbePolicy::PublicOnly).is_err(),
+                "{url} must not be probed"
+            );
+        }
+        for url in [
+            "https://example.com/",
+            "https://example.com./",
+            "https://localhost.example.com/",
+            "https://8.8.8.8/",
+            "https://[2606:4700:4700::1111]/",
+        ] {
+            assert!(
+                vet_probe_url(url, ProbePolicy::PublicOnly).is_ok(),
+                "{url} is a public HTTPS endpoint and must be probed"
+            );
+        }
+    }
+
+    /// The dev-stack escape hatch admits plaintext and private hosts, and
+    /// nothing more: credentials and non-HTTP schemes are still refused.
+    #[test]
+    fn allow_private_admits_dev_endpoints_but_not_credentials() {
+        for url in [
+            "http://localhost:8000/",
+            "http://127.0.0.1:9099/",
+            "http://[::1]:7037/",
+            "https://10.0.0.5/",
+        ] {
+            assert!(
+                vet_probe_url(url, ProbePolicy::AllowPrivate).is_ok(),
+                "{url} is a dev endpoint AllowPrivate exists for"
+            );
+        }
+        for url in [
+            "https://user:pass@10.0.0.5/",
+            "ftp://127.0.0.1/",
+            "not a url",
+        ] {
+            assert!(
+                vet_probe_url(url, ProbePolicy::AllowPrivate).is_err(),
+                "{url} must still be refused"
+            );
+        }
+    }
+
+    /// A blocked endpoint is stated, and is additive for `--json` consumers,
+    /// but it does not make the chain unhealthy.
+    #[test]
+    fn a_blocked_probe_is_a_finding_but_not_a_fault() {
+        let blocked = Probe::Blocked {
+            url: "https://127.0.0.1/".into(),
+            reason: "non-public host 127.0.0.1".into(),
+        };
+        assert_eq!(
+            serde_json::to_value(&blocked).expect("serialises"),
+            json!({
+                "status": "blocked",
+                "url": "https://127.0.0.1/",
+                "reason": "non-public host 127.0.0.1",
+            })
+        );
+
+        let mut party = resolved_party(
+            Role::Vtc,
+            "VTC",
+            "did:peer:2.x",
+            &json!({"service": [{
+                "id": "#dc", "type": "DIDCommMessaging",
+                "serviceEndpoint": "https://127.0.0.1/",
+            }]}),
+        );
+        party.resolved.as_mut().expect("resolved").probes = vec![blocked];
+        let parties = vec![party];
+        let notes = collect_notes(&parties, &[]);
+        assert!(
+            notes
+                .iter()
+                .any(|n| n.contains("https://127.0.0.1/ not probed (non-public host 127.0.0.1)")),
+            "{notes:?}"
+        );
+        assert!(
+            HealthReport {
+                parties,
+                links: Vec::new(),
+                notes,
+            }
+            .is_healthy()
         );
     }
 }

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -37,6 +37,9 @@ pub mod join;
 pub mod logs;
 pub mod members;
 pub mod messaging;
+// Crate-private stopgap: a copy of `affinidi-did-web`'s host classifier until
+// that crate exports it (see the module header).
+mod net_guard;
 #[cfg(feature = "openpgp-card")]
 pub mod openpgp_card;
 pub mod persona;

--- a/openvtc-core/src/net_guard.rs
+++ b/openvtc-core/src/net_guard.rs
@@ -1,0 +1,147 @@
+//! Which hosts an outbound probe must never be pointed at.
+//!
+//! **Keep in sync with `affinidi-did-web`** (`src/lib.rs`, `host_is_blocked` /
+//! `ip_is_blocked`; copied from 0.1.4). That crate already guards DID
+//! *resolution* and exports the connect-time half of the check
+//! ([`affinidi_did_web::guarded_dns_resolver`]), but keeps this classifier
+//! private. Replace this module with the exported API once one is published, so
+//! resolution and probing enforce one policy rather than two copies of it.
+//!
+//! This classifies a host **as written in the URL**. A hostname that resolves
+//! to one of these addresses is refused separately, at connect time, by the DNS
+//! resolver the probe client installs.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Whether `host` is one an outbound request must refuse: loopback, RFC-1918 /
+/// unique-local, carrier-grade NAT, link-local (which includes the
+/// cloud-metadata address `169.254.169.254`), unspecified, or broadcast. Bare
+/// `localhost` and `*.localhost` / `*.local` are refused by name.
+///
+/// Takes the host as `reqwest::Url::host_str` returns it: already WHATWG
+/// canonicalised (so `2130706433` and `0x7f.1` arrive as `127.0.0.1`), with
+/// IPv6 literals in brackets.
+pub(crate) fn is_blocked_host(host: &str) -> bool {
+    // A trailing root dot is part of a legal hostname and survives URL
+    // normalisation, so `localhost.` must normalise to `localhost` before the
+    // name comparisons -- otherwise it walks straight through this guard.
+    let h = host
+        .trim_end_matches('.')
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_ascii_lowercase();
+    if h == "localhost" || h.ends_with(".localhost") || h.ends_with(".local") {
+        return true;
+    }
+    match h.parse::<IpAddr>() {
+        Ok(a) => is_blocked_ip(a),
+        Err(_) => false,
+    }
+}
+
+/// Whether an address must never be connected to.
+fn is_blocked_ip(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(a) => ipv4_is_blocked(a),
+        IpAddr::V6(a) => ipv6_is_blocked(a),
+    }
+}
+
+fn ipv4_is_blocked(a: Ipv4Addr) -> bool {
+    let o = a.octets();
+    a.is_loopback()
+        || a.is_private()
+        || a.is_link_local() // 169.254.0.0/16 — covers cloud metadata 169.254.169.254
+        || a.is_broadcast()
+        || o[0] == 0 // 0.0.0.0/8 "this network" — includes the unspecified address
+        // 100.64.0.0/10 carrier-grade NAT: the Alibaba/Oracle metadata address
+        // 100.100.100.200 lives here, as do the node/pod CIDRs of many
+        // Kubernetes deployments. `Ipv4Addr::is_shared` is still unstable.
+        || (o[0] == 100 && (64..128).contains(&o[1]))
+        || (o[0] == 192 && o[1] == 0 && o[2] == 0) // 192.0.0.0/24 IETF protocol assignments
+        || (o[0] == 198 && (o[1] & 0xfe) == 18) // 198.18.0.0/15 benchmarking
+}
+
+fn ipv6_is_blocked(a: Ipv6Addr) -> bool {
+    if a.is_loopback() || a.is_unspecified() {
+        return true;
+    }
+    // Both IPv4-mapped (::ffff:a.b.c.d) and the deprecated IPv4-compatible
+    // (::a.b.c.d) forms reach the same v4 target on stacks that still route
+    // them, and `to_ipv4` — unlike `to_ipv4_mapped` — covers both.
+    if let Some(v4) = a.to_ipv4() {
+        return ipv4_is_blocked(v4);
+    }
+    let s = a.segments();
+    // NAT64 well-known prefix 64:ff9b::/96 embeds a v4 destination in the low
+    // 32 bits, so classify that destination.
+    if s[0] == 0x0064 && s[1] == 0xff9b && s[2..6] == [0, 0, 0, 0] {
+        let v4 = Ipv4Addr::from((u32::from(s[6]) << 16) | u32::from(s[7]));
+        return ipv4_is_blocked(v4);
+    }
+    (s[0] & 0xfe00) == 0xfc00 // unique-local fc00::/7
+        || (s[0] & 0xffc0) == 0xfe80 // link-local fe80::/10
+        || (s[0] & 0xffc0) == 0xfec0 // deprecated site-local fec0::/10
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Vectors copied from `affinidi-did-web` 0.1.4 — keep in sync with it.
+
+    #[test]
+    fn host_guard_blocks_internal_and_metadata() {
+        for h in [
+            "127.0.0.1",
+            "0.0.0.0",
+            "0.1.2.3", // 0.0.0.0/8 "this network"
+            "10.0.0.5",
+            "172.16.9.9",
+            "192.168.1.1",
+            "169.254.169.254", // cloud metadata
+            "100.100.100.200", // Alibaba/Oracle metadata, in CGNAT space
+            "100.64.0.1",      // CGNAT lower bound
+            "100.127.255.254", // CGNAT upper bound
+            "192.0.0.1",       // IETF protocol assignments
+            "198.19.0.1",      // benchmarking range
+            "255.255.255.255", // broadcast
+            "localhost",
+            "localhost.", // trailing root dot
+            "LOCALHOST",
+            "svc.localhost",
+            "svc.localhost.",
+            "printer.local",
+            "printer.local.",
+            "::1",
+            "[::1]",
+            "::ffff:127.0.0.1", // IPv4-mapped loopback
+            "::ffff:169.254.169.254",
+            "::127.0.0.1",     // IPv4-compatible loopback
+            "64:ff9b::7f00:1", // NAT64-embedded loopback
+            "fc00::1",         // unique-local
+            "fe80::1",         // link-local
+            "fec0::1",         // deprecated site-local
+        ] {
+            assert!(is_blocked_host(h), "{h} should be blocked");
+        }
+    }
+
+    #[test]
+    fn host_guard_allows_public_hosts() {
+        for h in [
+            "example.com",
+            "example.com.",
+            "did.example.org",
+            "localhost.example.com", // "localhost" only as the whole name or a suffix label
+            "8.8.8.8",
+            "99.64.0.1",   // just below CGNAT
+            "100.63.0.1",  // just below CGNAT
+            "100.128.0.1", // just above CGNAT
+            "2606:4700:4700::1111",
+            "64:ff9b::808:808", // NAT64-embedded public address
+        ] {
+            assert!(!is_blocked_host(h), "{h} should be allowed");
+        }
+    }
+}

--- a/openvtc/src/cli.rs
+++ b/openvtc/src/cli.rs
@@ -47,7 +47,9 @@ pub fn cli() -> Command {
                     "Map the messaging path between this client and a community.\n\n\
                      For every DID involved — each persona, the VTA, every mediator, and \
                      each VTC — this resolves the DID document, prints its service \
-                     definitions verbatim, and probes any transport URLs. It then runs \
+                     definitions verbatim, and probes any public HTTPS transport URLs \
+                     (plaintext and non-public ones are listed, not dialled; redirects \
+                     are not followed). It then runs \
                      the same TSP > DIDComm > REST negotiation a real send performs, so \
                      the reported transport is the one that would actually be used.\n\n\
                      Parties may sit behind different mediators; that is supported and \
@@ -77,6 +79,15 @@ pub fn cli() -> Command {
                         .help(
                             "Also report whether this account could be rebuilt from its \
                              Trust Context if this machine were lost. Read-only.",
+                        ),
+                    Arg::new("allow-private-probes")
+                        .long("allow-private-probes")
+                        .action(clap::ArgAction::SetTrue)
+                        .help(
+                            "Also probe transport URLs that are plaintext or that point at \
+                             loopback, private or link-local addresses. By default those are \
+                             listed but not dialled, because the URLs come from DID documents \
+                             anyone can publish. For local development stacks only.",
                         ),
                 ]),
         )

--- a/openvtc/src/health_cmd.rs
+++ b/openvtc/src/health_cmd.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use console::style;
 use openvtc_core::config::{Config, KeyBackend};
 use openvtc_core::health::{
-    HealthReport, LinkOutcome, Party, Probe, ProbeGrade, Role, Step, Subject,
+    HealthReport, LinkOutcome, Party, Probe, ProbeGrade, ProbePolicy, Role, Step, Subject,
     build_report_with_progress,
 };
 
@@ -32,6 +32,7 @@ pub async fn run(
     vtc_args: &[String],
     as_json: bool,
     recoverable: bool,
+    allow_private_probes: bool,
 ) -> Result<()> {
     let local = local_report(profile);
     let access = config.and_then(vta_access);
@@ -120,11 +121,28 @@ pub async fn run(
         std::process::exit(1);
     }
 
+    // Probe URLs come from DID documents anyone can publish, so by default a
+    // plaintext or non-public one is listed rather than dialled. The opt-out is
+    // for dev stacks on loopback, and says so every time it is used.
+    let policy = if allow_private_probes {
+        eprintln!(
+            "{}",
+            style(
+                "warning: --allow-private-probes: plaintext and loopback/private/link-local \
+                 transport URLs from DID documents will be probed."
+            )
+            .themed(CLI_CAUTION)
+        );
+        ProbePolicy::AllowPrivate
+    } else {
+        ProbePolicy::PublicOnly
+    };
+
     // Progress goes to stderr, the report to stdout. That keeps
     // `openvtc health --json > report.json` piping cleanly while still showing
     // the operator what is being waited on — and progress *is* wanted under
     // `--json`, since that is the run most likely to be watched rather than read.
-    let report = build_report_with_progress(&subjects, &|step| trace(&step)).await;
+    let report = build_report_with_progress(&subjects, &|step| trace(&step), policy).await;
 
     if as_json {
         // Additive: the existing report keys stay where they are, with the
@@ -511,6 +529,11 @@ fn trace(step: &Step) {
                 style("✗").themed(CLI_ERROR).bold(),
                 dim(secs(elapsed)),
             ),
+            Probe::Blocked { url, reason } => eprintln!(
+                "    {} {url} — {} ({reason})",
+                style("!").themed(CLI_CAUTION).bold(),
+                style("not probed").themed(CLI_CAUTION),
+            ),
         },
         Step::Negotiating { pairs } => {
             if *pairs > 0 {
@@ -667,6 +690,10 @@ fn render_party(party: &Party) {
                 "    probe {url} → {} ({error})",
                 style("unreachable").themed(CLI_ERROR).bold(),
             ),
+            Probe::Blocked { url, reason } => println!(
+                "    probe {url} → {} ({reason})",
+                style("not probed").themed(CLI_CAUTION).bold(),
+            ),
         }
     }
 }
@@ -679,6 +706,9 @@ fn render_party(party: &Party) {
 /// "responding", which is exactly what it is: the host is there and that path
 /// does not serve GETs.
 fn probe_words(probe: &Probe) -> (&'static str, crate::theme::Role) {
+    if let Probe::Blocked { .. } = probe {
+        return ("not probed", CLI_CAUTION);
+    }
     match probe.grade() {
         Some(ProbeGrade::Ok) => ("ok", CLI_INFO),
         Some(ProbeGrade::Responding) => ("responding", CLI_INFO),

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -452,7 +452,16 @@ async fn main() -> Result<()> {
         let as_json = health_args.get_flag("json");
         let config = load_config_for_health(&profile, unlock_code_arg.as_deref()).await;
         let recoverable = health_args.get_flag("recoverable");
-        return health_cmd::run(&profile, config.as_ref(), &vtc_dids, as_json, recoverable).await;
+        let allow_private_probes = health_args.get_flag("allow-private-probes");
+        return health_cmd::run(
+            &profile,
+            config.as_ref(),
+            &vtc_dids,
+            as_json,
+            recoverable,
+            allow_private_probes,
+        )
+        .await;
     }
 
     // Check if profile is currently active elsewhere?


### PR DESCRIPTION

## Summary

`openvtc health` probes the transport URLs published in each resolved DID document. Those URLs come from documents anyone can publish, and the probe client dialled them as written: any scheme the filter let through, any host, the system proxy, and up to 10 redirects. Resolution itself was already guarded by `affinidi-did-web`, but that guard lives on the resolver's own HTTP client and never reached the probe.

The probe now applies the same policy:

- **Probe client** (`probe_client`): redirects disabled (a 3xx still counts as reachable), no proxy, a connect timeout, and, by default, `affinidi_did_web::guarded_dns_resolver()`. That resolver refuses a hostname that resolves to a non-routable address and connects only to the addresses it checked.
- **URL vetting before any I/O** (`vet_probe_url`). The DNS guard never sees IP-literal hosts, so the parsed URL is checked first. It refuses:
  - an unparseable URL;
  - a non-HTTPS scheme (plaintext endpoints are listed, not dialled);
  - userinfo;
  - a loopback, private, CGNAT, link-local or `localhost`/`.local` host, checked after WHATWG canonicalisation.

  The parsed URL that was vetted is the one sent.
- **New `Probe::Blocked { url, reason }`** (`"status": "blocked"` in `--json`, additive). `grade()` returns `None` for it. It adds a finding line, and a DNS-guard refusal found in the error chain also maps to it. `is_healthy` is unchanged: a blocked endpoint is reported, not treated as a broken chain.
- **`--allow-private-probes`** on `health` restores plaintext and private-address probing for local development stacks, and prints a one-line warning when used. Userinfo and non-HTTP schemes are still refused. `build_report` stays public-only; `build_report_with_progress` now takes a `ProbePolicy`.

The host classifier is a local copy of `affinidi-did-web` 0.1.4's (`openvtc-core/src/net_guard.rs`), with that crate's test vectors. It is marked to be replaced by the exported API once `affinidi-did-web` publishes one. `affinidi-did-web` becomes a direct dependency at the version already in `Cargo.lock`, so there is no new crate and no version change (the lockfile diff is one line).

## Breaking change (library API)

`openvtc_core::health::build_report_with_progress` gains a `policy: ProbePolicy` argument, and `Probe` gains a variant. The only in-tree caller is `openvtc/src/health_cmd.rs`, which is updated.

## Tests

New in `openvtc-core/src/health.rs`:

- `probe_refuses_loopback_literal_without_dialing`: a loopback listener sees no connection.
- `probe_refuses_plain_http`
- `probe_client_dns_guard_refuses_localhost_name`: the DNS guard is installed and its refusal is recognised in the error chain.
- `probe_does_not_follow_redirects`: the redirect target receives no request.
- `health_report_blocks_did_peer_inline_internal_service`: end to end through `build_report`, for both plaintext and HTTPS forms.
- `probe_urls_are_vetted_after_canonicalisation`: alternate IP encodings, IPv6 forms, names, userinfo, schemes.
- `allow_private_admits_dev_endpoints_but_not_credentials`
- `a_blocked_probe_is_a_finding_but_not_a_fault`: JSON shape, finding line, health unchanged.

New in `openvtc-core/src/net_guard.rs`: the classifier vectors from `affinidi-did-web`.
