### PR TITLE
chore(deps): take the resolver line that refuses a did:webvh DID on a non-public host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **A `did:webvh` DID on a non-public host no longer resolves.** Resolving a
+  `did:webvh` DID fetches `did.jsonl` from the host the DID itself names, so
+  until now a DID such as `did:webvh:<scid>:localhost%3A9099` — or a public name
+  whose A record points at `169.254.169.254` — was fetched, on this machine's
+  own network, by `openvtc health`, by join and by messaging alike. The DID is
+  enough; no config had to be wrong.
+
+  `affinidi-did-resolver-cache-sdk` 0.8.37 (`didwebvh-rs` 0.7) now refuses
+  `localhost`, `*.localhost`, `*.local`, `*.internal`, `home.arpa` and
+  single-label names before any request, refuses a name whose resolved
+  addresses include a loopback, private, carrier-grade-NAT or link-local one,
+  connects only to the addresses it checked, follows no redirect and ignores
+  `HTTP_PROXY`/`HTTPS_PROXY`. `did:web` has been refused this way since the
+  probe hardening; this is the other half of it. A refused DID reports
+  `BlockedHost`.
+
+  **If your VTA, VTC or mediator DIDs genuinely live on loopback or a private
+  network**, `openvtc health --allow-private` now opts *resolution* in as well
+  as probing — the two run under one policy, so the report can no longer say
+  the endpoints may be dialled while refusing the documents that name them.
+  Everything else, including every default run, contacts public hosts only.
+
+  `openvtc health` also still distinguishes "we declined to dial this" from
+  "this host did not answer" when the refusal comes from the probe client's DNS
+  guard rather than from the URL. That guard moved into the shared
+  `affinidi-net-guard` crate and its refusals now read `blocked address <addr>
+  (<class>) for host <host>`; they are recognised by type rather than by that
+  wording, so the message is free to change again without a refusal being
+  reported as an unreachable host.
+
 - **Release builds no longer take their VTA or mediator from the environment.**
   `OPENVTC_VTA_URL`, `OPENVTC_VTA_DID` and `OPENVTC_MEDIATOR_DID` are honoured
   only by a build compiled with the new `dev-overrides` feature

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.8.36"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d261ce9e5886c890492a1ed7ae6f0b286f8c8c2c711af96eb1bdf1eee9efa6"
+checksum = "be0b2e768c75df1d0bca72f51ecb6bbb37fccc13e16bf9c093f8fc04e429e952"
 dependencies = [
  "affinidi-did-common",
  "affinidi-did-resolver-traits",
@@ -205,7 +205,7 @@ dependencies = [
  "ahash",
  "base64 0.23.1",
  "did-scid",
- "didwebvh-rs",
+ "didwebvh-rs 0.7.0",
  "highway",
  "moka",
  "rand 0.10.2",
@@ -237,16 +237,16 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-web"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8fc4d44f666b034f50cd753afc1bdfef6d7801cccc35672518ab2e2fda007c"
+checksum = "08ba8e331d31ff1c6bf9f5684d71471779e5f9fbf7167d93a4a34f2daece202b"
 dependencies = [
  "affinidi-did-common",
+ "affinidi-net-guard",
  "percent-encoding",
  "reqwest",
  "serde_json",
  "thiserror 2.0.20",
- "tokio",
  "tracing",
 ]
 
@@ -386,7 +386,7 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
- "didwebvh-rs",
+ "didwebvh-rs 0.6.1",
  "futures-util",
  "governor",
  "hostname",
@@ -533,6 +533,19 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "affinidi-net-guard"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43736e64c051b4689d39c08e781dae750a79fee9bbf44e4eb7ed93e081485184"
+dependencies = [
+ "reqwest",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2792,12 +2805,12 @@ dependencies = [
 
 [[package]]
 name = "did-scid"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c7754d192a630118d5fa3353f1cce5c291187762b0e493f397d3e0328b407d"
+checksum = "32bb54e6769f547fc641bbe63bb06f253fe41ad552e47e24cbd6c62a7b6436d8"
 dependencies = [
  "affinidi-did-common",
- "didwebvh-rs",
+ "didwebvh-rs 0.7.0",
  "regex",
  "serde_json",
  "thiserror 2.0.20",
@@ -2809,6 +2822,33 @@ name = "didwebvh-rs"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a6d8803724264019c1b1dda174b4f666b833e9ac05acd45e87e9fecef2c67b"
+dependencies = [
+ "affinidi-data-integrity",
+ "affinidi-did-common",
+ "affinidi-secrets-resolver",
+ "ahash",
+ "async-trait",
+ "base58",
+ "chrono",
+ "getrandom 0.4.3",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "serde_with",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "didwebvh-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa08dc5af02f6bc159c10271195f467a894b3b4fe67da9796009ee2da785043"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-common",
@@ -6114,7 +6154,7 @@ dependencies = [
  "dbus-secret-service-keyring-store",
  "dialoguer",
  "did-git-sign",
- "didwebvh-rs",
+ "didwebvh-rs 0.7.0",
  "dirs",
  "dtg-credentials 0.6.0",
  "ed25519-dalek-bip32",
@@ -6167,6 +6207,7 @@ dependencies = [
  "affinidi-messaging-delivery",
  "affinidi-messaging-sdk",
  "affinidi-messaging-test-mediator",
+ "affinidi-net-guard",
  "affinidi-tdk",
  "agent-names",
  "anyhow",
@@ -6178,7 +6219,7 @@ dependencies = [
  "card-backend-pcsc",
  "chrono",
  "criterion",
- "didwebvh-rs",
+ "didwebvh-rs 0.7.0",
  "dirs",
  "dtg-credentials 0.6.0",
  "ed25519-dalek-bip32",
@@ -9816,7 +9857,7 @@ dependencies = [
  "ciborium",
  "curve25519-dalek 5.0.0",
  "dbus-secret-service-keyring-store",
- "didwebvh-rs",
+ "didwebvh-rs 0.6.1",
  "dirs",
  "dtg-credentials 0.9.1",
  "ed25519-dalek 3.0.0",
@@ -9873,7 +9914,7 @@ dependencies = [
  "ciborium",
  "clap",
  "dialoguer",
- "didwebvh-rs",
+ "didwebvh-rs 0.6.1",
  "dirs",
  "dtg-credentials 0.9.1",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,14 +112,48 @@ futures-util = "0.3"
 # this line states it. Stating it keeps the manifest honest about what the graph
 # actually resolves rather than implying 0.1.2 is still viable.
 agent-names = "0.1.3"
-affinidi-did-resolver-cache-sdk = { version = "0.8.34", features = [
+# The floor names the patch, and 0.8.37 is the one that matters: it is the
+# release where **`did:webvh` resolution stops contacting non-public hosts**,
+# which is the half of the guard this repo was missing. `did:web` has been
+# guarded since 0.8.35 (`affinidi-did-web`, below); webvh — the method every
+# persona, VTA and VTC here actually uses — was not, so a DID naming
+# `localhost%3A9099` or a public name whose A record is `169.254.169.254` was
+# fetched anyway, by `health`, by join and by messaging alike.
+#
+# `DIDCacheClient::new` now builds both its did:web and did:webvh resolvers from
+# one `HostPolicy`, defaulting to `PublicOnly`, and `health` passes the policy
+# its probes already run under so resolution and probing cannot disagree (see
+# `openvtc-core::health::build_report_with_progress`). A caret below this
+# release admits 0.8.36, where the webvh half is simply absent, so the patch is
+# the floor rather than a record of what happens to resolve today.
+affinidi-did-resolver-cache-sdk = { version = "0.8.37", features = [
   "agent-names",
 ] }
 # The SSRF guard the resolver above already applies to did:web fetches, taken
 # directly so `health` can put the same connect-time check on its own probe
 # client (`guarded_dns_resolver`). Not a new crate: the resolver pulls in this
-# exact version on the same `reqwest` line, so the types unify.
-affinidi-did-web = "0.1.4"
+# exact version on the same `reqwest` line, so the types unify — which is why
+# this line moves with the resolver rather than independently. 0.1.5 moves the
+# classifier and the DNS-pinning resolver into the shared `affinidi-net-guard`
+# 0.1.0 crate with the public API unchanged, so `guarded_dns_resolver` and the
+# `HostPolicy` this workspace hands to the resolver behave exactly as on 0.1.4.
+affinidi-did-web = "0.1.5"
+# The guard `affinidi-did-web` 0.1.5 was refactored onto, taken directly for one
+# thing only: `blocked_in_chain`, which recovers a connect-time refusal from a
+# `reqwest` error chain **by type**. `health` has to tell a refusal apart from an
+# unreachable host — the two mean opposite things in a report — and until now it
+# did that by matching the sentence the refusal rendered. 0.1.5 changed that
+# sentence (the guard moved crates), which is exactly the failure mode a string
+# match has: every refusal would have been silently downgraded to "unreachable".
+#
+# Not a new crate in the graph: `affinidi-did-web` and `affinidi-tdk-common`
+# already pull this exact version, so naming it adds a requirement and nothing
+# else. `openvtc-core::net_guard` deliberately stays as it is — it classifies a
+# host *as written in the URL*, and this crate's classifier refuses a wider set
+# (documentation, multicast and reserved space, `*.internal`, single-label
+# names), which is a behaviour change to make on its own rather than inside a
+# dependency bump.
+affinidi-net-guard = "0.1.0"
 anyhow = "1.0"
 # Structure-aware fuzzing support (issue #124). Only pulled in when a crate
 # enables its own `arbitrary` feature; the `derive` feature provides the
@@ -143,7 +177,31 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 # the stack up when the stack goes.
 dirs = "6.0"
 dialoguer = { version = "0.12", features = ["password"] }
-didwebvh-rs = "0.6"
+# 0.7 is the release that carries the resolution host policy the cache SDK above
+# now configures: `localhost`, `*.localhost`, `*.local`, `*.internal`,
+# `home.arpa` and single-label names are refused before any request, the default
+# client vets every address a name resolves to and connects only to those, and
+# it ignores `HTTP_PROXY`/`HTTPS_PROXY` (a proxy resolves the name itself, past
+# the check). This line moves with `affinidi-did-resolver-cache-sdk`, not
+# independently: the SDK's 0.8.37 requires `^0.7`, so a `"0.6"` here would put a
+# second copy in the graph for nothing.
+#
+# What this workspace uses from the crate is unaffected by the move: `WebVHURL`,
+# `create_did`/`CreateDIDConfig`, `Parameters`, `LogEntryMethods` and
+# `DIDWebVHError` are unchanged (`DIDWebVHError` is `#[non_exhaustive]` and
+# gained `BlockedHost`, which `OpenVTCError::WebVH` carries through by `#[from]`
+# rather than matching on).
+#
+# **The graph does hold a second copy, 0.6.1, and that is the VTI patch block at
+# the foot of this file rather than anything chosen here.** Every VTI crate
+# declares `didwebvh-rs = "0.6"`, and `"0.6"` excludes 0.7, so `vta-sdk`,
+# `vta-keys` and `vta-tee` keep 0.6.1 until VTI takes 0.7 and releases. Nothing
+# crosses between the two — VTI's use is minting and log-entry work behind its
+# own API, and no didwebvh-rs type appears in a signature this workspace calls
+# — so the duplicate is a `cargo tree -d` row, not a type error. It collapses
+# when the VTI entries below go. `cargo tree -i didwebvh-rs` is the check: the
+# **resolution** path (`affinidi-did-resolver-cache-sdk`) must be the 0.7 node.
+didwebvh-rs = "0.7"
 ed25519-dalek-bip32 = "0.3"
 hkdf = "0.13"
 hex = "0.4"

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -38,6 +38,9 @@ reqwest = { workspace = true }
 # Those transport URLs come from DID documents anyone can publish, so the probe
 # client installs the resolver's own DNS guard rather than dialling them as-is.
 affinidi-did-web.workspace = true
+# `blocked_in_chain`, so `health` can tell that guard's refusal apart from a host
+# that simply did not answer — by type, rather than by the sentence it renders.
+affinidi-net-guard.workspace = true
 # `CancellationToken`, for `start_service`'s shutdown hook.
 tokio-util = { workspace = true }
 # The delivery layer this module now runs on (#189): `-delivery` is the durable

--- a/openvtc-core/src/health.rs
+++ b/openvtc-core/src/health.rs
@@ -355,8 +355,25 @@ pub async fn build_report_with_progress(
 ) -> HealthReport {
     let started = std::time::Instant::now();
     progress(Step::ResolverStarting);
+    // Resolution runs under the same policy as the probes, because resolving a
+    // `did:web`/`did:webvh` DID *is* an outbound fetch of a host the DID names.
+    // Since `affinidi-did-resolver-cache-sdk` 0.8.37 both methods refuse a
+    // non-public host by default, so without this line a `--allow-private` run
+    // against a development stack on loopback would be allowed to dial the
+    // endpoints while being refused the documents that name them — the report
+    // would read as "nothing resolves" rather than as a policy decision.
+    //
+    // The default stays `PublicOnly` on both halves: `ProbePolicy::default()`
+    // is `PublicOnly`, and the only caller that asks for `AllowPrivate` is the
+    // operator's explicit `health --allow-private`.
+    let host_policy = match policy {
+        ProbePolicy::PublicOnly => affinidi_did_web::HostPolicy::PublicOnly,
+        ProbePolicy::AllowPrivate => affinidi_did_web::HostPolicy::AllowPrivate,
+    };
     let resolver = match DIDCacheClient::new(
-        affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default().build(),
+        affinidi_did_resolver_cache_sdk::config::DIDCacheConfigBuilder::default()
+            .with_host_policy(host_policy)
+            .build(),
     )
     .await
     {
@@ -729,27 +746,25 @@ fn send_failure(url: &str, error: &reqwest::Error) -> Probe {
     }
 }
 
-/// The refusal `affinidi_did_web::guarded_dns_resolver` raised, if one is
+/// The refusal the probe client's guarded DNS resolver raised, if one is
 /// anywhere in `error`'s source chain.
 ///
-/// That crate keeps its error type private, so the refusal is recognised by the
-/// message it renders (`"<host> resolves to non-routable <addr>"`), walking the
-/// chain the way the crate does internally. The innermost match wins, since
-/// wrappers may repeat it with their own prefix.
-/// `probe_client_dns_guard_refuses_localhost_name` pins the text, so an upstream
-/// change to it fails a test rather than quietly turning refusals back into
-/// "unreachable".
+/// Recognised **by type**: `affinidi_net_guard::blocked_in_chain` downcasts each
+/// link of the chain to that crate's own `EgressError` and hands back the
+/// refusal itself. It is the same helper `affinidi-did-web` uses internally to
+/// turn one of these into `BlockedHost`, so probing and resolution agree on what
+/// counts as a refusal rather than each deciding for itself.
+///
+/// This replaced a match on the sentence the refusal used to render,
+/// `"<host> resolves to non-routable <addr>"`. `affinidi-did-web` 0.1.5 moved
+/// the guard into `affinidi-net-guard`, which renders
+/// `"blocked address <addr> (<class>) for host <host>"` instead — and a string
+/// match is precisely how that move would otherwise have turned every refusal
+/// quietly back into `Probe::Unreachable`, which reads as "the host did not
+/// answer" when what happened is "we declined to ask".
+/// `probe_client_dns_guard_refuses_localhost_name` covers the recovery.
 fn dns_refusal_in_chain(error: &(dyn std::error::Error + 'static)) -> Option<String> {
-    let mut found = None;
-    let mut next = Some(error);
-    while let Some(e) = next {
-        let message = e.to_string();
-        if message.contains(" resolves to non-routable ") {
-            found = Some(message);
-        }
-        next = e.source();
-    }
-    found
+    affinidi_net_guard::blocked_in_chain(error).map(ToString::to_string)
 }
 
 /// Negotiate the pairs that decide whether a join can complete: each persona
@@ -1490,6 +1505,12 @@ mod tests {
     /// literal, so the literal check above cannot be the whole guard; this goes
     /// straight to the client, past `vet_probe_url`, to prove the DNS guard is
     /// installed. `localhost` resolves to loopback everywhere without a network.
+    ///
+    /// What it pins is that the refusal is still *recoverable* from the error
+    /// chain, so a refusal keeps grading as [`Probe::Blocked`] rather than as an
+    /// unreachable host. It asserts on the host and the refusal's shape, not on
+    /// a whole sentence: the wording is the upstream crate's to change, and it
+    /// did change when the guard moved into `affinidi-net-guard`.
     #[tokio::test]
     async fn probe_client_dns_guard_refuses_localhost_name() {
         let (listener, port) = loopback_listener().await;
@@ -1505,12 +1526,56 @@ mod tests {
         assert!(
             refusal
                 .as_deref()
-                .is_some_and(|r| r.contains("localhost resolves to non-routable")),
-            "affinidi-did-web's refusal must be recoverable from the error chain: {error:?}"
+                .is_some_and(|r| r.contains("blocked address") && r.contains("localhost")),
+            "the guard's refusal must be recoverable from the error chain, and must \
+             name the host it refused: {error:?}"
         );
         assert!(
             matches!(send_failure(&url, &error), Probe::Blocked { .. }),
             "a DNS refusal is a block, not an unreachable host"
+        );
+        assert_never_dialled(&listener).await;
+    }
+
+    // ---- Resolution egress policy -------------------------------------------
+    //
+    // The probe tests above cover the URLs a *document* names. These cover the
+    // host the *DID* names, which is earlier and broader: resolving
+    // `did:webvh:<scid>:<host>` fetches `did.jsonl` from `<host>`, so a DID on
+    // its own — nothing misconfigured, no document served — is enough to point
+    // this machine at a service on its own network, and the resolution error
+    // then says whether it answered.
+
+    /// The resolver `build_report` builds must refuse a `did:webvh` DID on
+    /// loopback, and refuse it *before* connecting.
+    ///
+    /// Asserted through `build_report`, the entry point every caller actually
+    /// uses, rather than through a resolver the test configured itself — the
+    /// thing worth pinning is that this module's default is the guarded one.
+    #[tokio::test]
+    async fn health_report_refuses_a_localhost_webvh_did_without_dialing() {
+        let (listener, port) = loopback_listener().await;
+        let did = format!("did:webvh:QmStandInScidAAAAAAAAAAAAAAAAAAAA:localhost%3A{port}:agent");
+
+        let report = build_report(&[Subject::new(Role::Vta, "stand-in VTA", did.clone())]).await;
+
+        let party = report
+            .parties
+            .iter()
+            .find(|p| p.did == did)
+            .expect("a subject is reported whether or not it resolves");
+        assert!(
+            party.resolved.is_none(),
+            "a refused host must not yield a resolved party: {party:?}"
+        );
+        assert!(
+            party
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("BlockedHost")),
+            "the refusal must be reported as a blocked host, not as a timeout or \
+             an unreachable one: {:?}",
+            party.error
         );
         assert_never_dialled(&listener).await;
     }


### PR DESCRIPTION

`affinidi-did-resolver-cache-sdk` 0.8.34 → 0.8.37, `affinidi-did-web` 0.1.4 →
0.1.5, `didwebvh-rs` 0.6 → 0.7, and `affinidi-net-guard` 0.1.0 named directly.

## What changes for an operator

**A `did:webvh` DID whose host is not public stops resolving.**

Resolving a `did:webvh` DID is an outbound fetch: the DID itself names the host
that `did.jsonl` is read from. Until this bump, that host was contacted whatever
it was. `did:webvh:<scid>:localhost%3A9099` was fetched over plain `http://`, and
any other name was fetched from whatever address it resolved to — so a DID naming
a public hostname whose A record pointed at `169.254.169.254` reached the
metadata service instead. The DID was the whole input; no configuration had to be
wrong, and the resolution error text ("HTTP 404" versus connection refused) said
whether the internal target was listening. Every webvh resolution was affected,
not only `openvtc health`: join and messaging resolve DIDs on the same client.

`did:web` has been guarded this way since the probe hardening. This is the other
half of it, and it arrives as a dependency bump because the guard belongs
upstream rather than here.

After this change, resolution refuses, before any request is sent:

- the names `localhost`, `*.localhost`, `*.local`, `*.internal`, `home.arpa`,
  `*.home.arpa`, and single-label names;
- any name whose resolved addresses include a loopback, unspecified, RFC 1918,
  carrier-grade NAT (100.64.0.0/10), link-local (including cloud metadata),
  unique-local, multicast, reserved, benchmarking or documentation address, or
  an IPv4-mapped / NAT64 / 6to4 form embedding one.

It then connects only to the addresses it checked, which closes DNS rebinding; it
follows no redirect; and it ignores `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY`,
because a proxy resolves the target name itself, outside these checks. A refused
DID reports `BlockedHost`.

**If your VTA, VTC, mediator or persona DIDs genuinely live on loopback or a
private network**, `openvtc health --allow-private` now opts *resolution* in as
well as probing. The two run under one policy on purpose: otherwise the report
would say the endpoints may be dialled while refusing the documents that name
them, and read as "nothing resolves" rather than as a policy decision. Every
default run, and every other code path in the binary, contacts public hosts only.
There is no environment variable and no config key for this — it is an explicit
flag on an explicitly read-only command.

## Why `didwebvh-rs` 0.7 while VTI stays on 0.6

The graph holds both, and that is the `[patch.crates-io]` block rather than a
choice made here. Every VTI crate declares `didwebvh-rs = "0.6"`, which excludes
0.7, so `vta-sdk`, `vta-keys` and `vta-tee` keep 0.6.1 until VTI takes 0.7 and
releases. Nothing crosses between the copies — VTI's use is minting and
log-entry work behind its own API, and no `didwebvh-rs` type appears in a
signature this workspace calls — so the duplicate is a `cargo tree -d` row, not
a type error. `cargo deny` is clean (`multiple-versions = "warn"`).

What matters is which copy the **resolution** path holds, and
`cargo tree -i didwebvh-rs@0.7.0` puts `affinidi-did-resolver-cache-sdk` 0.8.37
on it. The duplicate collapses when the VTI entries go.

## The one code change beyond the manifests

`health`'s `dns_refusal_in_chain` recognised the probe client's connect-time
refusal by the sentence it rendered — `"<host> resolves to non-routable <addr>"`.
`affinidi-did-web` 0.1.5 moved that guard into the shared `affinidi-net-guard`
crate, which renders `"blocked address <addr> (<class>) for host <host>"`
instead. A string match is exactly how that move turns every refusal silently
back into `Probe::Unreachable`, which reads as "the host did not answer" when
what happened is "we declined to ask".

It now uses `affinidi_net_guard::blocked_in_chain`, which recovers the refusal
by downcasting to that crate's own error type — the same helper
`affinidi-did-web` uses internally — so probing and resolution agree on what
counts as a refusal instead of each deciding for itself. The existing test that
caught this was already there for the purpose; it now asserts on the host and
the refusal's shape rather than on a whole upstream sentence.

`openvtc-core/src/net_guard.rs` is deliberately unchanged. It classifies a host
*as written in the URL*, and `affinidi-net-guard`'s classifier refuses a wider
set (documentation, multicast and reserved space, `*.internal`, single-label
names). Adopting that set is a behaviour change worth making on its own, not
inside a dependency bump.

## Tests

- `openvtc-core`: `health_report_refuses_a_localhost_webvh_did_without_dialing`
  — `build_report` on `did:webvh:<scid>:localhost%3A<port>:agent` against a live
  loopback listener. The party comes back unresolved with `BlockedHost`, and the
  listener accepts **zero** connections: a refusal after a connection has
  already told the publisher of that DID that something is listening.
  Asserted through `build_report`, the entry point every caller uses, rather
  than through a resolver the test configured itself.
- The full `openvtc-core` suite passes (660 tests).

## Base

Rebased onto `origin/main` at **31c0dbb** (`fix(cli): announce env overrides with
a colour role that exists`, #308). That commit matters here only because it is
what makes the workspace build at all: before it, `openvtc/src/main.rs:565` used
`CLI_ORANGE`, which was defined nowhere in the tree, so `cargo clippy
--workspace` and `cargo test --workspace` failed with `error[E0425]` on `main`
itself. With #308 in, the whole workspace gate below is green. This branch
touches neither `main.rs`, `cli.rs` nor `.github/`.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all suites pass, 0 failed (660 in `openvtc-core`,
  579 in `openvtc`, plus the integration suites)
- `cargo clippy -p openvtc --all-targets --features dev-overrides -- -D warnings`
  — clean
- `cargo test -p openvtc --features dev-overrides` — 578 passed, 0 failed
- `cargo test -p openvtc-core --no-default-features` — 660 passed, 0 failed
- `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- `cargo tree -i didwebvh-rs@0.7.0` — resolution path is
  `didwebvh-rs 0.7.0 → affinidi-did-resolver-cache-sdk 0.8.37`;
  `cargo tree -i didwebvh-rs@0.6.1` shows the remaining copy reaching only
  `vta-sdk` through the VTI patch entries
