### PR TITLE
fix(cli): announce env overrides with a colour role that exists

### DIFF
--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -562,7 +562,7 @@ async fn main() -> Result<()> {
     // screen. The state handler applies them (dev-overrides builds only) and
     // repeats the outcome in the Activity Log.
     if let Some(notice) = env_overrides::startup_notice(|k| env::var(k).ok()) {
-        eprintln!("{}", style(notice).color256(CLI_ORANGE));
+        eprintln!("{}", style(notice).themed(CLI_CAUTION));
     }
 
     // Setup the initial state


### PR DESCRIPTION
**`main` does not compile.** `openvtc/src/main.rs:565` styles the environment-override startup notice with `CLI_ORANGE`, which no longer exists: the theme work (#299, #300) turned the CLI colours into roles applied through `Themed::themed`. The notice arrived in #305, which merged 17 minutes after those, with 7 failing checks.

**The fix** is that one line, now `style(notice).themed(CLI_CAUTION)`, matching every other warning in `main.rs`. `CLI_CAUTION` and `Themed` are already imported there, and this was the only stale use left in the tree.

**Note on #307:** its nine failing checks were all this same error, inherited from `main`, not anything in the vetting restore.

Locally: `cargo fmt --all -- --check` is clean and `cargo check --workspace --all-targets` passes.