### PR TITLE
fix(cli): a debug log only its owner can read, a passphrase file instead of argv, and no literal PIN

### DIFF
--- a/openvtc/src/cli.rs
+++ b/openvtc/src/cli.rs
@@ -1,6 +1,7 @@
 /*! Command Line Interface configuration
 */
 
+use anyhow::Context;
 use clap::{Arg, Command};
 #[cfg(feature = "openpgp-card")]
 use dialoguer::{Password, theme::ColorfulTheme};
@@ -16,11 +17,23 @@ pub fn cli() -> Command {
         .arg_required_else_help(false)
         .args([
             Arg::new("unlock-code").short('u').long("unlock-code").help(
-                "Unlock passphrase for the encrypted config. \
-                     WARNING: command-line arguments are visible to other \
-                     local users via the process list (`ps`, /proc); prefer \
-                     the interactive prompt on shared systems.",
+                "DEPRECATED: use --unlock-code-file instead. Unlock passphrase \
+                     for the encrypted config. WARNING: command-line arguments \
+                     are visible to other local users via the process list \
+                     (`ps`, /proc); prefer --unlock-code-file or the \
+                     interactive prompt on shared systems.",
             ),
+            Arg::new("unlock-code-file")
+                .long("unlock-code-file")
+                .value_name("PATH")
+                // One passphrase, one source. Taking both and silently
+                // preferring one is how the wrong one gets used quietly.
+                .conflicts_with("unlock-code")
+                .help(
+                    "Read the unlock passphrase from the first line of PATH, or \
+                     from standard input when PATH is `-`. Unlike --unlock-code \
+                     this keeps the passphrase out of the process list.",
+                ),
             Arg::new("profile")
                 .short('p')
                 .long("profile")
@@ -92,6 +105,41 @@ pub fn cli() -> Command {
                 ]),
         )
         .subcommand(crate::theme_cmd::command())
+}
+
+/// Read an unlock passphrase from `path`, or from standard input when `path` is
+/// `-`.
+///
+/// Only the first line is taken, and it is trimmed. A trailing newline is what
+/// every editor and every `echo` leaves behind, and a passphrase whose ends are
+/// whitespace cannot be told from one whose ends are not by the person typing it
+/// at the prompt — so both ends go, and anything after the first line is not
+/// part of the passphrase.
+///
+/// An empty first line is an error rather than an empty passphrase: it almost
+/// always means the file was not written, or was written somewhere else.
+pub fn read_unlock_code_file(path: &str) -> anyhow::Result<String> {
+    use std::io::BufRead;
+
+    let mut first_line = String::new();
+    if path == "-" {
+        std::io::stdin()
+            .lock()
+            .read_line(&mut first_line)
+            .context("failed to read the unlock passphrase from standard input")?;
+    } else {
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("failed to open unlock passphrase file `{path}`"))?;
+        std::io::BufReader::new(file)
+            .read_line(&mut first_line)
+            .with_context(|| format!("failed to read unlock passphrase file `{path}`"))?;
+    }
+
+    let passphrase = first_line.trim().to_string();
+    if passphrase.is_empty() {
+        anyhow::bail!("no unlock passphrase on the first line of `{path}`");
+    }
+    Ok(passphrase)
 }
 
 #[cfg(feature = "openpgp-card")]
@@ -226,6 +274,68 @@ mod tests {
                 .is_err(),
             "an unknown format is refused"
         );
+    }
+
+    #[test]
+    fn unlock_code_file_accepts_stdin() {
+        let matches = cli()
+            .try_get_matches_from(["openvtc", "--unlock-code-file", "-"])
+            .expect("`--unlock-code-file -` is valid");
+        assert_eq!(
+            matches
+                .get_one::<String>("unlock-code-file")
+                .map(String::as_str),
+            Some("-"),
+            "`-` reaches the reader as-is, which is how it means standard input"
+        );
+    }
+
+    #[test]
+    fn unlock_code_and_unlock_code_file_conflict() {
+        let err = cli()
+            .try_get_matches_from([
+                "openvtc",
+                "--unlock-code",
+                "from-argv",
+                "--unlock-code-file",
+                "-",
+            ])
+            .expect_err("two sources for one passphrase must be refused");
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::ArgumentConflict,
+            "expected an ArgumentConflict, got: {err}"
+        );
+    }
+
+    #[test]
+    fn unlock_code_file_reads_the_first_line_trimmed() {
+        let dir = std::env::temp_dir().join(format!("openvtc-unlockfile-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create the test directory");
+
+        let path = dir.join("passphrase");
+        // The trailing newline an editor leaves, surrounding whitespace, and a
+        // second line that is not part of the passphrase.
+        std::fs::write(&path, b"  correct horse battery staple  \nignored\n")
+            .expect("write the passphrase file");
+        assert_eq!(
+            read_unlock_code_file(&path.to_string_lossy()).expect("the file reads"),
+            "correct horse battery staple"
+        );
+
+        let empty = dir.join("empty");
+        std::fs::write(&empty, b"\n").expect("write the empty file");
+        assert!(
+            read_unlock_code_file(&empty.to_string_lossy()).is_err(),
+            "an empty first line is an error, not an empty passphrase"
+        );
+
+        assert!(
+            read_unlock_code_file(&dir.join("missing").to_string_lossy()).is_err(),
+            "a path that does not exist is an error"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/openvtc/src/cli.rs
+++ b/openvtc/src/cli.rs
@@ -148,11 +148,9 @@ pub fn get_user_pin() -> anyhow::Result<SecretString> {
         .with_prompt("Please enter Token User PIN")
         .allow_empty_password(false)
         .interact()?;
-    if user_pin.is_empty() {
-        Ok(SecretString::new("123456".into()))
-    } else {
-        Ok(SecretString::new(user_pin.into()))
-    }
+    // `allow_empty_password(false)` above means this cannot be empty, which is
+    // what made the factory-PIN fallback that used to sit here dead code.
+    Ok(SecretString::new(user_pin.into()))
 }
 
 #[cfg(test)]

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -301,6 +301,60 @@ fn redact_paths(msg: &str) -> String {
     }
 }
 
+/// Open the `OPENVTC_DEBUG_LOG` file for appending, owner-only on unix.
+///
+/// Append, never truncate. `File::create` truncated on every launch, so the
+/// evidence from a failed run was destroyed by the restart used to reproduce it
+/// — the exact workflow this variable exists to serve. Each run announces
+/// itself, so runs stay separable in one file.
+///
+/// Two things beyond a plain append:
+///
+/// * **Mode 0600.** Created with the process umask otherwise, which on a
+///   default `022` leaves a world-readable trace of DIDs, profile names and
+///   message metadata in whatever directory the operator named — often a shared
+///   `/tmp`. An already-existing file is tightened through the open handle, so
+///   a log left behind by an earlier, looser run does not stay readable.
+/// * **A symlink is refused.** Creating through a link planted in a
+///   world-writable directory would append this process's log to a file of the
+///   planter's choosing, so a symlink at `path` is an error, not a target.
+fn open_debug_log(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    // `symlink_metadata` does not follow the final component, so this sees the
+    // link itself rather than what it points at. A missing path is the normal
+    // case: it is about to be created.
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "refusing to write the debug log through a symlink",
+            ));
+        }
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options.open(path)?;
+
+    // `mode` above applies only when the file is created. Tighten an existing
+    // one too, through the handle rather than the path, so there is no window
+    // between the check and the change.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(file)
+}
+
 // ****************************************************************************
 // MAIN Function
 // ****************************************************************************
@@ -310,20 +364,19 @@ async fn main() -> Result<()> {
     // Optional file-based debug logging.
     // Set OPENVTC_DEBUG_LOG to a file path to enable, e.g.:
     //   OPENVTC_DEBUG_LOG=/tmp/openvtc.log cargo run -p openvtc
-    // Log level defaults to "debug" but can be overridden with RUST_LOG.
+    // Log level defaults to this workspace's own crates but can be overridden
+    // with RUST_LOG.
     if let Ok(log_path) = env::var("OPENVTC_DEBUG_LOG") {
-        // Append, never truncate. `File::create` truncated on every launch, so
-        // the evidence from a failed run was destroyed by the restart used to
-        // reproduce it — the exact workflow this variable exists to serve.
-        // Each run announces itself below, so runs stay separable in one file.
-        match std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&log_path)
-        {
+        match open_debug_log(std::path::Path::new(&log_path)) {
             Ok(log_file) => {
-                let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("debug"));
+                // Default to this workspace's own spans. The previous default
+                // was a bare "debug", which also turned on every dependency —
+                // hyper, the SDKs — and buried the openvtc trace in transport
+                // noise while widening what lands in the file. RUST_LOG wins.
+                let filter =
+                    tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                        tracing_subscriber::EnvFilter::new("info,openvtc=debug,openvtc_core=debug")
+                    });
                 tracing_subscriber::fmt()
                     .with_env_filter(filter)
                     .with_writer(std::sync::Mutex::new(log_file))
@@ -335,6 +388,13 @@ async fn main() -> Result<()> {
                 tracing::info!(
                     version = env!("CARGO_PKG_VERSION"),
                     "───── openvtc run started ─────  (appending to {log_path})"
+                );
+                // Say where it is and what is in it. The file carries DIDs,
+                // profile names and message metadata, so an operator about to
+                // attach it to a bug report should be told before they do.
+                eprintln!(
+                    "debug log enabled at {log_path}; it may contain identifiers and message \
+                     metadata — do not share it."
                 );
             }
             Err(e) => {
@@ -758,4 +818,99 @@ fn load_fast(profile: &str, unlock_code_arg: Option<&str>) -> Result<DeferredLoa
         #[cfg(feature = "openpgp-card")]
         user_pin,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A private directory under the system temp dir, following the convention
+    /// the rest of this crate's tests use.
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("openvtc-debuglog-{tag}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create the test directory");
+        dir
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn debug_log_is_created_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = temp_dir("mode");
+        let path = dir.join("openvtc.log");
+        let file = open_debug_log(&path).expect("a fresh path opens");
+        drop(file);
+
+        let mode = std::fs::metadata(&path)
+            .expect("the log exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "the debug log carries identifiers, so it must not be readable by other local users"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn debug_log_tightens_a_loose_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = temp_dir("tighten");
+        let path = dir.join("openvtc.log");
+        std::fs::write(&path, b"from an earlier run\n").expect("seed the log");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("loosen the log");
+
+        let file = open_debug_log(&path).expect("an existing path opens");
+        drop(file);
+
+        let mode = std::fs::metadata(&path)
+            .expect("the log exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "a log left loose by an earlier run is tightened"
+        );
+        // Tightening must not cost the earlier run's evidence.
+        assert_eq!(
+            std::fs::read(&path).expect("read the log"),
+            b"from an earlier run\n",
+            "the existing contents are appended to, not truncated"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn debug_log_refuses_a_symlink() {
+        let dir = temp_dir("symlink");
+        let target = dir.join("target.log");
+        let link = dir.join("link.log");
+        std::fs::write(&target, b"").expect("create the target");
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&target, &link).expect("create the symlink");
+
+        let err = open_debug_log(&link).expect_err("a symlink must be refused");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::InvalidInput,
+            "a pre-planted link is an error, not a target: {err}"
+        );
+        assert_eq!(
+            std::fs::read(&target).expect("read the target").len(),
+            0,
+            "nothing was written through the link"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -89,13 +89,19 @@ async fn load_config_for_health(
         fn touch_completed(&self) {}
     }
 
+    // `load_fast` hands back `None` when no card is in play, and `load_step2`
+    // still takes the argument it will not read: an empty secret, rather than a
+    // literal PIN standing in for one.
+    #[cfg(feature = "openpgp-card")]
+    let no_token_pin = SecretString::new(String::new().into());
+
     match Config::load_step2(
         &mut tdk,
         profile,
         deferred.public_config,
         deferred.unlock_passphrase.as_ref(),
         #[cfg(feature = "openpgp-card")]
-        &deferred.user_pin,
+        deferred.user_pin.as_ref().unwrap_or(&no_token_pin),
         #[cfg(feature = "openpgp-card")]
         &TouchPrompt,
         None,
@@ -841,11 +847,18 @@ fn load_fast(
         ConfigProtectionType::Plaintext => None,
     };
 
+    // Only a Token-protected profile ever talks to a card, so only that one asks
+    // for a PIN. There used to be a literal placeholder PIN here for every other
+    // protection type; `None` says the same thing without compiling a PIN into
+    // the binary.
     #[cfg(feature = "openpgp-card")]
     let user_pin = if matches!(&public_config.protection, ConfigProtectionType::Token(_)) {
-        get_user_pin().map_err(|e| OpenVTCError::Config(format!("Failed to get user PIN: {e}")))?
+        Some(
+            get_user_pin()
+                .map_err(|e| OpenVTCError::Config(format!("Failed to get user PIN: {e}")))?,
+        )
     } else {
-        SecretString::new("123456".into())
+        None
     };
 
     Ok(DeferredLoad {

--- a/openvtc/src/main.rs
+++ b/openvtc/src/main.rs
@@ -43,7 +43,10 @@ mod ui;
 /// command reads DID documents, and holding a live mediator connection open for
 /// that would add a second socket for the profile the running TUI may already
 /// own.
-async fn load_config_for_health(profile: &str, unlock_code_arg: Option<&str>) -> Option<Config> {
+async fn load_config_for_health(
+    profile: &str,
+    unlock_code_arg: Option<&SuppliedUnlockCode>,
+) -> Option<Config> {
     let deferred = match load_fast(profile, unlock_code_arg) {
         Ok(deferred) => deferred,
         Err(OpenVTCError::ConfigNotFound(_, _)) => return None,
@@ -425,7 +428,23 @@ async fn main() -> Result<()> {
         .get_one::<String>("profile")
         .cloned()
         .unwrap_or_else(|| "default".to_string());
-    let unlock_code_arg = matches.get_one::<String>("unlock-code").cloned();
+    // `--unlock-code-file` (a path, or `-` for standard input) takes the place of
+    // `--unlock-code`, which clap refuses alongside it. Read eagerly so a bad
+    // path fails here, with a clear message, rather than after the profile has
+    // been opened.
+    let unlock_code_arg = match matches.get_one::<String>("unlock-code-file") {
+        Some(path) => Some(SuppliedUnlockCode {
+            passphrase: cli::read_unlock_code_file(path)?,
+            from_argv: false,
+        }),
+        None => matches
+            .get_one::<String>("unlock-code")
+            .cloned()
+            .map(|passphrase| SuppliedUnlockCode {
+                passphrase,
+                from_argv: true,
+            }),
+    };
     let setup_requested = matches!(matches.subcommand(), Some(("setup", _)));
 
     // Optional invitation credential (VIC) to present when joining a community.
@@ -510,7 +529,7 @@ async fn main() -> Result<()> {
             .map(|values| values.cloned().collect())
             .unwrap_or_default();
         let as_json = health_args.get_flag("json");
-        let config = load_config_for_health(&profile, unlock_code_arg.as_deref()).await;
+        let config = load_config_for_health(&profile, unlock_code_arg.as_ref()).await;
         let recoverable = health_args.get_flag("recoverable");
         let allow_private_probes = health_args.get_flag("allow-private-probes");
         return health_cmd::run(
@@ -535,7 +554,7 @@ async fn main() -> Result<()> {
     }
 
     if let StartingMode::NotSet = starting_mode {
-        match load_fast(&profile, unlock_code_arg.as_deref()) {
+        match load_fast(&profile, unlock_code_arg.as_ref()) {
             Ok(deferred) => {
                 starting_mode = StartingMode::MainPageDeferred(deferred);
             }
@@ -740,24 +759,42 @@ pub fn apply_env_overrides(config: &mut Config) {
 /// Maximum number of interactive unlock attempts before aborting.
 const MAX_UNLOCK_ATTEMPTS: usize = 5;
 
+/// A non-interactive unlock passphrase, and where it came from.
+///
+/// The source is carried because only one of the two routes earns the
+/// process-list warning: `--unlock-code` puts the passphrase in argv, where any
+/// local user can read it out of `ps`, and `--unlock-code-file` exists precisely
+/// to avoid that. Warning about the safe route as well is how a warning gets
+/// trained out of people.
+struct SuppliedUnlockCode {
+    passphrase: String,
+    from_argv: bool,
+}
+
 /// Fast, synchronous load — only does local config read + terminal prompts.
 /// Network-heavy work (TDK init, DID resolution, VTA auth) is deferred to the state handler.
-fn load_fast(profile: &str, unlock_code_arg: Option<&str>) -> Result<DeferredLoad, OpenVTCError> {
+fn load_fast(
+    profile: &str,
+    unlock_code_arg: Option<&SuppliedUnlockCode>,
+) -> Result<DeferredLoad, OpenVTCError> {
     let public_config = Config::load_step1(profile)?;
 
     let unlock_passphrase = match &public_config.protection {
         ConfigProtectionType::Token { .. } => None,
         ConfigProtectionType::Encrypted => {
-            if let Some(passphrase) = unlock_code_arg {
-                eprintln!(
-                    "{}",
-                    style(
-                        "WARNING: --unlock-code exposes the passphrase in the process list; \
-                         prefer the interactive prompt on shared systems."
-                    )
-                    .themed(CLI_CAUTION)
-                );
-                Some(UnlockCode::from_string(passphrase)?)
+            if let Some(supplied) = unlock_code_arg {
+                if supplied.from_argv {
+                    eprintln!(
+                        "{}",
+                        style(
+                            "WARNING: --unlock-code exposes the passphrase in the process list; \
+                             prefer --unlock-code-file or the interactive prompt on shared \
+                             systems."
+                        )
+                        .themed(CLI_CAUTION)
+                    );
+                }
+                Some(UnlockCode::from_string(&supplied.passphrase)?)
             } else {
                 let mut result = None;
                 for attempt in 1..=MAX_UNLOCK_ATTEMPTS {

--- a/openvtc/src/state_handler/mod.rs
+++ b/openvtc/src/state_handler/mod.rs
@@ -270,8 +270,10 @@ pub struct DeferredLoad {
     pub profile: String,
     pub public_config: PublicConfig,
     pub unlock_passphrase: Option<UnlockCode>,
+    /// The card's User PIN, or `None` when the profile is not Token-protected
+    /// and no card is involved. Never a placeholder PIN.
     #[cfg(feature = "openpgp-card")]
-    pub user_pin: SecretString,
+    pub user_pin: Option<SecretString>,
 }
 
 pub enum StartingMode {
@@ -552,6 +554,12 @@ impl StateHandler {
                     #[cfg(not(feature = "openpgp-card"))]
                     drop(token_touch_tx);
 
+                    // No card in play means no PIN; `load_step2` still takes the
+                    // argument it will not read, so it gets an empty secret
+                    // rather than a literal PIN standing in for one.
+                    #[cfg(feature = "openpgp-card")]
+                    let no_token_pin = SecretString::new(String::new().into());
+
                     // PERF #1: load_step2 returns its live admin VTA session for
                     // reuse downstream instead of opening a second one here.
                     let (config, admin_session) = Config::load_step2(
@@ -560,7 +568,7 @@ impl StateHandler {
                         deferred.public_config,
                         deferred.unlock_passphrase.as_ref(),
                         #[cfg(feature = "openpgp-card")]
-                        &deferred.user_pin,
+                        deferred.user_pin.as_ref().unwrap_or(&no_token_pin),
                         #[cfg(feature = "openpgp-card")]
                         &token_notifier,
                         Some(&on_progress),


### PR DESCRIPTION

Three small, independent hardening items, one commit each.

## 1. The `OPENVTC_DEBUG_LOG` file

Opened with `create().append()` and nothing else, so the file was created with
the process umask — on a default 022 that leaves a **world-readable** trace of
DIDs, profile names and message metadata in whatever directory the operator
named, often a shared `/tmp`.

- Created `0600` on unix. An existing file is tightened through the open handle
  rather than the path, so there is no window between the check and the change,
  and a log left loose by an earlier run does not stay readable.
- A **symlink at the path is refused**. Creating through a link planted in a
  world-writable directory would append this process's log to a file of the
  planter's choosing. `symlink_metadata` does not follow the final component, so
  this sees the link rather than its target; a missing path is still fine.
- The default filter was a bare `"debug"`, which also turned on every dependency
  — hyper, the SDKs — and buried the openvtc trace in transport noise while
  widening what reached the file. Now `info,openvtc=debug,openvtc_core=debug`.
  `RUST_LOG` still wins.
- Enabling the log says so on stderr, and says the file carries identifiers,
  because the moment to tell someone that is before they attach it to an issue.

A spot-check for secret *values* reaching `debug!` found only message strings,
so no redaction layer is added here.

## 2. `--unlock-code-file <PATH|->`

`--unlock-code` puts the passphrase in argv, readable by any local user through
`ps` or `/proc`. It stays — scripts use it — but is marked DEPRECATED in its help
text, and the existing runtime warning now names the replacement.

The new flag reads the first line of `PATH`, trimmed, or standard input when
`PATH` is `-`. clap refuses both flags at once. An empty first line is an error
rather than an empty passphrase, and the path is read before the profile is
opened so a bad one fails with a clear message rather than mid-unlock.

The process-list warning is gated on where the passphrase came from: warning
about the route that exists to avoid the problem is how a warning gets trained
out of people. That is what the new `SuppliedUnlockCode { passphrase, from_argv }`
carries.

## 3. No literal PIN in the binary

`get_user_pin()` sets `.allow_empty_password(false)`, so its
`if user_pin.is_empty() { "123456" }` branch was dead — deleted. `load_fast`
also built a literal `"123456"` placeholder for every non-Token protection type,
where no card is ever used; `DeferredLoad.user_pin` becomes an `Option` and that
case is `None`. The two `load_step2` call sites pass an empty secret for the
argument the non-token path never reads, which is the idiom already used in
`dispatch_util.rs` and `setup_sequence/config.rs`.

Hygiene, not a live vulnerability — the branch was unreachable — but it stops the
scanners re-reporting a hardcoded PIN, and no PIN literal is compiled in.

## Tests

- `open_debug_log` extracted as a function: the created file is `0600`, a loose
  pre-existing file is tightened without truncating it, and a symlink is refused
  with `InvalidInput` and nothing written through the link.
- `--unlock-code-file -` parses; `--unlock-code` alongside it is an
  `ArgumentConflict`; the first line of a temp file is read and trimmed, a second
  line is ignored, and an empty or missing file is an error.

## Verification

On this branch: `cargo fmt --all --check` clean, `cargo clippy --workspace
--all-targets -- -D warnings` clean, `cargo test -p openvtc-core -p openvtc`
green (560 + 625 unit tests plus the integration suites), and `cargo check -p
openvtc --no-default-features` clean — the `user_pin` change sits behind
`#[cfg(feature = "openpgp-card")]`, so the feature-off shape is checked too.

## Note for reviewers

Branched from `0dd3cab` — `main` as it stood when #304 merged. `main` has since
moved to `8c23834` with #305 and #307 in it. This branch merges into that
cleanly: `main.rs` and `state_handler/mod.rs` both auto-merge, with no conflict.

That merge was tested rather than assumed. On the merged tree, the gate #305 added
to CI — `cargo clippy -p openvtc --all-targets --features dev-overrides -- -D
warnings` and `cargo test -p openvtc --features dev-overrides` — is clean and
passes 584 tests.

One local patch was needed to get that far, and it is **not** from this branch:
`main` at `8c23834` does not compile on its own. `main.rs` calls
`style(notice).color256(CLI_ORANGE)`, and no `CLI_ORANGE` exists in `colors.rs`
(`color256` also wants a `u8`, where the roles are `Role`). That is what the open
#308 fixes; I patched it locally to `.themed(CLI_CAUTION)` for the duration of
the check only. Worth landing #308 before this.
