### PR TITLE
ci: pin every action to a commit SHA, drop write-all, and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+# The workflows pin every action to a commit SHA with the tag in a trailing
+# comment; Dependabot understands that shape and bumps the SHA and the comment
+# together, which is what keeps pinning from going stale.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      # Let a hijacked or re-tagged release be noticed before it is proposed
+      # here. Security updates bypass the cooldown.
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci(deps)"
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      cargo:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,30 +6,50 @@ on:
   pull_request:
     branches: [main, development]
 
+# Read-only by default. Without this block every job inherits the repository
+# default, which is write-all, and hands that token to third-party actions.
+# Jobs that need more say so themselves (see `audit`).
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Every third-party action is pinned to a full-length commit SHA with the tag it
+# resolved from in a trailing comment: a tag is mutable, so `@v4` re-points
+# under us and a compromised upstream reaches CI without a commit here.
+# Dependabot bumps the SHA and the comment together (.github/dependabot.yml).
+#
+# The Rust toolchain is installed with plain `rustup`, which the hosted runners
+# already ship, rather than an action: `dtolnay/rust-toolchain@stable` is a
+# branch ref, and pinning a branch tip gives Dependabot no tag to follow.
 jobs:
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
-          components: rustfmt
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component rustfmt
+          rustup default stable
       - run: cargo fmt --all --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component clippy
+          rustup default stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -41,9 +61,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
@@ -58,9 +83,14 @@ jobs:
     name: Test (no default features)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install system dependencies
         # libpcsclite-dev: the pcsc build script runs even with default
         # features off (dev-dependency chain), and needs the system lib.
@@ -78,11 +108,14 @@ jobs:
     name: Test (dev-overrides)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component clippy
+          rustup default stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
       # The trust-anchor env overrides compile only under this feature, so the
@@ -94,9 +127,14 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
       - run: cargo doc --workspace --no-deps
@@ -107,9 +145,14 @@ jobs:
     name: Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
       - run: cargo bench --workspace --no-run
@@ -118,9 +161,15 @@ jobs:
     name: Minimum Supported Rust Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.95.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      # Pinned to the workspace's `rust-version`; move both together.
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install 1.95.0 --profile minimal
+          rustup default 1.95.0
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
       - run: cargo check --workspace
@@ -128,9 +177,18 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    # `checks: write` is what audit-check needs to publish its advisories as
+    # check-run annotations; without it the action cannot create the check and
+    # the job fails on that instead of on the advisory. Narrower than the
+    # repository default this job would otherwise inherit.
+    permissions:
+      contents: read
+      checks: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -138,8 +196,10 @@ jobs:
     name: Cargo Deny (licenses + advisories + bans)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories licenses bans sources
 
@@ -147,13 +207,21 @@ jobs:
     name: Coverage (llvm-cov)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
-          components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+          persist-credentials: false
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component llvm-tools-preview
+          rustup default stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      # `@cargo-llvm-cov` is a tool tag that upstream re-points on every
+      # release, so the tool moves to the `with: tool:` input and the action
+      # itself takes a versioned tag Dependabot can track.
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@9534c84618278caac52cb373bb164ed464dbd8af # v2.87.11
+        with:
+          tool: cargo-llvm-cov
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libpcsclite-dev libdbus-1-dev
       - name: Generate coverage (lcov)
@@ -161,7 +229,7 @@ jobs:
         # tests still contribute to the report.
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info -- --include-ignored
       - name: Upload lcov artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: lcov.info
           path: lcov.info

--- a/.github/workflows/verify-trust.yml
+++ b/.github/workflows/verify-trust.yml
@@ -27,12 +27,21 @@ jobs:
     if: vars.TRUST_REGISTRY_URL != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # The verifier walks raw commit objects across base..head.
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: OpenVTC/verifiable-git-infrastructure/.github/actions/verify-trust@v0.1.1
+      # Pinned to the v0.1.1 commit rather than the tag: a tag can be moved, and
+      # this action runs with the workflow's token on every pull request.
+      #
+      # TODO: move to VGI >= 0.4.9 when it is released. 0.4.9 is the fix for an
+      # input-injection issue in the composite action, and it also renames the
+      # `authority:` input to `vtc-did:` — so the upgrade is a SHA bump plus that
+      # input rename, not a drop-in. The latest VGI release is v0.4.8, which does
+      # not carry the fix, so there is nothing to move to yet.
+      - uses: OpenVTC/verifiable-git-infrastructure/.github/actions/verify-trust@d4186e5d819c2cbd1247a4d0e6cbd373d25dd0b2 # v0.1.1
         with:
           range: origin/${{ github.base_ref }}..HEAD
           registry-url: ${{ vars.TRUST_REGISTRY_URL }}


### PR DESCRIPTION

`ci.yml` and `verify-trust.yml` between them used **34** `uses:` refs, not one of
them pinned, and `ci.yml` had no `permissions:` block at all — so every job
inherited the repository default of write-all and handed that token to
third-party actions, one of which (`rustsec/audit-check`) is explicitly given
`secrets.GITHUB_TOKEN`.

## What changed

**Pinning.** The 25 refs that remain now name a full-length commit SHA with the
tag it resolved from in a trailing comment. SHAs were resolved with `gh api`,
dereferencing annotated tags:

| Action | Pin |
|---|---|
| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` # v4.4.0 |
| `Swatinem/rust-cache` | `6323deb102c322ba6fcbdcafc7e3dddab59af2b6` # v2.9.2 |
| `rustsec/audit-check` | `69366f33c96575abad1ee0dba8212993eecbe998` # v2.0.0 |
| `EmbarkStudios/cargo-deny-action` | `3c6349835b2b7b196a839186cb8b78e02f7b5f25` # v2.1.1 |
| `taiki-e/install-action` | `9534c84618278caac52cb373bb164ed464dbd8af` # v2.87.11 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` # v4.6.2 |
| `…/verify-trust` (VGI) | `d4186e5d819c2cbd1247a4d0e6cbd373d25dd0b2` # v0.1.1 |

`git grep -nE 'uses: *[^ .][^ ]*@' -- .github | grep -vE '@[0-9a-f]{40} '` is
now empty.

**The toolchain action is gone.** The nine `dtolnay/rust-toolchain@stable` /
`@1.95.0` refs were branch refs, and pinning a branch tip would leave Dependabot
nothing to follow. They are nine plain `rustup` steps now — the hosted runners
already ship rustup. The MSRV job stays on 1.95.0, the workspace's
`rust-version`; move both together. `taiki-e/install-action@cargo-llvm-cov` (a
tool tag upstream re-points on every release) becomes a versioned tag plus
`with: tool: cargo-llvm-cov`, which gives Dependabot a semver tag to track.

**Permissions.** Top-level `contents: read` on `ci.yml`. The `audit` job declares
`contents: read` + `checks: write`: that is what `rustsec/audit-check` needs to
publish advisories as check-run annotations (its README documents `checks: write`
for the check run, and `issues: write` only for the issue-filing mode this
workflow does not use). A job-level block replaces the top-level one rather than
adding to it, which is why `contents: read` is repeated there for the checkout.
`persist-credentials: false` on every checkout; none of them push.

**Dependabot.** New `.github/dependabot.yml` for `github-actions` (weekly,
grouped, `cooldown.default-days: 7`, `ci(deps)` prefix) and `cargo` (weekly,
grouped, `cooldown.default-days: 7`, `chore(deps)` prefix). Dependabot bumps the
SHA and its version comment together, which is what keeps the pins from going
stale. Security updates bypass the cooldown.

## The verify-trust action stays on v0.1.1 for now

This repo consumes
`OpenVTC/verifiable-git-infrastructure/.github/actions/verify-trust`, whose
input-injection issue is fixed in **0.4.9**. `gh release list --repo
OpenVTC/verifiable-git-infrastructure` shows the latest release is **v0.4.8**
(2026-09-10), so there is nothing to move to yet. The ref is pinned to the v0.1.1
commit and carries a TODO in the workflow, because the upgrade is a SHA bump
*plus* an input migration: 0.4.x renames `authority:` to `vtc-did:`. Worth a
follow-up issue once VGI cuts 0.4.9.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` parses all three files; `ci.yml`
  still has its 11 jobs.
- The pinning grep above is empty.
- Not exercised on a runner from this branch. The nine rustup steps and the
  `install-action` `tool:` input want a green CI run before merge — including on
  `windows-latest`, where the multi-line `run:` executes under pwsh.

## Note for reviewers

Rebased onto `8c23834`, so it includes #305 and #307. That matters: #305 added a
`test-dev-overrides` job to `ci.yml` after this work started, and it arrived with
three unpinned refs of its own. A plain merge would have left them unpinned and
quietly defeated the point, so that job is pinned here too — `checkout` and
`rust-cache` by SHA, and its `rust-toolchain@stable` (with `components: clippy`)
converted to the same rustup step as the `clippy` job.

Touches only `.github/`, so there is no overlap with the Rust changes in #305 or
with the sibling branch for the debug-log, unlock-file and PIN items.
