### PR TITLE
build(deps): take published did-git-sign 0.4.9 and drop the VGI patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,7 +2516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2775,8 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "did-git-sign"
-version = "0.4.8"
-source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?branch=chore%2Fvta-sdk-036#05daabc76251ea3cce343a8c031f1122b6c78efa"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669c60cff3a6fdb9ce9b21253be80e37814dae8f13d07b1fd0deeb43a12d954c"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -9636,8 +9637,9 @@ dependencies = [
 
 [[package]]
 name = "vgi-core"
-version = "0.4.8"
-source = "git+https://github.com/OpenVTC/verifiable-git-infrastructure?branch=chore%2Fvta-sdk-036#05daabc76251ea3cce343a8c031f1122b6c78efa"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0964e051cc46fdf01fcb28f017bf2a1e2677d2ae6e78f9f7ac920a00809dbb"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,13 +453,17 @@ codegen-units = 1
 strip = "symbols"
 
 
-# `[patch.crates-io]` is back, for two repositories and one release each.
+# `[patch.crates-io]` is back, for one repository and one release.
 #
-# VGI. `did-git-sign` 0.4.8 — the latest published — requires `vta-sdk ^0.35`, so
-# on the 0.36 line it would put a second sdk in this binary (the `vta-sdk` note
-# above says why two do not unify). VGI's `chore/vta-sdk-036` moves it to 0.36;
-# until that is released, `did-git-sign` and its path dependency `vgi-core`
-# resolve from that branch.
+# VGI is out. `did-git-sign` 0.4.9 and `vgi-core` 0.4.9 are published, and
+# neither depends on `vta-sdk` at all any more, so the second-sdk problem the
+# patch existed to avoid is gone with it. The floor in `openvtc/Cargo.toml` is
+# 0.4.9 and both crates resolve from crates.io.
+#
+# That block is also the cautionary tale for the paragraph below: it named a
+# *branch*, `chore/vta-sdk-036`, which was deleted once its work merged, and
+# every `cargo install` then failed with "failed to find branch". Pin a `rev`,
+# never a branch.
 #
 # VTI. `vta-sdk` 0.36.0 is published but the `vta-service` built on it is not:
 # 0.25.1 on crates.io still pulls `vta-sdk ^0.35` through its whole subsystem
@@ -486,9 +490,6 @@ strip = "symbols"
 # `trql-client` 0.17 were all published. As then, a patch here needs its entry in
 # `deny.toml` — `unknown-git = "deny"` — and a note on what makes it leave.
 [patch.crates-io]
-did-git-sign = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
-vgi-core = { git = "https://github.com/OpenVTC/verifiable-git-infrastructure", branch = "chore/vta-sdk-036" }
-
 vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
 vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
 vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }

--- a/deny.toml
+++ b/deny.toml
@@ -125,6 +125,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # onto the vta-sdk 0.36 line; VTI's release PR publishes the `vta-service` closure
 # on that line. Each URL leaves with its patch entries when its release publishes.
 allow-git = [
-    "https://github.com/OpenVTC/verifiable-git-infrastructure",
     "https://github.com/OpenVTC/verifiable-trust-infrastructure",
 ]

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -38,10 +38,10 @@ anyhow.workspace = true
 # own repo (OpenVTC/verifiable-git-infrastructure); openvtc is a downstream
 # consumer of the published crate.
 #
-# On the vta-sdk 0.36 line this resolves from VGI's `chore/vta-sdk-036` through
-# the root manifest's `[patch.crates-io]`, until VGI publishes that move; 0.4.8
-# requires `vta-sdk ^0.35`. The floor stays 0.4.8, which the patched branch
-# satisfies, and moves to the release when the patch leaves.
+# 0.4.9 is published and carries the vta-sdk 0.36 move, so the root manifest's
+# `[patch.crates-io]` entries for VGI are gone. Neither `did-git-sign` 0.4.9 nor
+# its `vgi-core` 0.4.9 dependency pulls `vta-sdk`, so there is no second sdk to
+# unify.
 #
 # Floor is 0.4.8, and on the 0.35 line it was also where this actually resolved
 # from. 0.4.8 is published and requires `vta-sdk ^0.35`, so
@@ -77,7 +77,7 @@ anyhow.workspace = true
 # rather than as a wall of satisfied constraints — 0.4.5 was the first release on
 # vta-sdk 0.25, 0.4.3 the first on 0.23, and 0.4.0/0.4.1 were on `^0.19` and put
 # a second vta-sdk *and* a second trust-tasks in the binary.
-did-git-sign = "0.4.8"
+did-git-sign = "0.4.9"
 base64.workspace = true
 byteorder.workspace = true
 chrono.workspace = true


### PR DESCRIPTION
## The break

`cargo install --path openvtc` fails on `main`:

```
error: failed to compile `openvtc v0.3.1`
Caused by: failed to load source for dependency `did-git-sign`
Caused by: unable to update https://github.com/OpenVTC/verifiable-git-infrastructure?branch=chore%2Fvta-sdk-036
Caused by: failed to find branch `chore/vta-sdk-036`
```

The two VGI `[patch.crates-io]` entries name a **branch**, and that branch was deleted when its work merged. Anyone building `main` hits this, not just a stale checkout.

The manifest already carried the lesson, in the paragraph covering the *VTI* entries:

> A `rev` on `main` stays fetchable, where the feature branches this used to name were deleted when the vetting stack merged.

The VTI entries took that advice. The VGI entries didn't.

## Why the patch goes rather than moves

Re-pointing at a `rev` would work, but the patch has no reason left to exist. It was there because:

> `did-git-sign` 0.4.8 — the latest published — requires `vta-sdk ^0.35`, so on the 0.36 line it would put a second sdk in this binary.

**`did-git-sign` 0.4.9 and `vgi-core` 0.4.9 are published, and neither depends on `vta-sdk` at all.** `vgi-core` 0.4.9's entire normal dependency set is `anyhow`, `base64`, `ed25519-dalek`, `multibase`, `serde_json`, `sha2`. So there is no second sdk to unify, and no reason to build VGI from git — which also removes a git dependency from the supply chain.

That is the exit the comment block itself specified: *"Each block leaves when its release is published: delete its entries here and its URL from `allow-git` in `deny.toml`. For VGI, also raise the `did-git-sign` floor in `openvtc/Cargo.toml` to that release."*

## Changes

- both VGI `[patch.crates-io]` entries removed
- `did-git-sign` floor raised to `0.4.9` in `openvtc/Cargo.toml`
- VGI URL removed from `allow-git` in `deny.toml`
- rationale block rewritten; the VTI block is untouched and still pins its `rev`, with the branch-deletion lesson now recorded next to it

## Lockfile

Both crates move from the git branch to crates.io with checksums. One unrelated line moves too: `data-encoding-macro-internal` shifts from `syn` 1.0.109 onto the `syn` 3.0.5 already in the tree. That is forced by re-resolution rather than chosen — the identical change appears from a minimal `cargo update -p did-git-sign -p vgi-core`. `syn` 1.0.109 remains for `wezterm-dynamic-derive`.

## Verification

- `cargo check -p openvtc --all-targets` — clean
- `cargo deny check sources` — `sources ok` (confirms the `allow-git` removal leaves nothing behind)
- exactly one `vta-sdk` in the graph: 0.36.0, still via the VTI `rev` patch

## Not fixed here

The graph still carries **both `didwebvh-rs` 0.6.1 and 0.7.0**, because the patched `vta-sdk` 0.36.0 requires `didwebvh-rs ^0.6`. That resolves when OpenVTC/verifiable-trust-infrastructure#1452 publishes `vta-sdk` 0.38.0, which carries the `HostPolicy::PublicOnly` webvh fix — at which point the VTI `rev` entries can move forward or leave entirely. Same pending item as VGI.
