### PR TITLE
ci: take the fixed verify-trust action (VGI v0.4.9), pinned by commit SHA

### DIFF
--- a/.github/workflows/verify-trust.yml
+++ b/.github/workflows/verify-trust.yml
@@ -4,11 +4,16 @@
 #
 #   TRUST_REGISTRY_URL   e.g. https://registry.example.com
 #   TRUST_REGISTRY_DID   DID of the registry
-#   TRUST_AUTHORITY_DID  DID of the authority governing this repo
+#   TRUST_AUTHORITY_DID  DID of the VTC whose authority commits are judged
+#                        under — passed as the action's `vtc-did:` input
 #
-# Also requires a committed `.did-signers` file (one DID per line) and,
-# for GitHub web-UI merge / Dependabot commits, a committed
-# `.github/trusted-platform-keys.asc` (GitHub's web-flow public key).
+# No signer list is committed any more: the action derives the signer set from
+# the commits themselves (each names its signer DID on its committer header),
+# and what scopes a signer to this repository is the `resource` — left at its
+# default of this repo, widened only by `fallback-resource` below. For GitHub
+# web-UI merge / Dependabot commits a committed
+# `.github/trusted-platform-keys.asc` (GitHub's web-flow public key) is still
+# required.
 #
 # The check itself now lives in OpenVTC/verifiable-git-infrastructure (VGI);
 # this workflow consumes its published Action, which downloads a prebuilt
@@ -33,20 +38,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Pinned to the v0.1.1 commit rather than the tag: a tag can be moved, and
-      # this action runs with the workflow's token on every pull request.
-      #
-      # TODO: move to VGI >= 0.4.9 when it is released. 0.4.9 is the fix for an
-      # input-injection issue in the composite action, and it also renames the
-      # `authority:` input to `vtc-did:` — so the upgrade is a SHA bump plus that
-      # input rename, not a drop-in. The latest VGI release is v0.4.8, which does
-      # not carry the fix, so there is nothing to move to yet.
-      - uses: OpenVTC/verifiable-git-infrastructure/.github/actions/verify-trust@d4186e5d819c2cbd1247a4d0e6cbd373d25dd0b2 # v0.1.1
+      # Pinned to the v0.4.9 commit rather than the tag: a tag can be moved, and
+      # this action runs with the workflow's token on every pull request. v0.4.9
+      # is the release in which the composite action passes every input to its
+      # run step through the environment instead of interpolating it into bash.
+      - uses: OpenVTC/verifiable-git-infrastructure/.github/actions/verify-trust@d103f98eb71dd36ee86b41f70e753578de7f0522 # v0.4.9
         with:
           range: origin/${{ github.base_ref }}..HEAD
           registry-url: ${{ vars.TRUST_REGISTRY_URL }}
           registry-did: ${{ vars.TRUST_REGISTRY_DID }}
-          authority: ${{ vars.TRUST_AUTHORITY_DID }}
+          # v0.4.x renamed `authority:` to `vtc-did:`; the value is the same DID,
+          # the community whose authority the trust tuple is evaluated under.
+          vtc-did: ${{ vars.TRUST_AUTHORITY_DID }}
           # Preserve the org-wide fallback the previous local action defaulted to.
           fallback-resource: ${{ github.repository_owner }}
           exempt-keyring: .github/trusted-platform-keys.asc
+          # Download the binary from the same release as the action pinned above,
+          # rather than whatever `latest` resolves to at run time.
+          version: v0.4.9


### PR DESCRIPTION

`.github/workflows/verify-trust.yml` consumed the shared `verify-trust`
composite action at VGI `v0.1.1`. That version interpolated `${{ inputs.* }}`
directly into the body of its `run:` step. An expression there is pasted into
the script as text before bash parses it, so the content of an input could
execute as shell in this job. openvtc was the last consumer still on it.

VGI `v0.4.9` fixes that: every input reaches the script through `env:` and is
referenced as a quoted variable, and the `verify-trust` CLI rejects
option-shaped `--range` values and passes `--end-of-options` to
`git rev-list`.

## Pinned by SHA

```
refs/tags/v0.4.9  -> tag    850b7aff732bd911ed8808259c5eec5293338d8f
v0.4.9            -> commit d103f98eb71dd36ee86b41f70e753578de7f0522
```

The annotated tag is dereferenced to its commit, and the action is pinned to
`d103f98eb71dd36ee86b41f70e753578de7f0522 # v0.4.9` rather than to the tag: a
tag can be moved, and this action runs with the workflow's token on every pull
request.

## Input migration

The schema changed between the 0.1 and 0.4 lines, so this is not a bare
version bump. Every input the workflow passed, mapped to `v0.4.9`:

| Old (v0.1.1) | New (v0.4.9) | Note |
| --- | --- | --- |
| `range` | `range` | unchanged, still required |
| `registry-url` | `registry-url` | now **optional**: by default the endpoint is discovered from `registry-did`'s DID document. Still passed, which keeps current behaviour |
| `registry-did` | `registry-did` | unchanged, still required |
| `authority` | **`vtc-did`** | renamed. Same value: the DID of the community whose authority the trust tuple is evaluated under (TRQP's `authority_id`) |
| `fallback-resource` | `fallback-resource` | unchanged; keeps the org-wide fallback |
| `exempt-keyring` | `exempt-keyring` | unchanged; still `.github/trusted-platform-keys.asc` |
| — | `version` | **now pinned to `v0.4.9`** instead of the default `latest` |

Removed upstream, with no equivalent to migrate to:

- **`signers-file`** (defaulted to `.did-signers`). The 0.4 action derives the
  signer set from the commits themselves — each names its signer DID on its
  committer header — so there is no per-repository signer list at all. What
  scopes a signer to this repository is `resource`, left at its default of
  `${{ github.repository }}`, widened only by the `fallback-resource` this
  workflow already passed. The workflow's header comment claimed a committed
  `.did-signers` file was required; no such file exists in this repo and the
  concept is gone, so that comment is corrected here.

New optional inputs, all deliberately left at their defaults: `action`
(`git.commit.sign`), `resource` (`${{ github.repository }}`), `max-signers`
(`32`), `resolve-agent-names` (`false`), `json` (`false`).

No required input lacks a value, so no new repository variable is needed:
`range`, `registry-did` and `vtc-did` are the three required inputs and all
three are passed. The existing `TRUST_AUTHORITY_DID` variable feeds `vtc-did`
unchanged — the variable is not renamed, so no repository settings change is
required; the header comment now says which input it feeds.

`version:` is pinned so the binary downloaded at run time comes from the same
release as the action, rather than from whatever the newest release happens to
be — otherwise a SHA-pinned action could still fetch a newer, unreviewed
binary.

## Behaviour otherwise unchanged

The job stays dormant until the repository variables are configured
(`if: vars.TRUST_REGISTRY_URL != ''`), keeps `permissions: contents: read`,
and keeps the `fetch-depth: 0` checkout the range walk needs.

## Interaction with #310

#310 (`sec-4045/ci-pinning`) pins actions across openvtc's workflows and
touches this same file: it SHA-pins the `actions/checkout` step, adds
`persist-credentials: false`, SHA-pins this action at v0.1.1, and leaves a
TODO saying to move to VGI >= 0.4.9 once released — noting the input rename
this PR performs. That TODO is now satisfied and should be dropped.

This branch is cut from `origin/main` and touches only
`.github/workflows/verify-trust.yml`, confined to the action step and the
header comment. It deliberately does **not** touch the `actions/checkout`
line, leaving that to #310. The two hunks are a few lines apart, so whichever
merges second may need a trivial rebase: keep #310's pinned `checkout` and
`persist-credentials: false`, keep this PR's `verify-trust` SHA, inputs and
`version:`, and delete #310's now-obsolete TODO comment and its v0.1.1
pinning note.

## Verification

- Workflow parses (`python3` + PyYAML), with `permissions: {contents: read}`,
  `if: vars.TRUST_REGISTRY_URL != ''` and `fetch-depth: 0` all confirmed
  present after the edit.
- Every input passed exists in `v0.4.9`'s `inputs:` block; all three required
  inputs are passed; no unknown input is passed.
- `gh api` output above confirms the pinned SHA is the commit `v0.4.9`
  resolves to; `git tag --points-at` on that commit reports exactly `v0.4.9`.
- `git grep` finds no remaining `verify-trust@v0.1.1`, and no `v0.1.1` string
  anywhere in the repo outside vendored third-party JS.

## Unrelated

`origin/main` does not currently compile: `CLI_ORANGE` is still unresolved at
`openvtc/src/main.rs:565`, which PR #308 fixes. This change touches only a
workflow file and neither causes nor addresses that.
