### PR TITLE
feat(vetting): guided join, vetter directory and profile, QR tickets, grant checks, resend and branding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -897,7 +897,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2874,7 +2874,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3200,7 +3200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5585,7 +5585,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6127,6 +6127,7 @@ dependencies = [
  "openpgp-card-rpgp",
  "openvtc-core",
  "pgp",
+ "qrcode",
  "rand 0.8.8",
  "ratatui",
  "regex",
@@ -6236,7 +6237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6975,6 +6976,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7068,7 +7075,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7663,7 +7670,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7721,7 +7728,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8369,7 +8376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8581,7 +8588,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8594,7 +8601,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9618,7 +9625,7 @@ dependencies = [
 [[package]]
 name = "vta-audit"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9635,7 +9642,7 @@ dependencies = [
 [[package]]
 name = "vta-backup"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -9662,7 +9669,7 @@ dependencies = [
 [[package]]
 name = "vta-cli-common"
 version = "0.15.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9689,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "vta-config"
 version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9705,7 +9712,7 @@ dependencies = [
 [[package]]
 name = "vta-keys"
 version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9738,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "vta-keyspaces"
 version = "0.2.7"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "vti-common",
 ]
@@ -9746,7 +9753,7 @@ dependencies = [
 [[package]]
 name = "vta-persona"
 version = "0.3.2"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -9764,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "vta-policy"
 version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "hex",
  "multibase",
@@ -9783,7 +9790,7 @@ dependencies = [
 [[package]]
 name = "vta-sdk"
 version = "0.36.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9797,6 +9804,7 @@ dependencies = [
  "affinidi-openid4vci",
  "affinidi-openid4vp",
  "affinidi-secrets-resolver",
+ "affinidi-status-list",
  "affinidi-tdk",
  "affinidi-vc",
  "agent-names",
@@ -9836,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "vta-service"
 version = "0.25.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9933,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "vta-support"
 version = "0.3.5"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9953,7 +9961,7 @@ dependencies = [
 [[package]]
 name = "vta-sweepers"
 version = "0.3.4"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "chrono",
  "serde_json",
@@ -9967,7 +9975,7 @@ dependencies = [
 [[package]]
 name = "vta-vault"
 version = "0.5.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9998,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "vta-webvh"
 version = "0.2.7"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10016,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "vtc-client"
 version = "0.6.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10031,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "vti-common"
 version = "0.18.3"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10074,7 +10082,7 @@ dependencies = [
 [[package]]
 name = "vti-rooms"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -10099,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "vti-rooms-dtg"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10116,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "vti-secrets"
 version = "0.3.5"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "hex",
  "serde",
@@ -10129,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "vti-webauthn"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=38ad2ed55988f9299596b8737c32d42d61131a1c#38ad2ed55988f9299596b8737c32d42d61131a1c"
+source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -10521,7 +10529,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,11 @@ linux-keyutils-keyring-store = "1"
 windows-native-keyring-store = "1"
 multibase = "0.9"
 pgp = "0.20"
+# Ticket QR codes on the Vetting page. Default features off: they pull `image`
+# for PNG/SVG output, and all the page needs is the module matrix, drawn with
+# Unicode half-blocks. MIT OR Apache-2.0 with no dependencies of its own, so
+# `deny.toml` needs nothing new.
+qrcode = { version = "0.14", default-features = false }
 # Stays on 0.8 because pgp 0.20 does: it takes an `R: Rng + CryptoRng` from
 # the rand_core 0.6 trait set for key signing / `set_password` / ESK
 # encryption, and we hand it our `OsRng` directly, so the two must agree.
@@ -389,10 +394,11 @@ strip = "symbols"
 # `cargo tree`, not only the two named in a manifest: a crate left on crates.io
 # would pull its own `vti-common` beside the patched one.
 #
-# The branch is the top of the VTI vetting stack (#1425–#1429), not `main`:
-# `vta-sdk`'s `vetting` feature, which this workspace enables, exists only there
-# until that stack merges. Once it has, point these back at `main`, and remove
-# them with the release that follows.
+# The VTI entries pin a commit on VTI `main` by `rev`: 14ef89a, where the vetter
+# registry work (OpenVTC/verifiable-trust-infrastructure#1430) merged. A `rev`
+# on `main` stays fetchable, where the feature branches this used to name were
+# deleted when the vetting stack merged. Move the pin forward only to another
+# commit on VTI `main`, and remove these entries with the release that follows.
 #
 # Each block leaves when its release is published: delete its entries here and
 # its URL from `allow-git` in `deny.toml`. For VGI, also raise the `did-git-sign`
@@ -406,23 +412,23 @@ strip = "symbols"
 did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
 vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
 
-vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-config = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-keys = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-keyspaces = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-persona = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-policy = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-support = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-sweepers = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-vault = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vta-webvh = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vtc-client = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vti-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vti-rooms = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vti-rooms-dtg = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vti-secrets = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
-vti-webauthn = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "38ad2ed55988f9299596b8737c32d42d61131a1c" }
+vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-config = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-keys = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-keyspaces = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-persona = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-policy = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-support = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-sweepers = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-vault = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vta-webvh = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vtc-client = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vti-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vti-rooms = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vti-rooms-dtg = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vti-secrets = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+vti-webauthn = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }

--- a/docs/design/vetting-process.md
+++ b/docs/design/vetting-process.md
@@ -1,8 +1,8 @@
 # SPEC — Vetted Admission: Peer Identity Vetting for Joining a VTC
 
 > Status: **DRAFT v3** — O1–O3 and O5 resolved 2026-09-11 (D15–D18); D1–D14
-> proposed, pending sign-off; D19–D24 record choices made while building V0,
-> marked *as built* where they depart from the text (§15). **V0 target: 5 Oct 2026.**
+> proposed, pending sign-off; D19–D29 record choices made while building V0
+> and the vetter registry, marked *as built* where they depart from the text (§15). **V0 target: 5 Oct 2026.**
 > Scope: end-to-end. This is an OpenVTC design doc, but most of the protocol
 > surface lands outside this repo. Each change is tagged with its home repo
 > (§14): `trustoverip/dtgwg-trust-tasks-tf`, `trustoverip/dtgwg-cred-spec`,
@@ -267,6 +267,20 @@ task specs **do not** declare consent or step-up; that is VTA policy (§11.3).
    unauthenticated at `GET /v1/community/public-profile` so a web page or
    `openvtc` can show it before any Trust Task is sent.
 
+*As built (branding, D29):*
+- `manifest/0.2` also carries the community's optional `branding`
+  (`displayName`, `accentColor`, `logoUrl`).
+- OpenVTC keeps the display name and accent from every manifest it reads,
+  whether or not the community vets, in `VettingBook::communities`. A branding
+  that breaks its schema is dropped whole.
+- The accent is drawn as a swatch (●) beside the community's name on the
+  Vetting page, the Communities panel and the join page. It is data about the
+  community, so it uses the literal colour rather than the theme.
+- The display name is a fallback. It is used only when there is neither a
+  membership name nor a verified agent name.
+- It is presentation only: nothing is trusted because of it, and the logo is
+  not fetched.
+
 `manifest` is the one join-family task that leaves no trace of an applicant.
 That keeps **informed non-application** possible: a person can learn that a
 community demands a passport check and walk away having disclosed nothing.
@@ -373,6 +387,44 @@ There are three routes, from most to least social.
    - Governed by a new `vetters.rego` projection policy, capped by the
      community's PII boundary like `directory.rego`.
 
+*As built (the vetter registry, VTI #1430):* the tasks are
+`vtc/vetting/vetters/profile/0.1` and `…/list/0.1`, not the sampled
+`vtc/vetters/list` sketched above.
+
+The community's side:
+- A vetter holding a live grant publishes a whole profile: listed or not, a
+  display name, languages, and a location (country, region, city).
+- The profile also lists methods, accepted documentation, availability, a
+  contact hint saying how to get a ticket, and up to 32 events.
+- The list filters by language, place, method, event dates and event name,
+  pages by cursor, and answers only callers it can identify.
+
+In OpenVTC:
+- **Find vetters** (`v` on an application) searches a community the persona is
+  applying to or has joined. It asks as the application's persona, else the
+  membership's.
+- Results are page state only: they describe other people and go stale.
+- **Ask this vetter** fills the request form with the vetter's DID and says a
+  ticket is still needed, quoting their contact hint.
+- **Your vetter profile** (`p` on Tickets) opens on the profile last sent to
+  that community. With none, it starts unlisted (listing is opt-in) and accepts
+  what the vetter's `VetterPolicy` accepts.
+- Typed text becomes the body in `vetting::registry`, and the SDK's
+  `check_shape` is the only validator. The client therefore never disagrees
+  with the community about what is valid; event dates are checked before
+  anything is sent.
+- The last profile sent is kept in the book as JSON, with the community's
+  answer: stored (listed or not), or refused with `notEligible`. JSON rather
+  than the SDK type, because that type refuses unknown members, and a profile a
+  newer build wrote must not stop an older build opening its config (D27).
+- Questions to a community (manifest, list, profile, resend) are remembered in
+  memory by document id (`vetting::queries`, D25).
+- An answer or a `trust-task-error` is claimed only when it threads on one of
+  those questions. Every other error still reaches the join handler.
+- A question unanswered after 30 seconds is reported as unanswered (R1.2).
+- An answer this client cannot read is reported as a disagreement about the
+  task, not as a refusal (R6.4).
+
 ### 7.1 Confirming a vetter is eligible before spending effort
 
 The vetter's `vetting/request` `#response` carries an **eligibility VP**: the
@@ -384,6 +436,25 @@ the `requestId` as the challenge. The applicant's client verifies:
 
 This works for unlisted vetters and needs no VTC round-trip. The VTC still
 re-checks eligibility at decision time (§10.2), so this is advisory.
+
+*As built (the revocation check, D28):*
+- Once the eligibility presentation verifies, the grant's `credentialStatus`
+  is checked with `vta_sdk::vetting::status::check_credential_status`, as a
+  background job in a dispatch domain of its own, so it never holds up a
+  vetting send.
+- OpenVTC supplies the fetch (`openvtc_core::vetting::status`):
+  - `https` only, including redirects, at most three of them;
+  - 5 seconds to connect and 10 seconds in all (R1.2);
+  - at most 6 MiB;
+  - error text that tells an unreachable host from an HTTP error from a body
+    that is not a status list (R6.4).
+- The result is recorded on the request and shown as one of:
+  - *named a vetter until …* with *not revoked when checked on …*;
+  - *the community has revoked this vetter's grant — their statement will not
+    count*;
+  - *could not check whether the grant was revoked (…)*. This covers a grant
+    that names no status list, and is never read as unrevoked.
+- The check is advisory, like the rest of this section.
 
 ---
 
@@ -427,6 +498,24 @@ Throttling:
 
 The mediator cannot see payloads (authcrypt), so it contributes only
 per-sender transport rate limiting.
+
+*As built (ticket link and QR code):*
+- The Tickets tab shows the selected ticket as a QR code of its
+  `vetting-ticket:` link (`vta_sdk::vetting::ticket_uri`).
+- The link carries the vetter's DID and the scanned form: the ticket id and its
+  32-byte secret. The short code stays beside it for reading aloud.
+- The code is drawn with Unicode half-blocks, black on white whatever the theme.
+  It uses error correction M (L if M does not fit) and a quiet zone of four
+  modules, narrowed to two or one to fit the window.
+- If it still does not fit, the page names the width needed.
+- `u` copies the link.
+- When asking a vetter, pasting a link fills in the vetter's DID and the
+  scanned ticket.
+- A link for another community is refused with a plain message: the vetter
+  would refuse it, and sending it would tie the application's DID to that
+  community.
+- The QR encoder is the `qrcode` crate 0.14 with default features off:
+  MIT OR Apache-2.0, with no dependencies of its own.
 
 ### 8.3 `vetting/request/0.1` payload
 
@@ -911,6 +1000,16 @@ Admins can also grant or revoke `vetter` directly
 (`governance/capability/*`). The policy decides whether manual grants may
 bypass rules.
 
+*As built (resend):*
+- A member who is active but holds no live vetter credential can ask the
+  community to deliver it again, with `vtc/vetting/vetters/resend/0.1` (`g` on
+  Tickets). That covers a grant issued while they were offline, and one they
+  lost.
+- The credential arrives through `credential-exchange/issue` as usual. The
+  answer says until when it is valid.
+- A `notGranted` refusal reads: the community holds no live vetter credential
+  for you — it has not named you a vetter, or the grant expired or was revoked.
+
 ### 10.4 Decision policy — vetting module in `join.rego`
 
 The sketch below predates the implementation. *As built*, the default
@@ -1216,6 +1315,41 @@ Following the existing patterns in
 - **Join flow** (`JoinPage`): after `EnterDid`, when the manifest has
   `vetting`, show the requirements in plain language and offer **Start
   application** (→ Vetting tab), replacing the submit step.
+
+  *As built (the guided path, D26):*
+  - After the community's DID, the join flow decides from what the book knows
+    (`VettingBook::knowledge`): it vets, it does not, or it was never asked.
+  - A community that vets gets a page with:
+    - its requirements in plain words (`vetting::guide`), with its DID under
+      its name;
+    - this persona's application, if there is one, with its progress and next
+      step;
+    - three ways on.
+  - The three ways on:
+    - **start the application**, choosing the persona and the context its face
+      is worn in. This opens the Vetting page on the application, with its next
+      step highlighted.
+    - **join anyway**, which the community refers to its moderators.
+    - **cancel**.
+  - An application that meets the published requirements joins as its own
+    persona, and the page says its statements are presented with the join.
+  - When the book does not know, the community is asked. The join flow cannot
+    hear the answer itself: its loop selects only on actions and interrupts, and
+    inbound messages are read by the runtime loop's own arm, which is parked
+    while the flow runs.
+  - So the flow sends `manifest/0.2` as the active persona, with the send
+    bounded at 15 seconds, and returns `JoinExit::AwaitRequirements`.
+  - The runtime loop keeps the join screen up in an *asking* state and goes on
+    reading inbound messages. It enters the flow again when one of these
+    happens:
+    - the manifest arrives;
+    - the community refuses, or answers in a form this client cannot read;
+    - 15 seconds pass with no answer.
+  - While it asks, `j` joins without waiting and Esc cancels.
+  - Nothing can hang: every wait ends on an inbound message or on a sweep with
+    a deadline.
+  - The degraded loop has no inbound arm, so there the flow uses only what the
+    book already knows.
 - Keys: choose from the unused set when implementing. The Communities panel
   already binds `⏎ f a m c p P l x d j v`.
 
@@ -1412,7 +1546,7 @@ modern-signature subgraph only (O7).
 
 ## 15. Decisions and open questions
 
-### 15.1 Decisions (D1–D14 proposed; D15–D18 agreed 2026-09-11; D19–D24 taken while building V0)
+### 15.1 Decisions (D1–D14 proposed; D15–D18 agreed 2026-09-11; D19–D29 taken while building)
 
 | # | Decision | Proposal |
 |---|---|---|
@@ -1440,6 +1574,11 @@ modern-signature subgraph only (O7).
 | D22 | `needs` | Policy returns the generic `vetting`; the host expands it to `vetting:statements:<n>` / `vetting:method:<method>:<n>`, so visually authored policy stays static |
 | D23 | Which criterion applies | The one whose `requirementsDigest` the applicant names in `extensions`; otherwise the first vetting criterion |
 | D24 | Session binding details | Match-code tag `vetting-session-match/v1\0`, distinct from `vtc-personhood-match/v1\0`. `eligibilityVp` carries `nonce` = the `vetting/request` document `id` and `domain` = the applicant's `joinDid` |
+| D25 | Answers to questions put to a community | **Matched by request document id, in memory only.** A directory page, a stored profile, a resent grant or a manifest reaches whoever asked. A `trust-task-error` is claimed only when it answers one of these questions, so the join handler keeps every other error. A question unanswered after 30 s is reported (R1.2) |
+| D26 | How the join flow learns whether a community vets | **From the book, else by asking and handing the wait to the runtime loop** (`JoinExit::AwaitRequirements`, 15 s). The flow's own loop cannot hear inbound messages, so it never waits there, and every wait ends on a message or a deadline |
+| D27 | Vetter profile | **Opt-in listing; the last profile sent is kept as JSON with the community's answer.** A first profile is unlisted and accepts what `VetterPolicy` accepts. The SDK's `check_shape` is the only validator |
+| D28 | Checking a vetter's grant for revocation | **After a verified acceptance, as a background job, https-only with finite timeouts.** Recorded per request as active, revoked or unknown, and unknown is never shown as unrevoked. Advisory; the community checks again when it decides |
+| D29 | Community branding | **Kept from every manifest; presentation only.** The accent is drawn as a literal-colour swatch. The display name is used only when there is no membership name or verified agent name. The logo is not fetched |
 
 ### 15.2 Open questions
 

--- a/openvtc-core/src/vetting/applicant.rs
+++ b/openvtc-core/src/vetting/applicant.rs
@@ -36,6 +36,8 @@ use vta_sdk::vetting::requirements::{
     Evaluation, REQUIREMENTS_DIGEST_MEMBER, StatementFacts, evaluate,
 };
 use vta_sdk::vetting::statement::verify_statement;
+use vta_sdk::vetting::status::StatusCheck;
+use vta_sdk::vetting::ticket_uri::{self, TicketUri};
 
 use crate::config::account::PersonaId;
 use crate::persona::disclosure::ReleasedClaim;
@@ -86,6 +88,39 @@ pub enum ApplicantError {
     /// The community's requirements cannot be evaluated.
     #[error("the community's vetting requirements are unusable: {0}")]
     InvalidRequirements(String),
+}
+
+/// Why a pasted ticket link cannot be used for this application.
+#[derive(Debug, thiserror::Error)]
+pub enum TicketUriError {
+    /// Not a ticket link this client can read.
+    #[error("that is not a vetting ticket link this client can read: {0}")]
+    Unreadable(VettingError),
+    /// A ticket for vetting in another community.
+    #[error(
+        "that ticket is for vetting in another community ({0}), not the one this application is to"
+    )]
+    OtherCommunity(String),
+}
+
+/// What an applicant should do next, from where the application stands.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NextStep {
+    /// A vetter opened a session and is waiting for the card.
+    SendCard {
+        /// The session.
+        session_id: String,
+    },
+    /// The community's requirements are not known yet.
+    LearnRequirements,
+    /// The published requirements are met: join.
+    Join,
+    /// Nothing has been shown to a vetter yet: choose the face they see.
+    ChooseFace,
+    /// More statements are needed and no vetter is working on one.
+    AskVetter,
+    /// Vetters have the request; wait for them.
+    WaitForVetters,
 }
 
 /// One application.
@@ -163,6 +198,51 @@ pub enum VetterEligibility {
     },
 }
 
+/// Whether the community has revoked the grant a vetter presented, as far as
+/// this client could find out (design §7.1). Advisory, like
+/// [`VetterEligibility`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum GrantStatus {
+    /// The status list is being fetched.
+    Checking {
+        /// Since when.
+        since: DateTime<Utc>,
+    },
+    /// The community's signed status list shows the grant unrevoked.
+    Active {
+        /// When.
+        checked_at: DateTime<Utc>,
+    },
+    /// The community has revoked (or suspended) the grant.
+    Revoked {
+        /// When this was learned.
+        checked_at: DateTime<Utc>,
+    },
+    /// It could not be established; never read as active.
+    Unknown {
+        /// Why, for the person and the log.
+        reason: String,
+        /// When the check gave up.
+        checked_at: DateTime<Utc>,
+    },
+}
+
+impl GrantStatus {
+    /// The result of a status check made at `now`.
+    #[must_use]
+    pub fn from_check(check: StatusCheck, now: DateTime<Utc>) -> Self {
+        match check {
+            StatusCheck::Active => GrantStatus::Active { checked_at: now },
+            StatusCheck::Revoked => GrantStatus::Revoked { checked_at: now },
+            StatusCheck::Unknown(reason) => GrantStatus::Unknown {
+                reason,
+                checked_at: now,
+            },
+        }
+    }
+}
+
 /// One request to one vetter.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OutboundRequest {
@@ -175,6 +255,9 @@ pub struct OutboundRequest {
     /// What the vetter's acceptance showed of their eligibility.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eligibility: Option<VetterEligibility>,
+    /// Whether the community has since revoked the grant they showed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grant_status: Option<GrantStatus>,
     /// When we sent it.
     pub sent_at: DateTime<Utc>,
     /// When it last moved.
@@ -411,6 +494,7 @@ impl Application {
             vetter: vetter.to_string(),
             state: RequestState::Sent,
             eligibility: None,
+            grant_status: None,
             sent_at: now,
             updated_at: now,
         });
@@ -496,6 +580,7 @@ impl Application {
             _ => return Err(ApplicantError::WrongState("be accepted")),
         }
         request.eligibility = Some(eligibility);
+        request.grant_status = None;
         request.state = RequestState::Accepted {
             request_id: body.request_id,
             accepts_documentation: body.accepts_documentation,
@@ -503,6 +588,79 @@ impl Application {
         };
         request.updated_at = now;
         Ok(())
+    }
+
+    /// Record what is known of whether the community revoked the grant the
+    /// vetter showed on request `request_document_id`.
+    ///
+    /// # Errors
+    ///
+    /// No request of ours to that vetter with that id.
+    pub fn record_grant_status(
+        &mut self,
+        request_document_id: &str,
+        vetter: &str,
+        status: GrantStatus,
+    ) -> Result<(), ApplicantError> {
+        let request = self.by_thread(request_document_id, vetter)?;
+        request.grant_status = Some(status);
+        Ok(())
+    }
+
+    /// Read a pasted ticket link (what a vetter's QR code carries): the vetter
+    /// to ask, and the ticket to present.
+    ///
+    /// # Errors
+    ///
+    /// Not a ticket link, or a ticket for vetting in another community — which
+    /// the vetter would refuse, and which would tie this application's DID to
+    /// that community if it were sent.
+    pub fn ticket_from_uri(&self, input: &str) -> Result<TicketUri, TicketUriError> {
+        let ticket = ticket_uri::decode(input).map_err(TicketUriError::Unreadable)?;
+        if ticket.community != self.community {
+            return Err(TicketUriError::OtherCommunity(ticket.community));
+        }
+        Ok(ticket)
+    }
+
+    /// What to do next.
+    ///
+    /// A waiting session comes first: it closes in minutes. Then, in order, the
+    /// requirements have to be known, the application may already be enough,
+    /// the first card needs a face, and a request that needs more statements
+    /// needs a vetter working on one.
+    #[must_use]
+    pub fn next_step(&self, now: DateTime<Utc>) -> NextStep {
+        if let Some(session_id) = self.requests.iter().find_map(|r| match &r.state {
+            RequestState::Session {
+                session,
+                card: None,
+                ..
+            } if session.expires_at > now => Some(session.id.clone()),
+            _ => None,
+        }) {
+            return NextStep::SendCard { session_id };
+        }
+        let Some(evaluation) = self.checklist(now) else {
+            return NextStep::LearnRequirements;
+        };
+        if evaluation.satisfied() {
+            return NextStep::Join;
+        }
+        if self.identity_claims.is_empty() && self.requests.is_empty() {
+            return NextStep::ChooseFace;
+        }
+        let in_progress = self.requests.iter().any(|r| {
+            matches!(
+                r.state,
+                RequestState::Sent | RequestState::Accepted { .. } | RequestState::Session { .. }
+            )
+        });
+        if in_progress {
+            NextStep::WaitForVetters
+        } else {
+            NextStep::AskVetter
+        }
     }
 
     /// The vetter refused the request (`trust-task-error`, threaded on it).

--- a/openvtc-core/src/vetting/book.rs
+++ b/openvtc-core/src/vetting/book.rs
@@ -9,13 +9,15 @@
 
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
-use vta_sdk::protocols::join_requests::JoinRequestManifestResponseBody;
+use vta_sdk::protocols::join_requests::{CommunityBranding, JoinRequestManifestResponseBody};
 use vta_sdk::protocols::vetting::{VettingRequirements, documentation};
 
 use super::applicant::{Application, RequestState};
+use super::queries::CommunityQuery;
+use super::registry::VetterProfileRecord;
 use super::tickets::{GuessThrottle, Ticket};
 use super::vetter::{DeskEntry, DeskState, IssuedStatement};
-use crate::config::account::PersonaId;
+use crate::config::account::{Account, CommunityRecord, PersonaId};
 
 /// A vetter's own rules (design §11.2). Every number is the vetter's choice;
 /// the community decides what counts, not what a vetter must accept.
@@ -122,6 +124,82 @@ impl VetterGrant {
     }
 }
 
+/// How a community presents itself, from its manifest's `branding`.
+///
+/// Presentation only: nothing is trusted because of it. Kept as this crate's
+/// own type rather than the SDK's, which refuses unknown members — a config
+/// written by a newer build must still open.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Branding {
+    /// The name the community gives itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// `#rrggbb`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub accent_color: Option<String>,
+}
+
+impl Branding {
+    fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    /// What of `branding` this client keeps: nothing, if it breaks its schema.
+    fn from_manifest(branding: &CommunityBranding) -> Self {
+        if branding.check_shape().is_err() {
+            return Self::default();
+        }
+        Self {
+            display_name: branding.display_name.clone(),
+            accent_color: branding.accent_color.clone(),
+        }
+    }
+
+    /// The accent colour as RGB.
+    #[must_use]
+    pub fn accent_rgb(&self) -> Option<(u8, u8, u8)> {
+        self.accent_color.as_deref().and_then(parse_accent)
+    }
+}
+
+/// `#rrggbb` as RGB; `None` for anything else.
+#[must_use]
+pub fn parse_accent(color: &str) -> Option<(u8, u8, u8)> {
+    let hex = color.strip_prefix('#')?;
+    if hex.len() != 6 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let channel = |i: usize| u8::from_str_radix(&hex[i..i + 2], 16).ok();
+    Some((channel(0)?, channel(2)?, channel(4)?))
+}
+
+/// A community whose manifest we have read — whether or not it vets.
+///
+/// The criteria alone cannot say "this community does not vet": a manifest
+/// with no vetting criterion leaves none behind. This record is what tells
+/// "does not vet" apart from "never asked".
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KnownCommunity {
+    /// The community.
+    pub community: String,
+    /// Its branding, if it publishes any.
+    #[serde(default, skip_serializing_if = "Branding::is_default")]
+    pub branding: Branding,
+    /// When its manifest was last read.
+    pub fetched_at: DateTime<Utc>,
+}
+
+/// What this book knows of whether a community vets its members.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Knowledge<'a> {
+    /// Its manifest has not been read.
+    Unknown,
+    /// Its manifest names no vetting.
+    NoVetting,
+    /// It vets: its first vetting criterion.
+    Vetting(&'a KnownCriterion),
+}
+
 /// All vetting state, for both sides.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct VettingBook {
@@ -149,6 +227,16 @@ pub struct VettingBook {
     /// Communities that named one of our personas a vetter.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub vetter_grants: Vec<VetterGrant>,
+    /// Communities whose manifests we have read, with their branding.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub communities: Vec<KnownCommunity>,
+    /// The vetter profile we last sent each community, per persona.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub vetter_profiles: Vec<VetterProfileRecord>,
+    /// Questions put to communities and not yet answered. Memory only — see
+    /// [`super::queries`].
+    #[serde(skip)]
+    pub queries: Vec<CommunityQuery>,
     /// Fields written by a newer build, preserved verbatim (D19).
     #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, serde_json::Value>,
@@ -166,6 +254,8 @@ impl VettingBook {
             && self.criteria.is_empty()
             && self.policy.is_default()
             && self.vetter_grants.is_empty()
+            && self.communities.is_empty()
+            && self.vetter_profiles.is_empty()
             && self.extra.is_empty()
     }
 
@@ -233,7 +323,112 @@ impl VettingBook {
             });
         self.criteria.retain(|k| k.community != community);
         self.criteria.extend(fresh);
-        !unchanged
+
+        let branding = manifest
+            .branding
+            .as_ref()
+            .map(Branding::from_manifest)
+            .unwrap_or_default();
+        // A re-read refreshes `fetched_at` without counting as a change: the
+        // same manifest again is not worth a save.
+        let branding_changed = match self
+            .communities
+            .iter_mut()
+            .find(|c| c.community == community)
+        {
+            Some(known) => {
+                known.fetched_at = now;
+                let changed = known.branding != branding;
+                known.branding = branding;
+                changed
+            }
+            None => {
+                self.communities.push(KnownCommunity {
+                    community: community.to_string(),
+                    branding,
+                    fetched_at: now,
+                });
+                true
+            }
+        };
+        !unchanged || branding_changed
+    }
+
+    /// Whether `community` vets its members, as far as this book knows.
+    ///
+    /// Criteria recorded before communities were ([`KnownCommunity`]) still
+    /// count as knowing that it vets.
+    #[must_use]
+    pub fn knowledge(&self, community: &str) -> Knowledge<'_> {
+        if let Some(criterion) = self.criteria.iter().find(|k| k.community == community) {
+            return Knowledge::Vetting(criterion);
+        }
+        if self.communities.iter().any(|c| c.community == community) {
+            Knowledge::NoVetting
+        } else {
+            Knowledge::Unknown
+        }
+    }
+
+    /// `community`'s branding, if it publishes any.
+    #[must_use]
+    pub fn branding(&self, community: &str) -> Option<&Branding> {
+        self.communities
+            .iter()
+            .find(|c| c.community == community)
+            .map(|c| &c.branding)
+            .filter(|b| !b.is_default())
+    }
+
+    /// Give application `application_id` the requirements already known for
+    /// its community — the criterion it chose, else the first — so a new
+    /// application shows them before its own manifest request is answered.
+    /// Returns whether anything changed.
+    pub fn adopt_known_requirements(&mut self, application_id: &str) -> bool {
+        let Some(app) = self.applications.iter().find(|a| a.id == application_id) else {
+            return false;
+        };
+        let mut known = self
+            .criteria
+            .iter()
+            .filter(|k| k.community == app.community);
+        let chosen = app
+            .criterion_id
+            .as_deref()
+            .and_then(|id| {
+                self.criteria
+                    .iter()
+                    .find(|k| k.community == app.community && k.criterion_id == id)
+            })
+            .or_else(|| known.next())
+            .cloned();
+        let (Some(criterion), Some(app)) = (chosen, self.application_by_id_mut(application_id))
+        else {
+            return false;
+        };
+        let changed = app.requirements.as_ref() != Some(&criterion.requirements)
+            || app.requirements_digest != criterion.requirements_digest
+            || app.criterion_id.as_deref() != Some(criterion.criterion_id.as_str());
+        app.criterion_id = Some(criterion.criterion_id);
+        app.requirements = Some(criterion.requirements);
+        app.requirements_digest = criterion.requirements_digest;
+        changed
+    }
+
+    /// Active memberships holding no live vetter grant — where a member the
+    /// community did name a vetter may simply never have received the
+    /// credential, and can ask for it again.
+    #[must_use]
+    pub fn resend_candidates<'a>(
+        &self,
+        account: &'a Account,
+        now: DateTime<Utc>,
+    ) -> Vec<&'a CommunityRecord> {
+        account
+            .memberships()
+            .filter(|m| m.status.is_active())
+            .filter(|m| self.vetter_grant(&m.vtc_did, m.persona_ref, now).is_none())
+            .collect()
     }
 
     /// The claim types a session for `community` should require: those of the
@@ -440,6 +635,139 @@ mod tests {
         book.start_application("did:web:other", persona, "did:key:zA", now)
             .unwrap();
         assert_eq!(book.applications.len(), 2);
+    }
+
+    fn manifest(
+        branding: Option<CommunityBranding>,
+        vetting: bool,
+    ) -> JoinRequestManifestResponseBody {
+        let requirements: VettingRequirements = serde_json::from_value(serde_json::json!({
+            "version": "0.1",
+            "statementType": vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE,
+            "minStatements": 1,
+            "acceptedMethods": ["inPerson"],
+            "requiredClaims": ["name.legal"],
+            "eligibleVetters": { "role": "vetter" }
+        }))
+        .unwrap();
+        JoinRequestManifestResponseBody {
+            community_did: "did:web:vtc".into(),
+            criteria: vec![vta_sdk::protocols::join_requests::ManifestCriterion {
+                id: "c1".into(),
+                description: None,
+                presentation_definition: serde_json::json!({}),
+                vetting: vetting.then_some(requirements),
+                requirements_digest: Some("zDigest".into()),
+            }],
+            branding,
+        }
+    }
+
+    #[test]
+    fn a_manifest_says_whether_a_community_vets_and_how_it_looks() {
+        let mut book = VettingBook::default();
+        let now = Utc::now();
+        assert_eq!(book.knowledge("did:web:vtc"), Knowledge::Unknown);
+
+        let branding = CommunityBranding {
+            display_name: Some("Kernel".into()),
+            accent_color: Some("#1a2B3c".into()),
+            ..CommunityBranding::default()
+        };
+        assert!(book.learn_manifest("did:web:vtc", &manifest(Some(branding.clone()), true), now));
+        assert!(matches!(
+            book.knowledge("did:web:vtc"),
+            Knowledge::Vetting(_)
+        ));
+        let known = book.branding("did:web:vtc").unwrap();
+        assert_eq!(known.display_name.as_deref(), Some("Kernel"));
+        assert_eq!(known.accent_rgb(), Some((0x1a, 0x2b, 0x3c)));
+        assert!(
+            !book.learn_manifest("did:web:vtc", &manifest(Some(branding), true), now),
+            "the same manifest again is not a change"
+        );
+
+        assert!(book.learn_manifest("did:web:open", &manifest(None, false), now));
+        assert_eq!(book.knowledge("did:web:open"), Knowledge::NoVetting);
+        assert!(book.branding("did:web:open").is_none());
+
+        let broken = CommunityBranding {
+            accent_color: Some("red".into()),
+            ..CommunityBranding::default()
+        };
+        book.learn_manifest("did:web:broken", &manifest(Some(broken), false), now);
+        assert!(
+            book.branding("did:web:broken").is_none(),
+            "a bad branding is dropped whole"
+        );
+    }
+
+    #[test]
+    fn only_rrggbb_is_an_accent() {
+        assert_eq!(parse_accent("#ff0080"), Some((255, 0, 128)));
+        for bad in ["ff0080", "#ff008", "#ff00800", "#gg0080", "#ff0 80"] {
+            assert_eq!(parse_accent(bad), None, "{bad}");
+        }
+    }
+
+    #[test]
+    fn a_new_application_takes_the_requirements_already_known() {
+        let mut book = VettingBook::default();
+        let now = Utc::now();
+        book.learn_manifest("did:web:vtc", &manifest(None, true), now);
+        let id = book
+            .start_application("did:web:vtc", PersonaId::new(), "did:key:zA", now)
+            .unwrap()
+            .id
+            .clone();
+        assert!(book.adopt_known_requirements(&id));
+        let app = book.application_by_id_mut(&id).unwrap();
+        assert_eq!(app.criterion_id.as_deref(), Some("c1"));
+        assert_eq!(app.requirements_digest.as_deref(), Some("zDigest"));
+        assert!(
+            !book.adopt_known_requirements(&id),
+            "nothing new the second time"
+        );
+    }
+
+    #[test]
+    fn a_member_without_a_live_grant_can_ask_for_it_again() {
+        let now = Utc::now();
+        let mut account = Account::default();
+        let persona = PersonaId::new();
+        for (vtc, active) in [
+            ("did:web:a", true),
+            ("did:web:b", true),
+            ("did:web:c", false),
+        ] {
+            let mut record = CommunityRecord::new_pending(
+                vtc.to_string(),
+                None,
+                "openvtc/test".to_string(),
+                persona,
+                uuid::Uuid::new_v4(),
+                now,
+            );
+            if active {
+                record.activate(now);
+            }
+            account.add_membership(record);
+        }
+        let mut book = VettingBook::default();
+        book.keep_vetter_grant(VetterGrant {
+            community: "did:web:a".into(),
+            persona,
+            credential_id: None,
+            valid_until: Some(now + Duration::days(30)),
+            received_at: now,
+            credential: serde_json::json!({}),
+        });
+        let candidates: Vec<&str> = book
+            .resend_candidates(&account, now)
+            .into_iter()
+            .map(|m| m.vtc_did.as_str())
+            .collect();
+        assert_eq!(candidates, vec!["did:web:b"]);
     }
 
     #[test]

--- a/openvtc-core/src/vetting/guide.rs
+++ b/openvtc-core/src/vetting/guide.rs
@@ -1,0 +1,196 @@
+//! What a community asks of someone who wants to join, in plain words.
+//!
+//! The requirements object is written for a policy engine: `minByMethod`,
+//! `P120D`, `name.legal`. A person deciding whether to apply needs to read that
+//! as sentences they can act on before anything about them is disclosed (design
+//! §6.1, "informed non-application"). The same sentences appear on the join page
+//! and the Vetting page, so they are made in one place.
+
+use vta_sdk::protocols::vetting::{
+    InvitationRequirement, VettingMethod, VettingRequirements, parse_iso8601_duration,
+};
+
+/// How a vetter meets an applicant, as the end of "a vetter can check you …".
+#[must_use]
+pub fn method_words(method: VettingMethod) -> &'static str {
+    match method {
+        VettingMethod::InPerson => "in person",
+        VettingMethod::Video => "on a video call",
+        VettingMethod::PriorAcquaintance => "because they already know you",
+        _ => "another way",
+    }
+}
+
+/// A claim type as a person says it: `name.legal` is "legal name".
+#[must_use]
+pub fn claim_words(claim_type: &str) -> String {
+    match claim_type {
+        "name.legal" => "legal name".to_string(),
+        "name.preferred" => "preferred name".to_string(),
+        "email.work" => "work email".to_string(),
+        "email.personal" => "personal email".to_string(),
+        "account.handle" => "account handle".to_string(),
+        "url.homepage" => "homepage".to_string(),
+        other => other.replace(['.', '_'], " "),
+    }
+}
+
+/// An ISO 8601 duration as words: `P120D` is "120 days". Anything that does
+/// not parse is shown as written rather than guessed at.
+#[must_use]
+pub fn duration_words(iso: &str) -> String {
+    let Some(duration) = parse_iso8601_duration(iso) else {
+        return iso.to_string();
+    };
+    let plural = |n: i64, unit: &str| format!("{n} {unit}{}", if n == 1 { "" } else { "s" });
+    if duration.num_days() >= 1 && duration.num_hours() % 24 == 0 {
+        plural(duration.num_days(), "day")
+    } else if duration.num_hours() >= 1 {
+        plural(duration.num_hours(), "hour")
+    } else {
+        plural(duration.num_minutes().max(1), "minute")
+    }
+}
+
+fn join_words(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [one] => one.clone(),
+        [init @ .., last] => format!("{} and {last}", init.join(", ")),
+    }
+}
+
+/// What `requirements` ask of an applicant, one sentence per line.
+#[must_use]
+pub fn describe_requirements(requirements: &VettingRequirements) -> Vec<String> {
+    let mut lines = Vec::new();
+    let n = requirements.min_statements;
+    lines.push(format!(
+        "{n} vetting statement{}, each from a different vetter the community has named",
+        if n == 1 { "" } else { "s" }
+    ));
+    for (method, floor) in &requirements.min_by_method {
+        lines.push(match method {
+            VettingMethod::PriorAcquaintance => {
+                format!("at least {floor} of them from a vetter who already knows you")
+            }
+            other => format!("at least {floor} of them {}", method_words(*other)),
+        });
+    }
+    let meetings: Vec<String> = requirements
+        .accepted_methods
+        .iter()
+        .filter(|m| **m != VettingMethod::PriorAcquaintance)
+        .map(|m| method_words(*m).to_string())
+        .collect();
+    let knows_you = requirements
+        .accepted_methods
+        .contains(&VettingMethod::PriorAcquaintance);
+    lines.push(match (meetings.is_empty(), knows_you) {
+        (false, true) => format!(
+            "a vetter checks you {}, or vouches for you if they already know you",
+            meetings.join(" or ")
+        ),
+        (false, false) => format!("a vetter checks you {}", meetings.join(" or ")),
+        (true, true) => "only vetters who already know you can vouch for you".to_string(),
+        (true, false) => "the community names no way to be vetted".to_string(),
+    });
+    if !requirements.required_claims.is_empty() {
+        let claims: Vec<String> = requirements
+            .required_claims
+            .iter()
+            .map(|c| claim_words(c))
+            .collect();
+        lines.push(match &requirements.accepted_document_classes {
+            Some(classes) if !classes.is_empty() => format!(
+                "each vetter checks your {} against a document — one of: {}",
+                join_words(&claims),
+                classes.join(", ")
+            ),
+            _ => format!(
+                "each vetter checks your {} — against whichever documents that vetter accepts",
+                join_words(&claims)
+            ),
+        });
+    }
+    if let Some(age) = &requirements.max_statement_age {
+        lines.push(format!(
+            "a statement counts for {} after it is signed",
+            duration_words(age)
+        ));
+    }
+    if matches!(
+        requirements.invitation,
+        Some(InvitationRequirement::Required)
+    ) {
+        lines.push("you also need an invitation from the community".to_string());
+    }
+    if let Some(sla) = &requirements.decision_sla {
+        lines.push(format!(
+            "the community says it decides within {}",
+            duration_words(sla)
+        ));
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requirements() -> VettingRequirements {
+        serde_json::from_value(serde_json::json!({
+            "version": "0.1",
+            "statementType": vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE,
+            "minStatements": 2,
+            "minByMethod": { "inPerson": 1 },
+            "acceptedMethods": ["inPerson", "video", "priorAcquaintance"],
+            "requiredClaims": ["name.legal"],
+            "maxStatementAge": "P120D",
+            "invitation": "required",
+            "decisionSla": "P14D",
+            "eligibleVetters": { "role": "vetter" }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn requirements_read_as_sentences() {
+        assert_eq!(
+            describe_requirements(&requirements()),
+            vec![
+                "2 vetting statements, each from a different vetter the community has named",
+                "at least 1 of them in person",
+                "a vetter checks you in person or on a video call, or vouches for you if they \
+                 already know you",
+                "each vetter checks your legal name — against whichever documents that vetter \
+                 accepts",
+                "a statement counts for 120 days after it is signed",
+                "you also need an invitation from the community",
+                "the community says it decides within 14 days",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_documentation_floor_is_named_when_the_community_sets_one() {
+        let mut r = requirements();
+        r.accepted_document_classes = Some(vec!["passport".into()]);
+        r.required_claims.push("email.work".into());
+        assert!(describe_requirements(&r).iter().any(|l| l
+            == "each vetter checks your legal name and work email against a document — one of: \
+                passport"));
+    }
+
+    #[test]
+    fn durations_read_in_the_largest_whole_unit() {
+        assert_eq!(duration_words("P1D"), "1 day");
+        assert_eq!(duration_words("PT36H"), "36 hours");
+        assert_eq!(duration_words("PT15M"), "15 minutes");
+        assert_eq!(
+            duration_words("soon"),
+            "soon",
+            "unparseable is shown as written"
+        );
+    }
+}

--- a/openvtc-core/src/vetting/inbound.rs
+++ b/openvtc-core/src/vetting/inbound.rs
@@ -15,7 +15,11 @@
 //!
 //! Handling never sends. A reply comes back unsigned in [`Handled::reply`] for
 //! the caller to sign as the named persona and send ([`wire::sign_and_send`]);
-//! anything a person should see comes back as a [`Notice`].
+//! anything a person should see comes back as a [`Notice`]. An answer to a
+//! question we put to a community — a directory page, a stored profile, a
+//! resent grant — comes back as a [`CommunityAnswer`] for whoever is waiting.
+//! A vetter's grant to check for revocation comes back as a [`GrantCheck`],
+//! because the check fetches over HTTPS and the caller owns the network.
 
 use std::sync::Arc;
 
@@ -32,7 +36,9 @@ use vta_sdk::protocols::join_requests::{
 use vta_sdk::protocols::vetting::{
     RevokeStatementResponseBody, VETTER_ROLE, VETTING_DECLINE_TYPE, VETTING_REQUEST_RESPONSE_TYPE,
     VETTING_REQUEST_TYPE, VETTING_REVOKE_STATEMENT_RESPONSE_TYPE, VETTING_SESSION_RESPONSE_TYPE,
-    VETTING_SESSION_TYPE, VettingDeclineBody, VettingRequestAcceptedBody, VettingRequestBody,
+    VETTING_SESSION_TYPE, VETTING_VETTER_LIST_RESPONSE_TYPE, VETTING_VETTER_PROFILE_RESPONSE_TYPE,
+    VETTING_VETTER_RESEND_RESPONSE_TYPE, VetterListResponseBody, VetterProfileResponseBody,
+    VetterResendResponseBody, VettingDeclineBody, VettingRequestAcceptedBody, VettingRequestBody,
     VettingSessionBody, VettingSessionResponseBody, role_matches,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
@@ -40,8 +46,10 @@ use vta_sdk::vetting::eligibility::{
     EligibilityExpectations, community_role, verify_eligibility_vp,
 };
 
-use super::applicant::VetterEligibility;
+use super::applicant::{GrantStatus, VetterEligibility};
 use super::book::{VetterGrant, VettingBook};
+use super::queries::{CommunityAnswer, CommunityQuery, QueryKind, refusal_words};
+use super::status::GrantCheck;
 use super::vetter::{IncomingRequest, Intake};
 use super::wire;
 use crate::config::account::{Account, PersonaId};
@@ -69,6 +77,10 @@ pub struct Handled {
     pub reply: Option<Reply>,
     /// Something a person should see.
     pub notice: Option<Notice>,
+    /// An answer to a question we put to a community.
+    pub answer: Option<CommunityAnswer>,
+    /// A vetter's grant to check for revocation, off the handler.
+    pub grant_check: Option<GrantCheck>,
 }
 
 /// A reply to sign as `persona` and send to the document's recipient.
@@ -186,6 +198,34 @@ pub enum Notice {
         /// The error code.
         code: String,
     },
+    /// Vetter: the community stored our vetter profile.
+    ProfilePublished {
+        /// The community.
+        community: String,
+        /// Whether it lists us in its directory.
+        listed: bool,
+    },
+    /// Vetter: the community refused our vetter profile.
+    ProfileRefused {
+        /// The community.
+        community: String,
+        /// The error code, e.g. `notEligible`.
+        code: String,
+    },
+    /// Vetter: the community is delivering our grant credential again.
+    GrantResent {
+        /// The community.
+        community: String,
+        /// The credential's `validUntil`.
+        valid_until: DateTime<Utc>,
+    },
+    /// Vetter: the community refused to resend our grant credential.
+    ResendRefused {
+        /// The community.
+        community: String,
+        /// The error code, e.g. `notGranted`.
+        code: String,
+    },
 }
 
 impl Notice {
@@ -243,6 +283,30 @@ impl Notice {
             Notice::WithdrawalRefused { statement_id, code } => format!(
                 "The community refused the withdrawal of statement {statement_id} [{code}]."
             ),
+            Notice::ProfilePublished {
+                community,
+                listed: true,
+            } => format!(
+                "{community} published your vetter profile — applicants can find you in its \
+                 directory."
+            ),
+            Notice::ProfilePublished { community, .. } => format!(
+                "{community} stored your vetter profile. It is not listed, so only people you \
+                 give a ticket to can reach you."
+            ),
+            Notice::ProfileRefused { community, code } => {
+                refusal_words(QueryKind::VetterProfile, community, code)
+            }
+            Notice::GrantResent {
+                community,
+                valid_until,
+            } => format!(
+                "{community} is sending your vetter credential again (valid until {}).",
+                valid_until.format("%Y-%m-%d")
+            ),
+            Notice::ResendRefused { community, code } => {
+                refusal_words(QueryKind::VetterResend, community, code)
+            }
         }
     }
 }
@@ -301,6 +365,9 @@ pub fn may_claim(typ: &str) -> bool {
         || matches!(
             typ,
             VETTING_REVOKE_STATEMENT_RESPONSE_TYPE
+                | VETTING_VETTER_LIST_RESPONSE_TYPE
+                | VETTING_VETTER_PROFILE_RESPONSE_TYPE
+                | VETTING_VETTER_RESEND_RESPONSE_TYPE
                 | JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE
                 | CREDENTIAL_ISSUE_TYPE
         )
@@ -321,7 +388,10 @@ pub async fn handle(
         VETTING_SESSION_RESPONSE_TYPE => card(book, ctx, message, sender).await,
         VETTING_DECLINE_TYPE => declined(book, ctx, message, sender).await,
         VETTING_REVOKE_STATEMENT_RESPONSE_TYPE => withdrawal_recorded(book, message, sender),
-        JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE => manifest(book, message, sender),
+        VETTING_VETTER_LIST_RESPONSE_TYPE => vetter_list(book, message, sender),
+        VETTING_VETTER_PROFILE_RESPONSE_TYPE => profile_stored(book, message, sender),
+        VETTING_VETTER_RESEND_RESPONSE_TYPE => resent(book, message, sender),
+        JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE => manifest(book, ctx, message, sender),
         CREDENTIAL_ISSUE_TYPE => return statement(book, ctx, message, sender).await,
         t if is_trust_task_error_type(t) => return refused(book, ctx, message, sender),
         _ => return None,
@@ -343,24 +413,66 @@ async fn opened<P: DeserializeOwned>(
     }
 }
 
-/// A document from a community, whose replies are authenticated by transport
-/// and not always signed: read the payload without requiring a proof.
-fn community_reply<P: DeserializeOwned>(message: &Message) -> Option<(Option<String>, P)> {
-    let thread = message.thid.clone().or_else(|| {
+/// The thread a community's reply names: the envelope's, or the document's.
+fn community_thread(message: &Message) -> Option<String> {
+    message.thid.clone().or_else(|| {
         message
             .body
             .get("threadId")
             .and_then(Value::as_str)
             .map(str::to_string)
-    });
+    })
+}
+
+/// A community reply's payload. Replies are authenticated by transport and not
+/// always signed, so no proof is required.
+fn community_payload<P: DeserializeOwned>(message: &Message) -> Result<P, String> {
     let payload = message.body.get("payload").cloned().unwrap_or(Value::Null);
-    match serde_json::from_value(payload) {
-        Ok(p) => Some((thread, p)),
+    serde_json::from_value(payload).map_err(|e| e.to_string())
+}
+
+/// A document from a community, whose replies are authenticated by transport
+/// and not always signed: read the payload without requiring a proof.
+fn community_reply<P: DeserializeOwned>(message: &Message) -> Option<(Option<String>, P)> {
+    match community_payload(message) {
+        Ok(p) => Some((community_thread(message), p)),
         Err(e) => {
             warn!(typ = %message.typ, error = %e, "malformed community reply");
             None
         }
     }
+}
+
+/// A community's answer to a question of ours of `kind`, with the question.
+///
+/// `None` when it answers nothing we asked. A payload this client cannot read,
+/// for a question we did ask, becomes [`CommunityAnswer::Unreadable`]. The
+/// person waiting then hears that the community and this client disagree,
+/// rather than waiting out the timeout and being told nobody answered.
+fn answer_to<P: DeserializeOwned>(
+    book: &mut VettingBook,
+    message: &Message,
+    sender: &str,
+    kind: QueryKind,
+) -> Option<(CommunityQuery, Result<P, CommunityAnswer>)> {
+    let Some(thread) = community_thread(message) else {
+        debug!(typ = %message.typ, %sender, "community answer with no thread — ignored");
+        return None;
+    };
+    let Some(query) = book.take_query(sender, &thread, Some(kind)) else {
+        debug!(typ = %message.typ, %sender, "community answer to nothing we asked — ignored");
+        return None;
+    };
+    let payload = community_payload::<P>(message).map_err(|detail| {
+        warn!(typ = %message.typ, %sender, error = %detail, "unreadable community answer");
+        CommunityAnswer::Unreadable {
+            query: query.document_id.clone(),
+            community: sender.to_string(),
+            kind,
+            detail,
+        }
+    });
+    Some((query, payload))
 }
 
 async fn take_request(
@@ -418,6 +530,7 @@ async fn take_request(
                     applicant: sender.to_string(),
                     community,
                 }),
+                ..Handled::default()
             }
         }
         Intake::Refused(code) => {
@@ -431,7 +544,7 @@ async fn take_request(
                         document,
                         eligibility: None,
                     }),
-                notice: None,
+                ..Handled::default()
             }
         }
         Intake::Silent => {
@@ -463,6 +576,8 @@ async fn accepted(
     };
     // Bound to our request by `nonce` and to us by `domain`, so a presentation
     // made for someone else, or before the vetter lost the role, does not pass.
+    // A verified grant's `credentialStatus` is kept for the revocation check.
+    let mut grant_status_entry: Option<Option<Value>> = None;
     let eligibility = match &opened.payload.eligibility_vp {
         None => VetterEligibility::NotShown,
         Some(vp) => {
@@ -475,10 +590,13 @@ async fn accepted(
                 now: ctx.now,
             };
             match verify_eligibility_vp(vp, &expect, ctx.resolver).await {
-                Ok(verified) => VetterEligibility::Shown {
-                    credential_id: verified.credential_id().map(str::to_string),
-                    valid_until: verified.valid_until(),
-                },
+                Ok(verified) => {
+                    grant_status_entry = Some(verified.credential_status().cloned());
+                    VetterEligibility::Shown {
+                        credential_id: verified.credential_id().map(str::to_string),
+                        valid_until: verified.valid_until(),
+                    }
+                }
                 Err(e) => {
                     warn!(%sender, error = %e, "vetter eligibility presentation did not verify");
                     VetterEligibility::Failed {
@@ -490,15 +608,40 @@ async fn accepted(
     };
     let shown_eligible = matches!(eligibility, VetterEligibility::Shown { .. });
     match application.on_accepted(thread, sender, opened.payload, eligibility, ctx.now) {
-        Ok(()) => Handled {
-            changed: true,
-            notice: Some(Notice::VetterAccepted {
-                application_id: application.id.clone(),
-                vetter: sender.to_string(),
-                shown_eligible,
-            }),
-            ..Handled::default()
-        },
+        Ok(()) => {
+            let grant_check = match grant_status_entry {
+                Some(Some(credential_status)) => {
+                    let checking = GrantStatus::Checking { since: ctx.now };
+                    let _ = application.record_grant_status(thread, sender, checking);
+                    Some(GrantCheck {
+                        application_id: application.id.clone(),
+                        request_document_id: thread.to_string(),
+                        vetter: sender.to_string(),
+                        issuer: application.community.clone(),
+                        credential_status,
+                    })
+                }
+                Some(None) => {
+                    let unknown = GrantStatus::Unknown {
+                        reason: "the vetter's credential names no status list to check".into(),
+                        checked_at: ctx.now,
+                    };
+                    let _ = application.record_grant_status(thread, sender, unknown);
+                    None
+                }
+                None => None,
+            };
+            Handled {
+                changed: true,
+                notice: Some(Notice::VetterAccepted {
+                    application_id: application.id.clone(),
+                    vetter: sender.to_string(),
+                    shown_eligible,
+                }),
+                grant_check,
+                ..Handled::default()
+            }
+        }
         Err(e) => {
             warn!(%sender, error = %e, "vetting acceptance not applied");
             Handled::default()
@@ -750,6 +893,38 @@ fn refused(
             },
         );
     }
+    if let Some(query) = book.take_query(sender, thread, None) {
+        info!(community = %sender, %code, kind = ?query.kind, "community refused a question of ours");
+        let (changed, notice) = match query.kind {
+            QueryKind::VetterProfile => (
+                book.on_profile_refused(sender, query.persona, &code, ctx.now),
+                Some(Notice::ProfileRefused {
+                    community: sender.to_string(),
+                    code: code.clone(),
+                }),
+            ),
+            QueryKind::VetterResend => (
+                false,
+                Some(Notice::ResendRefused {
+                    community: sender.to_string(),
+                    code: code.clone(),
+                }),
+            ),
+            QueryKind::Manifest | QueryKind::VetterList => (false, None),
+        };
+        return Some(Handled {
+            changed,
+            notice,
+            answer: Some(CommunityAnswer::Refused {
+                query: query.document_id,
+                community: sender.to_string(),
+                kind: query.kind,
+                code,
+                message: detail,
+            }),
+            ..Handled::default()
+        });
+    }
     let statement_id = book
         .issued
         .iter()
@@ -784,12 +959,31 @@ fn withdrawal_recorded(book: &mut VettingBook, message: &Message, sender: &str) 
     }
 }
 
-fn manifest(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
-    let Some((_, body)) = community_reply::<JoinRequestManifestResponseBody>(message) else {
-        return Handled::default();
+fn manifest(book: &mut VettingBook, ctx: &Context<'_>, message: &Message, sender: &str) -> Handled {
+    let thread = community_thread(message);
+    let body = match community_payload::<JoinRequestManifestResponseBody>(message) {
+        Ok(body) => body,
+        Err(detail) => {
+            warn!(typ = %message.typ, error = %detail, "malformed community reply");
+            // Whoever is waiting on this manifest hears why, now.
+            let answer = book
+                .take_manifest_queries(sender, thread.as_deref())
+                .into_iter()
+                .next()
+                .map(|q| CommunityAnswer::Unreadable {
+                    query: q.document_id,
+                    community: sender.to_string(),
+                    kind: QueryKind::Manifest,
+                    detail,
+                });
+            return Handled {
+                answer,
+                ..Handled::default()
+            };
+        }
     };
     let mut handled = Handled {
-        changed: book.learn_manifest(sender, &body, chrono::Utc::now()),
+        changed: book.learn_manifest(sender, &body, ctx.now),
         ..Handled::default()
     };
     for application in book
@@ -809,5 +1003,84 @@ fn manifest(book: &mut VettingBook, message: &Message, sender: &str) -> Handled 
             Err(e) => warn!(community = %sender, error = %e, "community manifest not adopted"),
         }
     }
+    if !book
+        .take_manifest_queries(sender, thread.as_deref())
+        .is_empty()
+    {
+        handled.answer = Some(CommunityAnswer::Manifest {
+            community: sender.to_string(),
+        });
+    }
     handled
+}
+
+fn vetter_list(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
+    let Some((query, page)) =
+        answer_to::<VetterListResponseBody>(book, message, sender, QueryKind::VetterList)
+    else {
+        return Handled::default();
+    };
+    Handled {
+        answer: Some(match page {
+            Ok(page) => CommunityAnswer::Vetters {
+                query: query.document_id,
+                community: sender.to_string(),
+                page,
+            },
+            Err(unreadable) => unreadable,
+        }),
+        ..Handled::default()
+    }
+}
+
+fn profile_stored(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
+    let Some((query, body)) =
+        answer_to::<VetterProfileResponseBody>(book, message, sender, QueryKind::VetterProfile)
+    else {
+        return Handled::default();
+    };
+    match body {
+        Ok(body) => Handled {
+            changed: book.on_profile_stored(sender, query.persona, &body),
+            notice: Some(Notice::ProfilePublished {
+                community: sender.to_string(),
+                listed: body.listed,
+            }),
+            answer: Some(CommunityAnswer::ProfileStored {
+                community: sender.to_string(),
+                listed: body.listed,
+                updated_at: body.updated_at,
+            }),
+            ..Handled::default()
+        },
+        Err(unreadable) => Handled {
+            answer: Some(unreadable),
+            ..Handled::default()
+        },
+    }
+}
+
+fn resent(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
+    let Some((_, body)) =
+        answer_to::<VetterResendResponseBody>(book, message, sender, QueryKind::VetterResend)
+    else {
+        return Handled::default();
+    };
+    match body {
+        Ok(body) => Handled {
+            notice: Some(Notice::GrantResent {
+                community: sender.to_string(),
+                valid_until: body.valid_until,
+            }),
+            answer: Some(CommunityAnswer::Resent {
+                community: sender.to_string(),
+                valid_until: body.valid_until,
+            }),
+            ..Handled::default()
+        },
+        Err(unreadable) => Handled {
+            answer: Some(unreadable),
+            ..Handled::default()
+        },
+    }
 }

--- a/openvtc-core/src/vetting/mod.rs
+++ b/openvtc-core/src/vetting/mod.rs
@@ -19,6 +19,11 @@
 //!   the statement, declines and withdrawals.
 //! - [`wire`] — the Trust Task documents and DIDComm messages on the peer path.
 //! - [`inbound`] — routing an inbound message to the right side.
+//! - [`queries`] — questions put to a community (manifest, directory, profile,
+//!   resend), matched to their answers.
+//! - [`registry`] — the vetter directory and a vetter's published profile.
+//! - [`guide`] — a community's requirements in plain words.
+//! - [`status`] — whether the community has revoked a vetter's grant.
 //!
 //! Every artifact's shape, signature and verification is vta-sdk's
 //! (`protocols::vetting`, and `vetting` behind the feature of that name). This
@@ -27,7 +32,11 @@
 
 pub mod applicant;
 pub mod book;
+pub mod guide;
 pub mod inbound;
+pub mod queries;
+pub mod registry;
+pub mod status;
 pub mod tickets;
 pub mod vetter;
 pub mod wire;

--- a/openvtc-core/src/vetting/queries.rs
+++ b/openvtc-core/src/vetting/queries.rs
@@ -1,0 +1,341 @@
+//! Questions put to a community whose answers arrive later: its manifest, the
+//! vetter directory, a vetter's own profile, and a resend of a vetter's grant.
+//!
+//! Each question is a signed Trust Task sent over DIDComm. The answer is a
+//! `#response` — or a `trust-task-error` — threaded on it, and it reaches the
+//! inbound handler whenever the community gets round to it. Matching the two
+//! takes the request's document id, which is what a [`CommunityQuery`] keeps.
+//!
+//! Questions live in memory only (`#[serde(skip)]` on the book). After a
+//! restart nobody is waiting for an answer, and an answer to a question we no
+//! longer remember is dropped. That is the right outcome for a directory page
+//! nobody is looking at, and it also means a `trust-task-error` is claimed only
+//! when it answers something we asked. Anything else still reaches the join
+//! handler, which owns the other errors a community sends.
+
+use chrono::{DateTime, Duration, Utc};
+use vta_sdk::protocols::vetting::{
+    VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE, VETTING_VETTER_RESEND_ERR_NOT_GRANTED,
+    VetterListResponseBody,
+};
+
+use super::book::VettingBook;
+use crate::config::account::PersonaId;
+
+/// How long a question waits before the person asking is told there was no
+/// answer (R1.2: a quiet community is an error, not a hang).
+pub const QUERY_TIMEOUT: Duration = Duration::seconds(30);
+
+/// What was asked.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueryKind {
+    /// `vtc/join-requests/manifest/0.2`.
+    Manifest,
+    /// `vtc/vetting/vetters/list/0.1`.
+    VetterList,
+    /// `vtc/vetting/vetters/profile/0.1`.
+    VetterProfile,
+    /// `vtc/vetting/vetters/resend/0.1`.
+    VetterResend,
+}
+
+impl QueryKind {
+    /// What was asked for, as the end of "no answer about …".
+    #[must_use]
+    pub fn describe(self) -> &'static str {
+        match self {
+            QueryKind::Manifest => "its vetting requirements",
+            QueryKind::VetterList => "its vetter directory",
+            QueryKind::VetterProfile => "your vetter profile",
+            QueryKind::VetterResend => "your vetter credential",
+        }
+    }
+}
+
+/// A question put to a community.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommunityQuery {
+    /// The request document's id — what the answer threads on.
+    pub document_id: String,
+    /// The community asked.
+    pub community: String,
+    /// The persona that asked.
+    pub persona: PersonaId,
+    /// What was asked.
+    pub kind: QueryKind,
+    /// When.
+    pub sent_at: DateTime<Utc>,
+}
+
+/// An answer to a [`CommunityQuery`], for whoever asked. Nothing here is
+/// persisted; a published profile's record is updated by the handler itself.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CommunityAnswer {
+    /// The community's manifest arrived and its requirements are now known.
+    Manifest {
+        /// The community.
+        community: String,
+    },
+    /// A page of the vetter directory.
+    Vetters {
+        /// The list request's document id.
+        query: String,
+        /// The community.
+        community: String,
+        /// The page.
+        page: VetterListResponseBody,
+    },
+    /// The community stored our vetter profile.
+    ProfileStored {
+        /// The community.
+        community: String,
+        /// Whether it lists us.
+        listed: bool,
+        /// When it stored the profile.
+        updated_at: DateTime<Utc>,
+    },
+    /// The community is delivering our vetter credential again.
+    Resent {
+        /// The community.
+        community: String,
+        /// The credential's `validUntil`.
+        valid_until: DateTime<Utc>,
+    },
+    /// The community refused the question.
+    Refused {
+        /// The request's document id.
+        query: String,
+        /// The community.
+        community: String,
+        /// What was asked.
+        kind: QueryKind,
+        /// The error code.
+        code: String,
+        /// The community's note, if any.
+        message: Option<String>,
+    },
+    /// The community answered in a shape this client cannot read — a contract
+    /// mismatch, not a refusal (R6.4).
+    Unreadable {
+        /// The request's document id.
+        query: String,
+        /// The community.
+        community: String,
+        /// What was asked.
+        kind: QueryKind,
+        /// The parser's detail.
+        detail: String,
+    },
+}
+
+impl CommunityAnswer {
+    /// The community that answered.
+    #[must_use]
+    pub fn community(&self) -> &str {
+        match self {
+            CommunityAnswer::Manifest { community }
+            | CommunityAnswer::Vetters { community, .. }
+            | CommunityAnswer::ProfileStored { community, .. }
+            | CommunityAnswer::Resent { community, .. }
+            | CommunityAnswer::Refused { community, .. }
+            | CommunityAnswer::Unreadable { community, .. } => community,
+        }
+    }
+}
+
+/// A refusal in words the person who asked can act on. `community` is the
+/// community's display name.
+///
+/// The codes the registry defines get their own sentence. A framework code
+/// says which kind of failure it was, because "denied", "could not read" and
+/// "something broke there" call for different next steps (R6.4).
+#[must_use]
+pub fn refusal_words(kind: QueryKind, community: &str, code: &str) -> String {
+    match code {
+        VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE => format!(
+            "{community} did not accept your profile: it does not count you as an active member \
+             holding a live vetter credential. If it named you a vetter, ask it to resend the \
+             credential."
+        ),
+        VETTING_VETTER_RESEND_ERR_NOT_GRANTED => format!(
+            "{community} holds no live vetter credential for you — it has not named you a \
+             vetter, or the grant expired or was revoked. Ask its admins for the vetter role."
+        ),
+        c if c.ends_with("permissionDenied") => format!(
+            "{community} would not answer this persona about {} ({code}).",
+            kind.describe()
+        ),
+        c if c.ends_with("malformedRequest") => format!(
+            "{community} could not read the request for {} ({code}) — this client and the \
+             community disagree about the task, so try again after updating.",
+            kind.describe()
+        ),
+        _ => format!(
+            "{community} refused the request for {} ({code}).",
+            kind.describe()
+        ),
+    }
+}
+
+impl VettingBook {
+    /// Remember a question sent to a community.
+    pub fn ask(&mut self, query: CommunityQuery) {
+        self.queries.push(query);
+    }
+
+    /// The unanswered question of `kind` to `community`, if there is one.
+    #[must_use]
+    pub fn waiting_on(&self, community: &str, kind: QueryKind) -> Option<&CommunityQuery> {
+        self.queries
+            .iter()
+            .find(|q| q.community == community && q.kind == kind)
+    }
+
+    /// Take the question `community`'s reply threaded on `thread` answers.
+    /// `kind`, when given, must match too: a directory page threaded on a
+    /// profile request answers nothing.
+    pub fn take_query(
+        &mut self,
+        community: &str,
+        thread: &str,
+        kind: Option<QueryKind>,
+    ) -> Option<CommunityQuery> {
+        let i = self.queries.iter().position(|q| {
+            q.community == community && q.document_id == thread && kind.is_none_or(|k| q.kind == k)
+        })?;
+        Some(self.queries.remove(i))
+    }
+
+    /// Take a manifest question to `community`: the one `thread` names, or else
+    /// any. A manifest is the same whoever asked, so a reply to one question
+    /// answers every question about it.
+    pub fn take_manifest_queries(
+        &mut self,
+        community: &str,
+        thread: Option<&str>,
+    ) -> Vec<CommunityQuery> {
+        let threaded =
+            thread.and_then(|t| self.take_query(community, t, Some(QueryKind::Manifest)));
+        let mut taken: Vec<CommunityQuery> = threaded.into_iter().collect();
+        let (answered, rest): (Vec<_>, Vec<_>) = std::mem::take(&mut self.queries)
+            .into_iter()
+            .partition(|q| q.community == community && q.kind == QueryKind::Manifest);
+        self.queries = rest;
+        taken.extend(answered);
+        taken
+    }
+
+    /// Forget a question whose send failed, so nothing waits for it.
+    pub fn forget_query(&mut self, document_id: &str) -> Option<CommunityQuery> {
+        let i = self
+            .queries
+            .iter()
+            .position(|q| q.document_id == document_id)?;
+        Some(self.queries.remove(i))
+    }
+
+    /// Remove and return every question unanswered for `after`.
+    pub fn expire_queries(&mut self, now: DateTime<Utc>, after: Duration) -> Vec<CommunityQuery> {
+        let (expired, rest): (Vec<_>, Vec<_>) = std::mem::take(&mut self.queries)
+            .into_iter()
+            .partition(|q| now - q.sent_at >= after);
+        self.queries = rest;
+        expired
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn query(id: &str, community: &str, kind: QueryKind, sent_at: DateTime<Utc>) -> CommunityQuery {
+        CommunityQuery {
+            document_id: id.into(),
+            community: community.into(),
+            persona: PersonaId::new(),
+            kind,
+            sent_at,
+        }
+    }
+
+    #[test]
+    fn a_reply_takes_only_the_question_it_threads_on() {
+        let now = Utc::now();
+        let mut book = VettingBook::default();
+        book.ask(query("q1", "did:web:a", QueryKind::VetterList, now));
+        book.ask(query("q2", "did:web:a", QueryKind::VetterProfile, now));
+
+        assert!(
+            book.take_query("did:web:b", "q1", None).is_none(),
+            "another community cannot answer our question"
+        );
+        assert!(
+            book.take_query("did:web:a", "q2", Some(QueryKind::VetterList))
+                .is_none(),
+            "a directory page does not answer a profile request"
+        );
+        assert_eq!(
+            book.take_query("did:web:a", "q1", Some(QueryKind::VetterList))
+                .map(|q| q.document_id),
+            Some("q1".to_string())
+        );
+        assert!(book.take_query("did:web:a", "q1", None).is_none(), "once");
+        assert!(
+            book.waiting_on("did:web:a", QueryKind::VetterProfile)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn a_manifest_answers_every_question_about_it() {
+        let now = Utc::now();
+        let mut book = VettingBook::default();
+        book.ask(query("m1", "did:web:a", QueryKind::Manifest, now));
+        book.ask(query("m2", "did:web:a", QueryKind::Manifest, now));
+        book.ask(query("m3", "did:web:b", QueryKind::Manifest, now));
+        let taken = book.take_manifest_queries("did:web:a", Some("unrelated-thread"));
+        assert_eq!(taken.len(), 2);
+        assert_eq!(book.queries.len(), 1);
+    }
+
+    #[test]
+    fn unanswered_questions_expire_and_are_not_persisted() {
+        let now = Utc::now();
+        let mut book = VettingBook::default();
+        book.ask(query(
+            "old",
+            "did:web:a",
+            QueryKind::VetterResend,
+            now - QUERY_TIMEOUT,
+        ));
+        book.ask(query("new", "did:web:a", QueryKind::VetterList, now));
+        let expired = book.expire_queries(now, QUERY_TIMEOUT);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].document_id, "old");
+        assert!(book.is_empty(), "questions are memory only");
+        assert_eq!(serde_json::to_value(&book).unwrap(), serde_json::json!({}));
+    }
+
+    #[test]
+    fn refusals_say_what_to_do_next() {
+        let not_granted = refusal_words(
+            QueryKind::VetterResend,
+            "Kernel",
+            VETTING_VETTER_RESEND_ERR_NOT_GRANTED,
+        );
+        assert!(not_granted.contains("has not named you a vetter"));
+        let not_eligible = refusal_words(
+            QueryKind::VetterProfile,
+            "Kernel",
+            VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE,
+        );
+        assert!(not_eligible.contains("resend"));
+        assert!(
+            refusal_words(QueryKind::VetterList, "Kernel", "permissionDenied")
+                .contains("would not answer this persona")
+        );
+        assert!(
+            refusal_words(QueryKind::VetterList, "Kernel", "malformedRequest").contains("disagree")
+        );
+    }
+}

--- a/openvtc-core/src/vetting/registry.rs
+++ b/openvtc-core/src/vetting/registry.rs
@@ -1,0 +1,660 @@
+//! The vetter registry: a vetter's published profile, the directory applicants
+//! search, and the forms both are typed into.
+//!
+//! A person types text; the community takes a `VetterProfileBody` or a
+//! `VetterListBody` and refuses anything that breaks its schema. This module
+//! sits between the two. It turns the text into the body, names the field a
+//! person got wrong in their own terms, and leaves every schema bound to the
+//! SDK's `check_shape`, so this client never disagrees with the community about
+//! what is valid.
+//!
+//! The last profile we published is kept in the book, so it can be edited
+//! rather than typed again. It is kept as the JSON we sent rather than as the
+//! SDK type. That type refuses unknown members, and a profile written by a
+//! newer build must not stop an older one from opening the config.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use vta_sdk::protocols::vetting::{
+    ShapeError, VetterEvent, VetterListBody, VetterLocation, VetterProfileBody,
+    VetterProfileResponseBody, VettingMethod,
+};
+
+use super::book::{VetterPolicy, VettingBook};
+use crate::config::account::PersonaId;
+
+/// Why typed text is not yet a body the community would accept.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DraftError {
+    /// A date is not `YYYY-MM-DD`.
+    #[error("{0} must be a date written YYYY-MM-DD, like 2026-10-05")]
+    Date(&'static str),
+    /// A region or city without a country.
+    #[error("{0}: a region or city needs a country, as a two-letter code such as CZ")]
+    LocationWithoutCountry(&'static str),
+    /// No method ticked.
+    #[error("choose at least one way you vet: in person, on video, or people you already know")]
+    NoMethods,
+    /// The community's schema refuses it.
+    #[error("the community would refuse this: {0}")]
+    Shape(ShapeError),
+}
+
+impl From<ShapeError> for DraftError {
+    fn from(e: ShapeError) -> Self {
+        DraftError::Shape(e)
+    }
+}
+
+/// Split a typed list on commas and whitespace, dropping empties and repeats.
+/// Repeats are dropped rather than refused: `en, en` is a slip, not a choice.
+fn split_list(text: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for item in text.split(|c: char| c == ',' || c.is_whitespace()) {
+        let item = item.trim();
+        if !item.is_empty() && !out.iter().any(|o| o == item) {
+            out.push(item.to_string());
+        }
+    }
+    out
+}
+
+fn optional(text: &str) -> Option<String> {
+    let text = text.trim();
+    (!text.is_empty()).then(|| text.to_string())
+}
+
+fn date(field: &'static str, text: &str) -> Result<NaiveDate, DraftError> {
+    NaiveDate::parse_from_str(text.trim(), "%Y-%m-%d").map_err(|_| DraftError::Date(field))
+}
+
+fn location(
+    what: &'static str,
+    country: &str,
+    region: &str,
+    city: &str,
+) -> Result<Option<VetterLocation>, DraftError> {
+    match optional(country) {
+        Some(country) => Ok(Some(VetterLocation {
+            country: country.to_uppercase(),
+            region: optional(region),
+            city: optional(city),
+        })),
+        None if optional(region).is_some() || optional(city).is_some() => {
+            Err(DraftError::LocationWithoutCountry(what))
+        }
+        None => Ok(None),
+    }
+}
+
+/// One event, as typed.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EventDraft {
+    pub name: String,
+    pub start_date: String,
+    pub end_date: String,
+    pub country: String,
+    pub region: String,
+    pub city: String,
+    pub url: String,
+}
+
+impl EventDraft {
+    /// The fields of `event`, for editing.
+    #[must_use]
+    pub fn from_event(event: &VetterEvent) -> Self {
+        let place = event.location.as_ref();
+        Self {
+            name: event.name.clone(),
+            start_date: event.start_date.format("%Y-%m-%d").to_string(),
+            end_date: event.end_date.format("%Y-%m-%d").to_string(),
+            country: place.map(|l| l.country.clone()).unwrap_or_default(),
+            region: place.and_then(|l| l.region.clone()).unwrap_or_default(),
+            city: place.and_then(|l| l.city.clone()).unwrap_or_default(),
+            url: event.url.clone().unwrap_or_default(),
+        }
+    }
+
+    /// The event, checked the way the community checks it.
+    ///
+    /// # Errors
+    ///
+    /// A date that does not parse, a place without a country, or anything
+    /// `VetterEvent::check_shape` refuses — an end before the start, a span
+    /// over 31 days, a URL that is not `https`.
+    pub fn to_event(&self) -> Result<VetterEvent, DraftError> {
+        let event = VetterEvent {
+            name: self.name.trim().to_string(),
+            start_date: date("the start date", &self.start_date)?,
+            end_date: date("the end date", &self.end_date)?,
+            location: location("the event", &self.country, &self.region, &self.city)?,
+            url: optional(&self.url),
+        };
+        event.check_shape()?;
+        Ok(event)
+    }
+}
+
+/// A vetter profile, as typed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProfileDraft {
+    /// Shown in the directory.
+    pub listed: bool,
+    pub display_name: String,
+    /// BCP 47 tags, separated by commas or spaces.
+    pub languages: String,
+    pub country: String,
+    pub region: String,
+    pub city: String,
+    /// In [`VettingMethod`] order.
+    pub methods: Vec<VettingMethod>,
+    /// Documentation tokens, separated by commas or spaces.
+    pub accepts_documentation: String,
+    pub availability: String,
+    pub contact_hint: String,
+    pub events: Vec<EventDraft>,
+}
+
+/// The order methods are kept and shown in.
+const METHOD_ORDER: [VettingMethod; 3] = [
+    VettingMethod::InPerson,
+    VettingMethod::Video,
+    VettingMethod::PriorAcquaintance,
+];
+
+impl ProfileDraft {
+    /// A first profile.
+    ///
+    /// Unlisted, because being listed is opt-in (design §7) and publishing is
+    /// not the same as choosing to be found. The documentation starts as the
+    /// vetter's own policy, because that is what their acceptances already
+    /// tell applicants (D16).
+    #[must_use]
+    pub fn new(policy: &VetterPolicy) -> Self {
+        Self {
+            listed: false,
+            display_name: String::new(),
+            languages: String::new(),
+            country: String::new(),
+            region: String::new(),
+            city: String::new(),
+            methods: vec![VettingMethod::InPerson, VettingMethod::Video],
+            accepts_documentation: policy.accepts_documentation.join(", "),
+            availability: String::new(),
+            contact_hint: String::new(),
+            events: Vec::new(),
+        }
+    }
+
+    /// The fields of a published profile, for editing.
+    #[must_use]
+    pub fn from_body(body: &VetterProfileBody) -> Self {
+        let place = body.location.as_ref();
+        Self {
+            listed: body.listed,
+            display_name: body.display_name.clone().unwrap_or_default(),
+            languages: body.languages.join(", "),
+            country: place.map(|l| l.country.clone()).unwrap_or_default(),
+            region: place.and_then(|l| l.region.clone()).unwrap_or_default(),
+            city: place.and_then(|l| l.city.clone()).unwrap_or_default(),
+            methods: METHOD_ORDER
+                .into_iter()
+                .filter(|m| body.methods.contains(m))
+                .collect(),
+            accepts_documentation: body.accepts_documentation.join(", "),
+            availability: body.availability.clone().unwrap_or_default(),
+            contact_hint: body.contact_hint.clone().unwrap_or_default(),
+            events: body.events.iter().map(EventDraft::from_event).collect(),
+        }
+    }
+
+    /// Tick or untick `method`, keeping the order stable.
+    pub fn toggle_method(&mut self, method: VettingMethod) {
+        let mut on: Vec<VettingMethod> = self.methods.clone();
+        if on.contains(&method) {
+            on.retain(|m| *m != method);
+        } else {
+            on.push(method);
+        }
+        self.methods = METHOD_ORDER
+            .into_iter()
+            .filter(|m| on.contains(m))
+            .collect();
+    }
+
+    /// The profile body, checked the way the community checks it.
+    ///
+    /// # Errors
+    ///
+    /// No method, a place without a country, a bad event, or anything
+    /// `VetterProfileBody::check_shape` refuses.
+    pub fn to_body(&self) -> Result<VetterProfileBody, DraftError> {
+        if self.methods.is_empty() {
+            return Err(DraftError::NoMethods);
+        }
+        let body = VetterProfileBody {
+            listed: self.listed,
+            display_name: optional(&self.display_name),
+            languages: split_list(&self.languages),
+            location: location("your location", &self.country, &self.region, &self.city)?,
+            methods: self.methods.clone(),
+            accepts_documentation: split_list(&self.accepts_documentation),
+            availability: optional(&self.availability),
+            contact_hint: optional(&self.contact_hint),
+            events: self
+                .events
+                .iter()
+                .map(EventDraft::to_event)
+                .collect::<Result<_, _>>()?,
+            ext: None,
+        };
+        body.check_shape()?;
+        Ok(body)
+    }
+}
+
+/// Directory filters, as typed. Empty means "any".
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DirectoryFilter {
+    pub language: String,
+    pub country: String,
+    pub region: String,
+    pub city: String,
+    pub method: Option<VettingMethod>,
+    pub event_from: String,
+    pub event_to: String,
+    pub event_name: String,
+}
+
+impl DirectoryFilter {
+    /// The list request for one page: `cursor` is the previous page's
+    /// `nextCursor`, or `None` for the first.
+    ///
+    /// # Errors
+    ///
+    /// A date that does not parse, or anything `VetterListBody::check_shape`
+    /// refuses — an end before the start, a country that is not two letters.
+    pub fn to_body(&self, cursor: Option<String>) -> Result<VetterListBody, DraftError> {
+        let body = VetterListBody {
+            language: optional(&self.language),
+            country: optional(&self.country).map(|c| c.to_uppercase()),
+            region: optional(&self.region),
+            city: optional(&self.city),
+            method: self.method,
+            event_from: optional(&self.event_from)
+                .map(|d| date("the first event date", &d))
+                .transpose()?,
+            event_to: optional(&self.event_to)
+                .map(|d| date("the last event date", &d))
+                .transpose()?,
+            event_name: optional(&self.event_name),
+            limit: None,
+            cursor,
+            ext: None,
+        };
+        body.check_shape()?;
+        Ok(body)
+    }
+}
+
+/// Where a community stands on the profile we last sent it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ProfileState {
+    /// Sent; no answer yet.
+    Sent {
+        /// When.
+        sent_at: DateTime<Utc>,
+    },
+    /// Stored.
+    Stored {
+        /// Whether it lists us.
+        listed: bool,
+        /// When it stored the profile.
+        updated_at: DateTime<Utc>,
+    },
+    /// Refused, e.g. `notEligible`.
+    Refused {
+        /// The error code.
+        code: String,
+        /// When the refusal arrived.
+        at: DateTime<Utc>,
+    },
+}
+
+/// The profile we last sent one community as one persona.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct VetterProfileRecord {
+    /// The community.
+    pub community: String,
+    /// Our member persona there.
+    pub persona: PersonaId,
+    /// The `VetterProfileBody` we sent, as JSON (see the module docs).
+    pub profile: Value,
+    /// Where it stands.
+    pub state: ProfileState,
+}
+
+impl VetterProfileRecord {
+    /// The profile, ready to edit. A record this build cannot read — written
+    /// by a newer one — starts from a first profile rather than failing.
+    #[must_use]
+    pub fn draft(&self, policy: &VetterPolicy) -> ProfileDraft {
+        serde_json::from_value::<VetterProfileBody>(self.profile.clone()).map_or_else(
+            |_| ProfileDraft::new(policy),
+            |b| ProfileDraft::from_body(&b),
+        )
+    }
+}
+
+impl VettingBook {
+    /// The profile we last sent `community` as `persona`.
+    #[must_use]
+    pub fn vetter_profile(
+        &self,
+        community: &str,
+        persona: PersonaId,
+    ) -> Option<&VetterProfileRecord> {
+        self.vetter_profiles
+            .iter()
+            .find(|r| r.community == community && r.persona == persona)
+    }
+
+    fn vetter_profile_mut(
+        &mut self,
+        community: &str,
+        persona: PersonaId,
+    ) -> Option<&mut VetterProfileRecord> {
+        self.vetter_profiles
+            .iter_mut()
+            .find(|r| r.community == community && r.persona == persona)
+    }
+
+    /// Record `body` as sent. Returns the record it replaced, so a failed send
+    /// can put it back ([`Self::restore_profile`]).
+    pub fn record_profile_sent(
+        &mut self,
+        community: &str,
+        persona: PersonaId,
+        body: &VetterProfileBody,
+        now: DateTime<Utc>,
+    ) -> Option<VetterProfileRecord> {
+        let record = VetterProfileRecord {
+            community: community.to_string(),
+            persona,
+            profile: serde_json::to_value(body).unwrap_or(Value::Null),
+            state: ProfileState::Sent { sent_at: now },
+        };
+        match self.vetter_profile_mut(community, persona) {
+            Some(existing) => Some(std::mem::replace(existing, record)),
+            None => {
+                self.vetter_profiles.push(record);
+                None
+            }
+        }
+    }
+
+    /// Undo [`Self::record_profile_sent`] after a send that never left.
+    pub fn restore_profile(
+        &mut self,
+        community: &str,
+        persona: PersonaId,
+        previous: Option<VetterProfileRecord>,
+    ) {
+        self.vetter_profiles
+            .retain(|r| !(r.community == community && r.persona == persona));
+        self.vetter_profiles.extend(previous);
+    }
+
+    /// The community stored the profile. Returns whether a record changed.
+    pub fn on_profile_stored(
+        &mut self,
+        community: &str,
+        persona: PersonaId,
+        response: &VetterProfileResponseBody,
+    ) -> bool {
+        match self.vetter_profile_mut(community, persona) {
+            Some(record) => {
+                record.state = ProfileState::Stored {
+                    listed: response.listed,
+                    updated_at: response.updated_at,
+                };
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// The community refused the profile. Returns whether a record changed.
+    pub fn on_profile_refused(
+        &mut self,
+        community: &str,
+        persona: PersonaId,
+        code: &str,
+        now: DateTime<Utc>,
+    ) -> bool {
+        match self.vetter_profile_mut(community, persona) {
+            Some(record) => {
+                record.state = ProfileState::Refused {
+                    code: code.to_string(),
+                    at: now,
+                };
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// A place in a line: `Prague, Central Bohemia, CZ`.
+#[must_use]
+pub fn location_line(location: &VetterLocation) -> String {
+    [
+        location.city.as_deref(),
+        location.region.as_deref(),
+        Some(location.country.as_str()),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(", ")
+}
+
+/// An event in a line: `LPC — 2026-10-05 to 2026-10-07, Prague, CZ`.
+#[must_use]
+pub fn event_line(event: &VetterEvent) -> String {
+    let dates = if event.start_date == event.end_date {
+        event.start_date.format("%Y-%m-%d").to_string()
+    } else {
+        format!(
+            "{} to {}",
+            event.start_date.format("%Y-%m-%d"),
+            event.end_date.format("%Y-%m-%d")
+        )
+    };
+    match &event.location {
+        Some(place) => format!("{} — {dates}, {}", event.name, location_line(place)),
+        None => format!("{} — {dates}", event.name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event() -> EventDraft {
+        EventDraft {
+            name: "Linux Plumbers".into(),
+            start_date: "2026-10-05".into(),
+            end_date: "2026-10-07".into(),
+            country: "cz".into(),
+            region: String::new(),
+            city: "Prague".into(),
+            url: "https://lpc.events".into(),
+        }
+    }
+
+    #[test]
+    fn a_first_profile_is_unlisted_and_accepts_what_the_vetter_already_accepts() {
+        let policy = VetterPolicy::default();
+        let draft = ProfileDraft::new(&policy);
+        assert!(!draft.listed, "being listed is opt-in");
+        let body = draft.to_body().unwrap();
+        assert_eq!(body.accepts_documentation, policy.accepts_documentation);
+        assert!(body.location.is_none());
+    }
+
+    #[test]
+    fn typed_lists_and_places_become_the_body() {
+        let mut draft = ProfileDraft::new(&VetterPolicy::default());
+        draft.listed = true;
+        draft.display_name = " Carol ".into();
+        draft.languages = "en, de-AT en".into();
+        draft.country = "de".into();
+        draft.city = "Berlin".into();
+        draft.events = vec![event()];
+        let body = draft.to_body().unwrap();
+        assert_eq!(body.display_name.as_deref(), Some("Carol"));
+        assert_eq!(body.languages, vec!["en", "de-AT"]);
+        assert_eq!(body.location.as_ref().unwrap().country, "DE");
+        assert_eq!(body.events[0].location.as_ref().unwrap().country, "CZ");
+        assert_eq!(ProfileDraft::from_body(&body).to_body().unwrap(), body);
+    }
+
+    #[test]
+    fn event_dates_are_checked_before_anything_is_sent() {
+        let mut bad = event();
+        bad.start_date = "5 Oct".into();
+        assert_eq!(bad.to_event(), Err(DraftError::Date("the start date")));
+
+        let mut backwards = event();
+        backwards.end_date = "2026-10-01".into();
+        assert!(matches!(backwards.to_event(), Err(DraftError::Shape(_))));
+
+        let mut too_long = event();
+        too_long.end_date = "2026-11-30".into();
+        assert!(matches!(too_long.to_event(), Err(DraftError::Shape(_))));
+
+        let mut http = event();
+        http.url = "http://lpc.events".into();
+        assert!(matches!(http.to_event(), Err(DraftError::Shape(_))));
+    }
+
+    #[test]
+    fn a_place_needs_a_country_and_a_method_is_required() {
+        let mut draft = ProfileDraft::new(&VetterPolicy::default());
+        draft.city = "Berlin".into();
+        assert_eq!(
+            draft.to_body(),
+            Err(DraftError::LocationWithoutCountry("your location"))
+        );
+        let mut draft = ProfileDraft::new(&VetterPolicy::default());
+        draft.toggle_method(VettingMethod::InPerson);
+        draft.toggle_method(VettingMethod::Video);
+        assert_eq!(draft.to_body(), Err(DraftError::NoMethods));
+        draft.toggle_method(VettingMethod::PriorAcquaintance);
+        draft.toggle_method(VettingMethod::InPerson);
+        assert_eq!(
+            draft.methods,
+            vec![VettingMethod::InPerson, VettingMethod::PriorAcquaintance],
+            "ticks keep a stable order"
+        );
+    }
+
+    #[test]
+    fn directory_filters_are_optional_and_checked() {
+        assert_eq!(
+            DirectoryFilter::default().to_body(None).unwrap(),
+            VetterListBody::default()
+        );
+        let filter = DirectoryFilter {
+            country: "cz".into(),
+            event_from: "2026-10-01".into(),
+            event_to: "2026-10-10".into(),
+            ..DirectoryFilter::default()
+        };
+        let body = filter.to_body(Some("next".into())).unwrap();
+        assert_eq!(body.country.as_deref(), Some("CZ"));
+        assert!(body.has_event_filter());
+        assert_eq!(body.cursor.as_deref(), Some("next"));
+
+        let backwards = DirectoryFilter {
+            event_from: "2026-10-10".into(),
+            event_to: "2026-10-01".into(),
+            ..DirectoryFilter::default()
+        };
+        assert!(matches!(backwards.to_body(None), Err(DraftError::Shape(_))));
+        let bad_date = DirectoryFilter {
+            event_to: "soon".into(),
+            ..DirectoryFilter::default()
+        };
+        assert_eq!(
+            bad_date.to_body(None),
+            Err(DraftError::Date("the last event date"))
+        );
+    }
+
+    #[test]
+    fn the_last_profile_sent_is_kept_and_follows_the_communitys_answer() {
+        let mut book = VettingBook::default();
+        let persona = PersonaId::new();
+        let now = Utc::now();
+        let policy = VetterPolicy::default();
+        let mut draft = ProfileDraft::new(&policy);
+        draft.display_name = "Carol".into();
+        let body = draft.to_body().unwrap();
+
+        assert!(
+            book.record_profile_sent("did:web:a", persona, &body, now)
+                .is_none()
+        );
+        let record = book.vetter_profile("did:web:a", persona).unwrap();
+        assert_eq!(
+            record.draft(&policy),
+            draft,
+            "edited later from what was sent"
+        );
+
+        assert!(book.on_profile_stored(
+            "did:web:a",
+            persona,
+            &VetterProfileResponseBody {
+                listed: false,
+                updated_at: now,
+            }
+        ));
+        assert!(matches!(
+            book.vetter_profile("did:web:a", persona).unwrap().state,
+            ProfileState::Stored { listed: false, .. }
+        ));
+
+        // A second send that never left puts the stored one back.
+        let previous = book.record_profile_sent("did:web:a", persona, &body, now);
+        book.restore_profile("did:web:a", persona, previous);
+        assert!(matches!(
+            book.vetter_profile("did:web:a", persona).unwrap().state,
+            ProfileState::Stored { .. }
+        ));
+
+        assert!(book.on_profile_refused("did:web:a", persona, "x:notEligible", now));
+        assert!(!book.on_profile_refused("did:web:b", persona, "x:notEligible", now));
+
+        let unreadable = VetterProfileRecord {
+            community: "did:web:c".into(),
+            persona,
+            profile: serde_json::json!({ "listed": true, "fromTheFuture": 1 }),
+            state: ProfileState::Sent { sent_at: now },
+        };
+        assert_eq!(unreadable.draft(&policy), ProfileDraft::new(&policy));
+    }
+
+    #[test]
+    fn places_and_events_read_as_one_line() {
+        let e = event().to_event().unwrap();
+        assert_eq!(
+            event_line(&e),
+            "Linux Plumbers — 2026-10-05 to 2026-10-07, Prague, CZ"
+        );
+    }
+}

--- a/openvtc-core/src/vetting/status.rs
+++ b/openvtc-core/src/vetting/status.rs
@@ -1,0 +1,314 @@
+//! Has the community revoked a vetter's grant?
+//!
+//! A vetter's acceptance carries their grant as an eligibility presentation.
+//! Verifying it (`verify_eligibility_vp`) proves the community issued the grant
+//! to that vetter for this request. It cannot say whether the community has
+//! since revoked it, because that needs the community's status list, fetched
+//! over HTTPS (design §7.1). This is that step, run as a background job after
+//! the acceptance is recorded.
+//!
+//! The SDK's `check_credential_status` does the reading: it verifies the list's
+//! proof and issuer, decodes the bitstring and reads the bit. This module
+//! supplies the one thing the SDK leaves to its caller, the fetch. The fetch
+//! has finite timeouts (R1.2), accepts only `https`, and bounds what it reads.
+//! Its error text says whether the host was unreachable, answered with an
+//! error, or sent something that is not a status list (R6.4), because "the
+//! community's server is down" and "this is not a status list" call for
+//! different things.
+//!
+//! The answer is advisory, like the eligibility check it follows. The community
+//! checks every vetter again when it decides.
+
+use std::time::Duration;
+
+use reqwest::{Client, Url, header::ACCEPT};
+use serde_json::Value;
+use vta_sdk::trust_task_proof::TrustTaskVmResolver;
+use vta_sdk::vetting::status::{StatusCheck, check_credential_status};
+
+/// How long to wait for a status list host to accept the connection.
+pub const STATUS_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long a whole status list fetch may take.
+pub const STATUS_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+/// The largest status list body read. The SDK reads at most 4 MiB of
+/// `encodedList`, and a credential around it adds little.
+pub const MAX_STATUS_LIST_BYTES: usize = 6 * 1024 * 1024;
+
+/// A grant to check: which request it arrived on, and what to check.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GrantCheck {
+    /// The application.
+    pub application_id: String,
+    /// Our `vetting/request` document id — the request the acceptance answered.
+    pub request_document_id: String,
+    /// The vetter.
+    pub vetter: String,
+    /// The community, which issued the grant and signs its status list.
+    pub issuer: String,
+    /// The grant's `credentialStatus`.
+    pub credential_status: Value,
+}
+
+impl GrantCheck {
+    /// Fetch the community's status list and read the grant's entry.
+    ///
+    /// The future is `Send`, so a caller can spawn it. That is why the fetch
+    /// hands `fetch_owned` a cloned client and an owned URL: a future that
+    /// kept the borrowed `&str` across its `.await` is not provably `Send` for
+    /// every lifetime the SDK's `AsyncFn(&str)` may be called with.
+    pub async fn run(&self, resolver: &TrustTaskVmResolver) -> StatusCheck {
+        let client = match status_client(true, STATUS_FETCH_TIMEOUT) {
+            Ok(client) => client,
+            Err(e) => return StatusCheck::Unknown(e),
+        };
+        check_credential_status(
+            &self.credential_status,
+            &self.issuer,
+            async move |url: &str| fetch_owned(client.clone(), url.to_string()).await,
+            resolver,
+        )
+        .await
+    }
+}
+
+/// [`fetch_status_list`] over owned arguments, so its future borrows nothing.
+fn fetch_owned(
+    client: Client,
+    url: String,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Value, String>> + Send>> {
+    Box::pin(async move { fetch_status_list(&client, &url).await })
+}
+
+/// The HTTP client a status fetch uses: finite connect and total timeouts, at
+/// most three redirects, and — outside tests — `https` only, redirects
+/// included.
+///
+/// # Errors
+///
+/// Only if the TLS backend cannot start.
+pub fn status_client(https_only: bool, timeout: Duration) -> Result<Client, String> {
+    Client::builder()
+        .connect_timeout(STATUS_CONNECT_TIMEOUT.min(timeout))
+        .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::limited(3))
+        .https_only(https_only)
+        .build()
+        .map_err(|e| format!("could not start an HTTP client to check the grant: {e}"))
+}
+
+/// A status list URL this client will fetch: `https`, with a host.
+///
+/// # Errors
+///
+/// Anything else, named plainly.
+pub fn status_list_url(url: &str) -> Result<Url, String> {
+    let parsed =
+        Url::parse(url).map_err(|_| "the grant's status list URL does not parse".to_string())?;
+    if parsed.scheme() != "https" {
+        return Err(format!(
+            "the grant's status list is not served over https ({})",
+            parsed.scheme()
+        ));
+    }
+    if parsed.host_str().is_none_or(str::is_empty) {
+        return Err("the grant's status list URL names no host".to_string());
+    }
+    Ok(parsed)
+}
+
+/// Fetch the status list at `url`, which must be `https`.
+///
+/// # Errors
+///
+/// A URL that is not `https`, a host that cannot be reached or does not answer
+/// in time, a non-success status, a body over [`MAX_STATUS_LIST_BYTES`], or a
+/// body that is not JSON — each with its own message.
+pub async fn fetch_status_list(client: &Client, url: &str) -> Result<Value, String> {
+    let url = status_list_url(url)?;
+    fetch_json(client, url).await
+}
+
+fn describe_transport_error(host: &str, e: &reqwest::Error) -> String {
+    if e.is_timeout() {
+        format!("no answer from {host} in time")
+    } else if e.is_connect() {
+        format!("could not reach {host}: {e}")
+    } else if e.is_redirect() {
+        format!("{host} redirected the status list somewhere this client will not follow")
+    } else {
+        format!("reading the status list from {host} failed: {e}")
+    }
+}
+
+async fn fetch_json(client: &Client, url: Url) -> Result<Value, String> {
+    let host = url.host_str().unwrap_or("the status list host").to_string();
+    let too_large = || {
+        format!(
+            "the status list from {host} is larger than {} MiB",
+            MAX_STATUS_LIST_BYTES / (1024 * 1024)
+        )
+    };
+    let mut response = client
+        .get(url)
+        .header(ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(|e| describe_transport_error(&host, &e))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!(
+            "{host} answered HTTP {} for the status list",
+            status.as_u16()
+        ));
+    }
+    if response
+        .content_length()
+        .is_some_and(|n| n > MAX_STATUS_LIST_BYTES as u64)
+    {
+        return Err(too_large());
+    }
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| describe_transport_error(&host, &e))?
+    {
+        if body.len() + chunk.len() > MAX_STATUS_LIST_BYTES {
+            return Err(too_large());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    serde_json::from_slice(&body)
+        .map_err(|e| format!("what {host} sent is not a status list (not JSON: {e})"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// The check is spawned by the TUI, so its future must be `Send`.
+    #[test]
+    fn the_check_can_be_spawned() {
+        fn assert_send<F: std::future::Future + Send>(_: F) {}
+        let check = GrantCheck {
+            application_id: String::new(),
+            request_document_id: String::new(),
+            vetter: String::new(),
+            issuer: String::new(),
+            credential_status: Value::Null,
+        };
+        let resolver = TrustTaskVmResolver::did_key_only();
+        assert_send(check.run(&resolver));
+    }
+
+    #[test]
+    fn only_https_status_lists_are_fetched() {
+        assert!(status_list_url("https://vtc.example.com/v1/status-lists/revocation").is_ok());
+        assert!(
+            status_list_url("http://vtc.example.com/list")
+                .unwrap_err()
+                .contains("not served over https")
+        );
+        assert!(status_list_url("file:///etc/passwd").is_err());
+        assert!(status_list_url("not a url").is_err());
+    }
+
+    async fn serve(response: ResponseTemplate) -> (MockServer, Url) {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(response)
+            .mount(&server)
+            .await;
+        let url = Url::parse(&server.uri()).unwrap();
+        (server, url)
+    }
+
+    fn test_client(timeout: Duration) -> Client {
+        status_client(false, timeout).unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_list_is_read_as_json() {
+        let (_server, url) =
+            serve(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "id": "x" }))).await;
+        let value = fetch_json(&test_client(STATUS_FETCH_TIMEOUT), url)
+            .await
+            .unwrap();
+        assert_eq!(value["id"], "x");
+    }
+
+    #[tokio::test]
+    async fn failures_say_which_kind_of_failure_they_are() {
+        let client = test_client(Duration::from_millis(300));
+
+        let (_s, url) = serve(ResponseTemplate::new(404)).await;
+        assert!(
+            fetch_json(&client, url)
+                .await
+                .unwrap_err()
+                .contains("answered HTTP 404")
+        );
+
+        let (_s, url) = serve(ResponseTemplate::new(200).set_body_string("<html>")).await;
+        assert!(
+            fetch_json(&client, url)
+                .await
+                .unwrap_err()
+                .contains("not JSON")
+        );
+
+        let (_s, url) = serve(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({}))
+                .set_delay(Duration::from_secs(2)),
+        )
+        .await;
+        assert!(
+            fetch_json(&client, url)
+                .await
+                .unwrap_err()
+                .contains("in time")
+        );
+
+        let (_s, url) =
+            serve(ResponseTemplate::new(200).set_body_bytes(vec![b' '; MAX_STATUS_LIST_BYTES + 1]))
+                .await;
+        assert!(
+            fetch_json(&test_client(STATUS_FETCH_TIMEOUT), url)
+                .await
+                .unwrap_err()
+                .contains("larger than")
+        );
+
+        // Nothing listens on port 9 of localhost.
+        let unreachable = Url::parse("http://127.0.0.1:9/list").unwrap();
+        let error = fetch_json(&client, unreachable).await.unwrap_err();
+        assert!(
+            error.contains("could not reach") || error.contains("in time"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_grant_without_a_usable_status_entry_is_not_called_active() {
+        let check = GrantCheck {
+            application_id: "a".into(),
+            request_document_id: "r".into(),
+            vetter: "did:key:zVetter".into(),
+            issuer: "did:key:zCommunity".into(),
+            credential_status: serde_json::json!({
+                "type": "BitstringStatusListEntry",
+                "statusPurpose": "revocation",
+                "statusListIndex": "7",
+                "statusListCredential": "http://vtc.example.com/list"
+            }),
+        };
+        let result = check.run(&TrustTaskVmResolver::did_key_only()).await;
+        assert!(
+            matches!(&result, StatusCheck::Unknown(reason) if reason.contains("https")),
+            "{result:?}"
+        );
+    }
+}

--- a/openvtc-core/src/vetting/tests.rs
+++ b/openvtc-core/src/vetting/tests.rs
@@ -5,30 +5,41 @@
 //! between them is a DIDComm `Message`, built and signed the way the client
 //! sends it. Nothing here touches a network: every DID is a `did:key`.
 
+use affinidi_data_integrity::{DataIntegrityProof, SignOptions};
 use affinidi_tdk::didcomm::Message;
 use affinidi_tdk::secrets_resolver::secrets::Secret;
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use dtg_credentials::DTGCredential;
 use serde_json::{Value, json};
 use trust_tasks_rs::TrustTask;
 use uuid::Uuid;
 use vta_sdk::protocols::join_requests::{
-    JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, JoinRequestManifestResponseBody, ManifestCriterion,
+    CommunityBranding, JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, JoinRequestManifestResponseBody,
+    ManifestCriterion,
 };
 use vta_sdk::protocols::vetting::{
     COMMUNITY_ROLE_ENDORSEMENT_TYPE, CardClaim, DeclaredRelationship, DeclineCode,
-    IDENTITY_VETTING_ENDORSEMENT_TYPE, RevocationReason, TicketPresentation, VETTER_ROLE,
-    VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_INVALID_TICKET, VETTING_REQUEST_ERR_NOT_ELIGIBLE,
-    VETTING_REQUEST_TYPE, VETTING_SESSION_TYPE, VettingMethod, VettingRequirements,
-    VettingSessionResponseBody,
+    IDENTITY_VETTING_ENDORSEMENT_TYPE, ListedVetter, RevocationReason, TicketPresentation,
+    VETTER_ROLE, VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_INVALID_TICKET,
+    VETTING_REQUEST_ERR_NOT_ELIGIBLE, VETTING_REQUEST_TYPE, VETTING_SESSION_TYPE,
+    VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE, VETTING_VETTER_RESEND_ERR_NOT_GRANTED, VetterListBody,
+    VetterListResponseBody, VetterProfileBody, VetterProfileResponseBody, VetterResendResponseBody,
+    VettingMethod, VettingRequirements, VettingSessionResponseBody,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::card::sign_card;
 use vta_sdk::vetting::statement::sign_statement;
+use vta_sdk::vetting::status::StatusCheck;
 
 use super::VettingBook;
-use super::applicant::{ApplicantError, RequestDraft, RequestState, VetterEligibility};
+use super::applicant::{
+    ApplicantError, Application, GrantStatus, NextStep, RequestDraft, RequestState, TicketUriError,
+    VetterEligibility,
+};
+use super::book::{Knowledge, VetterPolicy};
 use super::inbound::{Context, Handled, Notice, Reply, handle};
+use super::queries::{CommunityAnswer, CommunityQuery, QueryKind};
+use super::registry::{ProfileDraft, ProfileState};
 use super::tickets::{DEFAULT_VALIDITY, Ticket};
 use super::vetter::{Attestation, DeskState};
 use super::wire::{
@@ -176,9 +187,9 @@ fn requirements() -> VettingRequirements {
     .unwrap()
 }
 
-/// The community's manifest 0.2 reply, as its dispatcher sends it.
-fn manifest_reply() -> Message {
-    let body = JoinRequestManifestResponseBody {
+/// The community's manifest 0.2 body.
+fn manifest_body() -> JoinRequestManifestResponseBody {
+    JoinRequestManifestResponseBody {
         community_did: COMMUNITY.into(),
         criteria: vec![ManifestCriterion {
             id: "vetted".into(),
@@ -187,7 +198,13 @@ fn manifest_reply() -> Message {
             vetting: Some(requirements()),
             requirements_digest: Some("zRequirementsDigest".into()),
         }],
-    };
+        branding: None,
+    }
+}
+
+/// The community's manifest 0.2 reply, as its dispatcher sends it.
+fn manifest_reply() -> Message {
+    let body = manifest_body();
     Message::build(
         wire::new_id(),
         JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE.to_string(),
@@ -748,6 +765,7 @@ async fn the_communitys_decision_sla_is_known_once_its_manifest_is() {
             vetting: Some(requirements),
             requirements_digest: Some("zOther".into()),
         }],
+        branding: None,
     };
     let reply = Message::build(
         wire::new_id(),
@@ -760,5 +778,452 @@ async fn the_communitys_decision_sla_is_known_once_its_manifest_is() {
     assert_eq!(
         with_sla.book.decision_sla(COMMUNITY, with_sla.persona),
         chrono::Duration::try_days(21)
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Questions put to the community: the vetter registry, resends, the manifest
+// ----------------------------------------------------------------------------
+
+/// The community's answer to `request`, as its dispatcher sends it: unsigned
+/// (transport authenticates it) and threaded on the request.
+fn community_answer<P: serde::Serialize>(request: &TrustTask<Value>, payload: &P) -> Message {
+    wire::to_message(&wire::response(request, payload).unwrap()).unwrap()
+}
+
+/// The community refusing `request` with `code`.
+fn community_refusal(request: &TrustTask<Value>, code: &str) -> Message {
+    wire::to_message(&wire::refusal(request, code, Some("because")).unwrap()).unwrap()
+}
+
+fn asked(request: &TrustTask<Value>, persona: PersonaId, kind: QueryKind) -> CommunityQuery {
+    CommunityQuery {
+        document_id: request.id.clone(),
+        community: COMMUNITY.into(),
+        persona,
+        kind,
+        sent_at: Utc::now(),
+    }
+}
+
+fn listed_vetter() -> ListedVetter {
+    serde_json::from_value(json!({
+        "vetterDid": "did:key:zCarol",
+        "displayName": "Carol",
+        "languages": ["en", "cs"],
+        "location": { "country": "CZ", "city": "Prague" },
+        "methods": ["inPerson", "video"],
+        "acceptsDocumentation": ["passport"],
+        "contactHint": "find me at the LPC vetting desk",
+        "events": [{ "name": "LPC", "startDate": "2026-10-05", "endDate": "2026-10-07" }],
+        "grantValidUntil": "2027-09-01T00:00:00Z",
+        "updatedAt": "2026-09-01T00:00:00Z"
+    }))
+    .unwrap()
+}
+
+#[tokio::test]
+async fn a_vetter_publishes_a_profile_and_hears_the_communitys_answer() {
+    let mut vetter = Party::new(2).member_of(COMMUNITY);
+    vetter.named_vetter().await;
+    let now = Utc::now();
+    let mut draft = ProfileDraft::new(&VetterPolicy::default());
+    draft.listed = true;
+    draft.languages = "en, cs".into();
+    let body = draft.to_body().unwrap();
+
+    // What the community receives is signed by the vetter and opens as a profile.
+    let mut request = wire::vetter_profile_request(&vetter.did, COMMUNITY, &body).unwrap();
+    wire::sign(&mut request, &vetter.secret).await.unwrap();
+    let opened: wire::Opened<VetterProfileBody> = wire::open(
+        &wire::to_message(&request).unwrap(),
+        &vetter.did,
+        &TrustTaskVmResolver::did_key_only(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(opened.payload, body);
+
+    vetter
+        .book
+        .record_profile_sent(COMMUNITY, vetter.persona, &body, now);
+    vetter
+        .book
+        .ask(asked(&request, vetter.persona, QueryKind::VetterProfile));
+    let stored = VetterProfileResponseBody {
+        listed: true,
+        updated_at: now,
+    };
+    let handled = vetter
+        .receive(&community_answer(&request, &stored), COMMUNITY)
+        .await;
+    assert!(handled.changed, "the stored state is kept");
+    assert!(matches!(
+        handled.notice,
+        Some(Notice::ProfilePublished { listed: true, .. })
+    ));
+    assert!(matches!(
+        handled.answer,
+        Some(CommunityAnswer::ProfileStored { listed: true, .. })
+    ));
+    assert!(matches!(
+        vetter
+            .book
+            .vetter_profile(COMMUNITY, vetter.persona)
+            .unwrap()
+            .state,
+        ProfileState::Stored { listed: true, .. }
+    ));
+
+    // Published again, and refused: the community no longer counts the grant.
+    let request = wire::vetter_profile_request(&vetter.did, COMMUNITY, &body).unwrap();
+    vetter
+        .book
+        .record_profile_sent(COMMUNITY, vetter.persona, &body, now);
+    vetter
+        .book
+        .ask(asked(&request, vetter.persona, QueryKind::VetterProfile));
+    let handled = vetter
+        .receive(
+            &community_refusal(&request, VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE),
+            COMMUNITY,
+        )
+        .await;
+    assert!(matches!(
+        &handled.answer,
+        Some(CommunityAnswer::Refused { kind: QueryKind::VetterProfile, code, .. })
+            if code == VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE
+    ));
+    let notice = handled.notice.expect("a refusal is explained");
+    assert!(notice.describe().contains("live vetter credential"));
+    assert!(matches!(
+        vetter
+            .book
+            .vetter_profile(COMMUNITY, vetter.persona)
+            .unwrap()
+            .state,
+        ProfileState::Refused { .. }
+    ));
+}
+
+#[tokio::test]
+async fn the_directory_answers_only_what_was_asked() {
+    let mut applicant = Party::new(1);
+    let page = VetterListResponseBody {
+        vetters: vec![listed_vetter()],
+        next_cursor: Some("page-2".into()),
+    };
+    let request =
+        wire::vetter_list_request(&applicant.did, COMMUNITY, &VetterListBody::default()).unwrap();
+
+    // Nobody asked: the page answers nothing.
+    let handled = applicant
+        .receive(&community_answer(&request, &page), COMMUNITY)
+        .await;
+    assert!(handled.answer.is_none());
+
+    applicant
+        .book
+        .ask(asked(&request, applicant.persona, QueryKind::VetterList));
+    // Another community cannot answer our question.
+    let handled = applicant
+        .receive(&community_answer(&request, &page), "did:key:zElsewhere")
+        .await;
+    assert!(handled.answer.is_none());
+
+    let handled = applicant
+        .receive(&community_answer(&request, &page), COMMUNITY)
+        .await;
+    let Some(CommunityAnswer::Vetters {
+        query, page: got, ..
+    }) = handled.answer
+    else {
+        panic!("the page is handed to whoever asked");
+    };
+    assert_eq!(query, request.id);
+    assert_eq!(got, page);
+    assert!(!handled.changed, "a directory page is never saved");
+
+    // Refused: the community would not answer this caller.
+    let request =
+        wire::vetter_list_request(&applicant.did, COMMUNITY, &VetterListBody::default()).unwrap();
+    applicant
+        .book
+        .ask(asked(&request, applicant.persona, QueryKind::VetterList));
+    let handled = applicant
+        .receive(&community_refusal(&request, "permissionDenied"), COMMUNITY)
+        .await;
+    assert!(matches!(
+        &handled.answer,
+        Some(CommunityAnswer::Refused { kind: QueryKind::VetterList, code, .. })
+            if code == "permissionDenied"
+    ));
+
+    // An error that answers nothing we asked is left for the join handler.
+    let stray =
+        wire::vetter_list_request(&applicant.did, COMMUNITY, &VetterListBody::default()).unwrap();
+    let resolver = TrustTaskVmResolver::did_key_only();
+    let ctx = Context {
+        account: &applicant.account,
+        resolver: &resolver,
+        recipient: Some((applicant.persona, &applicant.did)),
+        now: Utc::now(),
+    };
+    assert!(
+        handle(
+            &mut applicant.book,
+            &ctx,
+            &community_refusal(&stray, "permissionDenied"),
+            COMMUNITY
+        )
+        .await
+        .is_none()
+    );
+
+    // An answer this client cannot read says so, rather than timing out.
+    let request =
+        wire::vetter_list_request(&applicant.did, COMMUNITY, &VetterListBody::default()).unwrap();
+    applicant
+        .book
+        .ask(asked(&request, applicant.persona, QueryKind::VetterList));
+    let handled = applicant
+        .receive(
+            &community_answer(&request, &json!({ "vetters": "not a list" })),
+            COMMUNITY,
+        )
+        .await;
+    assert!(matches!(
+        handled.answer,
+        Some(CommunityAnswer::Unreadable {
+            kind: QueryKind::VetterList,
+            ..
+        })
+    ));
+    assert!(applicant.book.queries.is_empty());
+}
+
+#[tokio::test]
+async fn a_resend_is_answered_or_refused_in_plain_words() {
+    let mut member = Party::new(5).member_of(COMMUNITY);
+    let request = wire::vetter_resend_request(&member.did, COMMUNITY).unwrap();
+    member
+        .book
+        .ask(asked(&request, member.persona, QueryKind::VetterResend));
+    let resent = VetterResendResponseBody {
+        credential_id: "urn:uuid:grant".into(),
+        valid_until: Utc::now() + Duration::days(300),
+    };
+    let handled = member
+        .receive(&community_answer(&request, &resent), COMMUNITY)
+        .await;
+    assert!(matches!(
+        handled.answer,
+        Some(CommunityAnswer::Resent { .. })
+    ));
+    assert!(matches!(handled.notice, Some(Notice::GrantResent { .. })));
+
+    let request = wire::vetter_resend_request(&member.did, COMMUNITY).unwrap();
+    member
+        .book
+        .ask(asked(&request, member.persona, QueryKind::VetterResend));
+    let handled = member
+        .receive(
+            &community_refusal(&request, VETTING_VETTER_RESEND_ERR_NOT_GRANTED),
+            COMMUNITY,
+        )
+        .await;
+    assert!(matches!(
+        handled.answer,
+        Some(CommunityAnswer::Refused {
+            kind: QueryKind::VetterResend,
+            ..
+        })
+    ));
+    let notice = handled.notice.expect("a refusal is explained");
+    assert!(notice.describe().contains("has not named you a vetter"));
+}
+
+#[tokio::test]
+async fn a_manifest_answers_whoever_asked_and_brings_the_communitys_branding() {
+    let mut applicant = Party::new(1);
+    let request = wire::manifest_request(&applicant.did, COMMUNITY).unwrap();
+    applicant
+        .book
+        .ask(asked(&request, applicant.persona, QueryKind::Manifest));
+    let mut body = manifest_body();
+    body.branding = Some(CommunityBranding {
+        display_name: Some("Kernel Developers".into()),
+        accent_color: Some("#336699".into()),
+        ..CommunityBranding::default()
+    });
+    let handled = applicant
+        .receive(&community_answer(&request, &body), COMMUNITY)
+        .await;
+    assert!(matches!(
+        handled.answer,
+        Some(CommunityAnswer::Manifest { .. })
+    ));
+    assert!(matches!(
+        applicant.book.knowledge(COMMUNITY),
+        Knowledge::Vetting(_)
+    ));
+    let branding = applicant.book.branding(COMMUNITY).unwrap();
+    assert_eq!(branding.display_name.as_deref(), Some("Kernel Developers"));
+    assert_eq!(branding.accent_rgb(), Some((0x33, 0x66, 0x99)));
+    assert!(applicant.book.queries.is_empty());
+}
+
+/// A community role credential carrying a status list entry, signed by
+/// `issuer`. `DTGCredential` does not model `credentialStatus`, so the
+/// credential is signed as JSON.
+async fn role_credential_with_status(issuer: &Secret, subject: &str) -> Value {
+    let now = Utc::now();
+    let credential = DTGCredential::new_vec(
+        did(issuer),
+        subject.to_string(),
+        now - Duration::minutes(1),
+        Some(now + Duration::days(365)),
+        json!({
+            "type": COMMUNITY_ROLE_ENDORSEMENT_TYPE,
+            "role": VETTER_ROLE,
+            "communityDid": COMMUNITY,
+        }),
+    )
+    .with_id(wire::new_id());
+    let mut value = serde_json::to_value(&credential).unwrap();
+    value.as_object_mut().unwrap().remove("proof");
+    value["credentialStatus"] = json!({
+        "id": "https://vtc.example.com/v1/status-lists/revocation#7",
+        "type": "BitstringStatusListEntry",
+        "statusPurpose": "revocation",
+        "statusListIndex": "7",
+        "statusListCredential": "https://vtc.example.com/v1/status-lists/revocation"
+    });
+    let proof = DataIntegrityProof::sign(
+        &value,
+        issuer,
+        SignOptions::new().with_proof_purpose("assertionMethod"),
+    )
+    .await
+    .unwrap();
+    value["proof"] = serde_json::to_value(proof).unwrap();
+    value
+}
+
+#[tokio::test]
+async fn a_verified_grant_is_handed_on_for_a_revocation_check() {
+    let (mut applicant, mut vetter, ticket) = ready().await;
+    let credential =
+        role_credential_with_status(&secret(COMMUNITY_SEED), &vetter.did.clone()).await;
+    let handled = vetter
+        .receive(&delivery(&credential, COMMUNITY), COMMUNITY)
+        .await;
+    assert!(matches!(handled.notice, Some(Notice::VetterGranted { .. })));
+
+    let message = request(&mut applicant, &vetter, ticket).await;
+    let reply = vetter
+        .receive(&message, &applicant.did)
+        .await
+        .reply
+        .expect("accepted");
+    let handled = applicant
+        .receive(&signed_reply(reply, &vetter.secret).await, &vetter.did)
+        .await;
+    let check = handled
+        .grant_check
+        .expect("a verified grant with a status entry is checked");
+    assert_eq!(check.issuer, COMMUNITY);
+    assert_eq!(check.vetter, vetter.did);
+    assert_eq!(check.credential_status["statusListIndex"], "7");
+    let app = applicant.application();
+    assert!(matches!(
+        app.requests[0].grant_status,
+        Some(GrantStatus::Checking { .. })
+    ));
+
+    app.record_grant_status(
+        &check.request_document_id,
+        &check.vetter,
+        GrantStatus::from_check(StatusCheck::Revoked, Utc::now()),
+    )
+    .unwrap();
+    assert!(matches!(
+        app.requests[0].grant_status,
+        Some(GrantStatus::Revoked { .. })
+    ));
+}
+
+#[tokio::test]
+async fn a_grant_that_names_no_status_list_is_not_called_unrevoked() {
+    let (mut applicant, mut vetter, ticket) = ready().await;
+    let message = request(&mut applicant, &vetter, ticket).await;
+    let reply = vetter
+        .receive(&message, &applicant.did)
+        .await
+        .reply
+        .unwrap();
+    let handled = applicant
+        .receive(&signed_reply(reply, &vetter.secret).await, &vetter.did)
+        .await;
+    assert!(handled.grant_check.is_none());
+    assert!(matches!(
+        applicant.application().requests[0].grant_status,
+        Some(GrantStatus::Unknown { .. })
+    ));
+}
+
+#[tokio::test]
+async fn a_scanned_ticket_link_is_enough_to_ask_and_another_communitys_is_refused() {
+    let (mut applicant, mut vetter, _) = ready().await;
+    let link = vetter.book.tickets[0].uri(&vetter.did);
+    let ticket = applicant.application().ticket_from_uri(&link).unwrap();
+    assert_eq!(ticket.vetter, vetter.did);
+    let message = request(&mut applicant, &vetter, ticket.presentation).await;
+    let handled = vetter.receive(&message, &applicant.did).await;
+    assert!(matches!(
+        handled.notice,
+        Some(Notice::RequestAccepted { .. })
+    ));
+
+    let elsewhere = Ticket::issue(
+        "did:key:zOtherCommunity",
+        vetter.persona,
+        vec![],
+        1,
+        DEFAULT_VALIDITY,
+        Utc::now(),
+    );
+    assert!(matches!(
+        applicant.application().ticket_from_uri(&elsewhere.uri(&vetter.did)),
+        Err(TicketUriError::OtherCommunity(c)) if c == "did:key:zOtherCommunity"
+    ));
+    assert!(matches!(
+        applicant.application().ticket_from_uri("K7QF-2M9X"),
+        Err(TicketUriError::Unreadable(_))
+    ));
+}
+
+#[tokio::test]
+async fn the_next_step_follows_the_application() {
+    let fresh = Application::new(COMMUNITY, PersonaId::new(), "did:key:zA", Utc::now()).unwrap();
+    assert_eq!(fresh.next_step(Utc::now()), NextStep::LearnRequirements);
+
+    let (mut applicant, mut vetter, _) = ready().await;
+    assert_eq!(
+        applicant.application().next_step(Utc::now()),
+        NextStep::ChooseFace
+    );
+    let (_, session_doc) = in_session(&mut applicant, &mut vetter).await;
+    assert_eq!(
+        applicant.application().next_step(Utc::now()),
+        NextStep::WaitForVetters
+    );
+    let message = signed(session_doc.clone(), &vetter.secret).await;
+    applicant.receive(&message, &vetter.did).await;
+    assert_eq!(
+        applicant.application().next_step(Utc::now()),
+        NextStep::SendCard {
+            session_id: session_doc.id.clone()
+        }
     );
 }

--- a/openvtc-core/src/vetting/tickets.rs
+++ b/openvtc-core/src/vetting/tickets.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 use vta_sdk::protocols::vetting::{
     TicketPresentation, VETTING_REQUEST_ERR_INVALID_TICKET, VettingMethod,
 };
+use vta_sdk::vetting::ticket_uri::{self, TicketUri};
 
 use crate::config::account::PersonaId;
 
@@ -129,6 +130,21 @@ impl Ticket {
             ticket_id: self.id.clone(),
             secret: self.secret.clone(),
         }
+    }
+
+    /// The ticket as a link — what its QR code carries. `vetter` is the DID of
+    /// the persona the ticket admits requests to.
+    ///
+    /// The link carries the scanned form: full-entropy, so it is refused
+    /// outright when wrong rather than silently throttled, and nobody guesses
+    /// it. The short code stays for reading aloud.
+    #[must_use]
+    pub fn uri(&self, vetter: &str) -> String {
+        ticket_uri::encode(&TicketUri {
+            community: self.community.clone(),
+            vetter: vetter.to_string(),
+            presentation: self.scanned_presentation(),
+        })
     }
 }
 
@@ -329,6 +345,15 @@ mod tests {
             };
             body.check_shape("did:key:zApplicant").unwrap();
         }
+    }
+
+    #[test]
+    fn a_ticket_link_carries_the_scanned_form() {
+        let t = ticket(PersonaId::new(), Utc::now());
+        let decoded = ticket_uri::decode(&t.uri("did:key:zVetter")).unwrap();
+        assert_eq!(decoded.community, COMMUNITY);
+        assert_eq!(decoded.vetter, "did:key:zVetter");
+        assert_eq!(decoded.presentation, t.scanned_presentation());
     }
 
     #[test]

--- a/openvtc-core/src/vetting/wire.rs
+++ b/openvtc-core/src/vetting/wire.rs
@@ -202,6 +202,54 @@ pub fn manifest_request(
     )
 }
 
+/// A `vtc/vetting/vetters/list/0.1` request for one page of `community_did`'s
+/// vetter directory. The community refuses a caller it cannot identify, so this
+/// is signed and sent as one of our personas like every other vetting task.
+pub fn vetter_list_request(
+    issuer: &str,
+    community_did: &str,
+    body: &vta_sdk::protocols::vetting::VetterListBody,
+) -> Result<TrustTask<Value>, OpenVTCError> {
+    document(
+        vta_sdk::protocols::vetting::VETTING_VETTER_LIST_TYPE,
+        issuer,
+        community_did,
+        new_id(),
+        body,
+    )
+}
+
+/// A `vtc/vetting/vetters/profile/0.1` request publishing (replacing) our
+/// vetter profile at `community_did`.
+pub fn vetter_profile_request(
+    vetter_did: &str,
+    community_did: &str,
+    body: &vta_sdk::protocols::vetting::VetterProfileBody,
+) -> Result<TrustTask<Value>, OpenVTCError> {
+    document(
+        vta_sdk::protocols::vetting::VETTING_VETTER_PROFILE_TYPE,
+        vetter_did,
+        community_did,
+        new_id(),
+        body,
+    )
+}
+
+/// A `vtc/vetting/vetters/resend/0.1` request asking `community_did` to
+/// deliver our live vetter grant credential again.
+pub fn vetter_resend_request(
+    vetter_did: &str,
+    community_did: &str,
+) -> Result<TrustTask<Value>, OpenVTCError> {
+    document(
+        vta_sdk::protocols::vetting::VETTING_VETTER_RESEND_TYPE,
+        vetter_did,
+        community_did,
+        new_id(),
+        &vta_sdk::protocols::vetting::VetterResendBody::default(),
+    )
+}
+
 /// Sign `document` with `persona`'s key and send it over DIDComm to its
 /// recipient. Returns the document id — what a reply threads on.
 ///

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -89,6 +89,7 @@ hex.workspace = true
 keyring-core.workspace = true
 multibase.workspace = true
 pgp.workspace = true
+qrcode.workspace = true
 rand.workspace = true
 regex.workspace = true
 secrecy.workspace = true

--- a/openvtc/src/state_handler/actions/mod.rs
+++ b/openvtc/src/state_handler/actions/mod.rs
@@ -315,12 +315,20 @@ pub enum VettingAction {
     Submit,
     /// Show a status line (e.g. a clipboard result).
     Status(String),
+    /// Pasted text that is a `vetting-ticket:` link, for the request form.
+    PasteTicket(String),
     // ── Applicant ────────────────────────────────────────────────────────
     StartApplication,
     ChooseFace,
     RequestVetter,
     RefreshRequirements,
     ReviewCard,
+    /// Open the vetter directory.
+    FindVetters,
+    /// Fetch the next (`true`) or previous directory page.
+    DirectoryPage(bool),
+    /// Ask the highlighted directory vetter: fill the request form.
+    AskListedVetter,
     // ── Vetter ───────────────────────────────────────────────────────────
     NewTicket,
     DeleteTicket,
@@ -328,6 +336,12 @@ pub enum VettingAction {
     StartAttest,
     ArmDecline,
     ArmWithdraw,
+    /// Open the vetter profile form.
+    EditProfile,
+    /// Remove the highlighted event from the profile form.
+    RemoveEvent,
+    /// Ask a community to send our vetter credential again.
+    AskResend,
 }
 
 /// A membership's VTA context, from the communities panel: deleting a finished
@@ -459,6 +473,20 @@ pub enum Action {
 
     /// Commit the highlighted context and launch the join in it.
     JoinContextChoose,
+
+    /// Vetting page: start the application to the community (or continue the
+    /// one under way) and go to it on the Vetting page.
+    JoinVettingApply,
+    /// Vetting page: join now — presenting the application's statements when
+    /// it meets the requirements, otherwise without them, which the community
+    /// refers to its moderators.
+    JoinVettingJoin,
+    /// Vetting page: ask the community for its requirements again.
+    JoinVettingAskAgain,
+    /// Vetting page: move the focus (`true` = next field).
+    JoinVettingField(bool),
+    /// Vetting page: cycle the focused choice (`true` = forwards).
+    JoinVettingCycle(bool),
 
     /// Issue this Active membership's reciprocal VMC (member → community) and
     /// send it to the community's VTC over DIDComm (`members/vmc/1.0`). Indexed

--- a/openvtc/src/state_handler/background_dispatch.rs
+++ b/openvtc/src/state_handler/background_dispatch.rs
@@ -123,6 +123,11 @@ pub(crate) enum DispatchDomain {
     /// Reading every membership context's device grants once a run, so the
     /// communities panel's detail can show them without being asked.
     DeviceGrantSweep,
+    /// Checking whether a community revoked a vetter's grant: one HTTPS fetch of
+    /// its status list. Never claimed with `try_begin` — each check is started
+    /// by an inbound acceptance, not a person, is independent of the others,
+    /// and must not hold up a vetting send the person is making.
+    VettingStatus,
 }
 
 impl DispatchDomain {
@@ -147,6 +152,7 @@ impl DispatchDomain {
             DispatchDomain::CommunityContexts => "Community context registration",
             DispatchDomain::CommunityAccess => "Community context request",
             DispatchDomain::DeviceGrantSweep => "Device access refresh",
+            DispatchDomain::VettingStatus => "Vetter grant check",
         }
     }
 }
@@ -269,6 +275,9 @@ pub(crate) enum DispatchOutcome {
     Panicked(DispatchDomain),
     /// A vetting send finished (or failed, and was undone).
     Vetting(crate::state_handler::vetting_actions::VettingOutcome),
+    /// A vetter grant's revocation check finished. Its own domain, so it never
+    /// releases the `Vetting` domain a person's send holds.
+    VettingStatus(crate::state_handler::vetting_actions::GrantChecked),
     /// Membership contexts were checked at the VTA: each context id, and
     /// whether it had to be created or why it could not be.
     CommunityContexts(Vec<(String, Result<bool, String>)>),
@@ -308,6 +317,7 @@ impl DispatchOutcome {
             DispatchOutcome::Vic(_) => DispatchDomain::Vic,
             DispatchOutcome::VicMutation(_) => DispatchDomain::Vic,
             DispatchOutcome::Vetting(_) => DispatchDomain::Vetting,
+            DispatchOutcome::VettingStatus(_) => DispatchDomain::VettingStatus,
             DispatchOutcome::CommunityContexts(_) => DispatchDomain::CommunityContexts,
             DispatchOutcome::CommunityContext(_) => DispatchDomain::CommunityAccess,
             DispatchOutcome::DeviceGrantSweep(_) => DispatchDomain::DeviceGrantSweep,
@@ -443,6 +453,7 @@ pub(crate) fn apply_outcome(
         },
         DispatchOutcome::Relationship(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Vetting(outcome) => outcome.apply(state, config, save),
+        DispatchOutcome::VettingStatus(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Inbox(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::Did(outcome) => outcome.apply(state, config, save),
         DispatchOutcome::AgentName(results) => {

--- a/openvtc/src/state_handler/join.rs
+++ b/openvtc/src/state_handler/join.rs
@@ -35,6 +35,78 @@ pub enum JoinPage {
     ContextChoice,
     /// Automated mint + join sequence progress / result.
     Progress,
+    /// A community that vets its members: what it requires, in plain words,
+    /// before anything about the applicant is sent — with the persona's
+    /// application if there is one, and the ways on (apply, join anyway,
+    /// cancel). Also the page shown while the community is being asked.
+    Vetting,
+}
+
+/// A community that vets, as the join flow's vetting page shows it.
+#[derive(Clone, Debug)]
+pub struct JoinVettingView {
+    /// The community's VTC DID.
+    pub community: String,
+    /// Its name, already sanitised.
+    pub name: String,
+    /// The accent colour it publishes.
+    pub accent: Option<(u8, u8, u8)>,
+    pub phase: VettingPhase,
+}
+
+/// How much is known of what a community requires.
+#[derive(Clone, Debug)]
+pub enum VettingPhase {
+    /// The community is being asked. The runtime loop, which hears the
+    /// answer, draws the page while it waits.
+    Asking,
+    /// Its requirements could not be learned; why.
+    Unknown { reason: String },
+    /// It vets, and this is what it asks.
+    Known(Box<KnownVetting>),
+}
+
+/// A vetting community's requirements and where this persona stands.
+#[derive(Clone, Debug, Default)]
+pub struct KnownVetting {
+    /// What it requires, one sentence each.
+    pub requirements: Vec<String>,
+    /// Where it says how it decides.
+    pub governance_url: Option<String>,
+    /// Our application to it, when there is one.
+    pub application: Option<JoinApplication>,
+    /// Personas a new application can be made as.
+    pub personas: Vec<ApplyAs>,
+    pub persona_index: usize,
+    /// Where a new application's face is worn.
+    pub context_options: Vec<ContextOption>,
+    pub context_index: usize,
+    /// 0 = persona, 1 = context.
+    pub field: usize,
+}
+
+/// A persona an application can be made as.
+#[derive(Clone, Debug)]
+pub struct ApplyAs {
+    pub persona: PersonaId,
+    pub label: String,
+    pub did: String,
+}
+
+/// An application already under way, as the join page shows it.
+#[derive(Clone, Debug)]
+pub struct JoinApplication {
+    pub id: String,
+    pub persona: PersonaId,
+    pub persona_label: String,
+    /// Statements that would be presented now.
+    pub statements: usize,
+    /// Progress against the published requirements.
+    pub progress: Option<String>,
+    /// What to do next, with its key on the Vetting page.
+    pub next_step: String,
+    /// It meets the published requirements.
+    pub satisfied: bool,
 }
 
 /// The identity a join presents, once chosen.
@@ -188,6 +260,8 @@ pub struct JoinState {
     pub context_slug: String,
     /// Display names for the communities listed under each context, by VTC DID.
     pub context_community_names: Vec<(String, String)>,
+    /// The vetting page, while the community being joined vets its members.
+    pub vetting: Option<JoinVettingView>,
 }
 
 impl JoinState {

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -20,11 +20,16 @@ use chrono::Utc;
 use openvtc_core::config::{
     Config,
     account::{CommunityRecord, PersonaId, VtcDid},
-    community_context::{self, ContextKind},
+    community_context::{self, ContextKind, ContextOption},
     context_path::{build_sub_context_id, parse_sub_context_id},
 };
 use openvtc_core::didcomm::Messaging;
 use openvtc_core::logs::LogFamily;
+use openvtc_core::vetting::applicant::Application;
+use openvtc_core::vetting::book::Knowledge;
+use openvtc_core::vetting::guide::describe_requirements;
+use openvtc_core::vetting::queries::{CommunityAnswer, CommunityQuery, QueryKind};
+use openvtc_core::vetting::wire;
 use tokio::sync::{broadcast, mpsc::UnboundedReceiver};
 use tracing::debug;
 use vta_sdk::{client::VtaClient, protocols::did_management::create::WebvhPathMode};
@@ -35,14 +40,370 @@ use crate::{
         StateHandler,
         actions::Action,
         join::{
-            AvailableVic, IdentityPick, JoinPage, JoinState, PersonaOption, PresentedInvitation,
+            ApplyAs, AvailableVic, IdentityPick, JoinApplication, JoinPage, JoinState,
+            JoinVettingView, KnownVetting, PersonaOption, PresentedInvitation, VettingPhase,
         },
         main_page::content::{VicLifecycle, VicSummary},
         main_page::{sanitize_display, shorten_did},
         setup_sequence::{Completion, MessageType, config::ConfigExtension, vta},
         state::{ActivePage, State},
+        vetting_actions,
     },
 };
+
+/// How the join flow is entered.
+pub(crate) enum JoinEntry {
+    /// From the Communities panel. `hears_replies` says whether the calling
+    /// loop reads inbound messages: only then can the flow ask a community for
+    /// its requirements and hand the wait for the answer to that loop.
+    Fresh { hears_replies: bool },
+    /// Back from waiting for a community's requirements.
+    Resume {
+        vtc_did: String,
+        outcome: RequirementsOutcome,
+    },
+}
+
+/// How a wait for a community's requirements ended.
+pub(crate) enum RequirementsOutcome {
+    /// Its manifest arrived; the book knows whether it vets.
+    Learned,
+    /// No usable answer, and why.
+    Unanswered(String),
+    /// The person chose to join without waiting.
+    Skipped,
+}
+
+/// A join waiting for a community's manifest. The join flow cannot wait
+/// itself: its loop selects only on actions and interrupts, and the answer
+/// arrives on the runtime loop's inbound arm. So the flow asks, returns this,
+/// and the runtime loop keeps the join screen up, hears the answer — or gives
+/// up after [`REQUIREMENTS_WAIT`] — and enters the flow again.
+pub(crate) struct AwaitingRequirements {
+    pub vtc_did: String,
+    /// The manifest request's document id.
+    pub document_id: String,
+    pub asked_at: std::time::Instant,
+}
+
+/// How long the join screen waits for a community's requirements before
+/// offering to go on without them.
+pub(crate) const REQUIREMENTS_WAIT: Duration = Duration::from_secs(15);
+
+/// How long sending the question may take before the page says so.
+const ASK_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// The entry a community's answer makes for the join waiting on it, if the
+/// answer is about that community's requirements.
+pub(crate) fn resume_for(
+    awaiting: &AwaitingRequirements,
+    answer: &CommunityAnswer,
+) -> Option<JoinEntry> {
+    if answer.community() != awaiting.vtc_did {
+        return None;
+    }
+    let outcome = match answer {
+        CommunityAnswer::Manifest { .. } => RequirementsOutcome::Learned,
+        CommunityAnswer::Refused {
+            kind: QueryKind::Manifest,
+            code,
+            ..
+        } => RequirementsOutcome::Unanswered(format!("it refused to say ({code})")),
+        CommunityAnswer::Unreadable {
+            kind: QueryKind::Manifest,
+            detail,
+            ..
+        } => RequirementsOutcome::Unanswered(format!(
+            "its answer is in a form this client cannot read ({detail})"
+        )),
+        _ => return None,
+    };
+    Some(JoinEntry::Resume {
+        vtc_did: awaiting.vtc_did.clone(),
+        outcome,
+    })
+}
+
+/// The contexts a new application by `persona` to `vtc_did` can use.
+fn application_contexts(
+    config: &Config,
+    vtc_did: &str,
+    persona: Option<PersonaId>,
+) -> Vec<ContextOption> {
+    let record = persona.and_then(|p| config.account.personas.get(&p));
+    community_context::context_options(&config.account, record, &suggested_context(config, vtc_did))
+}
+
+/// What the join flow shows for `vtc_did`, when the book knows it vets.
+pub(crate) fn vetting_view(
+    config: &Config,
+    vtc_did: &str,
+    now: chrono::DateTime<Utc>,
+) -> Option<JoinVettingView> {
+    let book = &config.private.vetting;
+    let Knowledge::Vetting(criterion) = book.knowledge(vtc_did) else {
+        return None;
+    };
+    let label =
+        |persona: PersonaId| sanitize_display(&config.persona_profile_label_for(persona), 128);
+    let applications: Vec<&Application> = book
+        .applications
+        .iter()
+        .filter(|a| a.community == vtc_did)
+        .collect();
+    let chosen = applications
+        .iter()
+        .find(|a| a.checklist(now).is_some_and(|e| e.satisfied()))
+        .or_else(|| applications.first())
+        .copied();
+    let application = chosen.map(|app| {
+        let evaluation = app.checklist(now);
+        JoinApplication {
+            id: app.id.clone(),
+            persona: app.persona,
+            persona_label: label(app.persona),
+            statements: app.presentable_statements(now).len(),
+            progress: evaluation.as_ref().map(vetting_actions::progress_line),
+            satisfied: evaluation.as_ref().is_some_and(|e| e.satisfied()),
+            next_step: vetting_actions::next_step_words(&app.next_step(now)),
+        }
+    });
+    let mut personas: Vec<ApplyAs> = config
+        .identities
+        .iter()
+        .map(|(id, identity)| ApplyAs {
+            persona: *id,
+            label: label(*id),
+            did: identity.persona_did().to_string(),
+        })
+        .collect();
+    personas.sort_by(|a, b| a.label.cmp(&b.label));
+    let context_options =
+        application_contexts(config, vtc_did, personas.first().map(|p| p.persona));
+    Some(JoinVettingView {
+        community: vtc_did.to_string(),
+        name: vetting_actions::community_display(config, vtc_did),
+        accent: book.branding(vtc_did).and_then(|b| b.accent_rgb()),
+        phase: VettingPhase::Known(Box::new(KnownVetting {
+            requirements: describe_requirements(&criterion.requirements)
+                .iter()
+                .map(|line| sanitize_display(line, 300))
+                .collect(),
+            governance_url: criterion
+                .requirements
+                .governance_framework_url
+                .as_deref()
+                .map(|u| sanitize_display(u, 300)),
+            application,
+            personas,
+            persona_index: 0,
+            context_options,
+            context_index: 0,
+            field: 0,
+        })),
+    })
+}
+
+/// Open the vetting page for `vtc_did` when the book knows it vets. Returns
+/// whether it did.
+fn show_vetting(state: &mut State, config: &Config, vtc_did: &str) -> bool {
+    let Some(view) = vetting_view(config, vtc_did, Utc::now()) else {
+        return false;
+    };
+    state.join.pending_vtc = Some(vtc_did.to_string());
+    state.join.vetting = Some(view);
+    state.join.messages.clear();
+    state.join.page = JoinPage::Vetting;
+    true
+}
+
+/// Open the vetting page saying the requirements could not be learned.
+fn show_unknown(state: &mut State, config: &Config, vtc_did: &str, reason: String) {
+    state.join.pending_vtc = Some(vtc_did.to_string());
+    state.join.vetting = Some(JoinVettingView {
+        community: vtc_did.to_string(),
+        name: vetting_actions::community_display(config, vtc_did),
+        accent: config
+            .private
+            .vetting
+            .branding(vtc_did)
+            .and_then(|b| b.accent_rgb()),
+        phase: VettingPhase::Unknown {
+            reason: sanitize_display(&reason, 300),
+        },
+    });
+    state.join.page = JoinPage::Vetting;
+}
+
+/// Ask `vtc_did` for its manifest, as the active persona, and show the page
+/// that waits for the answer. The answer reaches the caller's loop, not this
+/// one. `Err` means the page now says why the question could not be asked.
+async fn ask_requirements(
+    state: &mut State,
+    config: &mut Config,
+    tdk: &TDK,
+    messaging: Option<&Messaging>,
+    vtc_did: &str,
+) -> Result<AwaitingRequirements, ()> {
+    let sent: Result<(PersonaId, String), String> = async {
+        let service = messaging.ok_or_else(|| {
+            "messaging is not running, so its answer could not be heard".to_string()
+        })?;
+        let identity = config.active_identity().ok_or_else(|| {
+            "there is no persona to ask as — create one under My Identity".to_string()
+        })?;
+        let persona = identity.persona_id;
+        let document =
+            wire::manifest_request(identity.persona_did(), vtc_did).map_err(|e| e.to_string())?;
+        match tokio::time::timeout(
+            ASK_TIMEOUT,
+            wire::sign_and_send(config, tdk, service, persona, document),
+        )
+        .await
+        {
+            Ok(Ok(document_id)) => Ok((persona, document_id)),
+            Ok(Err(e)) => Err(format!("the question could not be sent: {e}")),
+            Err(_) => Err(format!(
+                "the question was not sent within {} seconds — your mediator may be unreachable",
+                ASK_TIMEOUT.as_secs()
+            )),
+        }
+    }
+    .await;
+    match sent {
+        Ok((persona, document_id)) => {
+            config.private.vetting.ask(CommunityQuery {
+                document_id: document_id.clone(),
+                community: vtc_did.to_string(),
+                persona,
+                kind: QueryKind::Manifest,
+                sent_at: Utc::now(),
+            });
+            state.join.pending_vtc = Some(vtc_did.to_string());
+            state.join.vetting = Some(JoinVettingView {
+                community: vtc_did.to_string(),
+                name: vetting_actions::community_display(config, vtc_did),
+                accent: None,
+                phase: VettingPhase::Asking,
+            });
+            state.join.messages.clear();
+            state.join.page = JoinPage::Vetting;
+            Ok(AwaitingRequirements {
+                vtc_did: vtc_did.to_string(),
+                document_id,
+                asked_at: std::time::Instant::now(),
+            })
+        }
+        Err(reason) => {
+            show_unknown(state, config, vtc_did, reason);
+            Err(())
+        }
+    }
+}
+
+fn known_vetting(state: &mut State) -> Option<&mut KnownVetting> {
+    match state.join.vetting.as_mut().map(|v| &mut v.phase) {
+        Some(VettingPhase::Known(known)) => Some(known),
+        _ => None,
+    }
+}
+
+/// The persona of an application that meets the published requirements.
+fn satisfied_application_persona(state: &State) -> Option<PersonaId> {
+    match state.join.vetting.as_ref().map(|v| &v.phase) {
+        Some(VettingPhase::Known(known)) => known
+            .application
+            .as_ref()
+            .filter(|a| a.satisfied)
+            .map(|a| a.persona),
+        _ => None,
+    }
+}
+
+fn cycle_vetting_choice(config: &Config, vtc_did: &str, known: &mut KnownVetting, forward: bool) {
+    let turn = |i: usize, n: usize| match n {
+        0 => 0,
+        n if forward => (i + 1) % n,
+        n => (i + n - 1) % n,
+    };
+    if known.field == 0 {
+        known.persona_index = turn(known.persona_index, known.personas.len());
+        known.context_options = application_contexts(
+            config,
+            vtc_did,
+            known.personas.get(known.persona_index).map(|p| p.persona),
+        );
+        known.context_index = 0;
+    } else {
+        known.context_index = turn(known.context_index, known.context_options.len());
+    }
+}
+
+/// Start (or continue) a vetting application to `vtc_did` from the join page,
+/// then show it on the Vetting page with its next step.
+fn apply_for_vetting(
+    state: &mut State,
+    config: &mut Config,
+    profile: &str,
+    vtc_did: &str,
+) -> Result<(), String> {
+    let Some(JoinVettingView {
+        name,
+        phase: VettingPhase::Known(known),
+        ..
+    }) = state.join.vetting.clone()
+    else {
+        return Err("The community's requirements are not known yet.".to_string());
+    };
+    if let Some(app) = &known.application {
+        let message = format!(
+            "Your application to {name}, as {}. Next: {}",
+            app.persona_label, app.next_step
+        );
+        vetting_actions::focus_application(state, config, &app.id, message);
+        return Ok(());
+    }
+    let Some(persona) = known.personas.get(known.persona_index).cloned() else {
+        return Err(
+            "Applying needs a persona: every card is signed by the DID you join with. Create one \
+             under My Identity, or join anyway (j), which makes one."
+                .to_string(),
+        );
+    };
+    let context = known
+        .context_options
+        .get(known.context_index)
+        .map(|o| o.context_id.clone());
+    let now = Utc::now();
+    let book = &mut config.private.vetting;
+    let id = match book.start_application(vtc_did, persona.persona, &persona.did, now) {
+        Ok(app) => {
+            if app.context_id.is_none() {
+                app.context_id = context;
+            }
+            app.id.clone()
+        }
+        Err(e) => return Err(format!("Could not start the application: {e}")),
+    };
+    book.adopt_known_requirements(&id);
+    let next = book
+        .applications
+        .iter()
+        .find(|a| a.id == id)
+        .map(|a| vetting_actions::next_step_words(&a.next_step(now)))
+        .unwrap_or_default();
+    save_config(config, profile).map_err(|e| format!("Could not save the application: {e}"))?;
+    vetting_actions::focus_application(
+        state,
+        config,
+        &id,
+        format!(
+            "Application to {name} started as {}. Next: {next}",
+            persona.label
+        ),
+    );
+    Ok(())
+}
 
 /// The persona + community of a just-completed join, handed back to the runtime
 /// loop so it can bring a live session up immediately (R-B-5 / D11) rather than
@@ -88,6 +449,7 @@ impl StateHandler {
         admin_vta: Option<&VtaClient>,
         profile: &str,
         messaging: Option<&Messaging>,
+        entry: JoinEntry,
     ) -> Result<JoinExit> {
         // Enter the flow on a fresh EnterDid page.
         state.join.reset();
@@ -95,6 +457,37 @@ impl StateHandler {
         // the transient join sub-state, so mirror the flag back in afterwards).
         state.join.has_invitation = state.invitation_credential.is_some();
         state.active_page = ActivePage::Join;
+        let hears_replies = match &entry {
+            JoinEntry::Fresh { hears_replies } => *hears_replies,
+            JoinEntry::Resume { .. } => true,
+        };
+        if let JoinEntry::Resume { vtc_did, outcome } = entry {
+            match outcome {
+                RequirementsOutcome::Unanswered(reason) => {
+                    show_unknown(state, config, &vtc_did, reason);
+                }
+                outcome => {
+                    let shown = matches!(outcome, RequirementsOutcome::Learned)
+                        && show_vetting(state, config, &vtc_did);
+                    if !shown
+                        && let Some(interrupted) = self
+                            .continue_join(
+                                vtc_did,
+                                interrupt_rx,
+                                state,
+                                tdk,
+                                config,
+                                admin_vta,
+                                profile,
+                                messaging,
+                            )
+                            .await
+                    {
+                        return Ok(JoinExit::Exit(interrupted));
+                    }
+                }
+            }
+        }
         let _ = self.state_tx.send(state.clone());
 
         loop {
@@ -200,32 +593,34 @@ impl StateHandler {
                             } else {
                                 vtc_did
                             };
-                            // Idempotency is now per-persona (R-B-9): a community may
-                            // be joined as more than one persona, so the duplicate
-                            // check happens once the identity is chosen (in the
-                            // sequence) rather than at the community level here.
-                            // Identity first: collect the invitations available for
-                            // this community so each persona can be badged with its
-                            // usable-invitation count, then let the operator pick the
-                            // identity to present (the invitation choice, if any,
-                            // follows for the chosen persona).
-                            state.join.available_vics =
-                                collect_available_vics(state, admin_vta, &vtc_did).await;
-                            let options =
-                                build_persona_options(config, &state.join.available_vics);
-                            if options.is_empty() {
-                                // First join — nothing to reuse; mint a fresh identity.
-                                // A new persona can't hold an existing invitation.
-                                state.invitation_credential = None;
-                                state.join.present_invitation = false;
-                                state.join.pending_vtc = Some(vtc_did.clone());
-                                if let Some(context_id) =
-                                    offer_contexts(state, config, IdentityPick::Mint, &vtc_did)
-                                    && let Some(interrupted) = self
-                                        .launch_join_sequence(
-                                            IdentityPick::Mint,
+                            // Peer identity vetting: a community that vets says what
+                            // it requires before anything about the applicant is sent
+                            // (vetting-process.md §6.1). What the book already knows
+                            // decides at once. Otherwise the community is asked, and
+                            // the wait happens in the caller's loop — the one that
+                            // hears the answer — which enters this flow again.
+                            let knowledge = match config.private.vetting.knowledge(&vtc_did) {
+                                Knowledge::Vetting(_) => Some(true),
+                                Knowledge::NoVetting => Some(false),
+                                Knowledge::Unknown => None,
+                            };
+                            match knowledge {
+                                Some(true) => {
+                                    show_vetting(state, config, &vtc_did);
+                                }
+                                None if hears_replies => {
+                                    if let Ok(awaiting) =
+                                        ask_requirements(state, config, tdk, messaging, &vtc_did)
+                                            .await
+                                    {
+                                        let _ = self.state_tx.send(state.clone());
+                                        return Ok(JoinExit::AwaitRequirements(awaiting));
+                                    }
+                                }
+                                _ => {
+                                    if let Some(interrupted) = self
+                                        .continue_join(
                                             vtc_did,
-                                            context_id,
                                             interrupt_rx,
                                             state,
                                             tdk,
@@ -235,16 +630,10 @@ impl StateHandler {
                                             messaging,
                                         )
                                         .await
-                                {
-                                    return Ok(JoinExit::Exit(interrupted));
+                                    {
+                                        return Ok(JoinExit::Exit(interrupted));
+                                    }
                                 }
-                            } else {
-                                state.join.pending_vtc = Some(vtc_did);
-                                state.join.persona_options = options;
-                                state.join.identity_selected = 0;
-                                state.join.reuse_confirm = None;
-                                state.join.page = JoinPage::IdentityChoice;
-                                let _ = self.state_tx.send(state.clone());
                             }
                         }
                         Action::JoinIdentitySelect(i) => {
@@ -299,49 +688,7 @@ impl StateHandler {
                                 continue;
                             }
                             state.join.reuse_confirm = None;
-                            // Invitations already known for the chosen persona:
-                            // this community's valid VICs whose subject is that
-                            // persona's DID.
-                            let persona_did = config
-                                .account
-                                .personas
-                                .get(&persona_id)
-                                .map(|p| p.did.clone());
-                            // …plus one the operator loaded for this join by hand
-                            // (`--invitation` / a paste on the entry page) whatever
-                            // its subject. Filtering that by subject too was how a
-                            // deliberately supplied invitation could disappear
-                            // between the entry page and the submit; a subject that
-                            // is not the presenting persona is what
-                            // `build_linkage_proof` exists for, not a reason to
-                            // drop it.
-                            let loaded = state
-                                .invitation_credential
-                                .as_ref()
-                                .and_then(|v| openvtc_core::join::invitation_id(v))
-                                .map(str::to_string);
-                            let invitations: Vec<AvailableVic> = state
-                                .join
-                                .available_vics
-                                .iter()
-                                .filter(|v| {
-                                    (persona_did.is_some() && v.subject == persona_did)
-                                        || loaded.as_deref() == Some(v.id.as_str())
-                                })
-                                .cloned()
-                                .collect();
-                            // Always offer the choice, including with none found.
-                            // The step carries a paste row, so an empty list is a
-                            // question ("do you have one?") rather than a reason
-                            // to skip. It used to launch straight into an open
-                            // request here, which is why an operator holding an
-                            // invitation was never asked for it.
-                            state.join.invitation_options = invitations;
-                            state.join.invitation_for_persona = Some(persona_id);
-                            state.join.invitation_persona_did = persona_did;
-                            state.join.invitation_use_selected = 0;
-                            state.join.messages.clear();
-                            state.join.page = JoinPage::InvitationChoice;
+                            open_invitation_choice(state, config, persona_id);
                             let _ = self.state_tx.send(state.clone());
                         }
                         Action::JoinReuseCancel => {
@@ -477,6 +824,79 @@ impl StateHandler {
                                 return Ok(JoinExit::Exit(interrupted));
                             }
                         }
+                        Action::JoinVettingField(forward) => {
+                            if let Some(known) = known_vetting(state) {
+                                let fields = if known.application.is_some() { 1 } else { 2 };
+                                known.field = if forward {
+                                    (known.field + 1) % fields
+                                } else {
+                                    (known.field + fields - 1) % fields
+                                };
+                            }
+                        }
+                        Action::JoinVettingCycle(forward) => {
+                            let vtc_did = state.join.pending_vtc.clone().unwrap_or_default();
+                            if let Some(known) = known_vetting(state) {
+                                cycle_vetting_choice(config, &vtc_did, known, forward);
+                            }
+                        }
+                        Action::JoinVettingApply => {
+                            let Some(vtc_did) = state.join.pending_vtc.clone() else {
+                                continue;
+                            };
+                            state.join.messages.clear();
+                            match apply_for_vetting(state, config, profile, &vtc_did) {
+                                Ok(()) => {
+                                    state.active_page = ActivePage::Main;
+                                    return Ok(JoinExit::Returned(None));
+                                }
+                                Err(why) => state.join.messages.push(MessageType::Error(why)),
+                            }
+                        }
+                        Action::JoinVettingJoin => {
+                            let Some(vtc_did) = state.join.pending_vtc.clone() else {
+                                continue;
+                            };
+                            state.join.messages.clear();
+                            // An application that meets the requirements joins as
+                            // its own persona, so its statements are presented.
+                            match satisfied_application_persona(state) {
+                                Some(persona_id) => {
+                                    state.join.available_vics =
+                                        collect_available_vics(state, admin_vta, &vtc_did).await;
+                                    open_invitation_choice(state, config, persona_id);
+                                }
+                                None => {
+                                    if let Some(interrupted) = self
+                                        .continue_join(
+                                            vtc_did,
+                                            interrupt_rx,
+                                            state,
+                                            tdk,
+                                            config,
+                                            admin_vta,
+                                            profile,
+                                            messaging,
+                                        )
+                                        .await
+                                    {
+                                        return Ok(JoinExit::Exit(interrupted));
+                                    }
+                                }
+                            }
+                        }
+                        Action::JoinVettingAskAgain => {
+                            let Some(vtc_did) = state.join.pending_vtc.clone() else {
+                                continue;
+                            };
+                            if hears_replies
+                                && let Ok(awaiting) =
+                                    ask_requirements(state, config, tdk, messaging, &vtc_did).await
+                            {
+                                let _ = self.state_tx.send(state.clone());
+                                return Ok(JoinExit::AwaitRequirements(awaiting));
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -486,6 +906,66 @@ impl StateHandler {
             }
             let _ = self.state_tx.send(state.clone());
         }
+    }
+
+    /// Go on with a join once any vetting has been dealt with: collect the
+    /// community's invitations, then choose the identity to present, or mint
+    /// one on a first join. `Some` when the person cancelled mid-sequence.
+    #[allow(clippy::too_many_arguments)]
+    async fn continue_join(
+        &self,
+        vtc_did: String,
+        interrupt_rx: &mut broadcast::Receiver<Interrupted>,
+        state: &mut State,
+        tdk: &TDK,
+        config: &mut Config,
+        admin_vta: Option<&VtaClient>,
+        profile: &str,
+        messaging: Option<&Messaging>,
+    ) -> Option<Interrupted> {
+        state.join.vetting = None;
+        // Idempotency is now per-persona (R-B-9): a community may
+        // be joined as more than one persona, so the duplicate
+        // check happens once the identity is chosen (in the
+        // sequence) rather than at the community level here.
+        // Identity first: collect the invitations available for
+        // this community so each persona can be badged with its
+        // usable-invitation count, then let the operator pick the
+        // identity to present (the invitation choice, if any,
+        // follows for the chosen persona).
+        state.join.available_vics = collect_available_vics(state, admin_vta, &vtc_did).await;
+        let options = build_persona_options(config, &state.join.available_vics);
+        if options.is_empty() {
+            // First join — nothing to reuse; mint a fresh identity.
+            // A new persona can't hold an existing invitation.
+            state.invitation_credential = None;
+            state.join.present_invitation = false;
+            state.join.pending_vtc = Some(vtc_did.clone());
+            if let Some(context_id) = offer_contexts(state, config, IdentityPick::Mint, &vtc_did) {
+                return self
+                    .launch_join_sequence(
+                        IdentityPick::Mint,
+                        vtc_did,
+                        context_id,
+                        interrupt_rx,
+                        state,
+                        tdk,
+                        config,
+                        admin_vta,
+                        profile,
+                        messaging,
+                    )
+                    .await;
+            }
+        } else {
+            state.join.pending_vtc = Some(vtc_did);
+            state.join.persona_options = options;
+            state.join.identity_selected = 0;
+            state.join.reuse_confirm = None;
+            state.join.page = JoinPage::IdentityChoice;
+        }
+        let _ = self.state_tx.send(state.clone());
+        None
     }
 
     /// Move to the progress page and run [`run_join_sequence`] for the chosen
@@ -574,6 +1054,54 @@ impl StateHandler {
         let _ = self.state_tx.send(state.clone());
         None
     }
+}
+
+/// Open the invitation step for a join as `persona_id`: this community's valid
+/// invitations bound to that persona, plus one loaded by hand.
+fn open_invitation_choice(state: &mut State, config: &Config, persona_id: PersonaId) {
+    // Invitations already known for the chosen persona:
+    // this community's valid VICs whose subject is that
+    // persona's DID.
+    let persona_did = config
+        .account
+        .personas
+        .get(&persona_id)
+        .map(|p| p.did.clone());
+    // …plus one the operator loaded for this join by hand
+    // (`--invitation` / a paste on the entry page) whatever
+    // its subject. Filtering that by subject too was how a
+    // deliberately supplied invitation could disappear
+    // between the entry page and the submit; a subject that
+    // is not the presenting persona is what
+    // `build_linkage_proof` exists for, not a reason to
+    // drop it.
+    let loaded = state
+        .invitation_credential
+        .as_ref()
+        .and_then(|v| openvtc_core::join::invitation_id(v))
+        .map(str::to_string);
+    let invitations: Vec<AvailableVic> = state
+        .join
+        .available_vics
+        .iter()
+        .filter(|v| {
+            (persona_did.is_some() && v.subject == persona_did)
+                || loaded.as_deref() == Some(v.id.as_str())
+        })
+        .cloned()
+        .collect();
+    // Always offer the choice, including with none found.
+    // The step carries a paste row, so an empty list is a
+    // question ("do you have one?") rather than a reason
+    // to skip. It used to launch straight into an open
+    // request here, which is why an operator holding an
+    // invitation was never asked for it.
+    state.join.invitation_options = invitations;
+    state.join.invitation_for_persona = Some(persona_id);
+    state.join.invitation_persona_did = persona_did;
+    state.join.invitation_use_selected = 0;
+    state.join.messages.clear();
+    state.join.page = JoinPage::InvitationChoice;
 }
 
 /// Whether `context_id` is already claimed: by a membership, a persona's keys,
@@ -779,6 +1307,10 @@ pub(crate) enum JoinExit {
     /// caller's loop. Carries the just-joined session when a join succeeded, so
     /// the runtime loop can register it + start its listener live (R-B-5).
     Returned(Option<JoinedSession>),
+    /// The community was asked what it requires. The caller keeps the join
+    /// screen up, waits for the answer, and enters the flow again
+    /// ([`AwaitingRequirements`]).
+    AwaitRequirements(AwaitingRequirements),
     /// Application is exiting (Exit / UXError / interrupt).
     Exit(Interrupted),
 }
@@ -2290,5 +2822,150 @@ mod tests {
             "an uninstalled listener must never be claimed"
         );
         service.shutdown().await;
+    }
+}
+
+#[cfg(test)]
+mod vetting_tests {
+    use super::*;
+    use crate::state_handler::dispatch_util::test_config;
+    use vta_sdk::protocols::join_requests::{JoinRequestManifestResponseBody, ManifestCriterion};
+
+    const VTC: &str = "did:web:kernel.example";
+
+    fn manifest(vets: bool) -> JoinRequestManifestResponseBody {
+        let requirements = serde_json::from_value(serde_json::json!({
+            "version": "0.1",
+            "statementType": vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE,
+            "minStatements": 2,
+            "acceptedMethods": ["inPerson", "video"],
+            "requiredClaims": ["name.legal"],
+            "maxStatementAge": "P120D",
+            "eligibleVetters": { "role": "vetter" }
+        }))
+        .unwrap();
+        JoinRequestManifestResponseBody {
+            community_did: VTC.into(),
+            criteria: vec![ManifestCriterion {
+                id: "vetted".into(),
+                description: None,
+                presentation_definition: serde_json::json!({}),
+                vetting: vets.then_some(requirements),
+                requirements_digest: Some("zDigest".into()),
+            }],
+            branding: None,
+        }
+    }
+
+    fn awaiting() -> AwaitingRequirements {
+        AwaitingRequirements {
+            vtc_did: VTC.into(),
+            document_id: "urn:uuid:m1".into(),
+            asked_at: std::time::Instant::now(),
+        }
+    }
+
+    /// Only an answer about the community being joined, and about its
+    /// requirements, resumes the join.
+    #[test]
+    fn only_the_awaited_manifest_resumes_the_join() {
+        let waiting = awaiting();
+        assert!(matches!(
+            resume_for(
+                &waiting,
+                &CommunityAnswer::Manifest {
+                    community: VTC.into()
+                }
+            ),
+            Some(JoinEntry::Resume {
+                outcome: RequirementsOutcome::Learned,
+                ..
+            })
+        ));
+        assert!(
+            resume_for(
+                &waiting,
+                &CommunityAnswer::Manifest {
+                    community: "did:web:other".into()
+                }
+            )
+            .is_none()
+        );
+        assert!(matches!(
+            resume_for(
+                &waiting,
+                &CommunityAnswer::Refused {
+                    query: "urn:uuid:m1".into(),
+                    community: VTC.into(),
+                    kind: QueryKind::Manifest,
+                    code: "permissionDenied".into(),
+                    message: None,
+                }
+            ),
+            Some(JoinEntry::Resume { outcome: RequirementsOutcome::Unanswered(reason), .. })
+                if reason.contains("permissionDenied")
+        ));
+        assert!(
+            resume_for(
+                &waiting,
+                &CommunityAnswer::Refused {
+                    query: "q".into(),
+                    community: VTC.into(),
+                    kind: QueryKind::VetterList,
+                    code: "permissionDenied".into(),
+                    message: None,
+                }
+            )
+            .is_none(),
+            "a directory refusal is not about joining"
+        );
+    }
+
+    /// The page says what the community requires in words, and shows the
+    /// application under way with its next step.
+    #[test]
+    fn a_vetting_community_is_explained_before_joining() {
+        let mut config = test_config();
+        let now = Utc::now();
+        assert!(vetting_view(&config, VTC, now).is_none(), "not known yet");
+
+        config
+            .private
+            .vetting
+            .learn_manifest(VTC, &manifest(false), now);
+        assert!(vetting_view(&config, VTC, now).is_none(), "does not vet");
+
+        config
+            .private
+            .vetting
+            .learn_manifest(VTC, &manifest(true), now);
+        let view = vetting_view(&config, VTC, now).unwrap();
+        let VettingPhase::Known(known) = &view.phase else {
+            panic!("known");
+        };
+        assert!(known.requirements[0].starts_with("2 vetting statements"));
+        assert!(known.requirements.iter().any(|l| l.contains("120 days")));
+        assert!(known.application.is_none());
+
+        let persona = PersonaId::new();
+        let id = config
+            .private
+            .vetting
+            .start_application(VTC, persona, "did:key:zA", now)
+            .unwrap()
+            .id
+            .clone();
+        config.private.vetting.adopt_known_requirements(&id);
+        let view = vetting_view(&config, VTC, now).unwrap();
+        let VettingPhase::Known(known) = &view.phase else {
+            panic!("known");
+        };
+        let app = known
+            .application
+            .as_ref()
+            .expect("the application under way");
+        assert_eq!(app.persona, persona);
+        assert!(!app.satisfied);
+        assert!(app.next_step.starts_with("f —"), "{}", app.next_step);
     }
 }

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -7,7 +7,10 @@ use openvtc_core::config::account::PersonaId;
 use openvtc_core::config::community_context::{
     ContextDeletion, ContextDeletionPreview, ContextOption, PersonaTakenAlong,
 };
-use vta_sdk::protocols::vetting::{DeclaredRelationship, RevocationReason, VettingMethod};
+use openvtc_core::vetting::registry::{DirectoryFilter, EventDraft, ProfileDraft};
+use vta_sdk::protocols::vetting::{
+    DeclaredRelationship, RevocationReason, TicketPresentation, VettingMethod,
+};
 
 /// Lazily-rendered raw credential JSON for credential detail views.
 ///
@@ -549,6 +552,8 @@ pub struct CommunitySummary {
     pub has_membership_credential: bool,
     /// Whether the role endorsement credential (VEC) has been received.
     pub has_role_credential: bool,
+    /// The accent colour the community publishes in its manifest's branding.
+    pub accent: Option<(u8, u8, u8)>,
 }
 
 // ****************************************************************************
@@ -1456,6 +1461,34 @@ pub const VETTING_WITHDRAWAL_REASONS: [RevocationReason; 4] = [
 /// How many requests a new ticket admits: one person, or a conference desk.
 pub const VETTING_TICKET_USES: [u32; 4] = [1, 5, 10, 25];
 
+/// Directory filter fields, before the results: community, language, country,
+/// region, city, method, events from, events until, event name.
+pub const DIRECTORY_FIELDS: usize = 9;
+
+/// Methods a directory search can ask for: any, then each.
+pub const DIRECTORY_METHODS: [Option<VettingMethod>; 4] = [
+    None,
+    Some(VettingMethod::InPerson),
+    Some(VettingMethod::Video),
+    Some(VettingMethod::PriorAcquaintance),
+];
+
+/// Profile form fields, before its events: community, listed, display name,
+/// languages, country, region, city, the three methods, documentation,
+/// availability and how to get a ticket.
+pub const PROFILE_FIELDS: usize = 13;
+
+/// Event form fields: name, first day, last day, country, region, city, page.
+pub const EVENT_FIELDS: usize = 7;
+
+/// Whether a line is good news, worth a second look, or bad news.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LineTone {
+    Good,
+    Caution,
+    Bad,
+}
+
 /// How a method reads on the page.
 #[must_use]
 pub fn method_label(method: VettingMethod) -> &'static str {
@@ -1541,6 +1574,12 @@ pub struct VettingState {
     /// The face each application wears, by application id, once read or
     /// chosen this run.
     pub worn_faces: std::collections::HashMap<String, String>,
+    /// Communities whose vetter directory can be searched: those applied to,
+    /// then those joined.
+    pub directory_communities: Arc<[DirectoryCommunity]>,
+    /// Active memberships holding no live vetter credential, which can ask for
+    /// it again.
+    pub resend_candidates: Arc<[VettingMembership]>,
 }
 
 impl VettingState {
@@ -1577,13 +1616,24 @@ pub enum VettingMode {
         faces: Vec<FaceChoice>,
         index: usize,
     },
-    /// Ask a vetter, with the ticket code they gave us.
+    /// Ask a vetter, with the ticket code they gave us or the link they showed.
     RequestVetter {
         application_id: String,
         vetter: String,
         code: String,
+        /// A scanned ticket from a pasted link, in place of the code.
+        ticket: Option<TicketPresentation>,
+        /// What the person should know before sending, e.g. how this vetter
+        /// hands out tickets.
+        note: Option<String>,
         field: usize,
     },
+    /// Search a community's vetter directory.
+    Directory(Box<DirectoryView>),
+    /// Edit and publish our vetter profile.
+    Profile(Box<VetterProfileForm>),
+    /// Ask a community to send our vetter credential again.
+    Resend { index: usize },
     /// Read the match code with the vetter, preview what the face shows, then
     /// send the card.
     SendCard {
@@ -1631,6 +1681,250 @@ impl VettingMode {
                 vetter, field: 0, ..
             } => Some(vetter),
             VettingMode::RequestVetter { code, field: 1, .. } => Some(code),
+            VettingMode::Directory(view) => view.text().map(String::as_str),
+            VettingMode::Profile(form) => match &form.event {
+                Some(event) => event.text().map(String::as_str),
+                None => form.text().map(String::as_str),
+            },
+            _ => None,
+        }
+    }
+
+    /// The focused text field, to edit.
+    pub fn focused_text_mut(&mut self) -> Option<&mut String> {
+        match self {
+            VettingMode::NewApplication {
+                community,
+                field: 0,
+                ..
+            } => Some(community),
+            VettingMode::RequestVetter {
+                vetter, field: 0, ..
+            } => Some(vetter),
+            VettingMode::RequestVetter { code, field: 1, .. } => Some(code),
+            VettingMode::Directory(view) => view.text_mut(),
+            VettingMode::Profile(form) => form.focused_text_mut(),
+            _ => None,
+        }
+    }
+}
+
+/// A community whose vetter directory can be searched.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DirectoryCommunity {
+    pub community: String,
+    pub name: String,
+    pub accent: Option<(u8, u8, u8)>,
+    /// The persona the list request is sent as: the application's, else the
+    /// membership's.
+    pub persona: PersonaId,
+    /// Our application to it, if any — the one a request from here goes into.
+    pub application_id: Option<String>,
+}
+
+/// The vetter directory, while it is open. Results are page state only: they
+/// describe other people and go stale, so none of it is saved.
+#[derive(Clone, Debug, Default)]
+pub struct DirectoryView {
+    /// Index into [`VettingState::directory_communities`].
+    pub community_index: usize,
+    pub filter: DirectoryFilter,
+    /// Index into [`DIRECTORY_METHODS`].
+    pub method_index: usize,
+    /// `0..DIRECTORY_FIELDS` are the filters; past them, a result row.
+    pub field: usize,
+    pub results: Vec<ListedVetterRow>,
+    /// The cursor each page shown so far was fetched with; the last is the
+    /// current page's. Its length is the page number.
+    pub cursors: Vec<Option<String>>,
+    /// The community's cursor for the page after this one.
+    pub next_cursor: Option<String>,
+    /// The list request waiting for its answer.
+    pub pending: Option<String>,
+    /// What `cursors` becomes when that answer arrives.
+    pub pending_cursors: Option<Vec<Option<String>>>,
+    /// A search has been answered at least once.
+    pub searched: bool,
+    /// Why the last search failed.
+    pub error: Option<String>,
+}
+
+impl DirectoryView {
+    /// The highlighted result, when a result row has the focus.
+    #[must_use]
+    pub fn result_index(&self) -> Option<usize> {
+        self.field
+            .checked_sub(DIRECTORY_FIELDS)
+            .filter(|i| *i < self.results.len())
+    }
+
+    /// Rows the focus moves through: the filters, then the results.
+    #[must_use]
+    pub fn rows(&self) -> usize {
+        DIRECTORY_FIELDS + self.results.len()
+    }
+
+    fn text(&self) -> Option<&String> {
+        let f = &self.filter;
+        match self.field {
+            1 => Some(&f.language),
+            2 => Some(&f.country),
+            3 => Some(&f.region),
+            4 => Some(&f.city),
+            6 => Some(&f.event_from),
+            7 => Some(&f.event_to),
+            8 => Some(&f.event_name),
+            _ => None,
+        }
+    }
+
+    fn text_mut(&mut self) -> Option<&mut String> {
+        let f = &mut self.filter;
+        match self.field {
+            1 => Some(&mut f.language),
+            2 => Some(&mut f.country),
+            3 => Some(&mut f.region),
+            4 => Some(&mut f.city),
+            6 => Some(&mut f.event_from),
+            7 => Some(&mut f.event_to),
+            8 => Some(&mut f.event_name),
+            _ => None,
+        }
+    }
+}
+
+/// One listed vetter, ready to show. Every string is already sanitised.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ListedVetterRow {
+    pub did: String,
+    /// The name they published, or their DID when they published none.
+    pub name: String,
+    pub languages: String,
+    pub location: Option<String>,
+    pub methods: String,
+    pub documentation: String,
+    pub availability: Option<String>,
+    /// How to get a ticket from them.
+    pub contact_hint: Option<String>,
+    /// Upcoming events, one line each.
+    pub events: Vec<String>,
+    /// When their grant runs out.
+    pub grant_until: String,
+}
+
+/// The vetter profile form.
+#[derive(Clone, Debug)]
+pub struct VetterProfileForm {
+    /// Index into [`VettingState::memberships`] — communities that named us a
+    /// vetter.
+    pub membership_index: usize,
+    pub draft: ProfileDraft,
+    /// `0..PROFILE_FIELDS` are the fields; then one row per event; then "add an
+    /// event".
+    pub field: usize,
+    /// The event being added or edited, while its form is open.
+    pub event: Option<EventForm>,
+    /// Why the profile cannot be sent as it stands.
+    pub error: Option<String>,
+    /// Where the community stands on what was last sent, and whether that is
+    /// good news.
+    pub state_line: Option<(LineTone, String)>,
+}
+
+impl VetterProfileForm {
+    /// Rows the focus moves through.
+    #[must_use]
+    pub fn rows(&self) -> usize {
+        PROFILE_FIELDS + self.draft.events.len() + 1
+    }
+
+    /// The event under the focus.
+    #[must_use]
+    pub fn event_index(&self) -> Option<usize> {
+        self.field
+            .checked_sub(PROFILE_FIELDS)
+            .filter(|i| *i < self.draft.events.len())
+    }
+
+    /// Whether the focus is on "add an event".
+    #[must_use]
+    pub fn on_add_event(&self) -> bool {
+        self.field == PROFILE_FIELDS + self.draft.events.len()
+    }
+
+    fn text(&self) -> Option<&String> {
+        let d = &self.draft;
+        match self.field {
+            2 => Some(&d.display_name),
+            3 => Some(&d.languages),
+            4 => Some(&d.country),
+            5 => Some(&d.region),
+            6 => Some(&d.city),
+            10 => Some(&d.accepts_documentation),
+            11 => Some(&d.availability),
+            12 => Some(&d.contact_hint),
+            _ => None,
+        }
+    }
+
+    /// The focused text field: the open event's, else the profile's.
+    fn focused_text_mut(&mut self) -> Option<&mut String> {
+        if self.event.is_some() {
+            return self.event.as_mut().and_then(EventForm::text_mut);
+        }
+        self.text_mut()
+    }
+
+    fn text_mut(&mut self) -> Option<&mut String> {
+        let d = &mut self.draft;
+        match self.field {
+            2 => Some(&mut d.display_name),
+            3 => Some(&mut d.languages),
+            4 => Some(&mut d.country),
+            5 => Some(&mut d.region),
+            6 => Some(&mut d.city),
+            10 => Some(&mut d.accepts_documentation),
+            11 => Some(&mut d.availability),
+            12 => Some(&mut d.contact_hint),
+            _ => None,
+        }
+    }
+}
+
+/// An event being added (`index` is `None`) or edited.
+#[derive(Clone, Debug, Default)]
+pub struct EventForm {
+    pub index: Option<usize>,
+    pub draft: EventDraft,
+    pub field: usize,
+    pub error: Option<String>,
+}
+
+impl EventForm {
+    fn text(&self) -> Option<&String> {
+        let d = &self.draft;
+        match self.field {
+            0 => Some(&d.name),
+            1 => Some(&d.start_date),
+            2 => Some(&d.end_date),
+            3 => Some(&d.country),
+            4 => Some(&d.region),
+            5 => Some(&d.city),
+            6 => Some(&d.url),
+            _ => None,
+        }
+    }
+
+    fn text_mut(&mut self) -> Option<&mut String> {
+        let d = &mut self.draft;
+        match self.field {
+            0 => Some(&mut d.name),
+            1 => Some(&mut d.start_date),
+            2 => Some(&mut d.end_date),
+            3 => Some(&mut d.country),
+            4 => Some(&mut d.region),
+            5 => Some(&mut d.city),
+            6 => Some(&mut d.url),
             _ => None,
         }
     }
@@ -1681,6 +1975,10 @@ pub struct ApplicationRow {
     pub id: String,
     pub community: String,
     pub community_name: Option<String>,
+    /// The community's published accent colour.
+    pub accent: Option<(u8, u8, u8)>,
+    /// What to do next, with the key that does it.
+    pub next_step: Option<String>,
     pub join_did: String,
     /// What the community requires, in a line; `None` until its manifest arrives.
     pub requirements: Option<String>,
@@ -1705,6 +2003,8 @@ pub struct RequestRow {
     /// What their acceptance showed of their eligibility, and whether that is
     /// good news.
     pub eligibility: Option<(bool, String)>,
+    /// Whether the community has since revoked their grant.
+    pub grant: Option<(LineTone, String)>,
 }
 
 /// Where a desk request is, for choosing what the keys do.
@@ -1742,6 +2042,9 @@ pub struct TicketRow {
     pub uses_left: u32,
     pub expires: String,
     pub live: bool,
+    /// The `vetting-ticket:` link its QR code carries, when the persona it
+    /// admits requests to is available.
+    pub uri: Option<String>,
 }
 
 /// One statement we signed, for display.
@@ -1770,6 +2073,7 @@ pub struct VettingMembership {
     pub community: String,
     pub name: String,
     pub persona: PersonaId,
+    pub accent: Option<(u8, u8, u8)>,
 }
 
 // ****************************************************************************

--- a/openvtc/src/state_handler/main_page/mod.rs
+++ b/openvtc/src/state_handler/main_page/mod.rs
@@ -584,12 +584,22 @@ impl MainPageState {
                 }
                 _ => String::new(),
             };
+            let branding = config.private.vetting.branding(&c.vtc_did);
             community_items.push(content::CommunitySummary {
+                // The name the community publishes in its branding comes after
+                // the membership's own and a verified agent name: it is what
+                // the community says about itself.
                 display_name: c
                     .display_name
                     .clone()
                     .or_else(|| config.agent_name_for(&c.vtc_did).map(str::to_owned))
+                    .or_else(|| {
+                        branding
+                            .and_then(|b| b.display_name.as_deref())
+                            .map(|n| sanitize_display(n, 128))
+                    })
                     .unwrap_or_else(|| shorten_did(&c.vtc_did, 40)),
+                accent: branding.and_then(|b| b.accent_rgb()),
                 status_label: community_status_label(&c.status),
                 persona_label,
                 member_since: c

--- a/openvtc/src/state_handler/message_dispatch.rs
+++ b/openvtc/src/state_handler/message_dispatch.rs
@@ -122,6 +122,12 @@ pub struct InboundEffects {
     /// Personhood challenges the community answered with. Display state with a
     /// ten-minute life — never persisted.
     pub personhood_challenges: Vec<openvtc_core::personhood::ChallengeReply>,
+    /// Communities' answers to questions we put to them — a directory page, a
+    /// stored profile, a resent grant, a manifest — for whoever is waiting.
+    pub vetting_answers: Vec<openvtc_core::vetting::queries::CommunityAnswer>,
+    /// Vetters' grants to check for revocation. The check fetches over HTTPS,
+    /// so the loop runs it as a background job.
+    pub vetting_grant_checks: Vec<openvtc_core::vetting::status::GrantCheck>,
 }
 
 /// Process an inbound DIDComm message.
@@ -142,6 +148,8 @@ pub async fn process_inbound_message(
         inactivated,
         capability_replies,
         personhood_challenges,
+        vetting_answers,
+        vetting_grant_checks,
     } = effects;
     // Drop messages outside the replay / freshness window before doing
     // any state-mutating work. Saves us from acting on stale captures
@@ -240,6 +248,12 @@ pub async fn process_inbound_message(
                     openvtc_core::vetting::wire::send_reply(config, tdk, service, reply).await
             {
                 warn!(to = %from_did, error = %e, "could not send vetting reply");
+            }
+            if let Some(answer) = handled.answer {
+                vetting_answers.push(answer);
+            }
+            if let Some(check) = handled.grant_check {
+                vetting_grant_checks.push(check);
             }
             let noticed = handled.notice.is_some();
             if let Some(notice) = handled.notice {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -1078,6 +1078,10 @@ impl StateHandler {
         let mut join_status_tick = tokio::time::interval(std::time::Duration::from_secs(60));
         let mut join_status_pacer = join_status_poll::PollPacer::default();
 
+        // The join flow to enter at the end of this iteration, and a join
+        // waiting on a community's requirements (see `join_flow::AwaitingRequirements`).
+        let mut join_entry: Option<join_flow::JoinEntry> = None;
+        let mut awaiting_requirements: Option<join_flow::AwaitingRequirements> = None;
         let result = loop {
             tokio::select! {
                 Some(action) = action_rx.recv() => match action {
@@ -1102,45 +1106,27 @@ impl StateHandler {
                         // State-B join from the live runtime: reuse the always-on
                         // admin VTA session. The DIDComm service keeps running in
                         // the background; the join flow owns the screen until the
-                        // user returns. Restart is required to activate the new
-                        // community (hot-start is a deliberate follow-up).
-                        match self
-                            .join_flow(
-                                &mut action_rx,
-                                &mut interrupt_rx,
-                                &mut state,
-                                &tdk,
-                                &mut config,
-                                admin_vta.as_ref(),
-                                self.profile.as_str(),
-                                Some(&didcomm_service),
-                            )
-                            .await
-                        {
-                            Ok(join_flow::JoinExit::Returned(joined)) => {
-                                state.active_page = state::ActivePage::Main;
-                                // R-B-5 / D11: bring the new community's session up
-                                // live so the VTC's async receipt is received now,
-                                // not only after a restart.
-                                if let Some(joined) = joined {
-                                    register_joined_session(
-                                        &mut session_manager,
-                                        &didcomm_service,
-                                        &tdk,
-                                        &config,
-                                        joined,
-                                        &mut state,
-                                    )
-                                    .await;
-                                }
-                            }
-                            Ok(join_flow::JoinExit::Exit(interrupted)) => {
-                                break interrupted;
-                            }
-                            Err(e) => {
-                                state.main_page.log_error("Join flow failed", &e);
-                                state.active_page = state::ActivePage::Main;
-                            }
+                        // user returns. Entered at the loop's tail, which is also
+                        // where a join waiting on a community's requirements is
+                        // entered again.
+                        join_entry = Some(join_flow::JoinEntry::Fresh { hears_replies: true });
+                    },
+                    // A join waiting on a community's requirements keeps its screen
+                    // up while this loop hears the answer, so the two keys that
+                    // page offers land here rather than in the join flow.
+                    Action::JoinCancel if awaiting_requirements.is_some() => {
+                        if let Some(awaiting) = awaiting_requirements.take() {
+                            config.private.vetting.forget_query(&awaiting.document_id);
+                        }
+                        state.active_page = state::ActivePage::Main;
+                    },
+                    Action::JoinVettingJoin if awaiting_requirements.is_some() => {
+                        if let Some(awaiting) = awaiting_requirements.take() {
+                            config.private.vetting.forget_query(&awaiting.document_id);
+                            join_entry = Some(join_flow::JoinEntry::Resume {
+                                vtc_did: awaiting.vtc_did,
+                                outcome: join_flow::RequirementsOutcome::Skipped,
+                            });
                         }
                     },
                     // Everything else acts on state and the resources below,
@@ -1201,6 +1187,8 @@ impl StateHandler {
                                 inactivated,
                                 capability_replies,
                                 personhood_challenges,
+                                vetting_answers,
+                                vetting_grant_checks,
                             } = effects;
 
                             // A live challenge is display state, not account
@@ -1299,6 +1287,27 @@ impl StateHandler {
                                 }
                             }
                             apply_capability_replies(&mut state, capability_replies);
+                            // A vetter's grant is checked for revocation off the
+                            // loop: the check fetches the community's status list.
+                            for check in vetting_grant_checks {
+                                vetting_actions::spawn_grant_check(&dispatch_tx, &tdk, check);
+                            }
+                            // The manifest a waiting join asked for resumes it; every
+                            // other answer goes to the Vetting page.
+                            let mut answers = Vec::with_capacity(vetting_answers.len());
+                            for answer in vetting_answers {
+                                match awaiting_requirements
+                                    .as_ref()
+                                    .and_then(|a| join_flow::resume_for(a, &answer))
+                                {
+                                    Some(entry) => {
+                                        awaiting_requirements = None;
+                                        join_entry = Some(entry);
+                                    }
+                                    None => answers.push(answer),
+                                }
+                            }
+                            vetting_actions::apply_answers(&mut state, &config, answers);
                         }
                         didcomm::DIDCommEvent::TrustPingReceived { from, listener_id, message_id } => {
                             let sender = from.as_deref().unwrap_or("unknown");
@@ -1557,6 +1566,22 @@ impl StateHandler {
                 // that lands while a save runs is re-scheduled on completion.
                 // When nothing is scheduled the arm parks forever (no busy-wait).
                 _ = capabilities_sweep.tick() => {
+                    // Questions to communities have a reply window too (R1.2).
+                    vetting_actions::expire_queries(&mut state, &mut config, chrono::Utc::now());
+                    if awaiting_requirements
+                        .as_ref()
+                        .is_some_and(|a| a.asked_at.elapsed() >= join_flow::REQUIREMENTS_WAIT)
+                        && let Some(awaiting) = awaiting_requirements.take()
+                    {
+                        config.private.vetting.forget_query(&awaiting.document_id);
+                        join_entry = Some(join_flow::JoinEntry::Resume {
+                            vtc_did: awaiting.vtc_did,
+                            outcome: join_flow::RequirementsOutcome::Unanswered(format!(
+                                "no answer within {} seconds — its service may be offline",
+                                join_flow::REQUIREMENTS_WAIT.as_secs()
+                            )),
+                        });
+                    }
                     // R4.3: a capability query has a defined reply window. The
                     // send was fire-and-forget; if no correlated reply arrived,
                     // fail the view closed with a distinct, actionable message.
@@ -1846,6 +1871,52 @@ impl StateHandler {
                     break interrupted;
                 }
             }
+            // Enter the join flow: from the Communities panel, or back from waiting
+            // on a community's requirements. Here rather than in an arm so every
+            // way in is handled the same.
+            if let Some(entry) = join_entry.take() {
+                awaiting_requirements = None;
+                match self
+                    .join_flow(
+                        &mut action_rx,
+                        &mut interrupt_rx,
+                        &mut state,
+                        &tdk,
+                        &mut config,
+                        admin_vta.as_ref(),
+                        self.profile.as_str(),
+                        Some(&didcomm_service),
+                        entry,
+                    )
+                    .await
+                {
+                    Ok(join_flow::JoinExit::Returned(joined)) => {
+                        state.active_page = state::ActivePage::Main;
+                        // R-B-5 / D11: bring the new community's session up live
+                        // so the VTC's async receipt is received now, not only
+                        // after a restart.
+                        if let Some(joined) = joined {
+                            register_joined_session(
+                                &mut session_manager,
+                                &didcomm_service,
+                                &tdk,
+                                &config,
+                                joined,
+                                &mut state,
+                            )
+                            .await;
+                        }
+                    }
+                    Ok(join_flow::JoinExit::AwaitRequirements(awaiting)) => {
+                        awaiting_requirements = Some(awaiting);
+                    }
+                    Ok(join_flow::JoinExit::Exit(interrupted)) => break interrupted,
+                    Err(e) => {
+                        state.main_page.log_error("Join flow failed", &e);
+                        state.active_page = state::ActivePage::Main;
+                    }
+                }
+            }
             // Keep the working-context selection valid against any account change
             // this iteration applied (join/leave/status transition) before the UI
             // re-renders from the broadcast (D10 / R-C-6), then point the runtime
@@ -2033,6 +2104,10 @@ impl StateHandler {
                                     // the early load-failure callers, which
                                     // cannot reach a join anyway.
                                     messaging,
+                                    // This loop has no inbound arm, so the flow
+                                    // cannot wait here for a community's
+                                    // requirements; it uses what the book knows.
+                                    join_flow::JoinEntry::Fresh { hears_replies: false },
                                 )
                                 .await
                             {
@@ -2060,6 +2135,10 @@ impl StateHandler {
                                     // the SDK, deleted at the mediator, and dropped.
                                     joined_a_community =
                                         joined.is_some() && ctx.config.active_identity().is_some();
+                                }
+                                // Not returned without `hears_replies`.
+                                Ok(join_flow::JoinExit::AwaitRequirements(_)) => {
+                                    state.active_page = state::ActivePage::Main;
                                 }
                                 Ok(join_flow::JoinExit::Exit(interrupted)) => {
                                     if let Err(e) = terminator.terminate(interrupted.clone()) {
@@ -2378,7 +2457,9 @@ impl StateHandler {
                     Action::JoinReuseConfirm | Action::JoinReuseCancel |
                     Action::JoinInvitationSelect(..) | Action::JoinInvitationChoose |
                     Action::JoinContextSelect(..) | Action::JoinContextSlug(..) |
-                    Action::JoinContextChoose |
+                    Action::JoinContextChoose | Action::JoinVettingApply | Action::JoinVettingJoin |
+                    Action::JoinVettingAskAgain | Action::JoinVettingField(..) |
+                    Action::JoinVettingCycle(..) |
                     Action::JoinCancel | Action::JoinPasteVic(..) | Action::JoinPasteFromClipboard |
                     Action::JoinClearVic | Action::ImportConfig(..) | Action::SetProtection(..) |
                     Action::VtaSubmitDid(..) | Action::VtaStartProvision(..) |

--- a/openvtc/src/state_handler/runtime_actions.rs
+++ b/openvtc/src/state_handler/runtime_actions.rs
@@ -1162,6 +1162,11 @@ pub(crate) async fn handle_action(ctx: &mut ActionCtx<'_>, action: Action) -> Ha
         | Action::JoinContextSelect(..)
         | Action::JoinContextSlug(..)
         | Action::JoinContextChoose
+        | Action::JoinVettingApply
+        | Action::JoinVettingJoin
+        | Action::JoinVettingAskAgain
+        | Action::JoinVettingField(..)
+        | Action::JoinVettingCycle(..)
         | Action::JoinCancel
         | Action::JoinPasteVic(..)
         | Action::JoinPasteFromClipboard

--- a/openvtc/src/state_handler/vetting_actions.rs
+++ b/openvtc/src/state_handler/vetting_actions.rs
@@ -20,17 +20,25 @@ use openvtc_core::config::context_path::parse_sub_context_id;
 use openvtc_core::didcomm::Messaging;
 use openvtc_core::persona::disclosure::{self, PresentError};
 use openvtc_core::persona::{binding, profile};
+use openvtc_core::vetting::VettingBook;
 use openvtc_core::vetting::applicant::{
-    Application, RequestDraft, RequestState, SentCard, VetterEligibility,
+    Application, GrantStatus, NextStep, RequestDraft, RequestState, SentCard, VetterEligibility,
 };
 use openvtc_core::vetting::book::FALLBACK_REQUIRED_CLAIMS;
+use openvtc_core::vetting::queries::{
+    CommunityAnswer, CommunityQuery, QUERY_TIMEOUT, QueryKind, refusal_words,
+};
+use openvtc_core::vetting::registry::{
+    EventDraft, ProfileDraft, ProfileState, VetterProfileRecord, event_line, location_line,
+};
+use openvtc_core::vetting::status::GrantCheck;
 use openvtc_core::vetting::tickets::{DEFAULT_VALIDITY, Ticket, normalise_code};
 use openvtc_core::vetting::vetter::{Attestation, DeskState};
 use openvtc_core::vetting::wire::{self, Document};
 use serde_json::Value;
 use vta_sdk::client::VtaClient;
 use vta_sdk::protocols::vetting::{
-    CardClaim, TicketPresentation, VETTING_DECLINE_TYPE, VETTING_REQUEST_TYPE,
+    CardClaim, ListedVetter, TicketPresentation, VETTING_DECLINE_TYPE, VETTING_REQUEST_TYPE,
     VETTING_REVOKE_STATEMENT_TYPE, VETTING_SESSION_RESPONSE_TYPE, VETTING_SESSION_TYPE,
     VettingMethod, VettingRequirements, VettingSessionResponseBody, documentation,
 };
@@ -38,17 +46,20 @@ use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::card::sign_card;
 use vta_sdk::vetting::requirements::{Evaluation, Need};
 use vta_sdk::vetting::statement::sign_statement;
+use vta_sdk::vetting::status::StatusCheck;
 
 use crate::state_handler::actions::VettingAction;
 use crate::state_handler::background_dispatch::{self, DispatchDomain, DispatchOutcome, InFlight};
 use crate::state_handler::dispatch_util::{self, Persist, SyncLog};
 use crate::state_handler::join_flow;
 use crate::state_handler::main_page::content::{
-    ApplicationRow, AttestForm, CardPreview, DeskRow, DeskStage, FaceChoice, IssuedRow, RequestRow,
-    TicketRow, VETTING_METHODS, VETTING_RELATIONSHIPS, VETTING_TICKET_USES,
-    VETTING_WITHDRAWAL_REASONS, VettingMembership, VettingMode, VettingPersona, VettingState,
-    VettingTab, method_label,
+    ApplicationRow, AttestForm, CardPreview, DIRECTORY_FIELDS, DIRECTORY_METHODS, DeskRow,
+    DeskStage, DirectoryCommunity, DirectoryView, EVENT_FIELDS, EventForm, FaceChoice, IssuedRow,
+    LineTone, ListedVetterRow, PROFILE_FIELDS, RequestRow, TicketRow, VETTING_METHODS,
+    VETTING_RELATIONSHIPS, VETTING_TICKET_USES, VETTING_WITHDRAWAL_REASONS, VetterProfileForm,
+    VettingMembership, VettingMode, VettingPersona, VettingState, VettingTab, method_label,
 };
+use crate::state_handler::main_page::menu::MainMenu;
 use crate::state_handler::main_page::{sanitize_display, shorten_did};
 use crate::state_handler::runtime_actions::ActionCtx;
 use crate::state_handler::save_coalesce::SaveScheduler;
@@ -63,14 +74,18 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
     let now = Utc::now();
     let book = &config.private.vetting;
     let name = |did: &str| config.agent_name_for(did).map(|n| sanitize_display(n, 256));
+    // The membership's own name first; the name the community gives itself in
+    // its branding only when there is none.
     let community_name = |did: &str| {
         config
             .account
             .memberships()
             .find(|m| m.vtc_did == did)
             .and_then(|m| m.display_name.as_deref())
+            .or_else(|| book.branding(did).and_then(|b| b.display_name.as_deref()))
             .map(|n| sanitize_display(n, 128))
     };
+    let accent = |did: &str| book.branding(did).and_then(|b| b.accent_rgb());
 
     vetting.personas = config
         .identities
@@ -91,14 +106,54 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
         .filter(|m| book.vetter_grant(&m.vtc_did, m.persona_ref, now).is_some())
         .map(|m| VettingMembership {
             community: m.vtc_did.clone(),
-            name: m
-                .display_name
-                .as_deref()
-                .map(|n| sanitize_display(n, 128))
-                .unwrap_or_else(|| shorten_did(&m.vtc_did, 48)),
+            name: community_name(&m.vtc_did).unwrap_or_else(|| shorten_did(&m.vtc_did, 48)),
             persona: m.persona_ref,
+            accent: accent(&m.vtc_did),
         })
         .collect();
+
+    vetting.resend_candidates = book
+        .resend_candidates(&config.account, now)
+        .into_iter()
+        .map(|m| VettingMembership {
+            community: m.vtc_did.clone(),
+            name: community_name(&m.vtc_did).unwrap_or_else(|| shorten_did(&m.vtc_did, 48)),
+            persona: m.persona_ref,
+            accent: accent(&m.vtc_did),
+        })
+        .collect();
+
+    // The directory is searched as a persona the community knows of: the
+    // application's join DID first, else the membership's.
+    let mut directory: Vec<DirectoryCommunity> = Vec::new();
+    for app in &book.applications {
+        if !directory.iter().any(|d| d.community == app.community) {
+            directory.push(DirectoryCommunity {
+                community: app.community.clone(),
+                name: community_name(&app.community)
+                    .unwrap_or_else(|| shorten_did(&app.community, 48)),
+                accent: accent(&app.community),
+                persona: app.persona,
+                application_id: Some(app.id.clone()),
+            });
+        }
+    }
+    for m in config
+        .account
+        .memberships()
+        .filter(|m| m.status.is_active())
+    {
+        if !directory.iter().any(|d| d.community == m.vtc_did) {
+            directory.push(DirectoryCommunity {
+                community: m.vtc_did.clone(),
+                name: community_name(&m.vtc_did).unwrap_or_else(|| shorten_did(&m.vtc_did, 48)),
+                accent: accent(&m.vtc_did),
+                persona: m.persona_ref,
+                application_id: None,
+            });
+        }
+    }
+    vetting.directory_communities = directory.into();
 
     vetting.documentation = book
         .policy
@@ -140,6 +195,8 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
                 id: app.id.clone(),
                 community: app.community.clone(),
                 community_name: community_name(&app.community),
+                accent: accent(&app.community),
+                next_step: Some(next_step_words(&app.next_step(now))),
                 join_did: app.join_did.clone(),
                 requirements: app.requirements.as_ref().map(requirements_line),
                 progress: evaluation.as_ref().map(progress_line),
@@ -196,6 +253,7 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
                             match_code,
                             card_session,
                             eligibility: r.eligibility.as_ref().map(eligibility_line),
+                            grant: r.grant_status.as_ref().map(grant_line),
                         }
                     })
                     .collect(),
@@ -278,6 +336,7 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
             uses_left: t.uses_left,
             expires: t.expires_at.format("%Y-%m-%d").to_string(),
             live: t.is_live(now),
+            uri: persona_did(config, t.persona).map(|did| t.uri(&did)),
         })
         .collect();
 
@@ -314,10 +373,7 @@ fn eligibility_line(eligibility: &VetterEligibility) -> (bool, String) {
     match eligibility {
         VetterEligibility::Shown { valid_until, .. } => (
             true,
-            format!(
-                "named a vetter by the community until {}",
-                valid_until.format("%Y-%m-%d")
-            ),
+            format!("named a vetter until {}", valid_until.format("%Y-%m-%d")),
         ),
         VetterEligibility::NotShown => (
             false,
@@ -332,6 +388,71 @@ fn eligibility_line(eligibility: &VetterEligibility) -> (bool, String) {
             ),
         ),
     }
+}
+
+/// Whether the community revoked the vetter's grant, in a line.
+fn grant_line(status: &GrantStatus) -> (LineTone, String) {
+    match status {
+        GrantStatus::Checking { .. } => (
+            LineTone::Caution,
+            "checking whether the community has revoked this vetter's grant…".to_string(),
+        ),
+        GrantStatus::Active { checked_at } => (
+            LineTone::Good,
+            format!(
+                "not revoked when checked on {}",
+                checked_at.format("%Y-%m-%d")
+            ),
+        ),
+        GrantStatus::Revoked { .. } => (
+            LineTone::Bad,
+            "the community has revoked this vetter's grant — their statement will not count"
+                .to_string(),
+        ),
+        GrantStatus::Unknown { reason, .. } => (
+            LineTone::Caution,
+            format!(
+                "could not check whether the grant was revoked ({})",
+                sanitize_display(reason, 200)
+            ),
+        ),
+    }
+}
+
+/// What to do next on an application, with the key that does it.
+pub(crate) fn next_step_words(step: &NextStep) -> String {
+    match step {
+        NextStep::SendCard { .. } => {
+            "c — a vetter opened a session: read the code together, then send your card"
+        }
+        NextStep::LearnRequirements => "m — ask the community what it requires",
+        NextStep::Join => "join from Communities (j) — your statements go with the request",
+        NextStep::ChooseFace => "f — choose the face vetters are shown, then ask a vetter",
+        NextStep::AskVetter => "r — ask a vetter with their ticket, or v to find one",
+        NextStep::WaitForVetters => "wait for your vetters — you are told when one answers",
+    }
+    .to_string()
+}
+
+/// A community's name for messages: the membership's, then the one it
+/// publishes, then a verified agent name, then its DID.
+pub(crate) fn community_display(config: &Config, did: &str) -> String {
+    let named = config
+        .account
+        .memberships()
+        .find(|m| m.vtc_did == did)
+        .and_then(|m| m.display_name.clone())
+        .or_else(|| {
+            config
+                .private
+                .vetting
+                .branding(did)
+                .and_then(|b| b.display_name.clone())
+        });
+    sanitize_display(
+        &crate::state_handler::community_label(config, did, named.as_deref(), 48),
+        128,
+    )
 }
 
 fn requirements_line(r: &VettingRequirements) -> String {
@@ -349,7 +470,7 @@ fn requirements_line(r: &VettingRequirements) -> String {
     line
 }
 
-fn progress_line(evaluation: &Evaluation) -> String {
+pub(crate) fn progress_line(evaluation: &Evaluation) -> String {
     if evaluation.satisfied() {
         return "meets the published requirements — join from Communities".to_string();
     }
@@ -414,7 +535,33 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
             let v = page(ctx);
             v.selected = i.min(v.tab_len().saturating_sub(1));
         }
-        VettingAction::Back => page(ctx).mode = VettingMode::List,
+        VettingAction::Back => back(page(ctx)),
+        VettingAction::PasteTicket(text) => paste_ticket(ctx, &text),
+        VettingAction::FindVetters => open_directory(ctx),
+        VettingAction::DirectoryPage(forward) => directory_page(ctx, forward).await,
+        VettingAction::AskListedVetter => ask_listed_vetter(ctx),
+        VettingAction::EditProfile => open_profile(ctx),
+        VettingAction::RemoveEvent => {
+            if let VettingMode::Profile(form) = &mut page(ctx).mode
+                && form.event.is_none()
+                && let Some(i) = form.event_index()
+            {
+                form.draft.events.remove(i);
+                form.field = form.field.min(form.rows() - 1);
+                form.error = None;
+            }
+        }
+        VettingAction::AskResend => {
+            if page(ctx).resend_candidates.is_empty() {
+                status(
+                    ctx,
+                    "Every community you are an active member of has already sent you a live \
+                     vetter credential — or you are not an active member of any.",
+                );
+            } else {
+                page(ctx).mode = VettingMode::Resend { index: 0 };
+            }
+        }
         VettingAction::Status(message) => status(ctx, message),
         VettingAction::Input(text) => {
             input(&mut page(ctx).mode, text);
@@ -423,18 +570,41 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
         VettingAction::NextField => move_field(page(ctx), true),
         VettingAction::PrevField => move_field(page(ctx), false),
         VettingAction::Cycle(forward) => {
+            let before = profile_membership(page(ctx));
             cycle(page(ctx), forward);
+            let after = profile_membership(page(ctx));
+            if let Some(index) = after
+                && before != after
+            {
+                // Each community has its own profile: show the one for this one.
+                let form = profile_form(
+                    &ctx.state.main_page.content_panel.vetting,
+                    &ctx.config.private.vetting,
+                    index,
+                    0,
+                );
+                page(ctx).mode = VettingMode::Profile(Box::new(form));
+            }
             refresh_application_contexts(ctx);
         }
-        VettingAction::Toggle => {
-            if let VettingMode::Attest { form, .. } = &mut page(ctx).mode {
+        VettingAction::Toggle => match &mut page(ctx).mode {
+            VettingMode::Attest { form, .. } => match form.field {
+                3 => form.liveness_confirmed = !form.liveness_confirmed,
+                4 => form.attested = !form.attested,
+                _ => {}
+            },
+            VettingMode::Profile(form) if form.event.is_none() => {
                 match form.field {
-                    3 => form.liveness_confirmed = !form.liveness_confirmed,
-                    4 => form.attested = !form.attested,
+                    1 => form.draft.listed = !form.draft.listed,
+                    7 => form.draft.toggle_method(VettingMethod::InPerson),
+                    8 => form.draft.toggle_method(VettingMethod::Video),
+                    9 => form.draft.toggle_method(VettingMethod::PriorAcquaintance),
                     _ => {}
                 }
+                form.error = None;
             }
-        }
+            _ => {}
+        },
         VettingAction::StartApplication => {
             if page(ctx).personas.is_empty() {
                 status(
@@ -465,6 +635,8 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
                     application_id: row.id,
                     vetter: String::new(),
                     code: String::new(),
+                    ticket: None,
+                    note: None,
                     field: 0,
                 };
             }
@@ -576,17 +748,43 @@ pub(crate) async fn dispatch(ctx: &mut ActionCtx<'_>, action: VettingAction) {
 }
 
 fn input(mode: &mut VettingMode, text: String) {
+    // Typing a code replaces a ticket read from a link.
+    if let VettingMode::RequestVetter {
+        ticket, field: 1, ..
+    } = mode
+    {
+        *ticket = None;
+    }
+    if let Some(focused) = mode.focused_text_mut() {
+        *focused = text;
+    }
     match mode {
-        VettingMode::NewApplication {
-            community,
-            field: 0,
-            ..
-        } => *community = text,
-        VettingMode::RequestVetter {
-            vetter, field: 0, ..
-        } => *vetter = text,
-        VettingMode::RequestVetter { code, field: 1, .. } => *code = text,
+        VettingMode::Directory(view) => view.error = None,
+        VettingMode::Profile(form) => {
+            form.error = None;
+            if let Some(event) = &mut form.event {
+                event.error = None;
+            }
+        }
         _ => {}
+    }
+}
+
+/// Esc: an open event form returns to its profile; anything else to the list.
+fn back(v: &mut VettingState) {
+    if let VettingMode::Profile(form) = &mut v.mode
+        && form.event.is_some()
+    {
+        form.event = None;
+        return;
+    }
+    v.mode = VettingMode::List;
+}
+
+fn profile_membership(v: &VettingState) -> Option<usize> {
+    match &v.mode {
+        VettingMode::Profile(form) => Some(form.membership_index),
+        _ => None,
     }
 }
 
@@ -606,6 +804,17 @@ fn move_field(v: &mut VettingState, forward: bool) {
         VettingMode::RequestVetter { field, .. } | VettingMode::NewTicket { field, .. } => {
             step(field, 2);
         }
+        VettingMode::Directory(view) => {
+            let rows = view.rows();
+            step(&mut view.field, rows);
+        }
+        VettingMode::Profile(form) => match &mut form.event {
+            Some(event) => step(&mut event.field, EVENT_FIELDS),
+            None => {
+                let rows = form.rows();
+                step(&mut form.field, rows);
+            }
+        },
         VettingMode::ChooseFace { faces, index, .. } => step(index, faces.len()),
         VettingMode::Attest { form, .. } => step(&mut form.field, AttestForm::FIELDS),
         _ => {}
@@ -625,7 +834,17 @@ fn cycle(v: &mut VettingState, forward: bool) {
     };
     let (personas, memberships, documentation) =
         (v.personas.len(), v.memberships.len(), v.documentation.len());
+    let (communities, resend) = (v.directory_communities.len(), v.resend_candidates.len());
     match &mut v.mode {
+        VettingMode::Directory(view) => match view.field {
+            0 => turn(&mut view.community_index, communities),
+            5 => turn(&mut view.method_index, DIRECTORY_METHODS.len()),
+            _ => {}
+        },
+        VettingMode::Profile(form) if form.event.is_none() && form.field == 0 => {
+            turn(&mut form.membership_index, memberships);
+        }
+        VettingMode::Resend { index } => turn(index, resend),
         VettingMode::NewApplication {
             persona_index,
             field: 1,
@@ -688,8 +907,15 @@ async fn submit(ctx: &mut ActionCtx<'_>) {
             application_id,
             vetter,
             code,
+            ticket,
             ..
-        } => request_vetter(ctx, &application_id, vetter.trim(), &code).await,
+        } => request_vetter(ctx, &application_id, vetter.trim(), &code, ticket).await,
+        VettingMode::Directory(view) => match view.result_index() {
+            Some(_) => ask_listed_vetter(ctx),
+            None => search_directory(ctx, vec![None]).await,
+        },
+        VettingMode::Profile(form) => profile_submit(ctx, *form).await,
+        VettingMode::Resend { index } => ask_resend(ctx, index).await,
         VettingMode::SendCard {
             application_id,
             session_id,
@@ -887,6 +1113,10 @@ async fn start_application(
         }
         Err(e) => return status(ctx, format!("Could not start the application: {e}")),
     };
+    ctx.config
+        .private
+        .vetting
+        .adopt_known_requirements(&application_id);
     {
         let v = page(ctx);
         v.mode = VettingMode::List;
@@ -903,12 +1133,32 @@ async fn start_application(
     refresh_requirements(ctx, &application_id).await;
 }
 
-async fn request_vetter(ctx: &mut ActionCtx<'_>, application_id: &str, vetter: &str, code: &str) {
+async fn request_vetter(
+    ctx: &mut ActionCtx<'_>,
+    application_id: &str,
+    vetter: &str,
+    code: &str,
+    ticket: Option<TicketPresentation>,
+) {
+    // A link typed into the DID field is read the same as a pasted one.
+    if vetter.to_ascii_lowercase().starts_with("vetting-ticket:") {
+        return paste_ticket(ctx, vetter);
+    }
     if !vetter.starts_with("did:") {
         return status(ctx, "Enter the vetter's DID (it starts with did:).");
     }
-    let Some(code) = normalise_code(code) else {
-        return status(ctx, "That is not a ticket code — they look like K7QF-2M9X.");
+    let presentation = match ticket {
+        Some(ticket) if code.is_empty() => ticket,
+        _ => match normalise_code(code) {
+            Some(code) => TicketPresentation::Code { code },
+            None => {
+                return status(
+                    ctx,
+                    "That is not a ticket code — they look like K7QF-2M9X. Or paste the link \
+                     from their QR code.",
+                );
+            }
+        },
     };
     if !begin(ctx) {
         return;
@@ -926,7 +1176,7 @@ async fn request_vetter(ctx: &mut ActionCtx<'_>, application_id: &str, vetter: &
     let body = match app.prepare_request(
         &document_id,
         vetter,
-        TicketPresentation::Code { code },
+        presentation,
         RequestDraft::default(),
         Utc::now(),
     ) {
@@ -960,6 +1210,447 @@ async fn request_vetter(ctx: &mut ActionCtx<'_>, application_id: &str, vetter: &
             app.forget_unsent(&document_id);
         }
         abandon(ctx, "Could not send the request", e);
+    }
+}
+
+/// Fill the request form from a pasted `vetting-ticket:` link — the vetter's
+/// DID and the scanned ticket — or say why it cannot be used.
+fn paste_ticket(ctx: &mut ActionCtx<'_>, text: &str) {
+    let VettingMode::RequestVetter { application_id, .. } = &page(ctx).mode else {
+        return;
+    };
+    let application_id = application_id.clone();
+    let Some(app) = ctx
+        .config
+        .private
+        .vetting
+        .applications
+        .iter()
+        .find(|a| a.id == application_id)
+    else {
+        return;
+    };
+    match app.ticket_from_uri(text) {
+        Ok(ticket) => {
+            let shown = shorten_did(&ticket.vetter, 64);
+            if let VettingMode::RequestVetter {
+                vetter,
+                code,
+                ticket: slot,
+                field,
+                ..
+            } = &mut page(ctx).mode
+            {
+                *vetter = ticket.vetter;
+                code.clear();
+                *slot = Some(ticket.presentation);
+                *field = 1;
+            }
+            status(
+                ctx,
+                format!("Filled in from the ticket link: {shown}. Enter sends the request."),
+            );
+        }
+        Err(e) => status(ctx, sanitize_display(&e.to_string(), 400)),
+    }
+}
+
+fn open_directory(ctx: &mut ActionCtx<'_>) {
+    let v = page(ctx);
+    if v.directory_communities.is_empty() {
+        return status(
+            ctx,
+            "The vetter directory is searched per community: start an application (n) or join a \
+             community first.",
+        );
+    }
+    let from_application = (v.tab == VettingTab::Applications)
+        .then(|| v.applications.get(v.selected))
+        .flatten()
+        .map(|a| a.community.clone());
+    let community_index = from_application
+        .and_then(|c| {
+            v.directory_communities
+                .iter()
+                .position(|d| d.community == c)
+        })
+        .unwrap_or(0);
+    v.mode = VettingMode::Directory(Box::new(DirectoryView {
+        community_index,
+        ..DirectoryView::default()
+    }));
+    v.status_message = None;
+}
+
+/// Ask the directory's community for one page. `cursors` is what the view's
+/// page stack becomes once the answer arrives; its last entry is the cursor
+/// sent.
+async fn search_directory(ctx: &mut ActionCtx<'_>, cursors: Vec<Option<String>>) {
+    let prepared = {
+        let v = page(ctx);
+        let VettingMode::Directory(view) = &mut v.mode else {
+            return;
+        };
+        if view.pending.is_some() {
+            return;
+        }
+        let Some(target) = v.directory_communities.get(view.community_index).cloned() else {
+            return;
+        };
+        let mut filter = view.filter.clone();
+        filter.method = DIRECTORY_METHODS[view.method_index.min(DIRECTORY_METHODS.len() - 1)];
+        match filter.to_body(cursors.last().cloned().flatten()) {
+            Ok(body) => (target, body),
+            Err(e) => {
+                view.error = Some(e.to_string());
+                return;
+            }
+        }
+    };
+    let (target, body) = prepared;
+    let Some(asker) = persona_did(ctx.config, target.persona) else {
+        return status(
+            ctx,
+            "The persona the directory would be searched as is not available.",
+        );
+    };
+    if !begin(ctx) {
+        return;
+    }
+    let document = match wire::vetter_list_request(&asker, &target.community, &body) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not search the directory", e),
+    };
+    let document_id = document.id.clone();
+    ctx.config.private.vetting.ask(CommunityQuery {
+        document_id: document_id.clone(),
+        community: target.community.clone(),
+        persona: target.persona,
+        kind: QueryKind::VetterList,
+        sent_at: Utc::now(),
+    });
+    if let VettingMode::Directory(view) = &mut page(ctx).mode {
+        view.pending = Some(document_id.clone());
+        view.pending_cursors = Some(cursors);
+        view.error = None;
+    }
+    status(
+        ctx,
+        format!("Asking {} for its vetter directory…", target.name),
+    );
+    let sent = Sent::Query {
+        document_id: document_id.clone(),
+        community: target.community.clone(),
+        kind: QueryKind::VetterList,
+    };
+    if let Err(e) = sign_and_send(ctx, target.persona, document, sent).await {
+        ctx.config.private.vetting.forget_query(&document_id);
+        if let VettingMode::Directory(view) = &mut page(ctx).mode {
+            view.pending = None;
+            view.pending_cursors = None;
+        }
+        abandon(ctx, "Could not search the directory", e);
+    }
+}
+
+async fn directory_page(ctx: &mut ActionCtx<'_>, forward: bool) {
+    let (mut cursors, next) = match &page(ctx).mode {
+        VettingMode::Directory(view) if view.pending.is_none() => {
+            (view.cursors.clone(), view.next_cursor.clone())
+        }
+        _ => return,
+    };
+    if forward {
+        let Some(next) = next else {
+            return status(ctx, "That is the last page.");
+        };
+        cursors.push(Some(next));
+    } else {
+        if cursors.len() <= 1 {
+            return status(ctx, "This is the first page.");
+        }
+        cursors.pop();
+    }
+    search_directory(ctx, cursors).await;
+}
+
+/// Open the request form for the highlighted directory vetter. The directory
+/// finds a vetter; it does not let anyone skip the ticket, so the form says
+/// how this vetter hands them out.
+fn ask_listed_vetter(ctx: &mut ActionCtx<'_>) {
+    let v = page(ctx);
+    let VettingMode::Directory(view) = &v.mode else {
+        return;
+    };
+    let Some(row) = view
+        .result_index()
+        .and_then(|i| view.results.get(i))
+        .cloned()
+    else {
+        return;
+    };
+    let Some(target) = v.directory_communities.get(view.community_index).cloned() else {
+        return;
+    };
+    let Some(application_id) = target.application_id.clone() else {
+        return status(
+            ctx,
+            format!(
+                "To ask {} you need an application to {} — start one on the Applications tab (n), \
+                 then find them here again.",
+                row.name, target.name
+            ),
+        );
+    };
+    let how = match &row.contact_hint {
+        Some(hint) => format!("they say: {hint}"),
+        None => "they have not said how, so ask them".to_string(),
+    };
+    let v = page(ctx);
+    v.mode = VettingMode::RequestVetter {
+        application_id,
+        vetter: row.did.clone(),
+        code: String::new(),
+        ticket: None,
+        note: Some(format!(
+            "{} still has to give you a ticket before they answer — {how}. Paste the link from \
+             their QR code, or type the code they read to you.",
+            row.name
+        )),
+        field: 1,
+    };
+    v.tab = VettingTab::Applications;
+}
+
+/// The profile form for membership `membership_index`, from what was last sent
+/// there — or a first profile from this vetter's own policy.
+pub(crate) fn profile_form(
+    v: &VettingState,
+    book: &VettingBook,
+    membership_index: usize,
+    field: usize,
+) -> VetterProfileForm {
+    let record = v
+        .memberships
+        .get(membership_index)
+        .and_then(|m| book.vetter_profile(&m.community, m.persona));
+    VetterProfileForm {
+        membership_index,
+        draft: record.map_or_else(
+            || ProfileDraft::new(&book.policy),
+            |r| r.draft(&book.policy),
+        ),
+        field,
+        event: None,
+        error: None,
+        state_line: record.map(profile_state_line),
+    }
+}
+
+fn profile_state_line(record: &VetterProfileRecord) -> (LineTone, String) {
+    let day = |at: &chrono::DateTime<Utc>| at.format("%Y-%m-%d").to_string();
+    match &record.state {
+        ProfileState::Sent { sent_at } => (
+            LineTone::Caution,
+            format!(
+                "Sent {} — the community has not answered yet.",
+                day(sent_at)
+            ),
+        ),
+        ProfileState::Stored {
+            listed: true,
+            updated_at,
+        } => (
+            LineTone::Good,
+            format!("Published {} and listed in the directory.", day(updated_at)),
+        ),
+        ProfileState::Stored { updated_at, .. } => (
+            LineTone::Good,
+            format!("Published {}, not listed.", day(updated_at)),
+        ),
+        ProfileState::Refused { code, at } => (
+            LineTone::Bad,
+            format!(
+                "Refused {} ({}) — the community did not count you as a vetter then.",
+                day(at),
+                sanitize_display(code, 80)
+            ),
+        ),
+    }
+}
+
+fn open_profile(ctx: &mut ActionCtx<'_>) {
+    let v = &ctx.state.main_page.content_panel.vetting;
+    if v.memberships.is_empty() {
+        let hint = if v.resend_candidates.is_empty() {
+            ""
+        } else {
+            " If one did and the credential never arrived, g asks it to send it again."
+        };
+        return status(
+            ctx,
+            format!(
+                "A profile is published to a community that named you a vetter, and none has.{hint}"
+            ),
+        );
+    }
+    let form = profile_form(v, &ctx.config.private.vetting, 0, 0);
+    page(ctx).mode = VettingMode::Profile(Box::new(form));
+}
+
+/// Enter on the profile form: keep an open event, open one, or publish.
+async fn profile_submit(ctx: &mut ActionCtx<'_>, form: VetterProfileForm) {
+    if let Some(event) = &form.event {
+        let result = event.draft.to_event();
+        if let VettingMode::Profile(open) = &mut page(ctx).mode {
+            match result {
+                Ok(_) => {
+                    let kept = match event.index {
+                        Some(i) if i < open.draft.events.len() => {
+                            open.draft.events[i] = event.draft.clone();
+                            i
+                        }
+                        _ => {
+                            open.draft.events.push(event.draft.clone());
+                            open.draft.events.len() - 1
+                        }
+                    };
+                    open.event = None;
+                    open.error = None;
+                    open.field = PROFILE_FIELDS + kept;
+                }
+                Err(e) => {
+                    if let Some(open_event) = &mut open.event {
+                        open_event.error = Some(e.to_string());
+                    }
+                }
+            }
+        }
+        return;
+    }
+    if let Some(i) = form.event_index() {
+        if let VettingMode::Profile(open) = &mut page(ctx).mode {
+            open.event = Some(EventForm {
+                index: Some(i),
+                draft: form.draft.events[i].clone(),
+                field: 0,
+                error: None,
+            });
+        }
+        return;
+    }
+    if form.on_add_event() {
+        if let VettingMode::Profile(open) = &mut page(ctx).mode {
+            open.event = Some(EventForm {
+                index: None,
+                draft: EventDraft::default(),
+                field: 0,
+                error: None,
+            });
+        }
+        return;
+    }
+    publish_profile(ctx, &form).await;
+}
+
+async fn publish_profile(ctx: &mut ActionCtx<'_>, form: &VetterProfileForm) {
+    let Some(membership) = page(ctx).memberships.get(form.membership_index).cloned() else {
+        return;
+    };
+    let body = match form.draft.to_body() {
+        Ok(body) => body,
+        Err(e) => {
+            if let VettingMode::Profile(open) = &mut page(ctx).mode {
+                open.error = Some(e.to_string());
+            }
+            return;
+        }
+    };
+    let Some(vetter_did) = persona_did(ctx.config, membership.persona) else {
+        return status(
+            ctx,
+            "The persona this community named a vetter is not available.",
+        );
+    };
+    if !begin(ctx) {
+        return;
+    }
+    let document = match wire::vetter_profile_request(&vetter_did, &membership.community, &body) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not publish your profile", e),
+    };
+    let document_id = document.id.clone();
+    let now = Utc::now();
+    let book = &mut ctx.config.private.vetting;
+    let previous = book.record_profile_sent(&membership.community, membership.persona, &body, now);
+    book.ask(CommunityQuery {
+        document_id: document_id.clone(),
+        community: membership.community.clone(),
+        persona: membership.persona,
+        kind: QueryKind::VetterProfile,
+        sent_at: now,
+    });
+    {
+        let v = page(ctx);
+        v.mode = VettingMode::List;
+        v.tab = VettingTab::Tickets;
+    }
+    persist(ctx, format!("Sending your profile to {}…", membership.name));
+    let sent = Sent::Profile {
+        document_id: document_id.clone(),
+        community: membership.community.clone(),
+        persona: membership.persona,
+        previous: previous.clone().map(Box::new),
+    };
+    if let Err(e) = sign_and_send(ctx, membership.persona, document, sent).await {
+        let book = &mut ctx.config.private.vetting;
+        book.restore_profile(&membership.community, membership.persona, previous);
+        book.forget_query(&document_id);
+        abandon(ctx, "Could not publish your profile", e);
+    }
+}
+
+async fn ask_resend(ctx: &mut ActionCtx<'_>, index: usize) {
+    let Some(target) = page(ctx).resend_candidates.get(index).cloned() else {
+        return;
+    };
+    let Some(did) = persona_did(ctx.config, target.persona) else {
+        return status(
+            ctx,
+            "The persona that belongs to this community is not available.",
+        );
+    };
+    if !begin(ctx) {
+        return;
+    }
+    let document = match wire::vetter_resend_request(&did, &target.community) {
+        Ok(d) => d,
+        Err(e) => return abandon(ctx, "Could not ask for your vetter credential", e),
+    };
+    let document_id = document.id.clone();
+    ctx.config.private.vetting.ask(CommunityQuery {
+        document_id: document_id.clone(),
+        community: target.community.clone(),
+        persona: target.persona,
+        kind: QueryKind::VetterResend,
+        sent_at: Utc::now(),
+    });
+    page(ctx).mode = VettingMode::List;
+    status(
+        ctx,
+        format!(
+            "Asking {} to send your vetter credential again…",
+            target.name
+        ),
+    );
+    let sent = Sent::Query {
+        document_id: document_id.clone(),
+        community: target.community.clone(),
+        kind: QueryKind::VetterResend,
+    };
+    if let Err(e) = sign_and_send(ctx, target.persona, document, sent).await {
+        ctx.config.private.vetting.forget_query(&document_id);
+        abandon(ctx, "Could not ask for your vetter credential", e);
     }
 }
 
@@ -1531,6 +2222,19 @@ pub(crate) enum Sent {
     Withdrawal {
         statement_id: String,
     },
+    /// A question to a community: its directory, or a resend of our grant.
+    Query {
+        document_id: String,
+        community: String,
+        kind: QueryKind,
+    },
+    /// Our vetter profile, and the record it replaced, for undoing.
+    Profile {
+        document_id: String,
+        community: String,
+        persona: PersonaId,
+        previous: Option<Box<VetterProfileRecord>>,
+    },
 }
 
 /// One vetting send. I/O only.
@@ -1839,7 +2543,17 @@ impl VettingOutcome {
     pub(crate) fn apply(self, state: &mut State, config: &mut Config, save: &mut SaveScheduler) {
         let v = &mut state.main_page.content_panel.vetting;
         let (message, persist) = match self {
-            VettingOutcome::Sent { sent, error } => sent_result(*sent, error, config),
+            VettingOutcome::Sent { sent, error } => {
+                if let (Sent::Query { document_id, .. }, Some(e)) = (&*sent, &error)
+                    && let VettingMode::Directory(view) = &mut v.mode
+                    && view.pending.as_deref() == Some(document_id.as_str())
+                {
+                    view.pending = None;
+                    view.pending_cursors = None;
+                    view.error = Some(format!("Could not ask the community: {e}"));
+                }
+                sent_result(*sent, error, config)
+            }
             VettingOutcome::Faces {
                 application_id,
                 result: Ok(faces),
@@ -2030,6 +2744,57 @@ fn sent_result(sent: Sent, error: Option<String>, config: &mut Config) -> (Strin
                 false,
             ),
             (
+                Sent::Query {
+                    kind: QueryKind::VetterResend,
+                    ..
+                },
+                None,
+            ) => (
+                "Asked — if the community holds a vetter credential for you, it arrives under \
+                 Tickets."
+                    .to_string(),
+                false,
+            ),
+            (Sent::Query { .. }, None) => (
+                "Asked the community — waiting for its answer.".to_string(),
+                false,
+            ),
+            (Sent::Profile { .. }, None) => (
+                "Profile sent — waiting for the community to store it.".to_string(),
+                true,
+            ),
+            (
+                Sent::Query {
+                    document_id,
+                    community,
+                    kind,
+                },
+                Some(e),
+            ) => {
+                book.forget_query(&document_id);
+                (
+                    format!(
+                        "Could not ask {} for {}: {e}",
+                        shorten_did(&community, 48),
+                        kind.describe()
+                    ),
+                    false,
+                )
+            }
+            (
+                Sent::Profile {
+                    document_id,
+                    community,
+                    persona,
+                    previous,
+                },
+                Some(e),
+            ) => {
+                book.restore_profile(&community, persona, previous.map(|p| *p));
+                book.forget_query(&document_id);
+                (format!("Could not send your profile: {e}"), true)
+            }
+            (
                 Sent::Request {
                     application_id,
                     document_id,
@@ -2084,11 +2849,524 @@ fn sent_result(sent: Sent, error: Option<String>, config: &mut Config) -> (Strin
     }
 }
 
+// ============================================================================
+// Answers from communities, revocation checks, and the join flow's hand-off
+// ============================================================================
+
+/// Fold communities' answers into the page: a directory page into the view
+/// that asked for it, everything else into the status line and the log.
+pub(crate) fn apply_answers(state: &mut State, config: &Config, answers: Vec<CommunityAnswer>) {
+    for answer in answers {
+        let name = community_display(config, answer.community());
+        let v = &mut state.main_page.content_panel.vetting;
+        let message = match answer {
+            CommunityAnswer::Manifest { .. } => None,
+            CommunityAnswer::Vetters { query, page, .. } => match &mut v.mode {
+                VettingMode::Directory(view) if view.pending.as_deref() == Some(query.as_str()) => {
+                    view.pending = None;
+                    if let Some(cursors) = view.pending_cursors.take() {
+                        view.cursors = cursors;
+                    }
+                    view.results = page.vetters.iter().map(|l| listed_row(config, l)).collect();
+                    view.next_cursor = page.next_cursor;
+                    view.searched = true;
+                    view.error = None;
+                    view.field = if view.results.is_empty() {
+                        view.field.min(DIRECTORY_FIELDS - 1)
+                    } else {
+                        DIRECTORY_FIELDS
+                    };
+                    Some(match view.results.len() {
+                        0 => format!("No vetter listed in {name} matches."),
+                        1 => format!("1 vetter listed in {name} matches."),
+                        n => format!("{n} vetters listed in {name} match, on this page."),
+                    })
+                }
+                _ => None,
+            },
+            CommunityAnswer::ProfileStored { listed, .. } => Some(if listed {
+                format!("{name} published your vetter profile and lists you in its directory.")
+            } else {
+                format!(
+                    "{name} stored your vetter profile. You are not listed, so only people you \
+                     give a ticket can reach you."
+                )
+            }),
+            CommunityAnswer::Resent { valid_until, .. } => Some(format!(
+                "{name} is sending your vetter credential again, valid until {}. It shows under \
+                 Tickets when it arrives.",
+                valid_until.format("%Y-%m-%d")
+            )),
+            CommunityAnswer::Refused {
+                query,
+                kind,
+                code,
+                message,
+                ..
+            } => {
+                let mut words = refusal_words(kind, &name, &sanitize_display(&code, 120));
+                if let Some(note) = message {
+                    words.push_str(&format!(" They said: {}", sanitize_display(&note, 300)));
+                }
+                directory_failed(v, &query, &words);
+                Some(words)
+            }
+            CommunityAnswer::Unreadable {
+                query,
+                kind,
+                detail,
+                ..
+            } => {
+                let words = format!(
+                    "{name} answered about {} in a form this client cannot read — the two \
+                     disagree about the task; it is not a refusal ({}).",
+                    kind.describe(),
+                    sanitize_display(&detail, 200)
+                );
+                directory_failed(v, &query, &words);
+                Some(words)
+            }
+        };
+        if let Some(message) = message {
+            state.main_page.content_panel.vetting.status_message = Some(message.clone());
+            state.main_page.log(message);
+        }
+    }
+}
+
+/// The directory view waiting on `query` stops waiting, and says why.
+fn directory_failed(v: &mut VettingState, query: &str, why: &str) {
+    if let VettingMode::Directory(view) = &mut v.mode
+        && view.pending.as_deref() == Some(query)
+    {
+        view.pending = None;
+        view.pending_cursors = None;
+        view.error = Some(why.to_string());
+    }
+}
+
+/// One listed vetter, ready to show. The name is the one they published — it
+/// is shown beside their DID, never instead of it.
+fn listed_row(config: &Config, listed: &ListedVetter) -> ListedVetterRow {
+    let join = |items: &[String], none: &str| {
+        if items.is_empty() {
+            none.to_string()
+        } else {
+            sanitize_display(&items.join(", "), 300)
+        }
+    };
+    ListedVetterRow {
+        did: listed.vetter_did.clone(),
+        name: listed
+            .display_name
+            .as_deref()
+            .or_else(|| config.agent_name_for(&listed.vetter_did))
+            .map(|n| sanitize_display(n, 128))
+            .unwrap_or_else(|| shorten_did(&listed.vetter_did, 48)),
+        languages: join(&listed.languages, "no language listed"),
+        location: listed
+            .location
+            .as_ref()
+            .map(|l| sanitize_display(&location_line(l), 300)),
+        methods: listed
+            .methods
+            .iter()
+            .map(|m| method_label(*m))
+            .collect::<Vec<_>>()
+            .join(", "),
+        documentation: join(
+            &listed.accepts_documentation,
+            "no documentation listed — ask them",
+        ),
+        availability: listed
+            .availability
+            .as_deref()
+            .map(|a| sanitize_display(a, 500)),
+        contact_hint: listed
+            .contact_hint
+            .as_deref()
+            .map(|h| sanitize_display(h, 300)),
+        events: listed
+            .events
+            .iter()
+            .map(|e| sanitize_display(&event_line(e), 300))
+            .collect(),
+        grant_until: listed.grant_valid_until.format("%Y-%m-%d").to_string(),
+    }
+}
+
+/// Tell whoever is waiting that a question went unanswered, and forget it. A
+/// manifest question is the join flow's, which keeps its own, shorter clock.
+pub(crate) fn expire_queries(state: &mut State, config: &mut Config, now: chrono::DateTime<Utc>) {
+    let expired = config.private.vetting.expire_queries(now, QUERY_TIMEOUT);
+    for query in expired {
+        if query.kind == QueryKind::Manifest {
+            continue;
+        }
+        let name = community_display(config, &query.community);
+        let words = format!(
+            "No answer from {name} about {} within {} seconds — its service may be offline. Try \
+             again later.",
+            query.kind.describe(),
+            QUERY_TIMEOUT.num_seconds()
+        );
+        let v = &mut state.main_page.content_panel.vetting;
+        directory_failed(v, &query.document_id, &words);
+        v.status_message = Some(words.clone());
+        state.main_page.log(words);
+    }
+}
+
+/// Check, off the loop, whether the community revoked a vetter's grant.
+///
+/// Not claimed through the busy-guard: a check starts from an inbound
+/// acceptance rather than a person, each is independent, and none may hold up
+/// a vetting send the person is making.
+pub(crate) fn spawn_grant_check(
+    dispatch_tx: &tokio::sync::mpsc::UnboundedSender<DispatchOutcome>,
+    tdk: &affinidi_tdk::TDK,
+    check: GrantCheck,
+) {
+    let resolver = TrustTaskVmResolver::new(tdk.did_resolver().clone());
+    background_dispatch::spawn_dispatch(
+        dispatch_tx.clone(),
+        DispatchDomain::VettingStatus,
+        async move {
+            let result = check.run(&resolver).await;
+            DispatchOutcome::VettingStatus(GrantChecked { check, result })
+        },
+    );
+}
+
+/// A finished revocation check.
+pub(crate) struct GrantChecked {
+    pub(crate) check: GrantCheck,
+    pub(crate) result: StatusCheck,
+}
+
+impl GrantChecked {
+    /// Record the result on the request. A revocation is said on the page;
+    /// the other results only change the request's line and the log.
+    pub(crate) fn apply(self, state: &mut State, config: &mut Config, save: &mut SaveScheduler) {
+        let GrantChecked { check, result } = self;
+        let vetter = config
+            .agent_name_for(&check.vetter)
+            .map(|n| sanitize_display(n, 128))
+            .unwrap_or_else(|| shorten_did(&check.vetter, 48));
+        let community = community_display(config, &check.issuer);
+        let message = match &result {
+            StatusCheck::Active => format!("{community} has not revoked {vetter}'s vetter grant."),
+            StatusCheck::Revoked => format!(
+                "{community} has revoked {vetter}'s vetter grant — a statement from them will not \
+                 count."
+            ),
+            StatusCheck::Unknown(reason) => format!(
+                "Could not check whether {community} revoked {vetter}'s vetter grant: {}",
+                sanitize_display(reason, 200)
+            ),
+        };
+        let revoked = result == StatusCheck::Revoked;
+        let recorded = config
+            .private
+            .vetting
+            .application_by_id_mut(&check.application_id)
+            .is_some_and(|app| {
+                app.record_grant_status(
+                    &check.request_document_id,
+                    &check.vetter,
+                    GrantStatus::from_check(result, Utc::now()),
+                )
+                .is_ok()
+            });
+        if !recorded {
+            // The application or request went away while the check ran.
+            state.main_page.log(message);
+            return;
+        }
+        if revoked {
+            dispatch_util::save_and_sync(
+                &mut state.main_page,
+                config,
+                save,
+                Persist::SaveAndSync,
+                |mp| &mut mp.content_panel.vetting.status_message,
+                message.clone(),
+                SyncLog::Plain(message),
+            );
+        } else {
+            save.mark_dirty();
+            state.main_page.sync_from_config(config);
+            state.main_page.log(message);
+        }
+    }
+}
+
+/// Show application `application_id` on the Vetting page, with `message`. Used
+/// by the join flow when a person starts or continues an application there.
+pub(crate) fn focus_application(
+    state: &mut State,
+    config: &Config,
+    application_id: &str,
+    message: String,
+) {
+    state.main_page.sync_from_config(config);
+    state.main_page.menu_panel.selected_menu = MainMenu::Vetting;
+    state.main_page.menu_panel.selected = false;
+    state.main_page.content_panel.selected = true;
+    let v = &mut state.main_page.content_panel.vetting;
+    v.tab = VettingTab::Applications;
+    v.mode = VettingMode::List;
+    if let Some(i) = v.applications.iter().position(|a| a.id == application_id) {
+        v.selected = i;
+    }
+    v.status_message = Some(message);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::state_handler::dispatch_util::test_config;
     use openvtc_core::vetting::applicant::Application;
+    use vta_sdk::protocols::vetting::{
+        VETTING_VETTER_RESEND_ERR_NOT_GRANTED, VetterListResponseBody,
+    };
+
+    fn listed(did: &str) -> ListedVetter {
+        serde_json::from_value(serde_json::json!({
+            "vetterDid": did,
+            "displayName": "Carol",
+            "languages": ["en"],
+            "methods": ["inPerson"],
+            "acceptsDocumentation": [],
+            "contactHint": "ask at the LPC desk",
+            "events": [],
+            "grantValidUntil": "2027-09-01T00:00:00Z",
+            "updatedAt": "2026-09-01T00:00:00Z"
+        }))
+        .unwrap()
+    }
+
+    fn directory_waiting_on(query: &str) -> State {
+        let mut state = State::default();
+        state.main_page.content_panel.vetting.mode =
+            VettingMode::Directory(Box::new(DirectoryView {
+                pending: Some(query.into()),
+                pending_cursors: Some(vec![None, Some("page-2".into())]),
+                cursors: vec![None],
+                ..DirectoryView::default()
+            }));
+        state
+    }
+
+    /// A directory page lands only in the view that asked for it, and moves the
+    /// focus onto the first result.
+    #[test]
+    fn a_directory_page_lands_only_where_it_was_asked_for() {
+        let config = test_config();
+        let mut state = directory_waiting_on("q1");
+        let page = VetterListResponseBody {
+            vetters: vec![listed("did:key:zCarol")],
+            next_cursor: None,
+        };
+        apply_answers(
+            &mut state,
+            &config,
+            vec![CommunityAnswer::Vetters {
+                query: "someone-else".into(),
+                community: "did:web:vtc".into(),
+                page: page.clone(),
+            }],
+        );
+        let VettingMode::Directory(view) = &state.main_page.content_panel.vetting.mode else {
+            panic!("still the directory");
+        };
+        assert!(view.results.is_empty() && view.pending.is_some());
+
+        apply_answers(
+            &mut state,
+            &config,
+            vec![CommunityAnswer::Vetters {
+                query: "q1".into(),
+                community: "did:web:vtc".into(),
+                page,
+            }],
+        );
+        let VettingMode::Directory(view) = &state.main_page.content_panel.vetting.mode else {
+            panic!("still the directory");
+        };
+        assert_eq!(view.results.len(), 1);
+        assert_eq!(view.results[0].name, "Carol");
+        assert_eq!(
+            view.results[0].documentation,
+            "no documentation listed — ask them"
+        );
+        assert_eq!(view.cursors.len(), 2, "this is page two");
+        assert_eq!(view.result_index(), Some(0));
+        assert!(view.pending.is_none());
+    }
+
+    /// A refusal reads as what to do next, on the page and in the view.
+    #[test]
+    fn refusals_are_said_plainly() {
+        let config = test_config();
+        let mut state = directory_waiting_on("q1");
+        apply_answers(
+            &mut state,
+            &config,
+            vec![CommunityAnswer::Refused {
+                query: "q1".into(),
+                community: "did:web:vtc".into(),
+                kind: QueryKind::VetterList,
+                code: "permissionDenied".into(),
+                message: None,
+            }],
+        );
+        let v = &state.main_page.content_panel.vetting;
+        let VettingMode::Directory(view) = &v.mode else {
+            panic!("still the directory");
+        };
+        assert!(view.pending.is_none());
+        assert!(
+            view.error
+                .as_deref()
+                .is_some_and(|e| e.contains("would not answer"))
+        );
+
+        apply_answers(
+            &mut state,
+            &config,
+            vec![CommunityAnswer::Refused {
+                query: "r1".into(),
+                community: "did:web:vtc".into(),
+                kind: QueryKind::VetterResend,
+                code: VETTING_VETTER_RESEND_ERR_NOT_GRANTED.into(),
+                message: None,
+            }],
+        );
+        assert!(
+            state
+                .main_page
+                .content_panel
+                .vetting
+                .status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("has not named you a vetter"))
+        );
+    }
+
+    /// A question nobody answered is said to be unanswered, not left spinning.
+    #[test]
+    fn an_unanswered_search_stops_waiting() {
+        let mut config = test_config();
+        let mut state = directory_waiting_on("q1");
+        config.private.vetting.ask(CommunityQuery {
+            document_id: "q1".into(),
+            community: "did:web:vtc".into(),
+            persona: PersonaId::new(),
+            kind: QueryKind::VetterList,
+            sent_at: Utc::now() - QUERY_TIMEOUT,
+        });
+        expire_queries(&mut state, &mut config, Utc::now());
+        let VettingMode::Directory(view) = &state.main_page.content_panel.vetting.mode else {
+            panic!("still the directory");
+        };
+        assert!(view.pending.is_none());
+        assert!(
+            view.error
+                .as_deref()
+                .is_some_and(|e| e.contains("No answer"))
+        );
+    }
+
+    fn application_with_request(config: &mut Config) -> (String, String) {
+        let mut app = Application::new(
+            "did:web:vtc.example",
+            PersonaId::new(),
+            "did:key:zApplicant",
+            Utc::now(),
+        )
+        .unwrap();
+        app.prepare_request(
+            "urn:uuid:r1",
+            "did:key:zVetter",
+            TicketPresentation::Code {
+                code: "K7QF-2M9X".into(),
+            },
+            RequestDraft::default(),
+            Utc::now(),
+        )
+        .unwrap();
+        let id = app.id.clone();
+        config.private.vetting.applications.push(app);
+        (id, "urn:uuid:r1".into())
+    }
+
+    /// A revoked grant is recorded on the request and said on the page.
+    #[test]
+    fn a_revoked_grant_is_recorded_and_said() {
+        let mut state = State::default();
+        let mut config = test_config();
+        let mut save = SaveScheduler::new("test");
+        let (application_id, request_document_id) = application_with_request(&mut config);
+        GrantChecked {
+            check: GrantCheck {
+                application_id,
+                request_document_id,
+                vetter: "did:key:zVetter".into(),
+                issuer: "did:web:vtc.example".into(),
+                credential_status: serde_json::json!({}),
+            },
+            result: StatusCheck::Revoked,
+        }
+        .apply(&mut state, &mut config, &mut save);
+        assert!(matches!(
+            config.private.vetting.applications[0].requests[0].grant_status,
+            Some(GrantStatus::Revoked { .. })
+        ));
+        let v = &state.main_page.content_panel.vetting;
+        assert!(
+            v.status_message
+                .as_deref()
+                .is_some_and(|m| m.contains("has revoked"))
+        );
+        assert_eq!(
+            v.applications[0].requests[0]
+                .grant
+                .as_ref()
+                .map(|(t, _)| *t),
+            Some(LineTone::Bad)
+        );
+    }
+
+    /// The form opens on what was last sent to that community.
+    #[test]
+    fn the_profile_form_opens_on_what_was_last_sent() {
+        let mut book = VettingBook::default();
+        let persona = PersonaId::new();
+        let mut draft = ProfileDraft::new(&book.policy);
+        draft.display_name = "Carol".into();
+        book.record_profile_sent(
+            "did:web:vtc",
+            persona,
+            &draft.to_body().unwrap(),
+            Utc::now(),
+        );
+        let v = VettingState {
+            memberships: vec![VettingMembership {
+                community: "did:web:vtc".into(),
+                name: "VTC".into(),
+                persona,
+                accent: None,
+            }]
+            .into(),
+            ..VettingState::default()
+        };
+        let form = profile_form(&v, &book, 0, 0);
+        assert_eq!(form.draft.display_name, "Carol");
+        assert!(matches!(form.state_line, Some((LineTone::Caution, _))));
+        let fresh = profile_form(&VettingState::default(), &book, 0, 0);
+        assert!(!fresh.draft.listed, "a first profile is unlisted");
+    }
 
     fn outcome(sent: Sent, error: Option<&str>) -> VettingOutcome {
         VettingOutcome::Sent {
@@ -2233,6 +3511,15 @@ mod tests {
         let mut v = VettingState::default();
         sync(&mut v, &config);
         assert_eq!(v.applications.len(), 1);
+        assert_eq!(
+            v.applications[0].next_step.as_deref(),
+            Some(next_step_words(&NextStep::LearnRequirements).as_str())
+        );
+        assert_eq!(
+            v.directory_communities.len(),
+            1,
+            "an application can search"
+        );
         assert_eq!(
             v.applications[0].identity,
             vec![("name.legal".to_string(), String::new())],

--- a/openvtc/src/ui/pages/join_flow/mod.rs
+++ b/openvtc/src/ui/pages/join_flow/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         pages::join_flow::{
             context_choice::ContextChoice, identity_choice::IdentityChoice,
             invitation_choice::InvitationChoice, join_progress::JoinProgress,
-            vtc_enter_did::VtcEnterDid,
+            vetting_requirements::VettingPage, vtc_enter_did::VtcEnterDid,
         },
     },
 };
@@ -33,6 +33,7 @@ pub mod context_choice;
 pub mod identity_choice;
 pub mod invitation_choice;
 pub mod join_progress;
+pub mod vetting_requirements;
 pub mod vtc_enter_did;
 
 /// Handles the join flow sequence.
@@ -58,6 +59,7 @@ pub struct JoinFlow {
     pub identity_choice: IdentityChoice,
     pub context_choice: ContextChoice,
     pub join_progress: JoinProgress,
+    pub vetting: VettingPage,
 
     /// State-mapped join props.
     pub props: Props,
@@ -120,6 +122,7 @@ impl Component for JoinFlow {
             identity_choice: IdentityChoice,
             context_choice: ContextChoice,
             join_progress: JoinProgress,
+            vetting: VettingPage,
             props: Props::from(state),
         }
         .move_with_state(state)
@@ -147,6 +150,7 @@ impl Component for JoinFlow {
             JoinPage::IdentityChoice => IdentityChoice::handle_key_event(self, key),
             JoinPage::ContextChoice => ContextChoice::handle_key_event(self, key),
             JoinPage::Progress => JoinProgress::handle_key_event(self, key),
+            JoinPage::Vetting => VettingPage::handle_key_event(self, key),
         }
     }
 
@@ -187,7 +191,10 @@ impl Component for JoinFlow {
                 slug.push_str(trimmed);
                 let _ = self.action_tx.send(Action::JoinContextSlug(slug));
             }
-            JoinPage::IdentityChoice | JoinPage::ContextChoice | JoinPage::Progress => {}
+            JoinPage::IdentityChoice
+            | JoinPage::ContextChoice
+            | JoinPage::Progress
+            | JoinPage::Vetting => {}
         }
     }
 }
@@ -203,6 +210,7 @@ impl ComponentRender<()> for JoinFlow {
             JoinPage::IdentityChoice => self.identity_choice.render(&self.props.state, frame),
             JoinPage::ContextChoice => self.context_choice.render(&self.props.state, frame),
             JoinPage::Progress => self.join_progress.render(&self.props.state, frame),
+            JoinPage::Vetting => self.vetting.render(&self.props.state, frame),
         }
     }
 }

--- a/openvtc/src/ui/pages/join_flow/vetting_requirements.rs
+++ b/openvtc/src/ui/pages/join_flow/vetting_requirements.rs
@@ -1,0 +1,428 @@
+//! Join flow — what a vetting community asks of the people who join.
+//!
+//! Shown after the community's DID when that community vets its members
+//! (`docs/design/vetting-process.md` §6.1, §12.3). It says in plain words what
+//! the community requires before anything about the applicant is sent. It
+//! shows this persona's application if there is one, and offers the ways on:
+//! apply (or continue), join anyway, or cancel.
+//!
+//! While the community is still being asked, this page is drawn by the runtime
+//! loop rather than the join flow, because that loop is the one that hears the
+//! answer. So only the two keys that loop handles are offered then: join
+//! without waiting, and cancel.
+
+use crate::colors::{
+    COLOR_BORDER, COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS,
+    COLOR_TEXT_DEFAULT, COLOR_WARNING_ACCESSIBLE_RED,
+};
+use crossterm::event::{KeyCode, KeyEvent};
+use openvtc_core::config::community_context::ContextOption;
+use openvtc_core::display::display_identifier;
+use ratatui::{
+    Frame,
+    layout::{
+        Constraint::{Length, Min},
+        Layout, Margin,
+    },
+    style::{Style, Stylize},
+    text::{Line, Span},
+    widgets::{Block, Padding, Paragraph, Wrap},
+};
+
+use crate::state_handler::{
+    actions::Action,
+    join::{JoinState, JoinVettingView, VettingPhase},
+    setup_sequence::MessageType,
+};
+use crate::ui::pages::join_flow::JoinFlow;
+use crate::ui::pages::main::components::vetting_panel::accent_swatch;
+
+#[derive(Clone, Debug, Default)]
+pub struct VettingPage;
+
+impl VettingPage {
+    pub fn handle_key_event(state: &mut JoinFlow, key: KeyEvent) {
+        if state.props.state.processing {
+            return;
+        }
+        let Some(view) = &state.props.state.vetting else {
+            if key.code == KeyCode::Esc {
+                let _ = state.action_tx.send(Action::JoinCancel);
+            }
+            return;
+        };
+        let satisfied = matches!(
+            &view.phase,
+            VettingPhase::Known(known) if known.application.as_ref().is_some_and(|a| a.satisfied)
+        );
+        let action = match (&view.phase, key.code) {
+            (_, KeyCode::F(10)) => Action::Exit,
+            (_, KeyCode::Esc) => Action::JoinCancel,
+            (_, KeyCode::Char('j' | 'J')) => Action::JoinVettingJoin,
+            (VettingPhase::Unknown { .. }, KeyCode::Enter | KeyCode::Char('r' | 'R')) => {
+                Action::JoinVettingAskAgain
+            }
+            (VettingPhase::Known(_), KeyCode::Enter) if satisfied => Action::JoinVettingJoin,
+            (VettingPhase::Known(_), KeyCode::Enter | KeyCode::Char('a' | 'A')) => {
+                Action::JoinVettingApply
+            }
+            (VettingPhase::Known(_), KeyCode::Up | KeyCode::BackTab) => {
+                Action::JoinVettingField(false)
+            }
+            (VettingPhase::Known(_), KeyCode::Down | KeyCode::Tab) => {
+                Action::JoinVettingField(true)
+            }
+            (VettingPhase::Known(_), KeyCode::Left) => Action::JoinVettingCycle(false),
+            (VettingPhase::Known(_), KeyCode::Right) => Action::JoinVettingCycle(true),
+            _ => return,
+        };
+        let _ = state.action_tx.send(action);
+    }
+
+    pub fn render(&self, state: &JoinState, frame: &mut Frame<'_>) {
+        let [middle, bottom] = Layout::vertical([Min(0), Length(3)]).areas(frame.area());
+        let Some(view) = &state.vetting else {
+            return;
+        };
+        frame.render_widget(
+            Block::bordered()
+                .fg(COLOR_BORDER)
+                .padding(Padding::proportional(1))
+                .title(format!(" Joining {} ", view.name)),
+            middle,
+        );
+        let inner = middle.inner(Margin::new(3, 2));
+        frame.render_widget(
+            Paragraph::new(body_lines(state, view)).wrap(Wrap { trim: false }),
+            inner,
+        );
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("[F10]", Style::new().fg(COLOR_BORDER).bold()),
+                Span::styled(" to quit", Style::new().fg(COLOR_TEXT_DEFAULT)),
+            ]))
+            .block(Block::new().padding(Padding::new(2, 0, 1, 0))),
+            bottom,
+        );
+    }
+}
+
+fn text() -> Style {
+    Style::new().fg(COLOR_TEXT_DEFAULT)
+}
+
+fn dim() -> Style {
+    Style::new().fg(COLOR_DARK_GRAY)
+}
+
+fn keys(pairs: &[(&str, &str)]) -> Line<'static> {
+    let mut spans = Vec::new();
+    for (key, what) in pairs {
+        spans.push(Span::styled(
+            format!("[{key}]"),
+            Style::new().fg(COLOR_BORDER).bold(),
+        ));
+        spans.push(Span::styled(format!(" {what}   "), text()));
+    }
+    Line::from(spans)
+}
+
+fn choice(name: &str, shown: String, focused: bool) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            if focused { "▸ " } else { "  " },
+            Style::new().fg(COLOR_SUCCESS).bold(),
+        ),
+        Span::styled(format!("{name:<10}"), text()),
+        Span::styled(shown, Style::new().fg(COLOR_SOFT_PURPLE)),
+        Span::styled(if focused { "  ←/→" } else { "" }, dim()),
+    ])
+}
+
+/// The page's lines, below its border.
+pub(crate) fn body_lines(state: &JoinState, view: &JoinVettingView) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    match &view.phase {
+        VettingPhase::Asking => {
+            lines.push(Line::from(vec![
+                accent_swatch(view.accent),
+                Span::styled(
+                    format!("Asking {} what it requires before you join…", view.name),
+                    Style::new().fg(COLOR_ORANGE).bold(),
+                ),
+            ]));
+            lines.push(Line::default());
+            lines.push(Line::styled(
+                "This takes a few seconds and gives up after 15. The question comes from your \
+                 active persona; nothing else about you is sent.",
+                dim(),
+            ));
+            lines.push(Line::default());
+            lines.push(keys(&[("J", "join without waiting"), ("ESC", "cancel")]));
+        }
+        VettingPhase::Unknown { reason } => {
+            lines.push(Line::from(vec![
+                accent_swatch(view.accent),
+                Span::styled(
+                    format!(
+                        "Could not learn whether {} vets the people who join — {reason}.",
+                        view.name
+                    ),
+                    Style::new().fg(COLOR_ORANGE),
+                ),
+            ]));
+            lines.push(Line::default());
+            lines.push(Line::styled(
+                "If it does, a request that arrives without vetting statements goes to its \
+                 moderators to decide.",
+                dim(),
+            ));
+            lines.push(Line::default());
+            lines.push(keys(&[
+                ("ENTER/R", "ask again"),
+                ("J", "join anyway"),
+                ("ESC", "cancel"),
+            ]));
+        }
+        VettingPhase::Known(known) => {
+            lines.push(Line::from(vec![
+                accent_swatch(view.accent),
+                Span::styled(view.name.clone(), text().bold()),
+                Span::styled(" vets the people who join.", text()),
+            ]));
+            lines.push(Line::default());
+            lines.push(Line::styled(
+                "Before it admits you, it asks for:",
+                Style::new().fg(COLOR_BORDER).bold(),
+            ));
+            for requirement in &known.requirements {
+                lines.push(Line::styled(
+                    format!("  • {requirement}"),
+                    Style::new().fg(COLOR_SOFT_PURPLE),
+                ));
+            }
+            lines.push(Line::default());
+            lines.push(Line::styled(
+                format!(
+                    "Nothing about you has been sent to {}. Each vetter sees the card you show \
+                     them; the community sees only their statements.",
+                    view.name
+                ),
+                dim(),
+            ));
+            if let Some(url) = &known.governance_url {
+                lines.push(Line::styled(format!("How it decides: {url}"), dim()));
+            }
+            lines.push(Line::default());
+            match &known.application {
+                Some(app) => {
+                    lines.push(Line::styled(
+                        format!("Your application, as {}", app.persona_label),
+                        Style::new().fg(COLOR_SUCCESS).bold(),
+                    ));
+                    lines.push(Line::styled(
+                        format!(
+                            "  {} statement{} held{}",
+                            app.statements,
+                            if app.statements == 1 { "" } else { "s" },
+                            app.progress
+                                .as_ref()
+                                .map(|p| format!(" — {p}"))
+                                .unwrap_or_default()
+                        ),
+                        text(),
+                    ));
+                    lines.push(Line::from(vec![
+                        Span::styled("  Next: ", text()),
+                        Span::styled(app.next_step.clone(), Style::new().fg(COLOR_SUCCESS).bold()),
+                    ]));
+                    lines.push(Line::default());
+                    if app.satisfied {
+                        lines.push(Line::styled(
+                            format!(
+                                "Joining now presents your {} vetting statement{} to {}.",
+                                app.statements,
+                                if app.statements == 1 { "" } else { "s" },
+                                view.name
+                            ),
+                            Style::new().fg(COLOR_SUCCESS),
+                        ));
+                        lines.push(Line::default());
+                        lines.push(keys(&[
+                            ("ENTER", "join and present your statements"),
+                            ("A", "open the application"),
+                            ("ESC", "cancel"),
+                        ]));
+                    } else {
+                        lines.push(keys(&[
+                            ("ENTER", "continue on the Vetting page"),
+                            (
+                                "J",
+                                "join anyway — the community refers the request to its moderators",
+                            ),
+                            ("ESC", "cancel"),
+                        ]));
+                    }
+                }
+                None => {
+                    lines.push(Line::styled(
+                        "Start an application",
+                        Style::new().fg(COLOR_BORDER).bold(),
+                    ));
+                    let persona = known.personas.get(known.persona_index).map_or_else(
+                        || "no persona yet — create one under My Identity".to_string(),
+                        |p| format!("{}  ({})", p.label, p.did),
+                    );
+                    lines.push(choice("Apply as", persona, known.field == 0));
+                    let context = known
+                        .context_options
+                        .get(known.context_index)
+                        .map_or_else(|| "—".to_string(), ContextOption::summary);
+                    lines.push(choice("Context", context, known.field == 1));
+                    lines.push(Line::styled(
+                        "The persona is fixed for the whole application: every card is signed by \
+                         it, and it is the DID the community admits.",
+                        dim(),
+                    ));
+                    lines.push(Line::default());
+                    lines.push(keys(&[
+                        ("ENTER", "start the application"),
+                        ("↑/↓", "field"),
+                        ("J", "join anyway — the community refers the request"),
+                        ("ESC", "cancel"),
+                    ]));
+                }
+            }
+        }
+    }
+    // The DID under the name, so the community being joined is never only a
+    // name it gave itself.
+    if !lines.is_empty() {
+        lines.insert(
+            1,
+            Line::styled(
+                display_identifier(None, &view.community, 96).into_owned(),
+                dim(),
+            ),
+        );
+    }
+    for message in &state.messages {
+        if let MessageType::Error(error) = message {
+            lines.push(Line::default());
+            lines.push(Line::styled(
+                error.clone(),
+                Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
+            ));
+        }
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_handler::join::{JoinApplication, JoinPage, KnownVetting};
+    use crate::state_handler::state::State;
+    use crate::ui::component::Component;
+    use crossterm::event::KeyModifiers;
+    use openvtc_core::config::account::PersonaId;
+    use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
+
+    fn view(phase: VettingPhase) -> JoinVettingView {
+        JoinVettingView {
+            community: "did:web:kernel".into(),
+            name: "Kernel".into(),
+            accent: Some((0x33, 0x66, 0x99)),
+            phase,
+        }
+    }
+
+    fn known(satisfied: Option<bool>) -> VettingPhase {
+        VettingPhase::Known(Box::new(KnownVetting {
+            requirements: vec!["2 vetting statements".into()],
+            application: satisfied.map(|satisfied| JoinApplication {
+                id: "a1".into(),
+                persona: PersonaId::new(),
+                persona_label: "alice".into(),
+                statements: 2,
+                progress: None,
+                next_step: "join".into(),
+                satisfied,
+            }),
+            ..KnownVetting::default()
+        }))
+    }
+
+    fn flow(phase: VettingPhase) -> (JoinFlow, UnboundedReceiver<Action>) {
+        let (tx, rx) = unbounded_channel();
+        let mut state = State::default();
+        state.join.page = JoinPage::Vetting;
+        state.join.vetting = Some(view(phase));
+        (JoinFlow::new(&state, tx), rx)
+    }
+
+    fn press(flow: &mut JoinFlow, code: KeyCode) {
+        VettingPage::handle_key_event(flow, KeyEvent::new(code, KeyModifiers::NONE));
+    }
+
+    #[test]
+    fn enter_starts_an_application_or_joins_one_that_is_ready() {
+        let (mut f, mut rx) = flow(known(None));
+        press(&mut f, KeyCode::Enter);
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinVettingApply)));
+        press(&mut f, KeyCode::Right);
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinVettingCycle(true))));
+        press(&mut f, KeyCode::Char('j'));
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinVettingJoin)));
+
+        let (mut f, mut rx) = flow(known(Some(true)));
+        press(&mut f, KeyCode::Enter);
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinVettingJoin)));
+        press(&mut f, KeyCode::Char('a'));
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinVettingApply)));
+    }
+
+    #[test]
+    fn while_asking_or_unknown_only_the_ways_on_are_offered() {
+        let (mut f, mut rx) = flow(VettingPhase::Asking);
+        press(&mut f, KeyCode::Enter);
+        assert!(rx.try_recv().is_err(), "nothing to confirm while asking");
+        press(&mut f, KeyCode::Char('j'));
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinVettingJoin)));
+        press(&mut f, KeyCode::Esc);
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinCancel)));
+
+        let (mut f, mut rx) = flow(VettingPhase::Unknown {
+            reason: "no answer".into(),
+        });
+        press(&mut f, KeyCode::Char('r'));
+        assert!(matches!(rx.try_recv(), Ok(Action::JoinVettingAskAgain)));
+    }
+
+    fn text_of(lines: &[Line<'_>]) -> String {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn the_page_says_what_is_required_and_that_statements_go_with_the_join() {
+        let state = JoinState::default();
+        let lines = body_lines(&state, &view(known(Some(true))));
+        let shown = text_of(&lines);
+        assert!(shown.contains("Kernel vets the people who join."));
+        assert!(shown.contains("• 2 vetting statements"));
+        assert!(shown.contains("Joining now presents your 2 vetting statements to Kernel."));
+        assert!(shown.contains("Nothing about you has been sent"));
+
+        let lines = body_lines(&state, &view(known(Some(false))));
+        assert!(text_of(&lines).contains("refers the request to its moderators"));
+    }
+}

--- a/openvtc/src/ui/pages/main/components/communities_panel.rs
+++ b/openvtc/src/ui/pages/main/components/communities_panel.rs
@@ -103,10 +103,14 @@ pub fn render(
         // membership is a selectable sub-row labelled by its presented persona.
         let new_group = i == 0 || state.items[i - 1].vtc_did != c.vtc_did;
         if new_group {
-            lines.push(Line::from(Span::styled(
-                format!("  {}", c.display_name),
-                Style::new().fg(COLOR_TEXT_DEFAULT).bold(),
-            )));
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                super::vetting_panel::accent_swatch(c.accent),
+                Span::styled(
+                    c.display_name.clone(),
+                    Style::new().fg(COLOR_TEXT_DEFAULT).bold(),
+                ),
+            ]));
         }
 
         let row_style = if is_selected {
@@ -705,6 +709,7 @@ mod key_hint_tests {
             request_id: String::new(),
             has_membership_credential: false,
             has_role_credential: false,
+            accent: None,
         }
     }
 

--- a/openvtc/src/ui/pages/main/components/mod.rs
+++ b/openvtc/src/ui/pages/main/components/mod.rs
@@ -10,6 +10,7 @@ pub mod inbox_panel;
 pub mod logs_panel;
 pub mod menu_panel;
 pub mod panel;
+pub mod qr;
 pub mod relationships_panel;
 pub mod settings_panel;
 pub mod status;

--- a/openvtc/src/ui/pages/main/components/qr.rs
+++ b/openvtc/src/ui/pages/main/components/qr.rs
@@ -1,0 +1,157 @@
+//! QR codes drawn with Unicode half-blocks, for a vetting ticket someone scans
+//! off the screen.
+//!
+//! One character cell holds one module across and two down: `▀` is a dark
+//! upper module, `▄` a dark lower one, `█` both and a space neither. That is the
+//! densest a terminal can draw a code and still keep it square enough to scan.
+//!
+//! The colours are fixed black on white, whatever the theme. A scanner needs
+//! dark modules on a light ground with a light margin (the quiet zone), and a
+//! theme's foreground and background are chosen for reading text, not for
+//! that.
+
+use qrcode::{Color as Module, EcLevel, QrCode};
+use ratatui::{
+    style::{Color, Style},
+    text::{Line, Span},
+};
+
+/// Why no code was drawn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QrError {
+    /// The narrowest code needs this many columns.
+    TooNarrow {
+        /// Columns needed.
+        needed: usize,
+    },
+    /// The data does not fit in any QR code.
+    TooLong,
+}
+
+/// Quiet zones tried, widest first. The specification asks for four modules;
+/// phones read two, and usually one, so a narrow window still gets a code.
+const QUIET_ZONES: [usize; 3] = [4, 2, 1];
+
+/// Error correction tried, strongest first. A phone photographing a screen
+/// gets a clean image, so the lower level is an acceptable price for a code
+/// that fits.
+const LEVELS: [EcLevel; 2] = [EcLevel::M, EcLevel::L];
+
+/// `data` as a QR code at most `max_width` columns wide, one line per text row.
+///
+/// # Errors
+///
+/// [`QrError::TooNarrow`] when even the smallest code with a one-module margin
+/// is wider than `max_width`; [`QrError::TooLong`] when no code holds `data`.
+pub fn qr_lines(data: &str, max_width: usize) -> Result<Vec<Line<'static>>, QrError> {
+    let mut narrowest: Option<usize> = None;
+    for level in LEVELS {
+        let Ok(code) = QrCode::with_error_correction_level(data, level) else {
+            continue;
+        };
+        let width = code.width();
+        for quiet in QUIET_ZONES {
+            if width + 2 * quiet <= max_width {
+                let modules = with_quiet_zone(&code.to_colors(), width, quiet);
+                let style = Style::new().fg(Color::Black).bg(Color::White);
+                return Ok(half_block_rows(&modules)
+                    .into_iter()
+                    .map(|row| Line::from(Span::styled(row, style)))
+                    .collect());
+            }
+        }
+        let needed = width + 2 * QUIET_ZONES[QUIET_ZONES.len() - 1];
+        narrowest = Some(narrowest.map_or(needed, |n| n.min(needed)));
+    }
+    Err(narrowest.map_or(QrError::TooLong, |needed| QrError::TooNarrow { needed }))
+}
+
+/// The module matrix, `true` for dark, surrounded by `quiet` light modules.
+fn with_quiet_zone(colors: &[Module], width: usize, quiet: usize) -> Vec<Vec<bool>> {
+    let side = width + 2 * quiet;
+    let mut rows = vec![vec![false; side]; side];
+    for (i, color) in colors.iter().enumerate() {
+        rows[quiet + i / width][quiet + i % width] = *color == Module::Dark;
+    }
+    rows
+}
+
+/// Rows of modules as rows of half-block characters, two module rows per text
+/// row. An odd last row is paired with a light one.
+pub(crate) fn half_block_rows(modules: &[Vec<bool>]) -> Vec<String> {
+    modules
+        .chunks(2)
+        .map(|pair| {
+            let upper = &pair[0];
+            let lower = pair.get(1);
+            upper
+                .iter()
+                .enumerate()
+                .map(|(x, &top)| {
+                    let bottom = lower.is_some_and(|row| row.get(x).copied().unwrap_or(false));
+                    match (top, bottom) {
+                        (true, true) => '█',
+                        (true, false) => '▀',
+                        (false, true) => '▄',
+                        (false, false) => ' ',
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LINK: &str = "vetting-ticket:?v=1&community=did%3Awebvh%3AQmCommunity%3Avtc.example.com\
+                        &vetter=did%3Awebvh%3AQmVetter%3Aexample.com%3Acarol\
+                        &ticket=vt-0123456789abcdef0123456789abcdef\
+                        &secret=AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8";
+
+    #[test]
+    fn each_cell_is_an_upper_and_a_lower_module() {
+        let modules = vec![
+            vec![true, true, false, false],
+            vec![true, false, true, false],
+            vec![false, true, false, true],
+        ];
+        assert_eq!(half_block_rows(&modules), vec!["█▀▄ ", " ▀ ▀"]);
+    }
+
+    #[test]
+    fn a_ticket_link_is_drawn_square_with_a_full_quiet_zone_when_there_is_room() {
+        let lines = qr_lines(LINK, 200).unwrap();
+        let columns = lines[0].width();
+        assert!(
+            lines.iter().all(|l| l.width() == columns),
+            "every row is as wide"
+        );
+        assert_eq!(lines.len(), columns.div_ceil(2), "two modules per text row");
+        let code = QrCode::with_error_correction_level(LINK, EcLevel::M).unwrap();
+        assert_eq!(columns, code.width() + 8);
+    }
+
+    #[test]
+    fn a_narrow_window_gets_a_tighter_code_or_is_told_how_wide_to_be() {
+        let full = qr_lines(LINK, 200).unwrap()[0].width();
+        let tight = qr_lines(LINK, full - 1).unwrap()[0].width();
+        assert!(tight < full);
+        match qr_lines(LINK, 20) {
+            Err(QrError::TooNarrow { needed }) => {
+                assert!(needed > 20);
+                assert!(
+                    qr_lines(LINK, needed).is_ok(),
+                    "the width it names is enough"
+                );
+            }
+            other => panic!("expected TooNarrow, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn data_no_code_can_hold_is_refused() {
+        assert_eq!(qr_lines(&"x".repeat(8000), 500), Err(QrError::TooLong));
+    }
+}

--- a/openvtc/src/ui/pages/main/components/status.rs
+++ b/openvtc/src/ui/pages/main/components/status.rs
@@ -43,6 +43,12 @@ fn wrap_width() -> usize {
     WRAP_WIDTH.get()
 }
 
+/// The content panel's usable width this frame, for a panel that has to fit
+/// something that cannot wrap — a QR code.
+pub fn content_width() -> usize {
+    WRAP_WIDTH.get()
+}
+
 /// Push a status message as one or more wrapped lines (no trailing blank).
 ///
 /// Messages that look like errors are rendered in the warning (red) color;

--- a/openvtc/src/ui/pages/main/components/vetting_panel.rs
+++ b/openvtc/src/ui/pages/main/components/vetting_panel.rs
@@ -6,24 +6,28 @@
 //! decides (D12).
 
 use super::panel::Panel;
+use super::qr::{QrError, qr_lines};
 use crate::colors::{
     COLOR_DARK_GRAY, COLOR_ORANGE, COLOR_SOFT_PURPLE, COLOR_SUCCESS, COLOR_TEXT_DEFAULT,
     COLOR_WARNING_ACCESSIBLE_RED,
 };
 use crate::state_handler::{
     main_page::content::{
-        AttestForm, CardPreview, ContentPanelState, DeskStage, VETTING_METHODS,
-        VETTING_RELATIONSHIPS, VETTING_TICKET_USES, VETTING_WITHDRAWAL_REASONS, VettingMode,
+        AttestForm, CardPreview, ContentPanelState, DIRECTORY_FIELDS, DIRECTORY_METHODS, DeskStage,
+        DirectoryView, EventForm, LineTone, PROFILE_FIELDS, VETTING_METHODS, VETTING_RELATIONSHIPS,
+        VETTING_TICKET_USES, VETTING_WITHDRAWAL_REASONS, VetterProfileForm, VettingMode,
         VettingState, VettingTab, method_label, reason_label, relationship_label,
     },
     state::ConnectionState,
 };
 use openvtc_core::config::community_context::ContextOption;
 use openvtc_core::display::display_identifier;
+use openvtc_core::vetting::registry::event_line;
 use ratatui::{
-    style::{Style, Stylize},
+    style::{Color, Style, Stylize},
     text::{Line, Span},
 };
+use vta_sdk::protocols::vetting::VettingMethod;
 
 /// Vetting content panel.
 pub struct VettingPanel;
@@ -49,6 +53,10 @@ pub fn mode_id(state: &VettingState) -> &'static str {
         (VettingMode::NewApplication { .. }, _) => "new-application",
         (VettingMode::ChooseFace { .. }, _) => "face",
         (VettingMode::RequestVetter { .. }, _) => "request",
+        (VettingMode::Directory(_), _) => "directory",
+        (VettingMode::Profile(form), _) if form.event.is_some() => "profile-event",
+        (VettingMode::Profile(_), _) => "profile",
+        (VettingMode::Resend { .. }, _) => "resend",
         (VettingMode::SendCard { .. }, _) => "card",
         (VettingMode::NewTicket { .. }, _) => "new-ticket",
         (VettingMode::OpenSession { .. }, _) => "session",
@@ -99,6 +107,27 @@ fn field(name: &str, shown: String, focused: bool, text: bool) -> Line<'static> 
 
 fn tick(on: bool) -> String {
     if on { "[x]" } else { "[ ]" }.to_string()
+}
+
+fn tone(tone: LineTone) -> Style {
+    match tone {
+        LineTone::Good => Style::new().fg(COLOR_SUCCESS),
+        LineTone::Caution => Style::new().fg(COLOR_ORANGE),
+        LineTone::Bad => Style::new().fg(COLOR_WARNING_ACCESSIBLE_RED),
+    }
+}
+
+/// A community's accent as a swatch before its name, or nothing.
+///
+/// The colour is data about the community — the accent it publishes in its
+/// branding — so it is drawn as that literal colour rather than mapped through
+/// the theme. It identifies; it carries no meaning a person has to read, and the
+/// name beside it is always shown.
+pub(crate) fn accent_swatch(accent: Option<(u8, u8, u8)>) -> Span<'static> {
+    match accent {
+        Some((r, g, b)) => Span::styled("● ", Style::new().fg(Color::Rgb(r, g, b))),
+        None => Span::raw(""),
+    }
 }
 
 /// Render the Vetting page.
@@ -230,19 +259,64 @@ pub fn render(v: &VettingState) -> Vec<Line<'static>> {
         VettingMode::RequestVetter {
             vetter,
             code,
+            ticket,
+            note,
             field: f,
             ..
         } => {
             lines.push(heading("Ask a vetter"));
             lines.push(Line::from(""));
             lines.push(hint(
-                "A vetter only answers a request carrying their ticket code — ask them for one first.",
+                "A vetter only answers a request carrying their ticket: a code they read to you, or",
             ));
+            lines.push(hint(
+                "the link in their QR code. Pasting that link fills in both fields.",
+            ));
+            if let Some(note) = note {
+                lines.push(Line::from(""));
+                lines.push(Line::from(note.clone()).fg(COLOR_ORANGE));
+            }
             lines.push(Line::from(""));
             lines.push(field("Vetter DID", vetter.clone(), *f == 0, true));
-            lines.push(field("Ticket code", code.clone(), *f == 1, true));
+            let shown = if ticket.is_some() && code.is_empty() {
+                "scanned ticket, from the link".to_string()
+            } else {
+                code.clone()
+            };
+            lines.push(field("Ticket code", shown, *f == 1, true));
             lines.push(Line::from(""));
             lines.push(hint("Enter: send  Tab: next field  Esc: cancel"));
+        }
+        VettingMode::Directory(view) => directory(&mut lines, v, view),
+        VettingMode::Profile(form) => match &form.event {
+            Some(event) => event_form(&mut lines, event),
+            None => profile(&mut lines, v, form),
+        },
+        VettingMode::Resend { index } => {
+            lines.push(heading("Ask for your vetter credential again"));
+            lines.push(Line::from(""));
+            lines.push(hint(
+                "If a community named you a vetter but the credential never reached you, or you lost",
+            ));
+            lines.push(hint(
+                "it, the community can send it again. It refuses if it has not named you a vetter.",
+            ));
+            lines.push(Line::from(""));
+            let mut line = field(
+                "Community",
+                v.resend_candidates
+                    .get(*index)
+                    .map(|m| m.name.clone())
+                    .unwrap_or_default(),
+                true,
+                false,
+            );
+            if let Some(m) = v.resend_candidates.get(*index) {
+                line.spans.insert(2, accent_swatch(m.accent));
+            }
+            lines.push(line);
+            lines.push(Line::from(""));
+            lines.push(hint("Enter: ask  ←/→: choose  Esc: cancel"));
         }
         VettingMode::SendCard {
             application_id,
@@ -401,6 +475,7 @@ fn applications(lines: &mut Vec<Line<'static>>, v: &VettingState) {
             .unwrap_or_else(|| app.community.clone());
         lines.push(Line::from(vec![
             Span::styled(if selected { "▸ " } else { "  " }, style),
+            accent_swatch(app.accent),
             Span::styled(name, style),
             Span::styled(
                 format!("  {} statement(s)", app.statements),
@@ -441,6 +516,12 @@ fn applications(lines: &mut Vec<Line<'static>>, v: &VettingState) {
                     Style::new().fg(COLOR_ORANGE)
                 },
             ),
+        ]));
+    }
+    if let Some(next) = &app.next_step {
+        lines.push(Line::from(vec![
+            Span::styled("Next         ", label()),
+            Span::styled(next.clone(), Style::new().fg(COLOR_SUCCESS).bold()),
         ]));
     }
     lines.push(Line::from(""));
@@ -498,11 +579,306 @@ fn applications(lines: &mut Vec<Line<'static>>, v: &VettingState) {
                 },
             )));
         }
+        if let Some((line_tone, line)) = &request.grant {
+            lines.push(Line::from(Span::styled(
+                format!("    {line}"),
+                tone(*line_tone),
+            )));
+        }
     }
     lines.push(Line::from(""));
     lines.push(hint(
-        "n: new  f: face  r: ask a vetter  c: send card  m: refresh requirements  Tab: next tab",
+        "n: new  f: face  r: ask a vetter  v: find vetters  c: send card  m: refresh requirements",
     ));
+    lines.push(hint("Tab: next tab"));
+}
+
+fn directory(lines: &mut Vec<Line<'static>>, v: &VettingState, view: &DirectoryView) {
+    lines.push(heading("Find a vetter"));
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "Vetters who chose to be listed, narrowed to what suits you. Finding one is not enough:",
+    ));
+    lines.push(hint(
+        "ask them for a ticket (each says how), then send your request with it.",
+    ));
+    lines.push(Line::from(""));
+    let f = view.field;
+    let community = v.directory_communities.get(view.community_index);
+    let mut line = field(
+        "Community",
+        community.map(|c| c.name.clone()).unwrap_or_default(),
+        f == 0,
+        false,
+    );
+    if let Some(c) = community {
+        line.spans.insert(2, accent_swatch(c.accent));
+    }
+    lines.push(line);
+    lines.push(field(
+        "Language",
+        view.filter.language.clone(),
+        f == 1,
+        true,
+    ));
+    lines.push(field("Country", view.filter.country.clone(), f == 2, true));
+    lines.push(field("Region", view.filter.region.clone(), f == 3, true));
+    lines.push(field("City", view.filter.city.clone(), f == 4, true));
+    let method = DIRECTORY_METHODS[view.method_index.min(DIRECTORY_METHODS.len() - 1)];
+    lines.push(field(
+        "Method",
+        method.map_or("any", method_label).to_string(),
+        f == 5,
+        false,
+    ));
+    lines.push(field(
+        "Events from",
+        view.filter.event_from.clone(),
+        f == 6,
+        true,
+    ));
+    lines.push(field(
+        "Events until",
+        view.filter.event_to.clone(),
+        f == 7,
+        true,
+    ));
+    lines.push(field(
+        "Event name",
+        view.filter.event_name.clone(),
+        f == 8,
+        true,
+    ));
+    lines.push(hint(
+        "  Language is a tag such as en or de, country a code such as CZ, dates YYYY-MM-DD.",
+    ));
+    lines.push(hint("  Leave a filter empty for any."));
+    lines.push(Line::from(""));
+
+    if view.pending.is_some() {
+        lines.push(Line::from("Asking the community…").fg(COLOR_ORANGE));
+    }
+    if let Some(error) = &view.error {
+        lines.push(Line::from(error.clone()).fg(COLOR_WARNING_ACCESSIBLE_RED));
+    }
+    if view.searched && view.pending.is_none() && view.error.is_none() && view.results.is_empty() {
+        lines.push(hint("No listed vetter matches. Fewer filters find more."));
+    }
+    for (i, row) in view.results.iter().enumerate() {
+        let selected = view.result_index() == Some(i);
+        let style = if selected {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            label()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(if selected { "▸ " } else { "  " }, style),
+            Span::styled(row.name.clone(), style),
+            Span::styled(
+                format!("  {}", display_identifier(None, &row.did, 48)),
+                dim(),
+            ),
+        ]));
+        let mut about = vec![format!("speaks {}", row.languages)];
+        about.extend(row.location.clone());
+        about.push(row.methods.clone());
+        lines.push(Line::from(Span::styled(
+            format!("    {}", about.join(" · ")),
+            value(),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("    accepts {}", row.documentation),
+            value(),
+        )));
+        if let Some(availability) = &row.availability {
+            lines.push(Line::from(Span::styled(
+                format!("    available {availability}"),
+                value(),
+            )));
+        }
+        for event in &row.events {
+            lines.push(Line::from(Span::styled(format!("    at {event}"), value())));
+        }
+        lines.push(Line::from(Span::styled(
+            format!(
+                "    getting a ticket: {}",
+                row.contact_hint
+                    .as_deref()
+                    .unwrap_or("they have not said — ask them in person or through the community")
+            ),
+            Style::new().fg(COLOR_TEXT_DEFAULT),
+        )));
+        lines.push(Line::from(Span::styled(
+            format!("    named a vetter until {}", row.grant_until),
+            dim(),
+        )));
+    }
+    lines.push(Line::from(""));
+    if view.searched {
+        let more = if view.next_cursor.is_some() {
+            "  n: next page"
+        } else {
+            "  last page"
+        };
+        let back = if view.cursors.len() > 1 {
+            "  p: previous page"
+        } else {
+            ""
+        };
+        lines.push(hint(format!(
+            "Page {}{more}{back}",
+            view.cursors.len().max(1)
+        )));
+    }
+    lines.push(hint(if f >= DIRECTORY_FIELDS {
+        "Enter or a: ask this vetter  ↑/↓: move  Esc: back"
+    } else {
+        "Enter: search  ↑/↓ or Tab: move  ←/→: choose  Esc: back"
+    }));
+}
+
+fn profile(lines: &mut Vec<Line<'static>>, v: &VettingState, form: &VetterProfileForm) {
+    lines.push(heading("Your vetter profile"));
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "What applicants see when they look for a vetter. Being listed is your choice: unlisted,",
+    ));
+    lines.push(hint(
+        "the community keeps the profile, and only people you give a ticket can reach you.",
+    ));
+    if let Some((line_tone, line)) = &form.state_line {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(line.clone(), tone(*line_tone))));
+    }
+    lines.push(Line::from(""));
+    let f = form.field;
+    let d = &form.draft;
+    let membership = v.memberships.get(form.membership_index);
+    let mut line = field(
+        "Community",
+        membership.map(|m| m.name.clone()).unwrap_or_default(),
+        f == 0,
+        false,
+    );
+    if let Some(m) = membership {
+        line.spans.insert(2, accent_swatch(m.accent));
+    }
+    lines.push(line);
+    lines.push(field(
+        "Listed",
+        format!("{}  show me in the directory", tick(d.listed)),
+        f == 1,
+        false,
+    ));
+    lines.push(field("Display name", d.display_name.clone(), f == 2, true));
+    lines.push(field("Languages", d.languages.clone(), f == 3, true));
+    lines.push(field("Country", d.country.clone(), f == 4, true));
+    lines.push(field("Region", d.region.clone(), f == 5, true));
+    lines.push(field("City", d.city.clone(), f == 6, true));
+    for (i, method) in [
+        VettingMethod::InPerson,
+        VettingMethod::Video,
+        VettingMethod::PriorAcquaintance,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        lines.push(field(
+            if i == 0 { "I vet" } else { "" },
+            format!(
+                "{}  {}",
+                tick(d.methods.contains(&method)),
+                method_label(method)
+            ),
+            f == 7 + i,
+            false,
+        ));
+    }
+    lines.push(field(
+        "Documents I accept",
+        d.accepts_documentation.clone(),
+        f == 10,
+        true,
+    ));
+    lines.push(field("Availability", d.availability.clone(), f == 11, true));
+    lines.push(field(
+        "How to get a ticket",
+        d.contact_hint.clone(),
+        f == 12,
+        true,
+    ));
+    lines.push(Line::from(""));
+    lines.push(Line::from(" Events you will vet at").fg(COLOR_SUCCESS));
+    for (i, event) in d.events.iter().enumerate() {
+        let selected = f == PROFILE_FIELDS + i;
+        let shown = match event.to_event() {
+            Ok(e) => event_line(&e),
+            Err(e) => format!("{} — {e}", event.name),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                if selected { "▸ " } else { "  " },
+                Style::new().fg(COLOR_SUCCESS).bold(),
+            ),
+            Span::styled(
+                shown,
+                if selected {
+                    Style::new().fg(COLOR_SUCCESS).bold()
+                } else {
+                    value()
+                },
+            ),
+        ]));
+    }
+    let add = form.on_add_event();
+    lines.push(Line::from(Span::styled(
+        format!("{}+ add an event", if add { "▸ " } else { "  " }),
+        if add {
+            Style::new().fg(COLOR_SUCCESS).bold()
+        } else {
+            dim()
+        },
+    )));
+    if let Some(error) = &form.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(error.clone()).fg(COLOR_WARNING_ACCESSIBLE_RED));
+    }
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "↑/↓: move  type to edit  Space: tick  Enter on an event: edit  x: remove it",
+    ));
+    lines.push(hint(
+        "Enter elsewhere: publish  ←/→: community  Esc: cancel",
+    ));
+}
+
+fn event_form(lines: &mut Vec<Line<'static>>, event: &EventForm) {
+    lines.push(heading(if event.index.is_some() {
+        "Edit an event"
+    } else {
+        "Add an event you will vet at"
+    }));
+    lines.push(Line::from(""));
+    lines.push(hint(
+        "Applicants find vetters by event, so they can meet you there. At most 31 days long.",
+    ));
+    lines.push(Line::from(""));
+    let d = &event.draft;
+    let f = event.field;
+    lines.push(field("Name", d.name.clone(), f == 0, true));
+    lines.push(field("First day", d.start_date.clone(), f == 1, true));
+    lines.push(field("Last day", d.end_date.clone(), f == 2, true));
+    lines.push(field("Country", d.country.clone(), f == 3, true));
+    lines.push(field("Region", d.region.clone(), f == 4, true));
+    lines.push(field("City", d.city.clone(), f == 5, true));
+    lines.push(field("Web page", d.url.clone(), f == 6, true));
+    lines.push(hint("  Days are YYYY-MM-DD; the page must be https."));
+    if let Some(error) = &event.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(error.clone()).fg(COLOR_WARNING_ACCESSIBLE_RED));
+    }
+    lines.push(Line::from(""));
+    lines.push(hint("Enter: keep it  ↑/↓: move  Esc: back to the profile"));
 }
 
 fn send_card(
@@ -763,7 +1139,10 @@ fn tickets(lines: &mut Vec<Line<'static>>, v: &VettingState) {
         lines.push(hint("You have no tickets out."));
         lines.push(Line::from(""));
         lines.push(hint(
-            "t: hand out a ticket — read the code to someone, or copy it to send them",
+            "t: hand out a ticket — read the code to someone, or show them its QR code",
+        ));
+        lines.push(hint(
+            "p: your vetter profile  g: ask a community to resend your vetter credential",
         ));
         return;
     }
@@ -795,9 +1174,42 @@ fn tickets(lines: &mut Vec<Line<'static>>, v: &VettingState) {
             ),
         ]));
     }
+    if let Some(row) = v.tickets.get(v.selected)
+        && row.live
+        && let Some(uri) = &row.uri
+    {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled("Read aloud   ", label()),
+            Span::styled(row.code.clone(), Style::new().fg(COLOR_SUCCESS).bold()),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(hint(
+            "Or let them scan this. It carries the ticket and your DID, so they can ask you at once:",
+        ));
+        lines.push(Line::from(""));
+        match qr_lines(uri, super::status::content_width()) {
+            Ok(code) => lines.extend(code),
+            Err(QrError::TooNarrow { needed }) => lines.push(
+                Line::from(format!(
+                    "Widen the window to {needed} columns to show the QR code, or copy the link with u."
+                ))
+                .fg(COLOR_ORANGE),
+            ),
+            Err(QrError::TooLong) => lines.push(
+                Line::from("This ticket's link is too long for a QR code — copy it with u instead.")
+                    .fg(COLOR_ORANGE),
+            ),
+        }
+        lines.push(Line::from(""));
+        lines.push(hint(uri.clone()));
+    }
     lines.push(Line::from(""));
     lines.push(hint(
-        "t: new ticket  y: copy code  d: delete  Tab: next tab",
+        "t: new ticket  y: copy code  u: copy link  d: delete  Tab: next tab",
+    ));
+    lines.push(hint(
+        "p: your vetter profile  g: ask a community to resend your vetter credential",
     ));
 }
 

--- a/openvtc/src/ui/pages/main/mod.rs
+++ b/openvtc/src/ui/pages/main/mod.rs
@@ -252,14 +252,20 @@ impl Component for MainPage {
                 }
             }
             MainMenu::Vetting => {
-                if let Some(current) = self
-                    .props
-                    .main_page
-                    .content_panel
-                    .vetting
-                    .mode
-                    .focused_text()
+                let mode = &self.props.main_page.content_panel.vetting.mode;
+                // A ticket link pasted into the request form fills the whole
+                // form, whichever field has the focus.
+                if matches!(
+                    mode,
+                    crate::state_handler::main_page::content::VettingMode::RequestVetter { .. }
+                ) && trimmed.to_ascii_lowercase().starts_with("vetting-ticket:")
                 {
+                    let _ = self.action_tx.send(Action::Vetting(
+                        crate::state_handler::actions::VettingAction::PasteTicket(
+                            trimmed.to_string(),
+                        ),
+                    ));
+                } else if let Some(current) = mode.focused_text() {
                     let updated = format!("{current}{trimmed}");
                     let _ = self.action_tx.send(Action::Vetting(
                         crate::state_handler::actions::VettingAction::Input(updated),
@@ -2464,6 +2470,11 @@ impl MainPage {
         if !matches!(vetting.mode, VettingMode::List) {
             let text = vetting.mode.focused_text().map(str::to_string);
             let confirming = matches!(vetting.mode, VettingMode::ConfirmDecline { .. });
+            let on_result = matches!(&vetting.mode, VettingMode::Directory(view) if view.result_index().is_some());
+            let on_event = matches!(
+                &vetting.mode,
+                VettingMode::Profile(form) if form.event.is_none() && form.event_index().is_some()
+            );
             let action = match key.code {
                 KeyCode::Esc => Some(V::Back),
                 KeyCode::Enter => Some(V::Submit),
@@ -2475,6 +2486,14 @@ impl MainPage {
                     Some(current) => edit_text(code, &current).map(V::Input),
                     None if code == KeyCode::Char('y') && confirming => Some(V::Submit),
                     None if code == KeyCode::Char('n') && confirming => Some(V::Back),
+                    None if on_result && code == KeyCode::Char('n') => Some(V::DirectoryPage(true)),
+                    None if on_result && code == KeyCode::Char('p') => {
+                        Some(V::DirectoryPage(false))
+                    }
+                    None if on_result && code == KeyCode::Char('a') => Some(V::AskListedVetter),
+                    None if on_event && matches!(code, KeyCode::Char('x') | KeyCode::Delete) => {
+                        Some(V::RemoveEvent)
+                    }
                     None if code == KeyCode::Char(' ') => Some(V::Toggle),
                     None => None,
                 },
@@ -2498,12 +2517,25 @@ impl MainPage {
             (VettingTab::Applications, KeyCode::Char('f')) => V::ChooseFace,
             (VettingTab::Applications, KeyCode::Char('r')) => V::RequestVetter,
             (VettingTab::Applications, KeyCode::Char('m')) => V::RefreshRequirements,
+            (VettingTab::Applications, KeyCode::Char('v')) => V::FindVetters,
             (VettingTab::Applications, KeyCode::Char('c') | KeyCode::Enter) => V::ReviewCard,
             (VettingTab::Desk, KeyCode::Char('o')) => V::OpenSession,
             (VettingTab::Desk, KeyCode::Char('a') | KeyCode::Enter) => V::StartAttest,
             (VettingTab::Desk, KeyCode::Char('x')) => V::ArmDecline,
             (VettingTab::Tickets, KeyCode::Char('t')) => V::NewTicket,
             (VettingTab::Tickets, KeyCode::Char('d')) => V::DeleteTicket,
+            (VettingTab::Tickets, KeyCode::Char('p')) => V::EditProfile,
+            (VettingTab::Tickets, KeyCode::Char('g')) => V::AskResend,
+            (VettingTab::Tickets, KeyCode::Char('u')) => {
+                let Some(uri) = vetting.tickets.get(selected).and_then(|t| t.uri.clone()) else {
+                    return true;
+                };
+                let status = match crate::clipboard::copy_to_clipboard(&uri) {
+                    Ok(method) => format!("Ticket link copied via {}.", method.label()),
+                    Err(e) => format!("Could not copy the link: {e}"),
+                };
+                V::Status(status)
+            }
             (VettingTab::Tickets, KeyCode::Char('y')) => {
                 let Some(ticket) = vetting.tickets.get(selected) else {
                     return true;
@@ -3521,6 +3553,7 @@ mod key_handler_tests {
             request_id: String::new(),
             has_membership_credential: false,
             has_role_credential: false,
+            accent: None,
         }
     }
 
@@ -3626,6 +3659,8 @@ mod key_handler_tests {
                 application_id: "a1".into(),
                 vetter: "did:key:z".into(),
                 code: String::new(),
+                ticket: None,
+                note: None,
                 field: 0,
             };
         });
@@ -3654,6 +3689,133 @@ mod key_handler_tests {
         });
         page.handle_key_event(press(KeyCode::Char('n')));
         assert!(matches!(vetting_action(&mut rx), V::Back));
+    }
+
+    #[test]
+    fn vetting_directory_results_page_and_ask_while_filters_take_text() {
+        use crate::state_handler::actions::VettingAction as V;
+        use crate::state_handler::main_page::content::{
+            DIRECTORY_FIELDS, DirectoryView, ListedVetterRow, VettingMode,
+        };
+        let row = ListedVetterRow {
+            did: "did:key:zCarol".into(),
+            name: "Carol".into(),
+            languages: "en".into(),
+            location: None,
+            methods: "in person".into(),
+            documentation: "passport".into(),
+            availability: None,
+            contact_hint: None,
+            events: vec![],
+            grant_until: "2027-09-01".into(),
+        };
+        let on = |field: usize| {
+            let row = row.clone();
+            page_for(MainMenu::Vetting, move |s| {
+                s.main_page.content_panel.vetting.mode =
+                    VettingMode::Directory(Box::new(DirectoryView {
+                        results: vec![row],
+                        searched: true,
+                        field,
+                        ..DirectoryView::default()
+                    }));
+            })
+        };
+        let (mut page, mut rx) = on(DIRECTORY_FIELDS);
+        page.handle_key_event(press(KeyCode::Char('n')));
+        assert!(matches!(vetting_action(&mut rx), V::DirectoryPage(true)));
+        page.handle_key_event(press(KeyCode::Char('p')));
+        assert!(matches!(vetting_action(&mut rx), V::DirectoryPage(false)));
+        page.handle_key_event(press(KeyCode::Char('a')));
+        assert!(matches!(vetting_action(&mut rx), V::AskListedVetter));
+        page.handle_key_event(press(KeyCode::Enter));
+        assert!(matches!(vetting_action(&mut rx), V::Submit));
+
+        // On the language filter the same letters are typing.
+        let (mut page, mut rx) = on(1);
+        page.handle_key_event(press(KeyCode::Char('n')));
+        assert!(matches!(vetting_action(&mut rx), V::Input(text) if text == "n"));
+    }
+
+    #[test]
+    fn vetting_tickets_tab_copies_the_link_and_opens_the_profile_and_resend() {
+        use crate::state_handler::actions::VettingAction as V;
+        use crate::state_handler::main_page::content::VettingTab;
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |s| {
+            s.main_page.content_panel.vetting.tab = VettingTab::Tickets;
+        });
+        page.handle_key_event(press(KeyCode::Char('p')));
+        assert!(matches!(vetting_action(&mut rx), V::EditProfile));
+        page.handle_key_event(press(KeyCode::Char('g')));
+        assert!(matches!(vetting_action(&mut rx), V::AskResend));
+        // No ticket selected: copying the link does nothing.
+        page.handle_key_event(press(KeyCode::Char('u')));
+        assert!(rx.try_recv().is_err());
+
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |_| {});
+        page.handle_key_event(press(KeyCode::Char('v')));
+        assert!(matches!(vetting_action(&mut rx), V::FindVetters));
+    }
+
+    #[test]
+    fn vetting_profile_event_rows_remove_and_ticks_toggle() {
+        use crate::state_handler::actions::VettingAction as V;
+        use crate::state_handler::main_page::content::{
+            PROFILE_FIELDS, VetterProfileForm, VettingMode,
+        };
+        use openvtc_core::vetting::book::VetterPolicy;
+        use openvtc_core::vetting::registry::{EventDraft, ProfileDraft};
+        let form = |field: usize| {
+            let mut draft = ProfileDraft::new(&VetterPolicy::default());
+            draft.events.push(EventDraft::default());
+            VetterProfileForm {
+                membership_index: 0,
+                draft,
+                field,
+                event: None,
+                error: None,
+                state_line: None,
+            }
+        };
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |s| {
+            s.main_page.content_panel.vetting.mode =
+                VettingMode::Profile(Box::new(form(PROFILE_FIELDS)));
+        });
+        page.handle_key_event(press(KeyCode::Char('x')));
+        assert!(matches!(vetting_action(&mut rx), V::RemoveEvent));
+
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, |s| {
+            s.main_page.content_panel.vetting.mode = VettingMode::Profile(Box::new(form(1)));
+        });
+        page.handle_key_event(press(KeyCode::Char(' ')));
+        assert!(matches!(vetting_action(&mut rx), V::Toggle));
+        page.handle_key_event(press(KeyCode::Char('x')));
+        assert!(rx.try_recv().is_err(), "x removes nothing off an event row");
+    }
+
+    #[test]
+    fn vetting_a_pasted_ticket_link_fills_the_request_form() {
+        use crate::state_handler::actions::VettingAction as V;
+        use crate::state_handler::main_page::content::VettingMode;
+        let request = |s: &mut State| {
+            s.main_page.content_panel.vetting.mode = VettingMode::RequestVetter {
+                application_id: "a1".into(),
+                vetter: String::new(),
+                code: String::new(),
+                ticket: None,
+                note: None,
+                field: 0,
+            };
+        };
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, request);
+        page.handle_paste_event("  vetting-ticket:?v=1&community=did%3Akey%3Az&vetter=x  ");
+        assert!(matches!(
+            vetting_action(&mut rx),
+            V::PasteTicket(text) if text.starts_with("vetting-ticket:")
+        ));
+        let (mut page, mut rx) = page_for(MainMenu::Vetting, request);
+        page.handle_paste_event("did:key:zCarol");
+        assert!(matches!(vetting_action(&mut rx), V::Input(text) if text == "did:key:zCarol"));
     }
 
     // ----- Communities -------------------------------------------------------


### PR DESCRIPTION
Restores #302 onto `main`.

**What happened:** #302's base was never moved from `feat/community-context-actions` to `main`, so squash-merging it landed the work on that branch, which GitHub then deleted with #301's merge. `main` was missing 33 files and roughly 6,900 lines: the guided join page, the vetter directory and profile editor, QR ticket links, the grant revocation check, grant resend and community branding.

**This PR** is that squash commit replayed onto `main`. #301's merged head and `main` have identical trees, so it applied with no conflicts, and the result matches what #302 merged byte for byte. The commit keeps its original message and sign-offs.

**VTI dependency:** the patches stay pinned by `rev` to VTI #1430's commit on VTI `main`, as #302 had them. They go when the VTI release publishes these crates.