### PR TITLE
fix(config): release builds ignore VTA and mediator environment overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,22 @@ jobs:
           cargo check -p openvtc-core --no-default-features --features arbitrary
           cargo test -p openvtc-core --features arbitrary --lib
 
+  test-dev-overrides:
+    name: Test (dev-overrides)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
+      # The trust-anchor env overrides compile only under this feature, so the
+      # default jobs never see that code. Lint and test it explicitly.
+      - run: cargo clippy -p openvtc --all-targets --features dev-overrides -- -D warnings
+      - run: cargo test -p openvtc --features dev-overrides
+
   doc:
     name: Documentation
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Release builds no longer take their VTA or mediator from the environment.**
+  `OPENVTC_VTA_URL`, `OPENVTC_VTA_DID` and `OPENVTC_MEDIATOR_DID` are honoured
+  only by a build compiled with the new `dev-overrides` feature
+  (`cargo run -p openvtc --features dev-overrides`). Any other build ignores
+  them and says so, on stderr before the TUI starts and in the Activity Log.
+  This covers the setup wizard's `OPENVTC_VTA_URL` shortcut too.
+
+  In a `dev-overrides` build the values are validated (DIDs must parse, the URL
+  must be http(s)). They apply to the running process only, and a red
+  `DEV OVERRIDE` badge stays in the bottom bar while they do. Saves and exports
+  keep writing the stored VTA URL, VTA DID and persona mediator. Before this
+  change, a variable set for one launch was written into the profile by the
+  next save and outlived the environment. CI now also runs
+  `cargo test -p openvtc --features dev-overrides`.
+
 ### Fixed
 
 - **The wipe-profile screen names the context it tells you to delete.** It sent

--- a/openvtc-core/README.md
+++ b/openvtc-core/README.md
@@ -56,7 +56,7 @@ requests, trust pings, VRC issuance, and maintainer list exchange.
 
 | Variable | Purpose |
 |----------|---------|
-| `OPENVTC_MEDIATOR_DID` | Override the default Linux Foundation public mediator DID. |
+| `OPENVTC_MEDIATOR_DID` | Not read by this crate. The `openvtc` binary honours it only when built with the `dev-overrides` feature (runtime-only, never saved); release builds ignore it. |
 | `OPENVTC_ORG_DID` | Override the default Linux Foundation organisation DID. |
 
 ## License

--- a/openvtc-core/src/config/loading.rs
+++ b/openvtc-core/src/config/loading.rs
@@ -681,6 +681,7 @@ impl Config {
                 integrity,
                 protected_key,
                 active_persona: None,
+                runtime_trust_overrides: None,
                 key_backend,
                 public: public_config,
                 private: private_cfg,

--- a/openvtc-core/src/config/mod.rs
+++ b/openvtc-core/src/config/mod.rs
@@ -351,6 +351,30 @@ pub struct Config {
     /// startup/setup (which run before any selection) behave exactly as before.
     /// Not persisted — a pure runtime selection pointer over `identities`.
     pub active_persona: Option<account::PersonaId>,
+
+    /// The persisted VTA trust anchor as it was before a runtime-only override
+    /// replaced it. `None` (the normal case) means `key_backend` holds exactly
+    /// what is on disk.
+    ///
+    /// Runtime-only, never serialized. Set only through
+    /// [`Config::override_vta_url_runtime`] / [`Config::override_vta_did_runtime`],
+    /// and read by every write path ([`Config::save`], [`Config::export`],
+    /// [`Config::clone_for_save`]) so an override never becomes the saved
+    /// anchor.
+    pub runtime_trust_overrides: Option<OriginalTrustAnchors>,
+}
+
+/// The VTA trust-anchor values an override displaced, kept so the save path can
+/// write them back instead of the override.
+///
+/// Each field is `Some` only when that value was overridden; the first original
+/// wins if the same value is overridden twice.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OriginalTrustAnchors {
+    /// The persisted `KeyBackend::Vta::vta_url`.
+    pub vta_url: Option<String>,
+    /// The persisted `KeyBackend::Vta::vta_did`.
+    pub vta_did: Option<String>,
 }
 
 /// Serializable bundle of public and secured config, used for import/export.
@@ -672,6 +696,84 @@ impl Config {
             ctx.mediator_did = Some(did.to_string());
         }
         true
+    }
+
+    /// Point the active persona's *runtime* identity at `did` for this process
+    /// only, leaving the persisted `account` record untouched.
+    ///
+    /// The sibling of [`Config::set_active_mediator_did`] for development
+    /// overrides: listeners and outbound sends read the runtime
+    /// `IdentityContext`, so the override takes effect, but nothing a save
+    /// writes changes, so it is gone on the next launch.
+    ///
+    /// Returns `false` when there is no active identity to set it on.
+    #[must_use = "a false return means the mediator DID was NOT set"]
+    pub fn set_active_mediator_did_runtime(&mut self, did: &str) -> bool {
+        let Some(id) = self.active_identity().map(|i| i.persona_id) else {
+            return false;
+        };
+        match self.identities.get_mut(&id) {
+            Some(ctx) => {
+                ctx.mediator_did = Some(did.to_string());
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Replace the VTA REST URL for this process only, recording the persisted
+    /// value so every save keeps writing it.
+    ///
+    /// Returns `false` (and changes nothing) for a non-VTA key backend.
+    #[must_use = "a false return means the VTA URL was NOT overridden"]
+    pub fn override_vta_url_runtime(&mut self, url: &str) -> bool {
+        let KeyBackend::Vta { vta_url, .. } = &mut self.key_backend else {
+            return false;
+        };
+        let original = std::mem::replace(vta_url, url.to_string());
+        self.runtime_trust_overrides
+            .get_or_insert_with(OriginalTrustAnchors::default)
+            .vta_url
+            .get_or_insert(original);
+        true
+    }
+
+    /// Replace the VTA DID for this process only, recording the persisted value
+    /// so every save keeps writing it.
+    ///
+    /// Returns `false` (and changes nothing) for a non-VTA key backend.
+    #[must_use = "a false return means the VTA DID was NOT overridden"]
+    pub fn override_vta_did_runtime(&mut self, did: &str) -> bool {
+        let KeyBackend::Vta { vta_did, .. } = &mut self.key_backend else {
+            return false;
+        };
+        let original = std::mem::replace(vta_did, did.to_string());
+        self.runtime_trust_overrides
+            .get_or_insert_with(OriginalTrustAnchors::default)
+            .vta_did
+            .get_or_insert(original);
+        true
+    }
+
+    /// The VTA `(url, did)` a save must write: the persisted originals where a
+    /// runtime override displaced them, the live values otherwise. `None` for a
+    /// non-VTA key backend.
+    pub fn persisted_vta_anchor(&self) -> Option<(&str, &str)> {
+        let KeyBackend::Vta {
+            vta_url, vta_did, ..
+        } = &self.key_backend
+        else {
+            return None;
+        };
+        let originals = self.runtime_trust_overrides.as_ref();
+        Some((
+            originals
+                .and_then(|o| o.vta_url.as_deref())
+                .unwrap_or(vta_url),
+            originals
+                .and_then(|o| o.vta_did.as_deref())
+                .unwrap_or(vta_did),
+        ))
     }
 
     /// Whether `did` is one of our resolved persona DIDs (vs. a relationship
@@ -1650,6 +1752,7 @@ mod tests {
             account: account::Account::default(),
             identities,
             active_persona: None,
+            runtime_trust_overrides: None,
         }
     }
 
@@ -1876,6 +1979,98 @@ mod tests {
                 .and_then(|p| p.mediator_did.as_deref()),
             Some("did:webvh:example:mediator"),
             "the persisted record must move too, or the change is lost on restart"
+        );
+    }
+
+    /// The runtime-only sibling moves what listeners read and nothing a save
+    /// writes.
+    #[test]
+    fn runtime_mediator_override_leaves_the_account_record_alone() {
+        let pid = account::PersonaId(uuid::Uuid::from_u128(1));
+        let mut identities = BTreeMap::new();
+        identities.insert(pid, test_identity(pid, "did:example:persona"));
+        let mut config = test_config(identities);
+        config.account.personas.insert(
+            pid,
+            account::PersonaRecord {
+                persona_id: pid,
+                did: "did:example:persona".to_string(),
+                did_document: None,
+                key_refs: Vec::new(),
+                mediator_did: Some("did:example:persisted-mediator".to_string()),
+                origin_context_id: "openvtc/test".to_string(),
+                created_at: chrono::Utc::now(),
+                label: None,
+                extra: serde_json::Map::new(),
+            },
+        );
+
+        assert!(config.set_active_mediator_did_runtime("did:example:runtime-mediator"));
+        assert_eq!(config.mediator_did(), "did:example:runtime-mediator");
+        assert_eq!(
+            config
+                .account
+                .personas
+                .get(&pid)
+                .and_then(|p| p.mediator_did.as_deref()),
+            Some("did:example:persisted-mediator"),
+        );
+
+        assert!(
+            !test_config(BTreeMap::new()).set_active_mediator_did_runtime("did:example:m"),
+            "no persona, nothing to set"
+        );
+    }
+
+    /// Every write path keeps the persisted VTA anchor while a runtime override
+    /// is in effect, and a second override does not lose the original.
+    #[test]
+    fn runtime_vta_override_is_never_what_a_save_writes() {
+        let mut config = test_config(BTreeMap::new());
+        assert!(!config.override_vta_url_runtime("http://127.0.0.1:1"));
+        assert_eq!(config.persisted_vta_anchor(), None);
+
+        config.key_backend = KeyBackend::Vta {
+            credential_bundle: SecretString::new("".into()),
+            credential_did: String::new(),
+            credential_private_key: SecretString::new("".into()),
+            vta_did: "did:example:vta".to_string(),
+            vta_url: "https://vta.example".to_string(),
+            mediator_did: None,
+            encryption_seed: SecretBox::new(Box::new(vec![0u8; 32])),
+        };
+        assert!(config.override_vta_url_runtime("http://127.0.0.1:1"));
+        assert!(config.override_vta_url_runtime("http://127.0.0.1:2"));
+        assert!(config.override_vta_did_runtime("did:example:other"));
+
+        let KeyBackend::Vta {
+            vta_url, vta_did, ..
+        } = &config.key_backend
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            (vta_url.as_str(), vta_did.as_str()),
+            ("http://127.0.0.1:2", "did:example:other")
+        );
+        assert_eq!(
+            config.persisted_vta_anchor(),
+            Some(("https://vta.example", "did:example:vta"))
+        );
+
+        let secured = secured_config::SecuredConfig::from(&config);
+        assert_eq!(secured.vta_url.as_deref(), Some("https://vta.example"));
+        assert_eq!(secured.vta_did.as_deref(), Some("did:example:vta"));
+
+        let KeyBackend::Vta {
+            vta_url, vta_did, ..
+        } = config.key_backend_for_save().expect("clone")
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            (vta_url.as_str(), vta_did.as_str()),
+            ("https://vta.example", "did:example:vta")
         );
     }
 

--- a/openvtc-core/src/config/saving.rs
+++ b/openvtc-core/src/config/saving.rs
@@ -73,6 +73,35 @@ fn clone_key_backend(backend: &KeyBackend) -> Result<KeyBackend, OpenVTCError> {
 }
 
 impl Config {
+    /// A deep clone of the key backend exactly as a save must write it.
+    ///
+    /// Where a runtime-only override replaced the VTA URL or DID
+    /// ([`Config::runtime_trust_overrides`]), the persisted original is put
+    /// back, so the override lives only as long as the process.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OpenVTCError::BIP32`] if a BIP32 backend's root cannot be
+    /// rebuilt from its seed.
+    pub fn key_backend_for_save(&self) -> Result<KeyBackend, OpenVTCError> {
+        let mut backend = clone_key_backend(&self.key_backend)?;
+        if let (
+            KeyBackend::Vta {
+                vta_url, vta_did, ..
+            },
+            Some(originals),
+        ) = (&mut backend, self.runtime_trust_overrides.as_ref())
+        {
+            if let Some(url) = &originals.vta_url {
+                vta_url.clone_from(url);
+            }
+            if let Some(did) = &originals.vta_did {
+                vta_did.clone_from(did);
+            }
+        }
+        Ok(backend)
+    }
+
     /// Produce an owned, `Send + 'static` snapshot of everything [`Config::save`]
     /// reads, so the (blocking) serialize + encrypt + file/keyring/card I/O can be
     /// moved off the async runtime onto a `spawn_blocking` thread (R11).
@@ -106,7 +135,8 @@ impl Config {
         Ok(Config {
             public: self.public.clone(),
             private: self.private.clone(),
-            key_backend: clone_key_backend(&self.key_backend)?,
+            // The persisted anchor, never a runtime-only override of it.
+            key_backend: self.key_backend_for_save()?,
             key_info: self.key_info.clone(),
             protection_method: self.protection_method.clone(),
             #[cfg(feature = "openpgp-card")]
@@ -129,6 +159,9 @@ impl Config {
             identities: BTreeMap::new(),
             integrity: crate::config::integrity::LoadIntegrity::default(),
             active_persona: None,
+            // `key_backend` above already carries the originals, so the
+            // snapshot has nothing left to restore.
+            runtime_trust_overrides: None,
         })
     }
 

--- a/openvtc-core/src/config/secured_config.rs
+++ b/openvtc-core/src/config/secured_config.rs
@@ -474,24 +474,28 @@ impl From<&Config> for SecuredConfig {
             },
             KeyBackend::Vta {
                 credential_bundle,
-                vta_did,
-                vta_url,
                 mediator_did,
                 ..
-            } => SecuredConfig {
-                bip32_seed: None,
-                credential_bundle: Some(credential_bundle.clone()),
-                protected_key: cfg.protected_key.clone(),
-                vta_url: if vta_url.is_empty() {
-                    None
-                } else {
-                    Some(vta_url.clone())
-                },
-                vta_did: Some(vta_did.clone()),
-                mediator_did: mediator_did.clone(),
-                key_info: cfg.key_info.clone(),
-                protection_method: cfg.protection_method.clone(),
-            },
+            } => {
+                // The persisted anchor, not the live one: a runtime-only
+                // override (see `Config::runtime_trust_overrides`) must never
+                // reach disk through `save` or `export`.
+                let (vta_url, vta_did) = cfg.persisted_vta_anchor().unwrap_or_default();
+                SecuredConfig {
+                    bip32_seed: None,
+                    credential_bundle: Some(credential_bundle.clone()),
+                    protected_key: cfg.protected_key.clone(),
+                    vta_url: if vta_url.is_empty() {
+                        None
+                    } else {
+                        Some(vta_url.to_string())
+                    },
+                    vta_did: Some(vta_did.to_string()),
+                    mediator_did: mediator_did.clone(),
+                    key_info: cfg.key_info.clone(),
+                    protection_method: cfg.protection_method.clone(),
+                }
+            }
         }
     }
 }

--- a/openvtc-core/src/lib.rs
+++ b/openvtc-core/src/lib.rs
@@ -51,7 +51,6 @@ pub mod tsp;
 pub mod vrc;
 
 /// Primary Linux Foundation Mediator DID.
-/// Can be overridden via the `OPENVTC_MEDIATOR_DID` environment variable.
 pub const LF_PUBLIC_MEDIATOR_DID: &str =
     "did:webvh:QmetnhxzJXTJ9pyXR1BbZ2h6DomY6SB1ZbzFPrjYyaEq9V:fpp.storm.ws:public-mediator";
 
@@ -62,9 +61,10 @@ pub const LF_ORG_DID: &str =
 
 /// Resolves the mediator DID from an optional caller-supplied override.
 ///
-/// The binary is the single boundary that reads the `OPENVTC_MEDIATOR_DID`
-/// environment variable and passes its value (if any) in here; core never
-/// reads process env itself. If `override_did` is `Some` and starts with
+/// Callers pass any override explicitly; core never reads process env itself.
+/// (The `openvtc` binary does not feed `OPENVTC_MEDIATOR_DID` in here: it
+/// honours that variable only in `dev-overrides` builds, as a runtime-only
+/// change to the active persona.) If `override_did` is `Some` and starts with
 /// `"did:"`, it is returned; otherwise a warning is logged and the default
 /// [`LF_PUBLIC_MEDIATOR_DID`] is returned instead.
 pub fn mediator_did(override_did: Option<&str>) -> String {

--- a/openvtc-core/tests/config_encryption.rs
+++ b/openvtc-core/tests/config_encryption.rs
@@ -441,6 +441,7 @@ mod export_import {
             // map type (HashMap today, BTreeMap after the determinism fix).
             identities: Default::default(),
             active_persona: None,
+            runtime_trust_overrides: None,
         }
     }
 

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -18,6 +18,11 @@ openpgp-card = [
   "dep:openpgp-card-rpgp",
   "openvtc-core/openpgp-card",
 ]
+# Development builds only. Honours OPENVTC_VTA_URL, OPENVTC_VTA_DID and
+# OPENVTC_MEDIATOR_DID for the current run (validated, never saved, with a
+# DEV OVERRIDE indicator). Without it those variables are ignored and the user
+# is told so. Never enable this for a build you distribute.
+dev-overrides = []
 
 [dependencies]
 openvtc-core.workspace = true

--- a/openvtc/README.md
+++ b/openvtc/README.md
@@ -129,9 +129,38 @@ cmdkey /list | findstr openvtc
 
 ## Feature Flags
 
-| Flag           | Description                               | Default |
-|----------------|-------------------------------------------|---------|
-| `openpgp-card` | OpenPGP-compatible hardware token support | Enabled |
+| Flag            | Description                                                        | Default  |
+|-----------------|--------------------------------------------------------------------|----------|
+| `openpgp-card`  | OpenPGP-compatible hardware token support                          | Enabled  |
+| `dev-overrides` | Honour trust-anchor environment overrides (development builds only) | Disabled |
+
+### Developer trust-anchor overrides
+
+`OPENVTC_VTA_URL`, `OPENVTC_VTA_DID` and `OPENVTC_MEDIATOR_DID` change which VTA
+and mediator this client authenticates to. Builds without the `dev-overrides`
+feature, which includes every release build, **ignore them**. Each one that is
+set is reported on stderr before the TUI starts and again in the Activity Log.
+
+To point a local build at a development VTA or mediator, compile the feature in:
+
+```bash
+OPENVTC_VTA_URL=http://127.0.0.1:8080 cargo run -p openvtc --features dev-overrides
+```
+
+In a `dev-overrides` build:
+
+| Variable | Effect |
+|---|---|
+| `OPENVTC_VTA_URL` | Must be an `http://` or `https://` URL with a host. The setup wizard uses it as the VTA REST endpoint and skips DID resolution; a loaded profile uses it for this run. |
+| `OPENVTC_VTA_DID` | Must parse as a DID. Replaces the profile's VTA DID for this run. |
+| `OPENVTC_MEDIATOR_DID` | Must parse as a DID. Replaces the active persona's mediator for this run. |
+
+An override applies to the running process only. Saves and exports keep writing
+the stored values, so the override is gone as soon as the variable is unset. A
+value that fails validation is ignored and logged. While an override is active,
+the bottom bar shows a red `DEV OVERRIDE` badge naming it.
+
+`OPENVTC_FRIENDLY_NAME` only changes the display name, and every build honours it.
 
 ## Troubleshooting
 

--- a/openvtc/src/env_overrides.rs
+++ b/openvtc/src/env_overrides.rs
@@ -1,0 +1,651 @@
+//! Environment overrides for a loaded [`Config`].
+//!
+//! `OPENVTC_VTA_URL`, `OPENVTC_VTA_DID` and `OPENVTC_MEDIATOR_DID` name the
+//! parties this client authenticates to, so they are trust anchors, not
+//! preferences. Only a build compiled with the `dev-overrides` feature honours
+//! them, and then only for the current run:
+//!
+//! - each value is validated (a DID must parse, the URL must be http(s));
+//! - it is applied to the runtime config only, and every save keeps writing the
+//!   persisted value ([`Config::runtime_trust_overrides`],
+//!   [`Config::set_active_mediator_did_runtime`]);
+//! - the TUI shows a persistent `DEV OVERRIDE` indicator for the session.
+//!
+//! A build without the feature never applies them. Each one that is set is
+//! reported as ignored, on stderr before the TUI starts and in the activity log.
+//!
+//! `OPENVTC_FRIENDLY_NAME` is cosmetic and honoured by every build.
+
+use crate::state_handler::main_page::MainPageState;
+use openvtc_core::config::Config;
+
+/// Pins the VTA REST base URL (and, in the setup wizard, skips DID resolution).
+pub(crate) const VTA_URL_VAR: &str = "OPENVTC_VTA_URL";
+/// Replaces the VTA DID.
+pub(crate) const VTA_DID_VAR: &str = "OPENVTC_VTA_DID";
+/// Replaces the active persona's mediator DID.
+pub(crate) const MEDIATOR_DID_VAR: &str = "OPENVTC_MEDIATOR_DID";
+/// Cosmetic display name; not a trust anchor.
+const FRIENDLY_NAME_VAR: &str = "OPENVTC_FRIENDLY_NAME";
+
+/// Every variable that can move a trust anchor.
+pub(crate) const TRUST_ANCHOR_VARS: [&str; 3] = [VTA_URL_VAR, VTA_DID_VAR, MEDIATOR_DID_VAR];
+
+/// Why a set variable was not applied.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum IgnoreReason {
+    /// This build was compiled without `dev-overrides`.
+    #[cfg_attr(
+        feature = "dev-overrides",
+        allow(dead_code, reason = "only a release build constructs it")
+    )]
+    ReleaseBuild,
+    /// The value did not validate.
+    #[cfg(feature = "dev-overrides")]
+    Invalid(String),
+    /// The profile has nowhere to apply it.
+    #[cfg(feature = "dev-overrides")]
+    NotApplicable(&'static str),
+}
+
+/// A trust-anchor variable that was set but not applied.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Ignored {
+    pub var: &'static str,
+    pub reason: IgnoreReason,
+}
+
+impl Ignored {
+    /// One line for stderr, the activity log and the setup wizard.
+    pub(crate) fn message(&self) -> String {
+        match &self.reason {
+            IgnoreReason::ReleaseBuild => format!(
+                "{} is set but ignored: release builds do not accept trust-anchor overrides.",
+                self.var
+            ),
+            #[cfg(feature = "dev-overrides")]
+            IgnoreReason::Invalid(why) => format!("{} is set but ignored: {why}.", self.var),
+            #[cfg(feature = "dev-overrides")]
+            IgnoreReason::NotApplicable(why) => {
+                format!("{} is set but ignored: {why}.", self.var)
+            }
+        }
+    }
+}
+
+/// What [`apply_from`] did with the trust-anchor variables.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct OverrideReport {
+    /// Variables applied to the runtime config, with the value used. Only ever
+    /// non-empty in a `dev-overrides` build.
+    pub applied: Vec<(&'static str, String)>,
+    /// Variables that were set but not applied.
+    pub ignored: Vec<Ignored>,
+}
+
+impl OverrideReport {
+    /// The persistent indicator text, when any override is in effect.
+    pub(crate) fn banner(&self) -> Option<String> {
+        if self.applied.is_empty() {
+            return None;
+        }
+        let parts: Vec<String> = self
+            .applied
+            .iter()
+            .map(|(var, value)| format!("{} → {value}", label(var)))
+            .collect();
+        Some(format!("DEV OVERRIDE: {}", parts.join(" · ")))
+    }
+}
+
+fn label(var: &str) -> &str {
+    match var {
+        VTA_URL_VAR => "VTA",
+        VTA_DID_VAR => "VTA DID",
+        MEDIATOR_DID_VAR => "mediator",
+        other => other,
+    }
+}
+
+/// A set, non-blank value. An exported-but-empty variable reads as unset.
+fn non_blank(env: &impl Fn(&str) -> Option<String>, var: &str) -> Option<String> {
+    env(var)
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Apply the `OPENVTC_*` overrides read from the process environment.
+pub(crate) fn apply_env_overrides(config: &mut Config) -> OverrideReport {
+    apply_from(config, |k| std::env::var(k).ok())
+}
+
+/// Apply overrides read through `env`, so tests supply their own environment
+/// instead of mutating the process's.
+pub(crate) fn apply_from(
+    config: &mut Config,
+    env: impl Fn(&str) -> Option<String>,
+) -> OverrideReport {
+    let mut report = OverrideReport::default();
+    for var in TRUST_ANCHOR_VARS {
+        if let Some(value) = non_blank(&env, var) {
+            apply_trust_anchor(config, var, value, &mut report);
+        }
+    }
+    if let Some(name) = env(FRIENDLY_NAME_VAR) {
+        config.public.friendly_name = name;
+    }
+    report
+}
+
+#[cfg(not(feature = "dev-overrides"))]
+fn apply_trust_anchor(
+    _config: &mut Config,
+    var: &'static str,
+    _value: String,
+    report: &mut OverrideReport,
+) {
+    report.ignored.push(Ignored {
+        var,
+        reason: IgnoreReason::ReleaseBuild,
+    });
+}
+
+#[cfg(feature = "dev-overrides")]
+fn apply_trust_anchor(
+    config: &mut Config,
+    var: &'static str,
+    value: String,
+    report: &mut OverrideReport,
+) {
+    const NOT_VTA: IgnoreReason = IgnoreReason::NotApplicable("this profile is not VTA-managed");
+    let outcome = match var {
+        VTA_URL_VAR => parse_vta_url(&value).and_then(|url| {
+            if config.override_vta_url_runtime(&url) {
+                Ok(url)
+            } else {
+                Err(NOT_VTA)
+            }
+        }),
+        VTA_DID_VAR => parse_did(&value).and_then(|did| {
+            if config.override_vta_did_runtime(&did) {
+                Ok(did)
+            } else {
+                Err(NOT_VTA)
+            }
+        }),
+        MEDIATOR_DID_VAR => parse_did(&value).and_then(|did| {
+            if config.set_active_mediator_did_runtime(&did) {
+                Ok(did)
+            } else {
+                Err(IgnoreReason::NotApplicable(
+                    "this profile has no persona to set a mediator on",
+                ))
+            }
+        }),
+        _ => return,
+    };
+    match outcome {
+        Ok(value) => report.applied.push((var, value)),
+        Err(reason) => report.ignored.push(Ignored { var, reason }),
+    }
+}
+
+/// Accept only an absolute http(s) URL with a host. The value is returned as
+/// given (trimmed): `Url`'s own rendering adds a trailing `/`, which would turn
+/// `{base}/auth/challenge` into `//auth/challenge`.
+#[cfg(feature = "dev-overrides")]
+pub(crate) fn parse_vta_url(raw: &str) -> Result<String, IgnoreReason> {
+    let url = url::Url::parse(raw)
+        .map_err(|e| IgnoreReason::Invalid(format!("not a valid URL ({e})")))?;
+    if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none_or(str::is_empty) {
+        return Err(IgnoreReason::Invalid(
+            "must be an http:// or https:// URL with a host".to_string(),
+        ));
+    }
+    Ok(raw.to_string())
+}
+
+#[cfg(feature = "dev-overrides")]
+fn parse_did(raw: &str) -> Result<String, IgnoreReason> {
+    raw.parse::<affinidi_tdk::did_common::DID>()
+        .map(|_| raw.to_string())
+        .map_err(|e| IgnoreReason::Invalid(format!("not a valid DID ({e})")))
+}
+
+/// The setup wizard's view of `OPENVTC_VTA_URL`, which it reads on its own
+/// before any config exists.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum WizardUrlOverride {
+    /// Not set (or blank).
+    Unset,
+    /// Set, but not used; the message says why.
+    Ignored(String),
+    /// Use this REST base URL (`dev-overrides` builds only).
+    #[cfg_attr(
+        not(feature = "dev-overrides"),
+        allow(dead_code, reason = "only a dev-overrides build constructs it")
+    )]
+    Active(String),
+}
+
+/// Gate an already-normalized `OPENVTC_VTA_URL` value for the setup wizard.
+pub(crate) fn wizard_vta_url_override(normalized: Option<String>) -> WizardUrlOverride {
+    let Some(raw) = normalized else {
+        return WizardUrlOverride::Unset;
+    };
+    #[cfg(not(feature = "dev-overrides"))]
+    {
+        let _ = raw;
+        WizardUrlOverride::Ignored(
+            Ignored {
+                var: VTA_URL_VAR,
+                reason: IgnoreReason::ReleaseBuild,
+            }
+            .message(),
+        )
+    }
+    #[cfg(feature = "dev-overrides")]
+    match parse_vta_url(&raw) {
+        Ok(url) => WizardUrlOverride::Active(url),
+        Err(reason) => WizardUrlOverride::Ignored(
+            Ignored {
+                var: VTA_URL_VAR,
+                reason,
+            }
+            .message(),
+        ),
+    }
+}
+
+/// One stderr line to print before the TUI takes the terminal, or `None` when
+/// no trust-anchor variable is set.
+pub(crate) fn startup_notice(env: impl Fn(&str) -> Option<String>) -> Option<String> {
+    let set: Vec<&str> = TRUST_ANCHOR_VARS
+        .into_iter()
+        .filter(|var| non_blank(&env, var).is_some())
+        .collect();
+    if set.is_empty() {
+        return None;
+    }
+    let names = set.join(", ");
+    if cfg!(feature = "dev-overrides") {
+        Some(format!(
+            "DEV OVERRIDE: {names} will be applied for this run only and never saved \
+             (dev-overrides build)."
+        ))
+    } else {
+        let verb = if set.len() == 1 { "is" } else { "are" };
+        Some(format!(
+            "{names} {verb} set but ignored: release builds do not accept trust-anchor overrides."
+        ))
+    }
+}
+
+/// Put the report in front of the user: every ignored variable goes to the
+/// activity log, and an applied override becomes the persistent indicator.
+pub(crate) fn surface(report: &OverrideReport, main_page: &mut MainPageState) {
+    for ignored in &report.ignored {
+        let message = ignored.message();
+        tracing::warn!("{message}");
+        main_page.log(message);
+    }
+    if let Some(banner) = report.banner() {
+        tracing::warn!("{banner}");
+        main_page.log(format!("{banner} (this run only, not saved)"));
+        main_page.dev_override = Some(banner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use affinidi_tdk::messaging::profiles::{ATMProfile, ATMProfileInner};
+    #[cfg(feature = "dev-overrides")]
+    use openvtc_core::config::secured_config::SecuredConfig;
+    use openvtc_core::config::{
+        KeyBackend,
+        account::{PersonaId, PersonaRecord},
+    };
+    use openvtc_core::identity::IdentityContext;
+    use secrecy::{SecretBox, SecretString};
+    use std::sync::Arc;
+
+    const LEGIT_URL: &str = "https://legit-vta.affinidi.example";
+    const LEGIT_DID: &str = "did:webvh:legit-vta.example";
+    const OVERRIDE_URL: &str = "http://127.0.0.1:9099";
+    const OVERRIDE_DID: &str = "did:web:127.0.0.1%3A9099";
+    const PERSISTED_MEDIATOR: &str = "did:web:mediator.example.com";
+    const OVERRIDE_MEDIATOR: &str = "did:web:127.0.0.1%3A7037";
+
+    /// A VTA-managed config, as the regression harness built it.
+    fn vta_config(vta_url: &str, vta_did: &str) -> Config {
+        Config {
+            public: Default::default(),
+            private: Default::default(),
+            key_backend: KeyBackend::Vta {
+                credential_bundle: SecretString::new("".into()),
+                credential_did: String::new(),
+                credential_private_key: SecretString::new("".into()),
+                vta_did: vta_did.to_string(),
+                vta_url: vta_url.to_string(),
+                mediator_did: None,
+                encryption_seed: SecretBox::new(Box::new(vec![0u8; 32])),
+            },
+            key_info: Default::default(),
+            protection_method: Default::default(),
+            #[cfg(feature = "openpgp-card")]
+            token_admin_pin: None,
+            #[cfg(feature = "openpgp-card")]
+            token_user_pin: SecretString::new("".into()),
+            unlock_code: None,
+            account: Default::default(),
+            protected_key: None,
+            integrity: Default::default(),
+            identities: Default::default(),
+            active_persona: None,
+            runtime_trust_overrides: None,
+        }
+    }
+
+    /// Add one persona, with matching account record and runtime identity, whose
+    /// mediator is `PERSISTED_MEDIATOR`.
+    fn with_persona(mut config: Config) -> (Config, PersonaId) {
+        let pid = PersonaId::new();
+        let did = "did:web:alice.example.com";
+        config.account.personas.insert(
+            pid,
+            PersonaRecord {
+                extra: serde_json::Map::new(),
+                persona_id: pid,
+                did: did.to_string(),
+                did_document: None,
+                key_refs: vec![],
+                mediator_did: Some(PERSISTED_MEDIATOR.to_string()),
+                origin_context_id: "openvtc/alice".into(),
+                created_at: chrono::Utc::now(),
+                label: None,
+            },
+        );
+        config.identities.insert(
+            pid,
+            IdentityContext {
+                persona_id: pid,
+                did: did.to_string(),
+                document: serde_json::from_value(serde_json::json!({ "id": did }))
+                    .expect("minimal DID document deserializes"),
+                profile: Arc::new(ATMProfile {
+                    inner: Arc::new(ATMProfileInner {
+                        did: did.to_string(),
+                        alias: did.to_string(),
+                        mediator: Arc::new(None),
+                    }),
+                }),
+                mediator_did: Some(PERSISTED_MEDIATOR.to_string()),
+            },
+        );
+        (config, pid)
+    }
+
+    fn env_of(pairs: &'static [(&'static str, &'static str)]) -> impl Fn(&str) -> Option<String> {
+        move |key| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == key)
+                .map(|(_, value)| value.to_string())
+        }
+    }
+
+    fn vta_of(backend: &KeyBackend) -> (String, String) {
+        match backend {
+            KeyBackend::Vta {
+                vta_url, vta_did, ..
+            } => (vta_url.clone(), vta_did.clone()),
+            KeyBackend::Bip32 { .. } => panic!("expected a VTA key backend"),
+        }
+    }
+
+    fn ignored_vars(report: &OverrideReport) -> Vec<&'static str> {
+        report.ignored.iter().map(|i| i.var).collect()
+    }
+
+    fn account_mediator(config: &Config, pid: PersonaId) -> Option<String> {
+        config
+            .account
+            .personas
+            .get(&pid)
+            .and_then(|p| p.mediator_did.clone())
+    }
+
+    #[cfg(not(feature = "dev-overrides"))]
+    #[test]
+    fn release_build_ignores_trust_anchor_env() {
+        let mut config = vta_config(LEGIT_URL, LEGIT_DID);
+
+        let report = apply_from(
+            &mut config,
+            env_of(&[(VTA_URL_VAR, OVERRIDE_URL), (VTA_DID_VAR, OVERRIDE_DID)]),
+        );
+
+        assert_eq!(
+            vta_of(&config.key_backend),
+            (LEGIT_URL.to_string(), LEGIT_DID.to_string()),
+            "a release build must not move the VTA trust anchor"
+        );
+        assert!(report.applied.is_empty());
+        assert_eq!(ignored_vars(&report), vec![VTA_URL_VAR, VTA_DID_VAR]);
+        assert!(
+            report
+                .ignored
+                .iter()
+                .all(|i| i.reason == IgnoreReason::ReleaseBuild)
+        );
+        assert_eq!(
+            report.ignored[0].message(),
+            "OPENVTC_VTA_URL is set but ignored: release builds do not accept trust-anchor overrides."
+        );
+        assert_eq!(config.runtime_trust_overrides, None);
+        assert_eq!(report.banner(), None);
+    }
+
+    #[cfg(not(feature = "dev-overrides"))]
+    #[test]
+    fn release_build_still_honours_the_friendly_name() {
+        let mut config = vta_config(LEGIT_URL, LEGIT_DID);
+
+        let report = apply_from(&mut config, env_of(&[(FRIENDLY_NAME_VAR, "Dev Box")]));
+
+        assert_eq!(config.public.friendly_name, "Dev Box");
+        assert_eq!(report, OverrideReport::default());
+    }
+
+    #[cfg(not(feature = "dev-overrides"))]
+    #[test]
+    fn release_build_startup_notice_says_the_variables_are_ignored() {
+        let notice = startup_notice(env_of(&[(VTA_URL_VAR, OVERRIDE_URL)]));
+        assert_eq!(
+            notice.as_deref(),
+            Some(
+                "OPENVTC_VTA_URL is set but ignored: release builds do not accept trust-anchor overrides."
+            )
+        );
+        assert_eq!(startup_notice(env_of(&[])), None);
+    }
+
+    #[cfg(not(feature = "dev-overrides"))]
+    #[test]
+    fn release_build_wizard_ignores_the_url_override() {
+        assert!(matches!(
+            wizard_vta_url_override(Some(OVERRIDE_URL.to_string())),
+            WizardUrlOverride::Ignored(message) if message.contains("release builds")
+        ));
+        assert_eq!(wizard_vta_url_override(None), WizardUrlOverride::Unset);
+    }
+
+    #[cfg(feature = "dev-overrides")]
+    #[test]
+    fn dev_build_applies_but_does_not_persist() {
+        let mut config = vta_config(LEGIT_URL, LEGIT_DID);
+
+        let report = apply_from(
+            &mut config,
+            env_of(&[(VTA_URL_VAR, OVERRIDE_URL), (VTA_DID_VAR, OVERRIDE_DID)]),
+        );
+
+        // Applied at runtime …
+        assert_eq!(
+            vta_of(&config.key_backend),
+            (OVERRIDE_URL.to_string(), OVERRIDE_DID.to_string())
+        );
+        assert_eq!(
+            report.applied,
+            vec![
+                (VTA_URL_VAR, OVERRIDE_URL.to_string()),
+                (VTA_DID_VAR, OVERRIDE_DID.to_string()),
+            ]
+        );
+        assert!(report.ignored.is_empty());
+        let banner = report.banner().expect("an applied override has a banner");
+        assert!(banner.starts_with("DEV OVERRIDE: VTA → http://127.0.0.1:9099"));
+
+        // … but the coalesced-save snapshot still carries the originals …
+        let snapshot = config.clone_for_save().expect("snapshot");
+        assert_eq!(
+            vta_of(&snapshot.key_backend),
+            (LEGIT_URL.to_string(), LEGIT_DID.to_string()),
+            "the save snapshot must keep the persisted VTA anchor"
+        );
+        assert_eq!(snapshot.runtime_trust_overrides, None);
+
+        // … and so does a direct `save` / `export` of the live config.
+        let secured = SecuredConfig::from(&config);
+        assert_eq!(secured.vta_url.as_deref(), Some(LEGIT_URL));
+        assert_eq!(secured.vta_did.as_deref(), Some(LEGIT_DID));
+    }
+
+    #[cfg(feature = "dev-overrides")]
+    #[test]
+    fn dev_build_rejects_values_that_do_not_validate() {
+        for (url, did) in [
+            ("ftp://127.0.0.1:9099", "not-a-did"),
+            ("127.0.0.1:9099", "did:"),
+            ("http://", "did:web:"),
+        ] {
+            let mut config = vta_config(LEGIT_URL, LEGIT_DID);
+            let pairs: &'static [(&'static str, &'static str)] =
+                Box::leak(Box::new([(VTA_URL_VAR, url), (VTA_DID_VAR, did)]));
+
+            let report = apply_from(&mut config, env_of(pairs));
+
+            assert!(report.applied.is_empty(), "{url} / {did} must not apply");
+            assert_eq!(ignored_vars(&report), vec![VTA_URL_VAR, VTA_DID_VAR]);
+            assert!(
+                report
+                    .ignored
+                    .iter()
+                    .all(|i| matches!(i.reason, IgnoreReason::Invalid(_)))
+            );
+            assert_eq!(
+                vta_of(&config.key_backend),
+                (LEGIT_URL.to_string(), LEGIT_DID.to_string())
+            );
+            assert_eq!(config.runtime_trust_overrides, None);
+        }
+    }
+
+    #[cfg(feature = "dev-overrides")]
+    #[test]
+    fn dev_build_wizard_validates_the_url_override() {
+        assert_eq!(
+            wizard_vta_url_override(Some(OVERRIDE_URL.to_string())),
+            WizardUrlOverride::Active(OVERRIDE_URL.to_string())
+        );
+        assert!(matches!(
+            wizard_vta_url_override(Some("file:///etc/passwd".to_string())),
+            WizardUrlOverride::Ignored(_)
+        ));
+    }
+
+    #[test]
+    fn mediator_env_override_never_touches_account_record() {
+        let (mut config, pid) = with_persona(vta_config(LEGIT_URL, LEGIT_DID));
+
+        let report = apply_from(
+            &mut config,
+            env_of(&[(MEDIATOR_DID_VAR, OVERRIDE_MEDIATOR)]),
+        );
+
+        assert_eq!(
+            account_mediator(&config, pid).as_deref(),
+            Some(PERSISTED_MEDIATOR),
+            "the persisted account record must never carry an env-supplied mediator"
+        );
+        let snapshot = config.clone_for_save().expect("snapshot");
+        assert_eq!(
+            account_mediator(&snapshot, pid).as_deref(),
+            Some(PERSISTED_MEDIATOR)
+        );
+
+        #[cfg(feature = "dev-overrides")]
+        {
+            assert_eq!(config.mediator_did(), OVERRIDE_MEDIATOR);
+            assert_eq!(
+                report.applied,
+                vec![(MEDIATOR_DID_VAR, OVERRIDE_MEDIATOR.to_string())]
+            );
+        }
+        #[cfg(not(feature = "dev-overrides"))]
+        {
+            assert_eq!(config.mediator_did(), PERSISTED_MEDIATOR);
+            assert_eq!(ignored_vars(&report), vec![MEDIATOR_DID_VAR]);
+        }
+    }
+
+    #[test]
+    fn blank_values_read_as_unset() {
+        let mut config = vta_config(LEGIT_URL, LEGIT_DID);
+
+        let report = apply_from(
+            &mut config,
+            env_of(&[
+                (VTA_URL_VAR, "  "),
+                (VTA_DID_VAR, ""),
+                (MEDIATOR_DID_VAR, "\t"),
+            ]),
+        );
+
+        assert_eq!(report, OverrideReport::default());
+        assert_eq!(
+            vta_of(&config.key_backend),
+            (LEGIT_URL.to_string(), LEGIT_DID.to_string())
+        );
+    }
+
+    #[test]
+    fn surfacing_logs_ignored_and_pins_the_banner() {
+        let mut main_page = MainPageState::default();
+        let report = OverrideReport {
+            applied: vec![(VTA_URL_VAR, OVERRIDE_URL.to_string())],
+            ignored: vec![Ignored {
+                var: VTA_DID_VAR,
+                reason: IgnoreReason::ReleaseBuild,
+            }],
+        };
+
+        surface(&report, &mut main_page);
+
+        assert_eq!(
+            main_page.dev_override.as_deref(),
+            Some("DEV OVERRIDE: VTA → http://127.0.0.1:9099")
+        );
+        let log: Vec<&str> = main_page
+            .activity_log
+            .iter()
+            .map(|e| e.summary.as_str())
+            .collect();
+        assert!(
+            log.iter()
+                .any(|l| l.contains("OPENVTC_VTA_DID is set but ignored"))
+        );
+        assert!(log.iter().any(|l| l.contains("DEV OVERRIDE")));
+    }
+}

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -25,6 +25,7 @@ use tokio::sync::broadcast;
 mod cli;
 mod clipboard;
 mod colors;
+mod env_overrides;
 mod health_cmd;
 mod state_handler;
 mod ui;
@@ -534,6 +535,14 @@ async fn main() -> Result<()> {
         bail!("Starting mode not set correctly!");
     }
 
+    // Trust-anchor env overrides are announced here, while stderr is still
+    // readable: once the TUI owns the terminal a stray write would corrupt the
+    // screen. The state handler applies them (dev-overrides builds only) and
+    // repeats the outcome in the Activity Log.
+    if let Some(notice) = env_overrides::startup_notice(|k| env::var(k).ok()) {
+        eprintln!("{}", style(notice).color256(CLI_ORANGE));
+    }
+
     // Setup the initial state
     let (terminator, mut interrupt_rx) = create_termination();
     let (mut state, state_rx) = StateHandler::new(&profile, starting_mode);
@@ -619,40 +628,6 @@ pub fn create_termination() -> (Terminator, broadcast::Receiver<Interrupted>) {
     tokio::spawn(terminate_by_unix_signal(terminator.clone()));
 
     (terminator, rx)
-}
-
-/// Applies OPENVTC_* environment variable overrides to a loaded Config.
-pub fn apply_env_overrides(config: &mut Config) {
-    use openvtc_core::config::KeyBackend;
-
-    if let Ok(val) = std::env::var("OPENVTC_MEDIATOR_DID")
-        && !config.set_active_mediator_did(&val)
-    {
-        // The override hangs off the active persona, so a State-A profile has
-        // nowhere to put it. Silently dropping an override the operator set on
-        // purpose is how it becomes a mystery later.
-        tracing::warn!(
-            did = %val,
-            "OPENVTC_MEDIATOR_DID ignored: this profile has no persona to set a mediator on"
-        );
-    }
-    if let Ok(val) = std::env::var("OPENVTC_VTA_URL")
-        && let KeyBackend::Vta {
-            ref mut vta_url, ..
-        } = config.key_backend
-    {
-        *vta_url = val;
-    }
-    if let Ok(val) = std::env::var("OPENVTC_VTA_DID")
-        && let KeyBackend::Vta {
-            ref mut vta_did, ..
-        } = config.key_backend
-    {
-        *vta_did = val;
-    }
-    if let Ok(val) = std::env::var("OPENVTC_FRIENDLY_NAME") {
-        config.public.friendly_name = val;
-    }
 }
 
 /// Maximum number of interactive unlock attempts before aborting.

--- a/openvtc/src/state_handler/dispatch_util.rs
+++ b/openvtc/src/state_handler/dispatch_util.rs
@@ -148,5 +148,6 @@ pub(crate) fn test_config() -> Config {
         account: Account::default(),
         identities: std::collections::BTreeMap::new(),
         active_persona: None,
+        runtime_trust_overrides: None,
     }
 }

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -85,6 +85,11 @@ pub struct MainPageState {
     /// entries by pointer rather than deep-copying each entry's summary and
     /// detail strings. Entries are immutable once written.
     pub activity_log: VecDeque<Arc<ActivityLogEntry>>,
+
+    /// `Some` for the whole session when a development build applied a
+    /// trust-anchor override (see `crate::env_overrides`). Rendered at the front
+    /// of the bottom bar, so the run cannot be mistaken for a normal one.
+    pub dev_override: Option<String>,
 }
 
 impl MainPageState {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -421,7 +421,8 @@ impl StateHandler {
                     .await
                 {
                     Ok(SetupWizardExit::Config(mut config)) => {
-                        crate::apply_env_overrides(&mut config);
+                        let overrides = crate::env_overrides::apply_env_overrides(&mut config);
+                        crate::env_overrides::surface(&overrides, &mut state.main_page);
 
                         // Show the loading screen during the slow post-setup work
                         // (keyring read, VTA round-trip, mediator handshake)
@@ -661,7 +662,8 @@ impl StateHandler {
                 };
 
                 let mut config = config;
-                crate::apply_env_overrides(&mut config);
+                let overrides = crate::env_overrides::apply_env_overrides(&mut config);
+                crate::env_overrides::surface(&overrides, &mut state.main_page);
 
                 let config = Box::new(config);
                 // Sync all display state from the loaded config

--- a/openvtc/src/state_handler/settings_actions.rs
+++ b/openvtc/src/state_handler/settings_actions.rs
@@ -32,9 +32,10 @@ pub fn update_friendly_name(config: &mut Config, name: &str) {
 
 // There is deliberately no `update_mediator_did`. A persona's mediator is chosen
 // when the persona is minted and published in its DID document, so the Settings
-// row is read-only (see `settings_panel::MEDIATOR_ROW`). The one remaining write
-// path is the `OPENVTC_MEDIATOR_DID` override in `main.rs`, which calls
-// `Config::set_active_mediator_did` directly and warns when it does not apply.
+// row is read-only (see `settings_panel::MEDIATOR_ROW`). The `OPENVTC_MEDIATOR_DID`
+// override in `env_overrides.rs` is not a write path: it exists only in
+// `dev-overrides` builds and calls `Config::set_active_mediator_did_runtime`,
+// which never touches the persisted account record.
 
 /// Update the organization DID.
 ///

--- a/openvtc/src/state_handler/setup_sequence/config.rs
+++ b/openvtc/src/state_handler/setup_sequence/config.rs
@@ -464,6 +464,7 @@ fn build_state_a_config(state: &SetupState) -> Result<Config> {
         account,
         identities: BTreeMap::new(),
         active_persona: None,
+        runtime_trust_overrides: None,
         key_backend,
         public: PublicConfig {
             config_version: openvtc_core::config::public_config::CONFIG_VERSION,

--- a/openvtc/src/state_handler/setup_vta_actions.rs
+++ b/openvtc/src/state_handler/setup_vta_actions.rs
@@ -1,3 +1,4 @@
+use crate::env_overrides::WizardUrlOverride;
 use crate::state_handler::{
     setup_sequence::{Completion, MessageType, RebuildOutcome, SetupPage},
     state::State,
@@ -11,17 +12,20 @@ use vta_sdk::provision_client::{
 };
 
 /// Env var that pins the VTA's REST base URL, bypassing `did:webvh`/DIDComm
-/// resolution. Set it (e.g. `http://127.0.0.1:8080`) to point the bootstrap at
-/// a local/loopback VTA whose DID does not resolve back to that URL — the
-/// integration-test seam (and a handy "talk to my dev VTA" override). When set,
-/// bootstrap talks plain REST to this URL and provisions URL-direct via
-/// `provision_admin_rotated_via_rest` (which never re-resolves the VTA DID).
-const VTA_URL_OVERRIDE_ENV: &str = "OPENVTC_VTA_URL";
+/// resolution. Honoured only by a `dev-overrides` build: set it (e.g.
+/// `http://127.0.0.1:8080`) to point the bootstrap at a local/loopback VTA whose
+/// DID does not resolve back to that URL — the integration-test seam. When
+/// honoured, bootstrap talks plain REST to this URL and provisions URL-direct
+/// via `provision_admin_rotated_via_rest` (which never re-resolves the VTA DID).
+/// A release build ignores it and says so on the enter-DID page.
+const VTA_URL_OVERRIDE_ENV: &str = crate::env_overrides::VTA_URL_VAR;
 
-/// The trimmed, non-empty value of [`VTA_URL_OVERRIDE_ENV`], or `None`. A blank
-/// or whitespace-only value is treated as unset.
-fn vta_url_override() -> Option<String> {
-    normalize_url_override(std::env::var(VTA_URL_OVERRIDE_ENV).ok())
+/// [`VTA_URL_OVERRIDE_ENV`] after trimming (blank reads as unset) and the
+/// `dev-overrides` gate.
+fn vta_url_override() -> WizardUrlOverride {
+    crate::env_overrides::wizard_vta_url_override(normalize_url_override(
+        std::env::var(VTA_URL_OVERRIDE_ENV).ok(),
+    ))
 }
 
 /// How the post-bootstrap `VtaClient` must authenticate, given the transport
@@ -85,13 +89,24 @@ pub(crate) async fn handle_vta_submit_did(
     state.setup.vta.completed = Completion::NotFinished;
     state.setup.vta.vta_did = vta_did.clone();
 
-    // OPENVTC_VTA_URL override: skip DID resolution and talk plain REST to the
-    // pinned URL. Lets bootstrap target a loopback/dev VTA whose DID can't be
-    // resolved back to its URL (the integration-test seam). DIDComm is not used
-    // on this path — provisioning goes URL-direct in `handle_vta_start_provision`.
-    if let Some(url) = vta_url_override() {
+    // OPENVTC_VTA_URL override (dev-overrides builds only): skip DID resolution
+    // and talk plain REST to the pinned URL. Lets bootstrap target a
+    // loopback/dev VTA whose DID can't be resolved back to its URL (the
+    // integration-test seam). DIDComm is not used on this path — provisioning
+    // goes URL-direct in `handle_vta_start_provision`. A release build ignores
+    // the variable, says so here, and resolves the DID as normal.
+    let url_override = vta_url_override();
+    if let WizardUrlOverride::Ignored(message) = &url_override {
+        state
+            .setup
+            .vta
+            .messages
+            .push(MessageType::Info(format!("Warning: {message}")));
+    }
+    if let WizardUrlOverride::Active(url) = url_override {
         state.setup.vta.messages.push(MessageType::Info(format!(
-            "{VTA_URL_OVERRIDE_ENV} set — using REST endpoint {url} (skipping DID resolution)."
+            "DEV OVERRIDE: {VTA_URL_OVERRIDE_ENV} set — using REST endpoint {url} \
+             (skipping DID resolution)."
         )));
         let _ = state_tx.send(state.clone());
         state.setup.vta.vta_url = url;
@@ -229,7 +244,7 @@ pub(crate) async fn handle_vta_start_provision(
     let mut connect_mediator_did: Option<String> = None;
     let mut connect_protocol: Option<Protocol> = None;
 
-    if let Some(url) = vta_url_override() {
+    if let WizardUrlOverride::Active(url) = vta_url_override() {
         // URL-direct: one REST round-trip to the pinned URL via the SDK's
         // URL-direct AdminRotated entry — no DID resolution, no DIDComm, no
         // diagnostics stream (it never re-resolves the VTA DID). The REST

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -2507,13 +2507,25 @@ impl ComponentRender<()> for MainPage {
             .collect();
         frame.render_widget(Paragraph::new(log_lines), log_inner);
 
-        // Bottom key hints (single line)
+        // Bottom key hints (single line). A development trust-anchor override
+        // takes the front of the line for the whole session, so an overridden
+        // run cannot be mistaken for a normal one.
+        let hints = " <TAB> switch panels  <Ctrl+K> switch community  <PgUp/PgDn/Home/End> scroll  <F10> quit";
+        let bottom_line = match &self.props.main_page.dev_override {
+            Some(banner) => Line::from(vec![
+                Span::styled(
+                    format!(" {banner} "),
+                    ratatui::style::Style::default()
+                        .fg(ratatui::style::Color::Black)
+                        .bg(COLOR_WARNING_ACCESSIBLE_RED)
+                        .bold(),
+                ),
+                Span::from(hints).dark_gray(),
+            ]),
+            None => Line::from(hints).dark_gray(),
+        };
         frame.render_widget(
-            Paragraph::new(
-                " <TAB> switch panels  <Ctrl+K> switch community  <PgUp/PgDn/Home/End> scroll  <F10> quit",
-            )
-            .dark_gray()
-            .alignment(Alignment::Left),
+            Paragraph::new(bottom_line).alignment(Alignment::Left),
             main_bottom,
         );
 


### PR DESCRIPTION

## Summary

`OPENVTC_VTA_URL`, `OPENVTC_VTA_DID` and `OPENVTC_MEDIATOR_DID` choose which VTA
and mediator OpenVTC authenticates to. Until now any build applied them without
validation or a visible indication, and the next save wrote them into the
profile:

- the VTA URL/DID reached `SecuredConfig`;
- the mediator went through `set_active_mediator_did` into the account record.

So a variable set for one launch stayed in effect after it was unset.

This PR makes them a development-only seam.

## Behaviour change

**Release builds (default features)**

- The three variables are never applied.
- Each one that is set is reported:
  - one line on stderr before the TUI starts: `OPENVTC_VTA_URL is set but ignored: release builds do not accept trust-anchor overrides.`;
  - the same message in the Activity Log.
- The setup wizard's `OPENVTC_VTA_URL` shortcut is gated the same way. The enter-DID page shows the warning and resolves the DID as normal.
- `OPENVTC_FRIENDLY_NAME` is cosmetic and still honoured.

**`dev-overrides` builds** (new cargo feature on `openvtc`, off by default)

- Values are validated:
  - `OPENVTC_VTA_DID` and `OPENVTC_MEDIATOR_DID` must parse as a DID;
  - `OPENVTC_VTA_URL` must be an `http://` or `https://` URL with a host.
  - A value that fails validation is ignored and logged.
- Overrides apply to the running process only:
  - the VTA URL/DID are replaced in memory, and the displaced values are kept in a new runtime-only `Config::runtime_trust_overrides`;
  - `Config::save`, `Config::export` and `Config::clone_for_save` write the stored originals (`SecuredConfig::from` and `Config::key_backend_for_save`);
  - the mediator override uses the new `Config::set_active_mediator_did_runtime`, which updates the runtime identity and never the account record.
- While any override is active, a red `DEV OVERRIDE: VTA → <url> · …` badge stays at the front of the main page's bottom bar. A startup line on stderr and an Activity Log entry also record it.

## Migration for developers

If you point a local build at a development VTA or mediator through these
variables, add the feature:

```bash
OPENVTC_VTA_URL=http://127.0.0.1:8080 cargo run -p openvtc --features dev-overrides
```

A binary built without the feature, including `cargo install`, release
artifacts and plain `cargo run`, now ignores the variables.

Usage search:

- In this repo, nothing but the code changed here reads them. Scripts,
  workflows and tests don't use them. `openvtc-core/tests/mockvta_bootstrap_e2e.rs`
  calls the URL-direct SDK function and never sets `OPENVTC_VTA_URL`.
- In `vti-setup`, `verifiable-trust-infrastructure`, `cierge` and `dtg-demo`
  there are no references, so no runbook or script depends on them with a
  release binary.

## Implementation

- `openvtc/src/env_overrides.rs` (new) contains the override logic, moved out of `main.rs`.
  - `apply_from(config, env_fn) -> OverrideReport { applied, ignored }` takes the environment as a closure.
  - `apply_env_overrides(config)` calls `apply_from` with the process environment.
  - Also here: the wizard URL gate, the pre-TUI notice, and `surface()`, which writes the report to the Activity Log and sets the badge.
- `openvtc-core`:
  - `Config::runtime_trust_overrides` / `OriginalTrustAnchors`;
  - `override_vta_url_runtime`, `override_vta_did_runtime`, `set_active_mediator_did_runtime`, `persisted_vta_anchor`, `key_backend_for_save`;
  - `SecuredConfig::from(&Config)` writes the persisted anchor.
- Both call sites in `state_handler/mod.rs` (post-setup and normal load) consume the report.
- The stderr line is printed in `main.rs` just before the TUI starts. The call sites run after the TUI has taken the terminal, where a stderr write would corrupt the screen.
- CI: a new `Test (dev-overrides)` job runs `cargo clippy -p openvtc --all-targets --features dev-overrides -- -D warnings` and `cargo test -p openvtc --features dev-overrides`.
- Docs: `openvtc/README.md` (feature flag table and a "Developer trust-anchor overrides" section), `openvtc-core/README.md`, `CHANGELOG.md`, and related doc comments.

`Config` gains a public field, so external code building `Config` with a
struct literal must add `runtime_trust_overrides: None`.

## Tests

All tests use an injected environment closure; none mutate the process
environment.

- Release builds:
  - `release_build_ignores_trust_anchor_env`
  - `release_build_still_honours_the_friendly_name`
  - `release_build_startup_notice_says_the_variables_are_ignored`
  - `release_build_wizard_ignores_the_url_override`
- `dev-overrides` builds:
  - `dev_build_applies_but_does_not_persist`: runtime values change; the `clone_for_save` snapshot and `SecuredConfig::from` of the live config keep the stored URL/DID.
  - `dev_build_rejects_values_that_do_not_validate`
  - `dev_build_wizard_validates_the_url_override`
- Both builds:
  - `mediator_env_override_never_touches_account_record`
  - `blank_values_read_as_unset`
  - `surfacing_logs_ignored_and_pins_the_banner`
- `openvtc-core`:
  - `runtime_mediator_override_leaves_the_account_record_alone`
  - `runtime_vta_override_is_never_what_a_save_writes`

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --features openvtc/dev-overrides -- -D warnings`
- `cargo test -p openvtc-core -p openvtc`
- `cargo test -p openvtc-core -p openvtc --features dev-overrides`

## Not in this PR

- `OPENVTC_CONFIG_PATH` and `OPENVTC_CONFIG_PROFILE` are unchanged.
- The wizard's "Warning:" line uses `MessageType::Info`. Adding a warning variant would touch every setup page renderer.
