### PR TITLE
build(deps): restore the rand and x25519-dalek pins the OpenPGP stack needs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,16 @@ updates:
         patterns: ["*"]
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # `rand` is held at 0.8 by the OpenPGP stack, not by inattention: `pgp`
+      # 0.20 (the latest release) declares `rand ^0.8.6` and takes an
+      # `R: CryptoRng + Rng` from that trait set, and `openpgp-card-rpgp` pins
+      # `pgp ^0.20`. A 0.10 bump merged once and stopped `main` compiling,
+      # because 0.10 removes `OsRng` and splits `RngCore`. The manifest entry
+      # explains the pin; lift both together when the OpenPGP stack moves.
+      - dependency-name: "rand"
+      # Held at 2.x for the same reason, and bumped to 3.0 in the same commit:
+      # our `StaticSecret` goes straight to pgp's `ecdh::Curve25519Legacy`, and
+      # a 3.x secret is a different type there. The graph carries a 3.x copy
+      # too, reached only through the vta-sdk crypto stack, and no type crosses.
+      - dependency-name: "x25519-dalek"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6168,7 +6168,7 @@ dependencies = [
  "openvtc-core",
  "pgp",
  "qrcode",
- "rand 0.10.2",
+ "rand 0.8.8",
  "ratatui",
  "regex",
  "secrecy",
@@ -6191,7 +6191,7 @@ dependencies = [
  "uuid",
  "vta-sdk",
  "windows-native-keyring-store",
- "x25519-dalek 3.0.0",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -6232,7 +6232,7 @@ dependencies = [
  "openpgp-card-rpgp",
  "openssl-sys",
  "pgp",
- "rand 0.10.2",
+ "rand 0.8.8",
  "regex",
  "reqwest",
  "secrecy",
@@ -6253,7 +6253,7 @@ dependencies = [
  "vta-sdk",
  "vta-service",
  "wiremock",
- "x25519-dalek 3.0.0",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,16 @@ qrcode = { version = "0.14", default-features = false }
 # latest release. aes-gcm no longer holds this pin — it moved to 0.11 and its
 # one RNG call site now fills the nonce from `rand`'s OsRng directly rather
 # than going through `AeadCore::generate_nonce`.
-rand = "0.10"
+#
+# Dependabot proposed 0.10 anyway and it merged (#314), which stopped `main`
+# compiling: 0.10 replaces `OsRng` with the fallible `rngs::SysRng` and splits
+# `RngCore` into `Rng`/`TryRng`, so all four call sites here fail to resolve,
+# and `pgp`'s `encrypt` still wants a rand 0.8 `CryptoRng + Rng` regardless.
+# There is no newer `pgp` to move to — 0.20.0 is the latest release and
+# declares `rand ^0.8.6`, and `openpgp-card-rpgp` 0.8.1 pins `pgp ^0.20` —
+# so the pin stays until the OpenPGP stack moves. `rand` is in Dependabot's
+# ignore list for that reason; delete both together, not this line alone.
+rand = "0.8"
 ratatui = "0.30"
 regex = "1.12"
 secrecy = { version = "0.10", features = ["serde"] }
@@ -425,7 +434,12 @@ reqwest = { version = "0.13", features = ["json"] }
 # `StaticSecret` is handed to. `cargo tree -i x25519-dalek@2.0.1` is where that
 # is checked. It collapses when `pgp` releases on 3.x; 0.20.0 is still its
 # latest and still declares `^2`.
-x25519-dalek = { version = "3.0", features = ["static_secrets"] }
+#
+# Dependabot proposed 3.0 and it merged alongside the `rand` bump (#314),
+# which stopped the binary compiling exactly as described above: `expected
+# x25519_dalek::x25519::StaticSecret, found StaticSecret`. It is in
+# Dependabot's ignore list with `rand`; lift both when `pgp` moves.
+x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 zeroize = "1.8"
 
 # Openpgp-Card Support


### PR DESCRIPTION
**`main` does not compile.** #314 bumped `rand` 0.8 → 0.10 and `x25519-dalek` 2.0 → 3.0 together, and both break the OpenPGP paths:

- **`rand` 0.10** removes `OsRng` (OS entropy is now the fallible `rngs::SysRng`) and splits `RngCore` into `Rng`/`TryRng`, so the four call sites in `secured_config.rs`, `openpgp_card/crypt.rs` and `vetting/tickets.rs` fail to resolve.
- **`x25519-dalek` 3.0** makes our `StaticSecret` a different type from the one `pgp`'s `ecdh::Curve25519Legacy` accepts: *expected `x25519_dalek::x25519::StaticSecret`, found `StaticSecret`*.

**There is nothing newer to move to.** `pgp` 0.20.0 is the latest release (June 2026) and still declares `rand ^0.8.6` and `x25519-dalek ^2.0.1`; `openpgp-card-rpgp` 0.8.1 pins `pgp ^0.20`. Both manifest entries already carried comments explaining the pins, which is what the bump walked past.

**This PR** restores both pins, records what happened in those comments, and adds `rand` and `x25519-dalek` to Dependabot's ignore list so the bump doesn't come back. No source changes. `x25519-dalek` 3.0.0 stays in the graph through the vta-sdk crypto stack, as the comment describes; 2.0.1 is the copy our `StaticSecret` is handed to.

Locally: `cargo fmt --all -- --check` clean, `cargo check --workspace --all-targets` clean, full test suite passing.