### PR TITLE
chore(deps): take the published VTI and VGI releases, and the generated vetting types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **The vetting wire types are the published, generated ones.** `vta-sdk` 0.37
+  deleted its hand-written copies of the peer-vetting payloads and re-exports
+  the generated `trust_tasks_rs::specs` types in their place, so what this
+  client puts on the wire is what the specifications state. Every vetting call
+  site moved with them: the generated structs are `#[non_exhaustive]` and are
+  built through `X::builder()`, constrained strings are newtypes, and
+  `check_shape()` arrives as the `CheckShape` trait.
+
+  The generated types **validate what the hand-written ones accepted**, and
+  three values this client used to send are now refused where they are built
+  rather than by the community:
+
+  - a vetter who accepts no documentation sent `acceptsDocumentation: []`. The
+    published response requires at least one entry, so the member is omitted
+    instead — a vetter may still accept nothing, which is what V0 intends for
+    someone they already know.
+  - a ticket code went out as it was typed. The published short code is
+    upper-case Crockford base32, so a typed code is normalised into that form
+    before the request is built, and a code that cannot be is refused with the
+    same sentence as before.
+  - a statement could list `none` among its document classes. No document is
+    the empty list, so `none` is dropped — and a documentary method left with
+    nothing to rely on is refused rather than attested.
+
+  The vocabulary is generated **per specification**, so `VettingMethod` exists
+  five times over (the manifest's, the request's, the session's, the profile's
+  and the listing's) with the same wire tokens and no relation between the Rust
+  types. This client keeps the community's copy in its own state and carries a
+  value across each task boundary by the token both spell.
+
+- **Every dependency resolves from crates.io again.** The `[patch.crates-io]`
+  block carrying twenty VTI crates and two VGI ones is deleted, and with it both
+  `allow-git` entries in `deny.toml`: `vta-sdk` 0.37, `vta-service` 0.26,
+  `vti-common` 0.18.4 and `did-git-sign` 0.4.9 are published. One thing the
+  unwind did not buy: `did-git-sign` 0.4.9 requires `vta-sdk ^0.36` against this
+  workspace's 0.37, so the graph still carries a second sdk — and no patch can
+  close it, because 0.4.9 is the commit VGI `main` is on. It closes when VGI
+  releases on 0.37.
+
 - **A `did:webvh` DID on a non-public host no longer resolves.** Resolving a
   `did:webvh` DID fetches `did.jsonl` from the host the DID itself names, so
   until now a DID such as `did:webvh:<scid>:localhost%3A9099` — or a public name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,7 +2799,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vgi-core",
- "vta-sdk",
+ "vta-sdk 0.36.0",
  "windows-native-keyring-store",
  "zeroize",
 ]
@@ -6190,7 +6190,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "windows-native-keyring-store",
  "x25519-dalek 2.0.1",
  "zeroize",
@@ -6251,7 +6251,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vta-service",
  "wiremock",
  "x25519-dalek 2.0.1",
@@ -9196,9 +9196,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-capability-client"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7b5f903a6209a0ae4fa4a8e3b33b9725e7037e0cdc3253402e5f293671cccd"
+checksum = "17cda83dbfa2a6e68b2784737f21f26dcb3119df4e4c0d5399f37e59693ccfcf"
 dependencies = [
  "chrono",
  "serde",
@@ -9210,9 +9210,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-didcomm"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a201c6a35b22a8dee360849713674088578fda52eec380c8ae7401ea6dda035"
+checksum = "b5657b84e6f47db783619aa146c2781f3533f93f997e9c41f37fd5b54d8920e0"
 dependencies = [
  "affinidi-messaging-didcomm",
  "base64 0.22.1",
@@ -9226,9 +9226,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-https"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bc820b3fecfbd92b212519086e967fab2f9a2290788dd039f643382b752d9d"
+checksum = "8002af0c794c56f4d2d9ee740592224ebdb76451d0412cff0054ed451808869e"
 dependencies = [
  "axum",
  "chrono",
@@ -9245,9 +9245,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-proof"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31443f250461a1718837ec744b666e23306125cc756055305ba7ed6cf600160f"
+checksum = "67b359d3cb88e1b684bd4c37058693d30a851fe2c6d47a47a24780340fc1af6c"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9262,9 +9262,9 @@ dependencies = [
 
 [[package]]
 name = "trust-tasks-rs"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dbddbfa65cacec94a8c6423fdde6bfd3236c1e2ac51fd6276c5f801682566f"
+checksum = "c2f308a570035bc810d285c264a202e267c553ec67a32dacbd79da8e304f7c89"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9668,25 +9668,28 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91a65dfa8f4843626ada808fc45dac64378ece80792fa15004ea199cc6d34147"
 dependencies = [
  "async-trait",
  "chrono",
  "hex",
+ "metrics",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-backup"
-version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a420598d65f26a0ee48f87d7925be040e40b206f4d4607344edecc88beaecd"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -9704,7 +9707,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vta-support",
  "vti-common",
  "zeroize",
@@ -9712,8 +9715,9 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.15.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb7bcb8fb32a6c7e15bcdb63d1590f23ad9479e60c0325a90be0923a383ab24"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9731,7 +9735,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vtc-client",
  "vti-common",
  "x25519-dalek 3.0.0",
@@ -9739,8 +9743,9 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9364abdfa1023499f8d5c3b8b68b76b94a7494ce0e47c8572625e60e168be1"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9748,15 +9753,16 @@ dependencies = [
  "sha2 0.11.0",
  "toml",
  "tracing",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vti-common",
  "vti-secrets",
 ]
 
 [[package]]
 name = "vta-keys"
-version = "0.4.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "badeb87f482165653c5d0f7f5c96c6def5bf50ac4a4e2b3b92ab04407173045b"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9779,7 +9785,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vti-common",
  "vti-secrets",
  "x25519-dalek 3.0.0",
@@ -9788,8 +9794,9 @@ dependencies = [
 
 [[package]]
 name = "vta-keyspaces"
-version = "0.2.7"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eed9f151bb65427157c255d9c541416925057eae3036dd696737450c7384cb0"
 dependencies = [
  "vti-common",
 ]
@@ -9797,7 +9804,8 @@ dependencies = [
 [[package]]
 name = "vta-persona"
 version = "0.3.2"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460c2b98df9f13cc16f28dcaf75d080077fcddb4637f3132c308a943589b1e2f"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -9814,8 +9822,9 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815f9e18dfbc33116cd1ccd6eb95a24ce76413febc50132f3cdaab57bd85dcb4"
 dependencies = [
  "hex",
  "multibase",
@@ -9827,14 +9836,61 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-sdk"
 version = "0.36.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba4a57d063ed5ccae8c8dd582d7e975b0d3fcd38aee5097bb852b4850e4010b"
+dependencies = [
+ "affinidi-crypto",
+ "affinidi-data-integrity",
+ "affinidi-did-common",
+ "affinidi-did-resolver-cache-sdk",
+ "affinidi-did-resolver-traits",
+ "affinidi-messaging-core",
+ "affinidi-messaging-delivery",
+ "affinidi-messaging-didcomm",
+ "affinidi-openid4vci",
+ "affinidi-openid4vp",
+ "affinidi-secrets-resolver",
+ "affinidi-tdk",
+ "affinidi-vc",
+ "agent-names",
+ "async-trait",
+ "base64 0.23.1",
+ "chrono",
+ "ciborium",
+ "curve25519-dalek 5.0.0",
+ "didwebvh-rs 0.6.1",
+ "dirs",
+ "ed25519-dalek 3.0.0",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hpke",
+ "multibase",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "trust-tasks-rs",
+ "url",
+ "uuid",
+ "x25519-dalek 3.0.0",
+ "zeroize",
+]
+
+[[package]]
+name = "vta-sdk"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96f16f01022012bc84d5e444b9a6f2694af9a5714ec523c500fc01b52ba6320"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9851,7 +9907,6 @@ dependencies = [
  "affinidi-status-list",
  "affinidi-tdk",
  "affinidi-vc",
- "agent-names",
  "apple-native-keyring-store",
  "async-trait",
  "base64 0.23.1",
@@ -9887,8 +9942,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.25.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c725987432fba3a23f9f2b037072421567d6a0b8c02f26568dba6328c1d491f"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9966,7 +10022,7 @@ dependencies = [
  "vta-keyspaces",
  "vta-persona",
  "vta-policy",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vta-support",
  "vta-sweepers",
  "vta-vault",
@@ -9984,8 +10040,9 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.5"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebaef655ac8ef9b41795fc6c70fa36efa6a967887927d7e35aec9c517f16b09"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -9998,14 +10055,15 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-sweepers"
-version = "0.3.4"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5abf46f60b7cf80761dcc2ebc39fddd2fc7857c28af75bee6c2ab163371d6be"
 dependencies = [
  "chrono",
  "serde_json",
@@ -10018,8 +10076,9 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.6"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2197585726cf5cc89de079707ed2316244401f40a056ec1b77593b7083f7fcd"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10042,15 +10101,16 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vti-common",
  "x509-parser 0.18.1",
 ]
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.7"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eedf06bb69e068ebb6ec3ef5d2564d36d5f832bcd44998335100fb8ec8fb69c"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10060,15 +10120,16 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vti-common",
  "zeroize",
 ]
 
 [[package]]
 name = "vtc-client"
-version = "0.6.0"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae7673d6b96970b0076a72e9c03a361e856132f25f54bd1dbbea0774315c79b7"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10076,14 +10137,15 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "trust-tasks-rs",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "vti-rooms",
 ]
 
 [[package]]
 name = "vti-common"
-version = "0.18.3"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdd33305b8656bd9b61829b4385ad4b66b0339325b844caeb995534f29adf54"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10118,7 +10180,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk",
+ "vta-sdk 0.37.0",
  "webauthn-rs",
  "zeroize",
 ]
@@ -10126,7 +10188,8 @@ dependencies = [
 [[package]]
 name = "vti-rooms"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64559fcb9b3fc014bf13767d153ce1acb766ef8ea32f1b9f0d01640b60393d62"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -10150,8 +10213,9 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms-dtg"
-version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5acd6a397fcc882cc2a87c79b6ea2d25219638b7361a7adf7e2001d91a98d1"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10167,8 +10231,9 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.5"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a26188a7fd97a2171eadb77f4b2054ebf6fe9d359fcbf2eb9a332a6d4ebcfa4"
 dependencies = [
  "hex",
  "serde",
@@ -10181,7 +10246,8 @@ dependencies = [
 [[package]]
 name = "vti-webauthn"
 version = "0.2.1"
-source = "git+https://github.com/OpenVTC/verifiable-trust-infrastructure?rev=14ef89a6ef9b330f7544414134d4818a6e2c7bfb#14ef89a6ef9b330f7544414134d4818a6e2c7bfb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd90a117f0599d443b9eff0f790fd0990162f003a10ebfead1ab8275f51c011"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-messaging-mediator"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f6e935295f1c9eec0fa7ee609f3f6e88f855b788712dbfac334c50279dbdf0"
+checksum = "3b6e6bc49148927068b3bb42e32e7ec3a26c8a1a118cd682acd6b876f0071e55"
 dependencies = [
  "affinidi-crypto",
  "affinidi-did-common",
@@ -386,7 +386,7 @@ dependencies = [
  "chrono",
  "clap",
  "dashmap",
- "didwebvh-rs 0.6.1",
+ "didwebvh-rs 0.7.0",
  "futures-util",
  "governor",
  "hostname",
@@ -727,14 +727,15 @@ dependencies = [
 
 [[package]]
 name = "affinidi-tdk-common"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864083bc98bc29e8ed049b8c477532f9f435a6befe75edb9cac2d9cf257842ec"
+checksum = "d6235d6d0506aed283966e11bbe4bf1e6cda94e0188aa09db15d9be95d3aa61f"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-did-authentication",
  "affinidi-did-common",
  "affinidi-did-resolver-cache-sdk",
+ "affinidi-net-guard",
  "affinidi-secrets-resolver",
  "ahash",
  "apple-native-keyring-store",
@@ -2135,9 +2136,9 @@ checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+checksum = "01a7799fd6b852db0e61728dde9a204c423b44d689dbd432522543614b490e78"
 dependencies = [
  "cfg-if",
 ]
@@ -4540,9 +4541,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+checksum = "0ab1baf72f08796de0260609515130699b890ac25f30e610ad894bc5856cafdb"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -4557,18 +4558,19 @@ dependencies = [
 
 [[package]]
 name = "jiff-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+checksum = "5e52fe76043ccecc9005d2305ebaadf7d7fc0cc89ca6baa10a94d6bc68c7128c"
 dependencies = [
  "defmt",
+ "log",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+checksum = "378268a1116ad67ae6228701118ac9f491d78fda38a40a1f1a9e1348de6f7212"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -5145,9 +5147,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
+checksum = "6480ccc157a1389bb2e4891b24751b0f798ba640d22386f23143fbcc89da195a"
 dependencies = [
  "libc",
 ]
@@ -6190,7 +6192,7 @@ dependencies = [
  "tui-input",
  "url",
  "uuid",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "windows-native-keyring-store",
  "x25519-dalek 2.0.1",
  "zeroize",
@@ -6251,7 +6253,7 @@ dependencies = [
  "trust-tasks-rs",
  "url",
  "uuid",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vta-service",
  "wiremock",
  "x25519-dalek 2.0.1",
@@ -8387,9 +8389,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "snafu"
@@ -9668,9 +9670,9 @@ dependencies = [
 
 [[package]]
 name = "vta-audit"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a65dfa8f4843626ada808fc45dac64378ece80792fa15004ea199cc6d34147"
+checksum = "9f20e989f6bc50a8603a9fba95d0814e505a28ee15c0c630ec2e94abec1ef898"
 dependencies = [
  "async-trait",
  "chrono",
@@ -9681,15 +9683,15 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vti-common",
 ]
 
 [[package]]
 name = "vta-backup"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a420598d65f26a0ee48f87d7925be040e40b206f4d4607344edecc88beaecd"
+checksum = "7750b47a50f70b2c83d961ac6cf9780a60fb6a22a830768ca893d5cf42b9a60c"
 dependencies = [
  "aes-gcm 0.11.1",
  "argon2 0.6.0",
@@ -9707,7 +9709,7 @@ dependencies = [
  "vta-config",
  "vta-keys",
  "vta-keyspaces",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vta-support",
  "vti-common",
  "zeroize",
@@ -9715,9 +9717,9 @@ dependencies = [
 
 [[package]]
 name = "vta-cli-common"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb7bcb8fb32a6c7e15bcdb63d1590f23ad9479e60c0325a90be0923a383ab24"
+checksum = "5850d4c28f9c60b54fa259b153d36dc9891ffb8b2c8f311960b85d9e032a11c1"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9735,7 +9737,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.20",
  "tokio",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vtc-client",
  "vti-common",
  "x25519-dalek 3.0.0",
@@ -9743,9 +9745,9 @@ dependencies = [
 
 [[package]]
 name = "vta-config"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9364abdfa1023499f8d5c3b8b68b76b94a7494ce0e47c8572625e60e168be1"
+checksum = "515851c8e28e26bf175be26904925467c52cbcfe917ae62004901adb0bd272a6"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -9753,16 +9755,16 @@ dependencies = [
  "sha2 0.11.0",
  "toml",
  "tracing",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vti-common",
  "vti-secrets",
 ]
 
 [[package]]
 name = "vta-keys"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badeb87f482165653c5d0f7f5c96c6def5bf50ac4a4e2b3b92ab04407173045b"
+checksum = "7639ba9e099e41a8cd128238c235b30e561d700eef8be820e462e84699d03416"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9785,7 +9787,7 @@ dependencies = [
  "uuid",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vti-common",
  "vti-secrets",
  "x25519-dalek 3.0.0",
@@ -9803,9 +9805,9 @@ dependencies = [
 
 [[package]]
 name = "vta-persona"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460c2b98df9f13cc16f28dcaf75d080077fcddb4637f3132c308a943589b1e2f"
+checksum = "beb69debca1d66128104cdf13a3bedb9ac0ff89374e51cda39d24646d570c0d2"
 dependencies = [
  "chrono",
  "hmac 0.13.0",
@@ -9822,9 +9824,9 @@ dependencies = [
 
 [[package]]
 name = "vta-policy"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815f9e18dfbc33116cd1ccd6eb95a24ce76413febc50132f3cdaab57bd85dcb4"
+checksum = "ff764d6cf0f38c4ec765e6ef4dde87fc8d3507df2eb8571a079cb0218c8ba333"
 dependencies = [
  "hex",
  "multibase",
@@ -9836,7 +9838,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vti-common",
 ]
 
@@ -9888,9 +9890,9 @@ dependencies = [
 
 [[package]]
 name = "vta-sdk"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96f16f01022012bc84d5e444b9a6f2694af9a5714ec523c500fc01b52ba6320"
+checksum = "75232f010392bd234dab89bcdc15e7edf47677b4591e941860013a1d5e81bc7a"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -9914,7 +9916,7 @@ dependencies = [
  "ciborium",
  "curve25519-dalek 5.0.0",
  "dbus-secret-service-keyring-store",
- "didwebvh-rs 0.6.1",
+ "didwebvh-rs 0.7.0",
  "dirs",
  "dtg-credentials 0.9.1",
  "ed25519-dalek 3.0.0",
@@ -9942,9 +9944,9 @@ dependencies = [
 
 [[package]]
 name = "vta-service"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c725987432fba3a23f9f2b037072421567d6a0b8c02f26568dba6328c1d491f"
+checksum = "49c7521eea5ada7ce6ec28ec88b11674cc5a75f2b8e998918e2978e6ef9903bd"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-crypto",
@@ -9972,7 +9974,7 @@ dependencies = [
  "ciborium",
  "clap",
  "dialoguer",
- "didwebvh-rs 0.6.1",
+ "didwebvh-rs 0.7.0",
  "dirs",
  "dtg-credentials 0.9.1",
  "ed25519-dalek 3.0.0",
@@ -10022,7 +10024,7 @@ dependencies = [
  "vta-keyspaces",
  "vta-persona",
  "vta-policy",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vta-support",
  "vta-sweepers",
  "vta-vault",
@@ -10040,9 +10042,9 @@ dependencies = [
 
 [[package]]
 name = "vta-support"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebaef655ac8ef9b41795fc6c70fa36efa6a967887927d7e35aec9c517f16b09"
+checksum = "daae7ca7aa23c4f53a61409bb8efe6c45571cdd2344b13af7ea59f2e1ff16207"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",
@@ -10055,7 +10057,7 @@ dependencies = [
  "tracing",
  "vta-config",
  "vta-keyspaces",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vti-common",
 ]
 
@@ -10076,9 +10078,9 @@ dependencies = [
 
 [[package]]
 name = "vta-vault"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2197585726cf5cc89de079707ed2316244401f40a056ec1b77593b7083f7fcd"
+checksum = "d4671f8802c04473408a62c1dd11d1276f5fab5aca9c0a5bacf4690321288d36"
 dependencies = [
  "affinidi-crypto",
  "affinidi-data-integrity",
@@ -10101,16 +10103,16 @@ dependencies = [
  "tracing",
  "uuid",
  "vta-keyspaces",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vti-common",
  "x509-parser 0.18.1",
 ]
 
 [[package]]
 name = "vta-webvh"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eedf06bb69e068ebb6ec3ef5d2564d36d5f832bcd44998335100fb8ec8fb69c"
+checksum = "48cc981d04f8564b42553d592ca6aca0c1ea327796f5ba21b834f31e25da1a0b"
 dependencies = [
  "affinidi-tdk",
  "chrono",
@@ -10120,16 +10122,16 @@ dependencies = [
  "tracing",
  "url",
  "vta-keyspaces",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vti-common",
  "zeroize",
 ]
 
 [[package]]
 name = "vtc-client"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7673d6b96970b0076a72e9c03a361e856132f25f54bd1dbbea0774315c79b7"
+checksum = "b39066fcf958e337e5b7aef48c80cb0f32f42fbcfaba7ec758154fd8c2adf59c"
 dependencies = [
  "chrono",
  "reqwest",
@@ -10137,15 +10139,15 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "trust-tasks-rs",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "vti-rooms",
 ]
 
 [[package]]
 name = "vti-common"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdd33305b8656bd9b61829b4385ad4b66b0339325b844caeb995534f29adf54"
+checksum = "59033dc828ed87783e699c113e71d5c08d8f67aa355375c3ead26507a8cf1301"
 dependencies = [
  "aes-gcm 0.11.1",
  "affinidi-data-integrity",
@@ -10180,20 +10182,20 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
- "vta-sdk 0.37.0",
+ "vta-sdk 0.38.0",
  "webauthn-rs",
  "zeroize",
 ]
 
 [[package]]
 name = "vti-rooms"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64559fcb9b3fc014bf13767d153ce1acb766ef8ea32f1b9f0d01640b60393d62"
+checksum = "0fa25875fcd25a260c1ccaf2e15cb9d1e315cf0222e93e18c7baa7c15fa3c2e1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
- "chacha20poly1305 0.10.1",
+ "chacha20poly1305 0.11.0",
  "chrono",
  "getrandom 0.2.17",
  "getrandom 0.4.3",
@@ -10213,9 +10215,9 @@ dependencies = [
 
 [[package]]
 name = "vti-rooms-dtg"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5acd6a397fcc882cc2a87c79b6ea2d25219638b7361a7adf7e2001d91a98d1"
+checksum = "fe6183d111d9b651583af2eb619bb31f281cb496e81d43e95e4335b8d5c4dd05"
 dependencies = [
  "affinidi-data-integrity",
  "affinidi-secrets-resolver",
@@ -10231,9 +10233,9 @@ dependencies = [
 
 [[package]]
 name = "vti-secrets"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a26188a7fd97a2171eadb77f4b2054ebf6fe9d359fcbf2eb9a332a6d4ebcfa4"
+checksum = "357ccee11387b5f1549157a6792d021706d29e8877a0312a45f2a4b76f8e5a32"
 dependencies = [
  "hex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ aes-gcm = "0.11"
 # `affinidi-messaging-sdk`, and no line we control moves it. The bump puts us on
 # the same copy as `vta-service` rather than on the older one.
 argon2 = "0.6"
-# The floor is set by the graph, not chosen here: `vta-sdk` 0.36 and
-# `vta-service` on VTI `main` both declare `^0.14`, and `affinidi-messaging-test-mediator`
+# The floor is set by the graph, not chosen here: `vta-sdk` 0.37 and
+# `vta-service` 0.26 both declare `^0.14`, and `affinidi-messaging-test-mediator`
 # 0.7 does too. This line only records it.
 affinidi-tdk = "0.14"
 affinidi-data-integrity = "0.7"
@@ -85,7 +85,7 @@ affinidi-messaging-core = "0.1.6"
 # `atm.trust_tasks().account_update`), so its line is not independent of the one
 # below: a copy left on an older trust-tasks is a *second* semver-incompatible
 # `trust-tasks-rs` whose types do not unify. 0.24 is the line built on
-# trust-tasks 0.20, and it is also what `vta-sdk` 0.36 and
+# trust-tasks 0.20, and it is also what `vta-sdk` 0.37 and
 # `affinidi-messaging-test-mediator` 0.7 declare — so it is the graph's floor
 # whether or not this line states it.
 #
@@ -192,15 +192,17 @@ dialoguer = { version = "0.12", features = ["password"] }
 # gained `BlockedHost`, which `OpenVTCError::WebVH` carries through by `#[from]`
 # rather than matching on).
 #
-# **The graph does hold a second copy, 0.6.1, and that is the VTI patch block at
-# the foot of this file rather than anything chosen here.** Every VTI crate
-# declares `didwebvh-rs = "0.6"`, and `"0.6"` excludes 0.7, so `vta-sdk`,
-# `vta-keys` and `vta-tee` keep 0.6.1 until VTI takes 0.7 and releases. Nothing
-# crosses between the two — VTI's use is minting and log-entry work behind its
-# own API, and no didwebvh-rs type appears in a signature this workspace calls
-# — so the duplicate is a `cargo tree -d` row, not a type error. It collapses
-# when the VTI entries below go. `cargo tree -i didwebvh-rs` is the check: the
-# **resolution** path (`affinidi-did-resolver-cache-sdk`) must be the 0.7 node.
+# **The graph does hold a second copy, 0.6.1, and it is the published VTI crates
+# that hold it there rather than anything chosen here.** Every VTI crate declares
+# `didwebvh-rs = "0.6"`, and `"0.6"` excludes 0.7, so `vta-sdk` 0.37 and its
+# closure keep 0.6.1. Taking the release rather than the patch did not collapse
+# this one: `vta-sdk` 0.37 declares `^0.6` exactly as the patched checkout did.
+# Nothing crosses between the two — VTI's use is minting and log-entry work
+# behind its own API, and no didwebvh-rs type appears in a signature this
+# workspace calls — so the duplicate is a `cargo tree -d` row, not a type error.
+# It collapses when VTI takes 0.7 and releases. `cargo tree -i didwebvh-rs` is
+# the check: the **resolution** path (`affinidi-did-resolver-cache-sdk`) must be
+# the 0.7 node.
 didwebvh-rs = "0.7"
 ed25519-dalek-bip32 = "0.3"
 hkdf = "0.13"
@@ -280,10 +282,14 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # rows means this pin has drifted from vta-sdk's again, whichever direction it
 # drifted.
 #
-# The patch is named because vta-sdk 0.36 declares `^0.20.3`, not a bare `^0.20`
+# The patch is named because vta-sdk 0.37 declares `^0.20.4`, not a bare `^0.20`
 # — a floor below what the sdk itself requires is a floor that does nothing.
-# 0.20.3 is the release VTI main pins across the whole stack, so that is the
-# line the services actually build against.
+# 0.20.4 is the release the whole published VTI stack is built on (`vta-sdk`
+# 0.37, `vta-service` 0.26, `vtc-client` 0.6.1, `vti-common` 0.18.4 all declare
+# it), and it is the release that *generates* the vetting wire types the sdk now
+# re-exports. So this line is forced by the graph rather than chosen here: the
+# generated types reach this repo through `vta_sdk::protocols::vetting`, and a
+# `trust-tasks-rs` a patch behind would re-export a different set of them.
 #
 # `trust-tasks-capability-client` moves with it for the same reason — it
 # re-exports the same `TrustTask`. Upstream releases the six siblings as one
@@ -299,22 +305,32 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # messaging stack carries `trust-tasks-rs` types in its own API, so
 # `affinidi-messaging-sdk` (above) and the `affinidi-messaging-test-mediator`
 # dev-dependency both have to sit on the line built against it.
-trust-tasks-rs = "0.20.3"
-trust-tasks-capability-client = "0.20.3"
+trust-tasks-rs = "0.20.4"
+trust-tasks-capability-client = "0.20.4"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-# The 0.36 line — the one VTI main builds `vta-service` on and deploys, and the
-# one that declares `trust-tasks-rs ^0.20.3`. As always this pin *follows* the
-# VTA rather than leading it; see the `trust-tasks-rs` note above for why the two
-# versions cannot be chosen independently.
+# The 0.37 line — the published release the rest of the VTI stack is built on
+# (`vta-service` 0.26, `vtc-client` 0.6.1, `vti-common` 0.18.4), and the one that
+# declares `trust-tasks-rs ^0.20.4`. As always this pin *follows* the VTA rather
+# than leading it; see the `trust-tasks-rs` note above for why the two versions
+# cannot be chosen independently.
 #
-# 0.36 is taken for peer identity vetting (`docs/design/vetting-process.md`): the
-# `vetting` feature and `protocols::vetting` land on this line (VTI #1425
-# onward, unreleased). Nothing else in 0.36 touches this repo's use of the sdk. Its one
-# breaking change, VTI #1417, domain-separates the opaque `keys/sign` oracle, and
-# nothing here calls it — every proof this repo produces is built locally by
-# `affinidi-data-integrity`.
+# **0.37 is where the vetting wire types stop being the sdk's own.** VTI #1439
+# deleted the hand-written `protocols::vetting` bodies and re-exports the
+# generated `trust_tasks_rs::specs` types in their place, so what this repo puts
+# on the wire is what the specifications state. For a consumer that is a rewrite
+# of the call sites rather than a version bump: the generated structs are
+# `#[non_exhaustive]` and built through `X::builder()`, constrained strings are
+# newtypes, and `check_shape()` arrives as the `CheckShape` trait. The behaviour
+# to know at this level is that the generated types *validate* what the
+# hand-written ones accepted — unique lists, claim-type patterns, `urn:uuid` card
+# ids, absolute https URIs — so a value the schema refuses now fails here instead
+# of being refused by the community after it was sent.
+#
+# 0.36 was where the `vetting` feature and `protocols::vetting` first landed (VTI
+# #1425 onward). It was never resolvable from crates.io as a whole stack, which
+# is why this workspace carried a patch block across that line and does not now.
 #
 # **0.35 refuses an unsigned trust-task reply by default, and that is a
 # deployment ordering constraint rather than a code one.** The only API change
@@ -366,20 +382,26 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # ContextDirection}` as its own public API, so the two copies carry types that
 # cannot unify, and in practice the build fails outright rather than mis-typing.
 #
-# There are two such edges. One still moves here; the other has stopped.
+# There are two such edges, and on this line they do not move together:
 #
-# - `vta-service`, which `openvtc-core` dev-depends on for `MockVta`. The
-#   published 0.25.1 is still built on 0.35, so on this line it resolves from VTI
-#   `main` through the patch block at the foot of this file. Dev-only, which is exactly why it gets forgotten —
-#   the *shipped* graph looks clean while the harness tests this client against
-#   a server it is no longer paired with.
-# - `did-git-sign`, the standing obligation — **settled, and no longer an sdk
-#   obligation at all**. It blocked six consecutive minors (0.23, 0.25, 0.27,
-#   0.31, 0.32, 0.34); 0.35 was the one it did not, because 0.4.8 resolved from
-#   crates.io. 0.36 reintroduced it briefly, since 0.4.8 required `vta-sdk
-#   ^0.35`. That ended with 0.4.9: neither it nor its `vgi-core` 0.4.9
-#   dependency pulls `vta-sdk`, so it resolves from crates.io and an sdk bump
-#   cannot block on VGI again.
+# - `vta-service`, which `openvtc-core` dev-depends on for `MockVta`. **0.26 is
+#   published and built on 0.37**, so the dev graph resolves from crates.io
+#   again. Dev-only, which is exactly why it gets forgotten — the *shipped*
+#   graph looks clean while the harness tests this client against a server it is
+#   no longer paired with.
+# - `did-git-sign`, the standing obligation, **unsatisfied on this line and not
+#   fixable from here**. 0.4.9 is the newest release and requires `vta-sdk
+#   ^0.36`, so the graph carries a second sdk: 0.37.0 for this workspace, 0.36.x
+#   beneath `did-git-sign`. A `[patch]` cannot close it this time — 0.4.9 was cut
+#   from VGI `main` and `main` is on 0.36 too, so there is no newer commit to
+#   point at. It blocked six consecutive minors before this one (0.23, 0.25,
+#   0.27, 0.31, 0.32, 0.34) and 0.35 was the only line it did not.
+#
+#   The duplicate costs a `cargo tree -d` row rather than a build failure, and
+#   the reason is narrow enough to be worth stating: we use
+#   `did_git_sign::{config, init}` only, so no sdk type crosses that boundary.
+#   One new import is all it would take. It closes when VGI takes 0.37 and
+#   releases, and the floor in `openvtc/Cargo.toml` moves to that release.
 #
 # `trql-client`, the third git-pinned edge in this ecosystem, does **not**
 # depend on `vta-sdk` at all, so the trust registry needs no release for an sdk
@@ -398,7 +420,7 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # pane now calls both. On 0.34.0 the pane compiles and then cannot find the
 # constants; naming the patch is what turns that into a resolver error at the
 # point where it can be read.
-vta-sdk = { version = "0.36", features = [
+vta-sdk = { version = "0.37", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses
@@ -410,7 +432,8 @@ vta-sdk = { version = "0.36", features = [
   "provision-client",
   # Peer identity vetting: the Vetting Card and Statement, their verification,
   # requirement evaluation and the session match code
-  # (`docs/design/vetting-process.md`).
+  # (`docs/design/vetting-process.md`). The wire types the feature operates on
+  # are generated and always compiled — `protocols::vetting` is not behind it.
   "vetting",
   # Routes the Trust-Task surface over TSP as a leg of the existing DIDComm
   # session (VTI #803 / #810) — no second socket, no second mediator connection.
@@ -454,60 +477,24 @@ codegen-units = 1
 strip = "symbols"
 
 
-# `[patch.crates-io]` is back, for one repository and one release.
+# No `[patch.crates-io]`.
 #
-# VGI is out. `did-git-sign` 0.4.9 and `vgi-core` 0.4.9 are published, and
-# neither depends on `vta-sdk` at all any more, so the second-sdk problem the
-# patch existed to avoid is gone with it. The floor in `openvtc/Cargo.toml` is
-# 0.4.9 and both crates resolve from crates.io.
+# The block that stood here carried two repositories across one release each, and
+# both releases have landed: VTI published `vta-sdk` 0.37 with the whole
+# `vta-service` 0.26 closure behind it, and VGI published `did-git-sign` 0.4.9.
+# So every dependency resolves from crates.io and the block is deleted rather
+# than left empty, so that adding one back is a visible decision.
 #
-# That block is also the cautionary tale for the paragraph below: it named a
-# *branch*, `chore/vta-sdk-036`, which was deleted once its work merged, and
-# every `cargo install` then failed with "failed to find branch". Pin a `rev`,
-# never a branch.
+# What the unwind did *not* buy is the thing a patch block is usually kept for.
+# `did-git-sign` 0.4.9 requires `vta-sdk ^0.36` against this workspace's 0.37, so
+# the graph still holds two sdks — and a patch is no longer the lever, because
+# VGI `main` is the commit 0.4.9 was cut from. The `vta-sdk` note above has the
+# detail; the fix is a VGI release, not an entry here.
 #
-# VTI. `vta-sdk` 0.36.0 is published but the `vta-service` built on it is not:
-# 0.25.1 on crates.io still pulls `vta-sdk ^0.35` through its whole subsystem
-# closure, and that closure no longer compiles against `vta-sdk` 0.35.1
-# (`vta-keys` 0.4.5, missing `KeyRecord::exportable`). The release PR
-# (OpenVTC/verifiable-trust-infrastructure#1416) publishes the lot. Until it
-# merges, every VTI crate this graph reaches resolves from one checkout of the
-# repository, so there is exactly one of each. The list is every VTI crate in
-# `cargo tree`, not only the two named in a manifest: a crate left on crates.io
-# would pull its own `vti-common` beside the patched one.
-#
-# The VTI entries pin a commit on VTI `main` by `rev`: 14ef89a, where the vetter
-# registry work (OpenVTC/verifiable-trust-infrastructure#1430) merged. A `rev`
-# on `main` stays fetchable, where the feature branches this used to name were
-# deleted when the vetting stack merged. Move the pin forward only to another
-# commit on VTI `main`, and remove these entries with the release that follows.
-#
-# Each block leaves when its release is published: delete its entries here and
-# its URL from `allow-git` in `deny.toml`. For VGI, also raise the `did-git-sign`
-# floor in `openvtc/Cargo.toml` to that release.
-#
-# The history, kept short: this workspace carried a patch for six consecutive sdk
-# minors and unwound it on 0.35, when `did-git-sign` 0.4.8, `vta-sdk` 0.35.0 and
-# `trql-client` 0.17 were all published. As then, a patch here needs its entry in
-# `deny.toml` — `unknown-git = "deny"` — and a note on what makes it leave.
-[patch.crates-io]
-vta-audit = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-backup = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-cli-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-config = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-keys = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-keyspaces = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-persona = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-policy = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-sdk = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-service = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-support = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-sweepers = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-vault = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vta-webvh = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vtc-client = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vti-common = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vti-rooms = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vti-rooms-dtg = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vti-secrets = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
-vti-webauthn = { git = "https://github.com/OpenVTC/verifiable-trust-infrastructure", rev = "14ef89a6ef9b330f7544414134d4818a6e2c7bfb" }
+# `deny.toml`'s `allow-git` list is the other half of every entry, and is empty
+# again too. The two are edited together: `unknown-git = "deny"` means a patch
+# added here without an entry there fails `cargo deny check sources`, and nothing
+# in either file points at the other. Adding one back means adding it in both
+# places, and writing down here what has to happen for it to leave again — the
+# entries removed each carried that note, and it is the only reason this unwind
+# and the one before it were tractable.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ aes-gcm = "0.11"
 # `affinidi-messaging-sdk`, and no line we control moves it. The bump puts us on
 # the same copy as `vta-service` rather than on the older one.
 argon2 = "0.6"
-# The floor is set by the graph, not chosen here: `vta-sdk` 0.37 and
-# `vta-service` 0.26 both declare `^0.14`, and `affinidi-messaging-test-mediator`
+# The floor is set by the graph, not chosen here: `vta-sdk` 0.38 and
+# `vta-service` 0.27 both declare `^0.14`, and `affinidi-messaging-test-mediator`
 # 0.7 does too. This line only records it.
 affinidi-tdk = "0.14"
 affinidi-data-integrity = "0.7"
@@ -85,7 +85,7 @@ affinidi-messaging-core = "0.1.6"
 # `atm.trust_tasks().account_update`), so its line is not independent of the one
 # below: a copy left on an older trust-tasks is a *second* semver-incompatible
 # `trust-tasks-rs` whose types do not unify. 0.24 is the line built on
-# trust-tasks 0.20, and it is also what `vta-sdk` 0.37 and
+# trust-tasks 0.20, and it is also what `vta-sdk` 0.38 and
 # `affinidi-messaging-test-mediator` 0.7 declare — so it is the graph's floor
 # whether or not this line states it.
 #
@@ -192,17 +192,18 @@ dialoguer = { version = "0.12", features = ["password"] }
 # gained `BlockedHost`, which `OpenVTCError::WebVH` carries through by `#[from]`
 # rather than matching on).
 #
-# **The graph does hold a second copy, 0.6.1, and it is the published VTI crates
-# that hold it there rather than anything chosen here.** Every VTI crate declares
-# `didwebvh-rs = "0.6"`, and `"0.6"` excludes 0.7, so `vta-sdk` 0.37 and its
-# closure keep 0.6.1. Taking the release rather than the patch did not collapse
-# this one: `vta-sdk` 0.37 declares `^0.6` exactly as the patched checkout did.
-# Nothing crosses between the two — VTI's use is minting and log-entry work
-# behind its own API, and no didwebvh-rs type appears in a signature this
-# workspace calls — so the duplicate is a `cargo tree -d` row, not a type error.
-# It collapses when VTI takes 0.7 and releases. `cargo tree -i didwebvh-rs` is
-# the check: the **resolution** path (`affinidi-did-resolver-cache-sdk`) must be
-# the 0.7 node.
+# **The second copy has narrowed to one cause, the same one as the second sdk.**
+# It was 0.6.1, held by every VTI crate declaring `didwebvh-rs = "0.6"`, which
+# excludes 0.7. `vta-sdk` 0.38 declares `^0.7` and `vta-service` 0.27 does too,
+# so the published closure no longer holds it. What remains is `vta-sdk` 0.36.0,
+# and the only thing pulling *that* is `did-git-sign` 0.4.9 — so this row and the
+# second sdk are now the same obligation with two names, and both close on a VGI
+# release. Nothing crosses between the two copies (VTI's use is minting and
+# log-entry work behind its own API, and no didwebvh-rs type appears in a
+# signature this workspace calls), so it costs a `cargo tree -d` row rather than
+# a build failure. `cargo tree -i didwebvh-rs` is the check: the **resolution**
+# path (`affinidi-did-resolver-cache-sdk`) must be the 0.7 node, and after the
+# VGI release there should be no other.
 didwebvh-rs = "0.7"
 ed25519-dalek-bip32 = "0.3"
 hkdf = "0.13"
@@ -282,10 +283,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # rows means this pin has drifted from vta-sdk's again, whichever direction it
 # drifted.
 #
-# The patch is named because vta-sdk 0.37 declares `^0.20.4`, not a bare `^0.20`
+# The patch is named because vta-sdk 0.38 declares `^0.20.4`, not a bare `^0.20`
 # — a floor below what the sdk itself requires is a floor that does nothing.
 # 0.20.4 is the release the whole published VTI stack is built on (`vta-sdk`
-# 0.37, `vta-service` 0.26, `vtc-client` 0.6.1, `vti-common` 0.18.4 all declare
+# 0.38, `vta-service` 0.27, `vtc-client` 0.6.2, `vti-common` 0.18.5 all declare
 # it), and it is the release that *generates* the vetting wire types the sdk now
 # re-exports. So this line is forced by the graph rather than chosen here: the
 # generated types reach this repo through `vta_sdk::protocols::vetting`, and a
@@ -310,11 +311,16 @@ trust-tasks-capability-client = "0.20.4"
 tui-input = "0.15"
 url = "2.5"
 uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
-# The 0.37 line — the published release the rest of the VTI stack is built on
-# (`vta-service` 0.26, `vtc-client` 0.6.1, `vti-common` 0.18.4), and the one that
+# The 0.38 line — the published release the rest of the VTI stack is built on
+# (`vta-service` 0.27, `vtc-client` 0.6.2, `vti-common` 0.18.5), and the one that
 # declares `trust-tasks-rs ^0.20.4`. As always this pin *follows* the VTA rather
 # than leading it; see the `trust-tasks-rs` note above for why the two versions
 # cannot be chosen independently.
+#
+# 0.38 itself adds one thing this workspace should know about: the resolver
+# refuses `did:webvh` resolution to non-public hosts by default (VTI #1448).
+# That is the same rule this repo took in #312, so it is a floor moving under a
+# behaviour already adopted rather than a new one arriving.
 #
 # **0.37 is where the vetting wire types stop being the sdk's own.** VTI #1439
 # deleted the hand-written `protocols::vetting` bodies and re-exports the
@@ -384,24 +390,25 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 #
 # There are two such edges, and on this line they do not move together:
 #
-# - `vta-service`, which `openvtc-core` dev-depends on for `MockVta`. **0.26 is
-#   published and built on 0.37**, so the dev graph resolves from crates.io
+# - `vta-service`, which `openvtc-core` dev-depends on for `MockVta`. **0.27 is
+#   published and built on 0.38**, so the dev graph resolves from crates.io
 #   again. Dev-only, which is exactly why it gets forgotten — the *shipped*
 #   graph looks clean while the harness tests this client against a server it is
 #   no longer paired with.
 # - `did-git-sign`, the standing obligation, **unsatisfied on this line and not
 #   fixable from here**. 0.4.9 is the newest release and requires `vta-sdk
-#   ^0.36`, so the graph carries a second sdk: 0.37.0 for this workspace, 0.36.x
-#   beneath `did-git-sign`. A `[patch]` cannot close it this time — 0.4.9 was cut
-#   from VGI `main` and `main` is on 0.36 too, so there is no newer commit to
-#   point at. It blocked six consecutive minors before this one (0.23, 0.25,
-#   0.27, 0.31, 0.32, 0.34) and 0.35 was the only line it did not.
+#   ^0.36`, so the graph carries a second sdk: 0.38.0 for this workspace, 0.36.x
+#   beneath `did-git-sign`. A `[patch]` cannot close it — 0.4.9 was cut from VGI
+#   `main`, so there is no newer commit to point at. It blocked six consecutive
+#   minors before this one (0.23, 0.25, 0.27, 0.31, 0.32, 0.34) and 0.35 was the
+#   only line it did not.
 #
 #   The duplicate costs a `cargo tree -d` row rather than a build failure, and
 #   the reason is narrow enough to be worth stating: we use
 #   `did_git_sign::{config, init}` only, so no sdk type crosses that boundary.
-#   One new import is all it would take. It closes when VGI takes 0.37 and
-#   releases, and the floor in `openvtc/Cargo.toml` moves to that release.
+#   One new import is all it would take. **VGI `main` is already on 0.38** (VGI
+#   #51), so what remains is a VGI *release*: when one is cut, the floor in
+#   `openvtc/Cargo.toml` moves to it and this row disappears.
 #
 # `trql-client`, the third git-pinned edge in this ecosystem, does **not**
 # depend on `vta-sdk` at all, so the trust registry needs no release for an sdk
@@ -420,7 +427,7 @@ uuid = { version = "1.23", features = ["v4", "fast-rng", "serde"] }
 # pane now calls both. On 0.34.0 the pane compiles and then cannot find the
 # constants; naming the patch is what turns that into a resolver error at the
 # point where it can be read.
-vta-sdk = { version = "0.37", features = [
+vta-sdk = { version = "0.38", features = [
   "session",
   "client",
   # The SAME per-platform credential-store registration pnm-cli uses
@@ -481,12 +488,13 @@ strip = "symbols"
 #
 # The block that stood here carried two repositories across one release each, and
 # both releases have landed: VTI published `vta-sdk` 0.37 with the whole
-# `vta-service` 0.26 closure behind it, and VGI published `did-git-sign` 0.4.9.
+# `vta-service` 0.26 closure behind it — since superseded by 0.38 and 0.27, which
+# is what these floors now name — and VGI published `did-git-sign` 0.4.9.
 # So every dependency resolves from crates.io and the block is deleted rather
 # than left empty, so that adding one back is a visible decision.
 #
 # What the unwind did *not* buy is the thing a patch block is usually kept for.
-# `did-git-sign` 0.4.9 requires `vta-sdk ^0.36` against this workspace's 0.37, so
+# `did-git-sign` 0.4.9 requires `vta-sdk ^0.36` against this workspace's 0.38, so
 # the graph still holds two sdks — and a patch is no longer the lever, because
 # VGI `main` is the commit 0.4.9 was cut from. The `vta-sdk` note above has the
 # detail; the fix is a VGI release, not an entry here.

--- a/deny.toml
+++ b/deny.toml
@@ -120,10 +120,9 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # Adding one back means adding it in both places, and writing down here what has
 # to happen for it to leave again. The entries that were removed each carried
 # that note, and it is the only reason the unwind was tractable six minors later.
-# Now two entries, each for as long as one release — see the patch block at the
-# foot of the root `Cargo.toml`. VGI's `chore/vta-sdk-036` carries `did-git-sign`
-# onto the vta-sdk 0.36 line; VTI's release PR publishes the `vta-service` closure
-# on that line. Each URL leaves with its patch entries when its release publishes.
-allow-git = [
-    "https://github.com/OpenVTC/verifiable-trust-infrastructure",
-]
+# Both entries are gone again, and for the reason the paragraph above describes:
+# VTI published `vta-sdk` 0.37 with the `vta-service` 0.26 closure behind it, and
+# VGI published `did-git-sign` 0.4.9. The patch block at the foot of the root
+# `Cargo.toml` went with them, so nothing resolves from a git source and there is
+# nothing left to allow.
+allow-git = []

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -115,7 +115,7 @@ affinidi-messaging-test-mediator = "0.7"
 # `vta-service` is the VTA server crate; it carries the credential-vault
 # lifecycle tasks (receive/query/archive/delete/restore/purge) + the
 # `MockVta::start_provisionable` seams used by the e2e tests. Track this with
-# the vta-sdk major: **0.26 is the line built against 0.37**, and it is published,
+# the vta-sdk major: **0.27 is the line built against 0.38**, and it is published,
 # so this resolves from crates.io again rather than through the patch block the
 # 0.36 line needed. 0.25 was the line built against 0.35, as 0.24 was
 # against 0.34, 0.23 against 0.32, 0.19 against 0.27, 0.17 against 0.25, 0.15
@@ -124,9 +124,17 @@ affinidi-messaging-test-mediator = "0.7"
 # wire types are generated, so a mismatch is a type error rather than a silent
 # shape difference.
 #
-# 0.26 also declares `trust-tasks-rs ^0.20.4` and `affinidi-tdk ^0.14`, which is
+# 0.27 also declares `trust-tasks-rs ^0.20.4` and `affinidi-tdk ^0.14`, which is
 # what keeps the **dev** graph from growing the second copy of each that the
 # root manifest's notes warn about.
+#
+# The move from 0.26 to 0.27 is that warning coming true rather than a routine
+# refresh. 0.26 requires `vta-sdk ^0.37` and `didwebvh-rs ^0.6`; with the
+# workspace on `vta-sdk` 0.38 that dev edge alone held a third sdk node (0.37.0)
+# in the graph and kept `didwebvh-rs` 0.6.1 beside the 0.7 the resolver uses.
+# 0.27 requires `^0.38` and `^0.7`, so raising this floor is what collapses both.
+# The shipped graph looked clean throughout — this is exactly the dev-only edge
+# the note above says gets forgotten.
 #
 # Its `affinidi-messaging-sdk` edge is still on `^0.21` upstream, one line
 # behind the runtime graph — but it sits behind the non-default `tsp` feature,
@@ -141,7 +149,7 @@ affinidi-messaging-test-mediator = "0.7"
 # ApproveScope, ContextDirection}` as its own public API, so a graph holding two
 # sdks has two distinct `ApproveScope` types that do not unify. VTI republished
 # this crate for exactly this reason (see its Cargo.toml note on `publish`).
-vta-service = { version = "0.26", default-features = false, features = ["test-support", "rest", "didcomm"] }
+vta-service = { version = "0.27", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc-core/Cargo.toml
+++ b/openvtc-core/Cargo.toml
@@ -115,15 +115,16 @@ affinidi-messaging-test-mediator = "0.7"
 # `vta-service` is the VTA server crate; it carries the credential-vault
 # lifecycle tasks (receive/query/archive/delete/restore/purge) + the
 # `MockVta::start_provisionable` seams used by the e2e tests. Track this with
-# the vta-sdk major: on the 0.36 line this resolves from VTI `main` through the
-# root manifest's `[patch.crates-io]` — the published 0.25.1 is still built on
-# 0.35 — and the floor moves to the release that publishes it (VTI #1416). 0.25
-# was the line built against 0.35, as 0.24 was
+# the vta-sdk major: **0.26 is the line built against 0.37**, and it is published,
+# so this resolves from crates.io again rather than through the patch block the
+# 0.36 line needed. 0.25 was the line built against 0.35, as 0.24 was
 # against 0.34, 0.23 against 0.32, 0.19 against 0.27, 0.17 against 0.25, 0.15
 # against 0.23 and 0.14 against 0.21. An older line pulls an older sdk into the test build and the two
-# disagree about the wire types the e2e tests assert on.
+# disagree about the wire types the e2e tests assert on — and on this line those
+# wire types are generated, so a mismatch is a type error rather than a silent
+# shape difference.
 #
-# VTI `main` also carries `trust-tasks-rs ^0.20.3` and `affinidi-tdk ^0.14`, which is
+# 0.26 also declares `trust-tasks-rs ^0.20.4` and `affinidi-tdk ^0.14`, which is
 # what keeps the **dev** graph from growing the second copy of each that the
 # root manifest's notes warn about.
 #
@@ -140,7 +141,7 @@ affinidi-messaging-test-mediator = "0.7"
 # ApproveScope, ContextDirection}` as its own public API, so a graph holding two
 # sdks has two distinct `ApproveScope` types that do not unify. VTI republished
 # this crate for exactly this reason (see its Cargo.toml note on `publish`).
-vta-service = { version = "0.25.1", default-features = false, features = ["test-support", "rest", "didcomm"] }
+vta-service = { version = "0.26", default-features = false, features = ["test-support", "rest", "didcomm"] }
 base64 = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 secrecy = { workspace = true }

--- a/openvtc-core/src/vetting/applicant.rs
+++ b/openvtc-core/src/vetting/applicant.rs
@@ -20,11 +20,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
-use vta_sdk::protocols::join_requests::JoinRequestManifestResponseBody;
+use vta_sdk::protocols::join_requests::manifest;
 use vta_sdk::protocols::vetting::{
-    CardClaim, DeclaredRelationship, DeclineCode, ShapeError, TicketPresentation, VETTER_ROLE,
-    VettingDeclineBody, VettingMethod, VettingRequestAcceptedBody, VettingRequestBody,
-    VettingRequirements, VettingSessionBody,
+    CheckShape, ShapeError, VETTER_ROLE, VettingMethod, VettingRelationship, VettingRequirements,
+    check_request, decline, request, session,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::VettingError;
@@ -124,7 +123,12 @@ pub enum NextStep {
 }
 
 /// One application.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+///
+/// No `PartialEq`: it carries the community's generated requirements and the
+/// generated card claims, and the generated wire types derive only
+/// `Serialize`, `Deserialize`, `Clone` and `Debug`. Requirements are compared
+/// with [`super::book::same_requirements`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Application {
     /// Local handle.
     pub id: String,
@@ -157,7 +161,7 @@ pub struct Application {
     /// name differently commit to different identities, and the community
     /// refers the application.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub identity_claims: Vec<CardClaim>,
+    pub identity_claims: Vec<session::v0_1::VettingCardClaim>,
     /// Requests to vetters, newest last.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requests: Vec<OutboundRequest>,
@@ -302,7 +306,7 @@ pub enum RequestState {
     Declined {
         /// Their reason code, if they gave one.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        code: Option<DeclineCode>,
+        code: Option<decline::v0_1::PayloadCode>,
         /// Their note, if any.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         message: Option<String>,
@@ -362,7 +366,7 @@ pub struct HeldStatement {
     /// How they vetted us.
     pub method: VettingMethod,
     /// The relationship they declared.
-    pub declared_relationship: DeclaredRelationship,
+    pub declared_relationship: VettingRelationship,
     /// What they relied on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub document_classes: Vec<String>,
@@ -434,10 +438,9 @@ impl Application {
     /// [`ApplicantError::InvalidRequirements`].
     pub fn adopt_manifest(
         &mut self,
-        manifest: &JoinRequestManifestResponseBody,
+        manifest: &manifest::v0_2::Response,
     ) -> Result<bool, ApplicantError> {
-        let with_vetting =
-            |c: &&vta_sdk::protocols::join_requests::ManifestCriterion| c.vetting.is_some();
+        let with_vetting = |c: &&manifest::v0_2::Criterion| c.vetting.is_some();
         let chosen = self
             .criterion_id
             .as_deref()
@@ -446,19 +449,26 @@ impl Application {
                     .criteria
                     .iter()
                     .filter(with_vetting)
-                    .find(|c| c.id == id)
+                    .find(|c| c.id.as_str() == id)
             })
             .or_else(|| manifest.criteria.iter().find(with_vetting))
             .ok_or(ApplicantError::NoVettingCriterion)?;
         let requirements = chosen.vetting.clone().expect("filtered on vetting");
         requirements
-            .validate()
-            .map_err(|e| ApplicantError::InvalidRequirements(e.0))?;
-        let changed = self.requirements.as_ref() != Some(&requirements)
-            || self.requirements_digest != chosen.requirements_digest;
-        self.criterion_id = Some(chosen.id.clone());
+            .check_shape()
+            .map_err(|e| ApplicantError::InvalidRequirements(e.to_string()))?;
+        let digest = chosen
+            .requirements_digest
+            .as_ref()
+            .map(|d| d.as_str().to_string());
+        let changed = !self
+            .requirements
+            .as_ref()
+            .is_some_and(|r| super::book::same_requirements(r, &requirements))
+            || self.requirements_digest != digest;
+        self.criterion_id = Some(chosen.id.as_str().to_string());
         self.requirements = Some(requirements);
-        self.requirements_digest = chosen.requirements_digest.clone();
+        self.requirements_digest = digest;
         Ok(changed)
     }
 
@@ -472,23 +482,53 @@ impl Application {
         &mut self,
         document_id: &str,
         vetter: &str,
-        ticket: TicketPresentation,
+        ticket: request::v0_1::Ticket,
         draft: RequestDraft,
         now: DateTime<Utc>,
-    ) -> Result<VettingRequestBody, ShapeError> {
-        let body = VettingRequestBody {
-            community: self.community.clone(),
-            requirements_digest: self.requirements_digest.clone(),
-            join_did: self.join_did.clone(),
-            ticket: Some(ticket),
-            introduction: None,
-            preferred_method: draft.preferred_method,
-            languages: draft.languages,
-            message: draft.message,
-            availability: draft.availability,
-            ext: None,
-        };
-        body.check_shape(&self.join_did)?;
+    ) -> Result<request::v0_1::Payload, ShapeError> {
+        let schema = |e: &dyn std::fmt::Display| ShapeError::Schema(e.to_string());
+        let languages = draft
+            .languages
+            .iter()
+            .map(|l| {
+                request::v0_1::PayloadLanguagesItem::try_from(l.as_str()).map_err(|e| schema(&e))
+            })
+            .collect::<Result<Vec<_>, ShapeError>>()?;
+        let message = draft
+            .message
+            .map(|m| request::v0_1::PayloadMessage::try_from(m).map_err(|e| schema(&e)))
+            .transpose()?;
+        let availability = draft
+            .availability
+            .map(|a| request::v0_1::PayloadAvailability::try_from(a).map_err(|e| schema(&e)))
+            .transpose()?;
+        // The request task carries its own copy of the method vocabulary.
+        let preferred = draft
+            .preferred_method
+            .map(|m| {
+                super::same_token::<_, request::v0_1::VettingMethod>(&m).map_err(|e| schema(&e))
+            })
+            .transpose()?;
+        let digest = self
+            .requirements_digest
+            .as_deref()
+            .map(|d| request::v0_1::DigestMultibase::try_from(d).map_err(|e| schema(&e)))
+            .transpose()?;
+        let body = request::v0_1::Payload::try_from(
+            request::v0_1::Payload::builder()
+                .community(self.community.as_str())
+                .join_did(self.join_did.as_str())
+                .ticket(Some(ticket))
+                .requirements_digest(digest)
+                .preferred_method(preferred)
+                // An empty `languages` is sent as `[]` on this line where it
+                // used to be omitted, so "no preference" stays absent.
+                .languages((!languages.is_empty()).then_some(languages))
+                .message(message)
+                .availability(availability),
+        )
+        .map_err(|e| schema(&e))?;
+        check_request(&body, &self.join_did)?;
         self.requests.push(OutboundRequest {
             document_id: document_id.to_string(),
             vetter: vetter.to_string(),
@@ -568,7 +608,7 @@ impl Application {
         &mut self,
         thread: &str,
         vetter: &str,
-        body: VettingRequestAcceptedBody,
+        body: request::v0_1::Response,
         eligibility: VetterEligibility,
         now: DateTime<Utc>,
     ) -> Result<(), ApplicantError> {
@@ -576,15 +616,23 @@ impl Application {
         let request = self.by_thread(thread, vetter)?;
         match &request.state {
             RequestState::Sent => {}
-            RequestState::Accepted { request_id, .. } if *request_id == body.request_id => {}
+            RequestState::Accepted { request_id, .. }
+                if request_id.as_str() == body.request_id.as_str() => {}
             _ => return Err(ApplicantError::WrongState("be accepted")),
         }
         request.eligibility = Some(eligibility);
         request.grant_status = None;
         request.state = RequestState::Accepted {
-            request_id: body.request_id,
-            accepts_documentation: body.accepts_documentation,
-            session_hint: body.session_hint,
+            request_id: body.request_id.as_str().to_string(),
+            // `acceptsDocumentation` is absent rather than empty when a vetter
+            // accepts none, so an absent list and an empty one are one case.
+            accepts_documentation: body
+                .accepts_documentation
+                .iter()
+                .flatten()
+                .map(|d| d.as_str().to_string())
+                .collect(),
+            session_hint: body.session_hint.map(|h| h.as_str().to_string()),
         };
         request.updated_at = now;
         Ok(())
@@ -696,32 +744,47 @@ impl Application {
         &mut self,
         session_document_id: &str,
         vetter: &str,
-        body: VettingSessionBody,
+        body: session::v0_1::Payload,
         now: DateTime<Utc>,
     ) -> Result<OpenSession, ApplicantError> {
         body.check_shape()?;
-        if body.domain != self.community {
+        if body.domain.as_str() != self.community {
             return Err(ApplicantError::WrongCommunity);
         }
         if body.expires_at <= now {
             return Err(ApplicantError::SessionExpired);
         }
-        let request = self.by_request_id(&body.request_id, vetter)?;
+        let request = self.by_request_id(body.request_id.as_str(), vetter)?;
         if matches!(request.state, RequestState::Attested { .. }) {
             return Err(ApplicantError::WrongState("open another session"));
         }
+        // The session task has its own copy of the method vocabulary.
+        let method = super::same_token(&body.method).map_err(
+            |e: <VettingMethod as std::str::FromStr>::Err| {
+                ApplicantError::Shape(ShapeError::Schema(e.to_string()))
+            },
+        )?;
         let session = OpenSession {
             id: session_document_id.to_string(),
-            challenge: body.challenge,
-            domain: body.domain,
-            method: body.method,
-            required_claims: body.required_claims,
-            optional_claims: body.optional_claims,
+            challenge: body.challenge.as_str().to_string(),
+            domain: body.domain.as_str().to_string(),
+            method,
+            required_claims: body
+                .required_claims
+                .iter()
+                .map(|c| c.as_str().to_string())
+                .collect(),
+            optional_claims: body
+                .optional_claims
+                .iter()
+                .flatten()
+                .map(|c| c.as_str().to_string())
+                .collect(),
             expires_at: body.expires_at,
             match_code: vetting_match_code(session_document_id),
         };
         request.state = RequestState::Session {
-            request_id: body.request_id,
+            request_id: body.request_id.as_str().to_string(),
             session: session.clone(),
             card: None,
         };
@@ -769,7 +832,7 @@ impl Application {
         &self,
         session_id: &str,
         released: &[ReleasedClaim],
-    ) -> Result<Vec<CardClaim>, ApplicantError> {
+    ) -> Result<Vec<session::v0_1::VettingCardClaim>, ApplicantError> {
         let (_, session) = self
             .session(session_id)
             .ok_or(ApplicantError::NoMatchingRequest)?;
@@ -788,23 +851,29 @@ impl Application {
             if self
                 .identity_claims
                 .iter()
-                .any(|shown| shown.claim_type == claim.claim_type && shown.value != value)
+                .any(|shown| shown.type_.as_str() == claim.claim_type && shown.value != value)
             {
                 return Err(ApplicantError::IdentityChanged(claim.claim_type.clone()));
             }
-            claims.push(CardClaim {
-                claim_type: claim.claim_type.clone(),
-                value,
-                provenance: claim
-                    .provenance
-                    .clone()
-                    .unwrap_or_else(|| "unstated".to_string()),
-            });
+            claims.push(
+                session::v0_1::VettingCardClaim::try_from(
+                    session::v0_1::VettingCardClaim::builder()
+                        .type_(claim.claim_type.as_str())
+                        .value(value)
+                        .provenance(
+                            claim
+                                .provenance
+                                .clone()
+                                .unwrap_or_else(|| "unstated".to_string()),
+                        ),
+                )
+                .map_err(|e| ApplicantError::Shape(ShapeError::Schema(e.to_string())))?,
+            );
         }
         if let Some(missing) = session
             .required_claims
             .iter()
-            .find(|t| !claims.iter().any(|c| &c.claim_type == *t))
+            .find(|t| !claims.iter().any(|c| c.type_.as_str() == t.as_str()))
         {
             return Err(ApplicantError::MissingClaim(missing.clone()));
         }
@@ -821,15 +890,17 @@ impl Application {
         &mut self,
         session_id: &str,
         card: SentCard,
-        claims: &[CardClaim],
+        claims: &[session::v0_1::VettingCardClaim],
         now: DateTime<Utc>,
     ) -> Result<(), ApplicantError> {
         if let Some(changed) = claims.iter().find(|c| {
             self.identity_claims
                 .iter()
-                .any(|shown| shown.claim_type == c.claim_type && shown.value != c.value)
+                .any(|shown| shown.type_.as_str() == c.type_.as_str() && shown.value != c.value)
         }) {
-            return Err(ApplicantError::IdentityChanged(changed.claim_type.clone()));
+            return Err(ApplicantError::IdentityChanged(
+                changed.type_.as_str().to_string(),
+            ));
         }
         let request = self
             .requests
@@ -844,7 +915,7 @@ impl Application {
             if !self
                 .identity_claims
                 .iter()
-                .any(|shown| shown.claim_type == claim.claim_type)
+                .any(|shown| shown.type_.as_str() == claim.type_.as_str())
             {
                 self.identity_claims.push(claim.clone());
             }
@@ -862,7 +933,7 @@ impl Application {
     pub fn card_draft(
         &self,
         session_id: &str,
-        claims: Vec<CardClaim>,
+        claims: Vec<session::v0_1::VettingCardClaim>,
         now: DateTime<Utc>,
     ) -> Result<CardDraft, ApplicantError> {
         let (vetter, session) = self
@@ -871,17 +942,18 @@ impl Application {
         if session.expires_at <= now {
             return Err(ApplicantError::SessionExpired);
         }
-        let claims: Vec<CardClaim> = claims
+        let claims: Vec<session::v0_1::VettingCardClaim> = claims
             .into_iter()
             .filter(|c| {
-                session.required_claims.contains(&c.claim_type)
-                    || session.optional_claims.contains(&c.claim_type)
+                let wanted = |t: &String| t.as_str() == c.type_.as_str();
+                session.required_claims.iter().any(wanted)
+                    || session.optional_claims.iter().any(wanted)
             })
             .collect();
         if let Some(missing) = session
             .required_claims
             .iter()
-            .find(|t| !claims.iter().any(|c| &c.claim_type == *t))
+            .find(|t| !claims.iter().any(|c| c.type_.as_str() == t.as_str()))
         {
             return Err(ApplicantError::MissingClaim(missing.clone()));
         }
@@ -944,9 +1016,9 @@ impl Application {
         )
         .await?;
         let recorded = SentCard {
-            id: verified.card().id.clone(),
+            id: verified.card().id.as_str().to_string(),
             digest_multibase: verified.digest_multibase().to_string(),
-            identity_commitment: verified.card().identity_commitment.clone(),
+            identity_commitment: verified.card().identity_commitment.as_str().to_string(),
             sent_at: now,
         };
         *sent = Some(recorded.clone());
@@ -1012,8 +1084,16 @@ impl Application {
             vetter: vetter.to_string(),
             method: endorsement.method,
             declared_relationship: endorsement.declared_relationship,
-            document_classes: endorsement.document_classes.clone(),
-            claims_verified: endorsement.claims_verified.clone(),
+            document_classes: endorsement
+                .document_classes
+                .iter()
+                .map(|d| d.as_str().to_string())
+                .collect(),
+            claims_verified: endorsement
+                .claims_verified
+                .iter()
+                .map(|c| c.as_str().to_string())
+                .collect(),
             identity_commitment: endorsement.identity_commitment.clone(),
             valid_from: verified.valid_from(),
             valid_until: verified.valid_until(),
@@ -1037,17 +1117,17 @@ impl Application {
     pub fn on_decline(
         &mut self,
         vetter: &str,
-        body: VettingDeclineBody,
+        body: decline::v0_1::Payload,
         now: DateTime<Utc>,
     ) -> Result<(), ApplicantError> {
         body.check_shape()?;
-        let request = self.by_request_id(&body.request_id, vetter)?;
+        let request = self.by_request_id(body.request_id.as_str(), vetter)?;
         if matches!(request.state, RequestState::Attested { .. }) {
             return Err(ApplicantError::WrongState("be declined after attesting"));
         }
         request.state = RequestState::Declined {
             code: body.code,
-            message: body.message,
+            message: body.message.map(|m| m.as_str().to_string()),
         };
         request.updated_at = now;
         Ok(())

--- a/openvtc-core/src/vetting/book.rs
+++ b/openvtc-core/src/vetting/book.rs
@@ -9,8 +9,8 @@
 
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
-use vta_sdk::protocols::join_requests::{CommunityBranding, JoinRequestManifestResponseBody};
-use vta_sdk::protocols::vetting::{VettingRequirements, documentation};
+use vta_sdk::protocols::join_requests::manifest;
+use vta_sdk::protocols::vetting::{CheckShape, VettingRequirements, documentation};
 
 use super::applicant::{Application, RequestState};
 use super::queries::CommunityQuery;
@@ -79,7 +79,13 @@ impl VetterPolicy {
 pub const FALLBACK_REQUIRED_CLAIMS: &[&str] = &["name.legal"];
 
 /// A community's vetting criterion, as last read from its manifest.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+///
+/// No `PartialEq`: it carries the generated [`VettingRequirements`], and the
+/// generated wire types derive only `Serialize`, `Deserialize`, `Clone` and
+/// `Debug`. Two criteria are compared by what they serialise to
+/// ([`same_requirements`]), which is what "the community changed what it asks"
+/// actually means.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KnownCriterion {
     /// The community.
     pub community: String,
@@ -145,13 +151,19 @@ impl Branding {
     }
 
     /// What of `branding` this client keeps: nothing, if it breaks its schema.
-    fn from_manifest(branding: &CommunityBranding) -> Self {
+    fn from_manifest(branding: &manifest::v0_2::CommunityBranding) -> Self {
         if branding.check_shape().is_err() {
             return Self::default();
         }
         Self {
-            display_name: branding.display_name.clone(),
-            accent_color: branding.accent_color.clone(),
+            display_name: branding
+                .display_name
+                .as_ref()
+                .map(|n| n.as_str().to_string()),
+            accent_color: branding
+                .accent_color
+                .as_ref()
+                .map(|c| c.as_str().to_string()),
         }
     }
 
@@ -190,7 +202,10 @@ pub struct KnownCommunity {
 }
 
 /// What this book knows of whether a community vets its members.
-#[derive(Clone, Copy, Debug, PartialEq)]
+///
+/// No `PartialEq`: [`Knowledge::Vetting`] borrows a [`KnownCriterion`], which
+/// carries the generated requirements. Match on it rather than compare it.
+#[derive(Clone, Copy, Debug)]
 pub enum Knowledge<'a> {
     /// Its manifest has not been read.
     Unknown,
@@ -200,8 +215,21 @@ pub enum Knowledge<'a> {
     Vetting(&'a KnownCriterion),
 }
 
+/// Whether two published requirements are the same value.
+///
+/// The generated [`VettingRequirements`] derives no `PartialEq`, so they are
+/// compared as what they serialise to — the wire value, which is what a
+/// community actually changed.
+#[must_use]
+pub fn same_requirements(a: &VettingRequirements, b: &VettingRequirements) -> bool {
+    serde_json::to_value(a).ok() == serde_json::to_value(b).ok()
+}
+
 /// All vetting state, for both sides.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+///
+/// No `PartialEq`: it holds applications, desk entries and criteria, and those
+/// carry generated wire types that derive none.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct VettingBook {
     /// Our applications, one per community and persona.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -292,7 +320,7 @@ impl VettingBook {
     pub fn learn_manifest(
         &mut self,
         community: &str,
-        manifest: &JoinRequestManifestResponseBody,
+        manifest: &manifest::v0_2::Response,
         now: DateTime<Utc>,
     ) -> bool {
         let fresh: Vec<KnownCriterion> = manifest
@@ -300,11 +328,14 @@ impl VettingBook {
             .iter()
             .filter_map(|c| {
                 let requirements = c.vetting.clone()?;
-                requirements.validate().ok()?;
+                requirements.check_shape().ok()?;
                 Some(KnownCriterion {
                     community: community.to_string(),
-                    criterion_id: c.id.clone(),
-                    requirements_digest: c.requirements_digest.clone(),
+                    criterion_id: c.id.as_str().to_string(),
+                    requirements_digest: c
+                        .requirements_digest
+                        .as_ref()
+                        .map(|d| d.as_str().to_string()),
                     requirements,
                     fetched_at: now,
                 })
@@ -319,7 +350,7 @@ impl VettingBook {
             && known.iter().zip(&fresh).all(|(a, b)| {
                 a.criterion_id == b.criterion_id
                     && a.requirements_digest == b.requirements_digest
-                    && a.requirements == b.requirements
+                    && same_requirements(&a.requirements, &b.requirements)
             });
         self.criteria.retain(|k| k.community != community);
         self.criteria.extend(fresh);
@@ -406,7 +437,10 @@ impl VettingBook {
         else {
             return false;
         };
-        let changed = app.requirements.as_ref() != Some(&criterion.requirements)
+        let changed = !app
+            .requirements
+            .as_ref()
+            .is_some_and(|r| same_requirements(r, &criterion.requirements))
             || app.requirements_digest != criterion.requirements_digest
             || app.criterion_id.as_deref() != Some(criterion.criterion_id.as_str());
         app.criterion_id = Some(criterion.criterion_id);
@@ -450,10 +484,17 @@ impl VettingBook {
             })
             .or_else(|| ours.next());
         match chosen {
-            Some(k) if !k.requirements.required_claims.is_empty() => {
-                (k.requirements.required_claims.clone(), true)
-            }
-            Some(_) => (Vec::new(), true),
+            // `requiredClaims` is an optional list of the generated `ClaimType`
+            // on this line, so an absent list and an empty one are one case.
+            Some(k) => (
+                k.requirements
+                    .required_claims
+                    .iter()
+                    .flatten()
+                    .map(|c| c.as_str().to_string())
+                    .collect(),
+                true,
+            ),
             None => (
                 FALLBACK_REQUIRED_CLAIMS
                     .iter()
@@ -472,16 +513,16 @@ impl VettingBook {
         let from_application = self
             .application(community, persona)
             .and_then(|a| a.requirements.as_ref())
-            .and_then(|r| r.decision_sla.as_deref());
+            .and_then(|r| r.decision_sla.clone());
         let from_criteria = || {
             self.criteria
                 .iter()
                 .filter(|k| k.community == community)
-                .find_map(|k| k.requirements.decision_sla.as_deref())
+                .find_map(|k| k.requirements.decision_sla.clone())
         };
         from_application
             .or_else(from_criteria)
-            .and_then(vta_sdk::protocols::vetting::parse_iso8601_duration)
+            .and_then(|sla| vta_sdk::protocols::vetting::parse_iso8601_duration(sla.as_str()))
     }
 
     /// Our application to `community` as `persona`.
@@ -637,10 +678,14 @@ mod tests {
         assert_eq!(book.applications.len(), 2);
     }
 
+    /// A `requirementsDigest` the published criterion accepts: base58btc, and
+    /// at least 16 characters. The old `"zDigest"` is refused on this line.
+    const DIGEST: &str = "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
+
     fn manifest(
-        branding: Option<CommunityBranding>,
+        branding: Option<manifest::v0_2::CommunityBranding>,
         vetting: bool,
-    ) -> JoinRequestManifestResponseBody {
+    ) -> manifest::v0_2::Response {
         let requirements: VettingRequirements = serde_json::from_value(serde_json::json!({
             "version": "0.1",
             "statementType": vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE,
@@ -650,30 +695,41 @@ mod tests {
             "eligibleVetters": { "role": "vetter" }
         }))
         .unwrap();
-        JoinRequestManifestResponseBody {
-            community_did: "did:web:vtc".into(),
-            criteria: vec![vta_sdk::protocols::join_requests::ManifestCriterion {
-                id: "c1".into(),
-                description: None,
-                presentation_definition: serde_json::json!({}),
-                vetting: vetting.then_some(requirements),
-                requirements_digest: Some("zDigest".into()),
-            }],
-            branding,
-        }
+        let criterion = manifest::v0_2::Criterion::try_from(
+            manifest::v0_2::Criterion::builder()
+                .id("c1")
+                .presentation_definition(serde_json::Map::new())
+                .vetting(vetting.then_some(requirements))
+                .requirements_digest(Some(
+                    manifest::v0_2::DigestMultibase::try_from(DIGEST).unwrap(),
+                )),
+        )
+        .unwrap();
+        manifest::v0_2::Response::try_from(
+            manifest::v0_2::Response::builder()
+                .community_did("did:web:vtc")
+                .criteria(vec![criterion])
+                .branding(branding),
+        )
+        .unwrap()
     }
 
     #[test]
     fn a_manifest_says_whether_a_community_vets_and_how_it_looks() {
         let mut book = VettingBook::default();
         let now = Utc::now();
-        assert_eq!(book.knowledge("did:web:vtc"), Knowledge::Unknown);
+        assert!(matches!(book.knowledge("did:web:vtc"), Knowledge::Unknown));
 
-        let branding = CommunityBranding {
-            display_name: Some("Kernel".into()),
-            accent_color: Some("#1a2B3c".into()),
-            ..CommunityBranding::default()
-        };
+        let branding = manifest::v0_2::CommunityBranding::try_from(
+            manifest::v0_2::CommunityBranding::builder()
+                .display_name(Some(
+                    manifest::v0_2::CommunityBrandingDisplayName::try_from("Kernel").unwrap(),
+                ))
+                .accent_color(Some(
+                    manifest::v0_2::CommunityBrandingAccentColor::try_from("#1a2B3c").unwrap(),
+                )),
+        )
+        .unwrap();
         assert!(book.learn_manifest("did:web:vtc", &manifest(Some(branding.clone()), true), now));
         assert!(matches!(
             book.knowledge("did:web:vtc"),
@@ -688,13 +744,22 @@ mod tests {
         );
 
         assert!(book.learn_manifest("did:web:open", &manifest(None, false), now));
-        assert_eq!(book.knowledge("did:web:open"), Knowledge::NoVetting);
+        assert!(matches!(
+            book.knowledge("did:web:open"),
+            Knowledge::NoVetting
+        ));
         assert!(book.branding("did:web:open").is_none());
 
-        let broken = CommunityBranding {
-            accent_color: Some("red".into()),
-            ..CommunityBranding::default()
-        };
+        // An accent the published type refuses cannot be built at all now, so
+        // what still reaches this client is branding the schema admits and
+        // `check_shape` refuses by hand: a `logoUrl` that is not an absolute
+        // https URI.
+        assert!(manifest::v0_2::CommunityBrandingAccentColor::try_from("red").is_err());
+        let broken: manifest::v0_2::CommunityBranding = serde_json::from_value(serde_json::json!({
+            "displayName": "Elsewhere",
+            "logoUrl": "http://vtc.example/logo.png"
+        }))
+        .expect("the schema admits it");
         book.learn_manifest("did:web:broken", &manifest(Some(broken), false), now);
         assert!(
             book.branding("did:web:broken").is_none(),
@@ -723,7 +788,7 @@ mod tests {
         assert!(book.adopt_known_requirements(&id));
         let app = book.application_by_id_mut(&id).unwrap();
         assert_eq!(app.criterion_id.as_deref(), Some("c1"));
-        assert_eq!(app.requirements_digest.as_deref(), Some("zDigest"));
+        assert_eq!(app.requirements_digest.as_deref(), Some(DIGEST));
         assert!(
             !book.adopt_known_requirements(&id),
             "nothing new the second time"

--- a/openvtc-core/src/vetting/guide.rs
+++ b/openvtc-core/src/vetting/guide.rs
@@ -7,7 +7,7 @@
 //! and the Vetting page, so they are made in one place.
 
 use vta_sdk::protocols::vetting::{
-    InvitationRequirement, VettingMethod, VettingRequirements, parse_iso8601_duration,
+    VettingMethod, VettingRequirements, VettingRequirementsInvitation, parse_iso8601_duration,
 };
 
 /// How a vetter meets an applicant, as the end of "a vetter can check you …".
@@ -64,7 +64,7 @@ fn join_words(items: &[String]) -> String {
 #[must_use]
 pub fn describe_requirements(requirements: &VettingRequirements) -> Vec<String> {
     let mut lines = Vec::new();
-    let n = requirements.min_statements;
+    let n = requirements.min_statements.get();
     lines.push(format!(
         "{n} vetting statement{}, each from a different vetter the community has named",
         if n == 1 { "" } else { "s" }
@@ -95,17 +95,21 @@ pub fn describe_requirements(requirements: &VettingRequirements) -> Vec<String> 
         (true, true) => "only vetters who already know you can vouch for you".to_string(),
         (true, false) => "the community names no way to be vetted".to_string(),
     });
-    if !requirements.required_claims.is_empty() {
-        let claims: Vec<String> = requirements
-            .required_claims
+    let required_claims = requirements.required_claims.as_deref().unwrap_or_default();
+    if !required_claims.is_empty() {
+        let claims: Vec<String> = required_claims
             .iter()
-            .map(|c| claim_words(c))
+            .map(|c| claim_words(c.as_str()))
             .collect();
         lines.push(match &requirements.accepted_document_classes {
             Some(classes) if !classes.is_empty() => format!(
                 "each vetter checks your {} against a document — one of: {}",
                 join_words(&claims),
-                classes.join(", ")
+                classes
+                    .iter()
+                    .map(|c| c.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
             _ => format!(
                 "each vetter checks your {} — against whichever documents that vetter accepts",
@@ -116,19 +120,19 @@ pub fn describe_requirements(requirements: &VettingRequirements) -> Vec<String> 
     if let Some(age) = &requirements.max_statement_age {
         lines.push(format!(
             "a statement counts for {} after it is signed",
-            duration_words(age)
+            duration_words(age.as_str())
         ));
     }
     if matches!(
         requirements.invitation,
-        Some(InvitationRequirement::Required)
+        Some(VettingRequirementsInvitation::Required)
     ) {
         lines.push("you also need an invitation from the community".to_string());
     }
     if let Some(sla) = &requirements.decision_sla {
         lines.push(format!(
             "the community says it decides within {}",
-            duration_words(sla)
+            duration_words(sla.as_str())
         ));
     }
     lines
@@ -175,8 +179,10 @@ mod tests {
     #[test]
     fn a_documentation_floor_is_named_when_the_community_sets_one() {
         let mut r = requirements();
-        r.accepted_document_classes = Some(vec!["passport".into()]);
-        r.required_claims.push("email.work".into());
+        r.accepted_document_classes = Some(vec!["passport".try_into().unwrap()]);
+        r.required_claims
+            .get_or_insert_with(Vec::new)
+            .push("email.work".try_into().unwrap());
         assert!(describe_requirements(&r).iter().any(|l| l
             == "each vetter checks your legal name and work email against a document — one of: \
                 passport"));

--- a/openvtc-core/src/vetting/inbound.rs
+++ b/openvtc-core/src/vetting/inbound.rs
@@ -31,15 +31,14 @@ use tracing::{debug, info, warn};
 use trust_tasks_rs::TrustTask;
 use vta_sdk::protocols::credential_exchange::ISSUE as CREDENTIAL_ISSUE_TYPE;
 use vta_sdk::protocols::join_requests::{
-    JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, JoinRequestManifestResponseBody,
+    JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, manifest as join_manifest,
 };
 use vta_sdk::protocols::vetting::{
-    RevokeStatementResponseBody, VETTER_ROLE, VETTING_DECLINE_TYPE, VETTING_REQUEST_RESPONSE_TYPE,
-    VETTING_REQUEST_TYPE, VETTING_REVOKE_STATEMENT_RESPONSE_TYPE, VETTING_SESSION_RESPONSE_TYPE,
-    VETTING_SESSION_TYPE, VETTING_VETTER_LIST_RESPONSE_TYPE, VETTING_VETTER_PROFILE_RESPONSE_TYPE,
-    VETTING_VETTER_RESEND_RESPONSE_TYPE, VetterListResponseBody, VetterProfileResponseBody,
-    VetterResendResponseBody, VettingDeclineBody, VettingRequestAcceptedBody, VettingRequestBody,
-    VettingSessionBody, VettingSessionResponseBody, role_matches,
+    VETTER_ROLE, VETTING_DECLINE_TYPE, VETTING_REQUEST_RESPONSE_TYPE, VETTING_REQUEST_TYPE,
+    VETTING_REVOKE_STATEMENT_RESPONSE_TYPE, VETTING_SESSION_RESPONSE_TYPE, VETTING_SESSION_TYPE,
+    VETTING_VETTER_LIST_RESPONSE_TYPE, VETTING_VETTER_PROFILE_RESPONSE_TYPE,
+    VETTING_VETTER_RESEND_RESPONSE_TYPE, decline, request, revoke_statement, role_matches, session,
+    vetters,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::eligibility::{
@@ -484,10 +483,10 @@ async fn take_request(
     let Some((persona, _)) = ctx.recipient else {
         return Handled::default();
     };
-    let Some(opened) = opened::<VettingRequestBody>(message, sender, ctx.resolver).await else {
+    let Some(opened) = opened::<request::v0_1::Payload>(message, sender, ctx.resolver).await else {
         return Handled::default();
     };
-    let community = opened.payload.community.clone();
+    let community = opened.payload.community.as_str().to_string();
     // A vetter is who the community named: an active member holding its live
     // role credential (design §10.3). The community checks again.
     let grant = book.vetter_grant(&community, persona, ctx.now).cloned();
@@ -510,7 +509,7 @@ async fn take_request(
     let throttled = book.throttle != throttle;
     match intake {
         Intake::Accepted(body) => {
-            let request_id = body.request_id.clone();
+            let request_id = body.request_id.as_str().to_string();
             let eligibility = grant.map(|g| EligibilityPresentation {
                 credentials: vec![g.credential],
                 nonce: opened.document.id.clone(),
@@ -563,7 +562,7 @@ async fn accepted(
     message: &Message,
     sender: &str,
 ) -> Handled {
-    let Some(opened) = opened::<VettingRequestAcceptedBody>(message, sender, ctx.resolver).await
+    let Some(opened) = opened::<request::v0_1::Response>(message, sender, ctx.resolver).await
     else {
         return Handled::default();
     };
@@ -578,7 +577,11 @@ async fn accepted(
     // made for someone else, or before the vetter lost the role, does not pass.
     // A verified grant's `credentialStatus` is kept for the revocation check.
     let mut grant_status_entry: Option<Option<Value>> = None;
-    let eligibility = match &opened.payload.eligibility_vp {
+    // The presentation is verified **as received** rather than re-serialised
+    // from the parsed response: it carries its own proof, and a parsed value
+    // written back out is not guaranteed to be the same bytes.
+    let presented = opened.document.payload.get("eligibilityVp");
+    let eligibility = match presented {
         None => VetterEligibility::NotShown,
         Some(vp) => {
             let expect = EligibilityExpectations {
@@ -658,10 +661,10 @@ async fn session(
     let Some((persona, _)) = ctx.recipient else {
         return Handled::default();
     };
-    let Some(opened) = opened::<VettingSessionBody>(message, sender, ctx.resolver).await else {
+    let Some(opened) = opened::<session::v0_1::Payload>(message, sender, ctx.resolver).await else {
         return Handled::default();
     };
-    let Some(application) = book.application_mut(&opened.payload.domain, persona) else {
+    let Some(application) = book.application_mut(opened.payload.domain.as_str(), persona) else {
         warn!(%sender, "vetting session for a community we are not applying to");
         return Handled::default();
     };
@@ -692,22 +695,21 @@ async fn card(
     let Some((_, our_did)) = ctx.recipient else {
         return Handled::default();
     };
-    let Some(opened) = opened::<VettingSessionResponseBody>(message, sender, ctx.resolver).await
-    else {
+    // Opened as the payload it arrived as: the card's `digestMultibase` — what
+    // the statement names — is taken over the bytes the applicant signed, so the
+    // card is never parsed and written back out on the way to verification.
+    let Some(opened) = opened::<Value>(message, sender, ctx.resolver).await else {
         return Handled::default();
     };
     let Some(session_id) = opened.document.thread_id.clone() else {
         return Handled::default();
     };
+    let Some(card) = opened.payload.get("card") else {
+        warn!(%sender, "vetting session response carries no card");
+        return Handled::default();
+    };
     match book
-        .receive_card(
-            our_did,
-            sender,
-            &session_id,
-            opened.payload,
-            ctx.resolver,
-            ctx.now,
-        )
+        .receive_card(our_did, sender, &session_id, card, ctx.resolver, ctx.now)
         .await
     {
         Ok(entry) => Handled {
@@ -731,7 +733,7 @@ async fn declined(
     message: &Message,
     sender: &str,
 ) -> Handled {
-    let Some(opened) = opened::<VettingDeclineBody>(message, sender, ctx.resolver).await else {
+    let Some(opened) = opened::<decline::v0_1::Payload>(message, sender, ctx.resolver).await else {
         return Handled::default();
     };
     for application in &mut book.applications {
@@ -944,7 +946,8 @@ fn refused(
 }
 
 fn withdrawal_recorded(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
-    let Some((Some(thread), body)) = community_reply::<RevokeStatementResponseBody>(message) else {
+    let Some((Some(thread), body)) = community_reply::<revoke_statement::v0_1::Response>(message)
+    else {
         return Handled::default();
     };
     match book.on_withdrawal_recorded(sender, &thread, body.recorded_at) {
@@ -961,7 +964,7 @@ fn withdrawal_recorded(book: &mut VettingBook, message: &Message, sender: &str) 
 
 fn manifest(book: &mut VettingBook, ctx: &Context<'_>, message: &Message, sender: &str) -> Handled {
     let thread = community_thread(message);
-    let body = match community_payload::<JoinRequestManifestResponseBody>(message) {
+    let body = match community_payload::<join_manifest::v0_2::Response>(message) {
         Ok(body) => body,
         Err(detail) => {
             warn!(typ = %message.typ, error = %detail, "malformed community reply");
@@ -1016,7 +1019,7 @@ fn manifest(book: &mut VettingBook, ctx: &Context<'_>, message: &Message, sender
 
 fn vetter_list(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
     let Some((query, page)) =
-        answer_to::<VetterListResponseBody>(book, message, sender, QueryKind::VetterList)
+        answer_to::<vetters::list::v0_1::Response>(book, message, sender, QueryKind::VetterList)
     else {
         return Handled::default();
     };
@@ -1034,9 +1037,12 @@ fn vetter_list(book: &mut VettingBook, message: &Message, sender: &str) -> Handl
 }
 
 fn profile_stored(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
-    let Some((query, body)) =
-        answer_to::<VetterProfileResponseBody>(book, message, sender, QueryKind::VetterProfile)
-    else {
+    let Some((query, body)) = answer_to::<vetters::profile::v0_1::Response>(
+        book,
+        message,
+        sender,
+        QueryKind::VetterProfile,
+    ) else {
         return Handled::default();
     };
     match body {
@@ -1061,9 +1067,12 @@ fn profile_stored(book: &mut VettingBook, message: &Message, sender: &str) -> Ha
 }
 
 fn resent(book: &mut VettingBook, message: &Message, sender: &str) -> Handled {
-    let Some((_, body)) =
-        answer_to::<VetterResendResponseBody>(book, message, sender, QueryKind::VetterResend)
-    else {
+    let Some((_, body)) = answer_to::<vetters::resend::v0_1::Response>(
+        book,
+        message,
+        sender,
+        QueryKind::VetterResend,
+    ) else {
         return Handled::default();
     };
     match body {

--- a/openvtc-core/src/vetting/mod.rs
+++ b/openvtc-core/src/vetting/mod.rs
@@ -30,6 +30,31 @@
 //! module owns state and sequencing only; it never re-implements a check the
 //! SDK makes.
 
+/// Carry a generated vocabulary value into another specification's copy of it.
+///
+/// `trust-tasks-codegen` generates the vetting vocabulary **per specification**:
+/// `VettingMethod` exists in `join-requests/manifest/0.2`, `vetting/request/0.1`,
+/// `vetting/session/0.1`, `vetters/profile/0.1` and `vetters/list/0.1` as five
+/// distinct Rust types with the same variants and the same wire tokens, and
+/// `VettingDocumentation`, `ClaimType`, `CountryCode`, `PlaceName`,
+/// `LanguageTag` and `CalendarDate` are duplicated the same way. They do not
+/// unify, so a method chosen on the Vetting page cannot be handed straight to a
+/// session payload.
+///
+/// This carries a value across by the token both spell — the only thing the two
+/// copies agree on, and the thing that actually travels. It converts between
+/// two generated types; it does not restate either of them.
+///
+/// This repo keeps one of each in its own state (the manifest's, which is the
+/// vocabulary a community publishes) and converts at each task boundary.
+pub(crate) fn same_token<A, B>(value: &A) -> Result<B, B::Err>
+where
+    A: std::fmt::Display,
+    B: std::str::FromStr,
+{
+    value.to_string().parse()
+}
+
 pub mod applicant;
 pub mod book;
 pub mod guide;

--- a/openvtc-core/src/vetting/queries.rs
+++ b/openvtc-core/src/vetting/queries.rs
@@ -15,8 +15,7 @@
 
 use chrono::{DateTime, Duration, Utc};
 use vta_sdk::protocols::vetting::{
-    VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE, VETTING_VETTER_RESEND_ERR_NOT_GRANTED,
-    VetterListResponseBody,
+    VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE, VETTING_VETTER_RESEND_ERR_NOT_GRANTED, vetters,
 };
 
 use super::book::VettingBook;
@@ -69,7 +68,12 @@ pub struct CommunityQuery {
 
 /// An answer to a [`CommunityQuery`], for whoever asked. Nothing here is
 /// persisted; a published profile's record is updated by the handler itself.
-#[derive(Clone, Debug, PartialEq)]
+///
+/// No `PartialEq`: a directory page is the generated
+/// `vtc/vetting/vetters/list/0.1` response, and the generated wire types derive
+/// only `Serialize`, `Deserialize`, `Clone` and `Debug`. Comparing two answers
+/// means comparing what they carry.
+#[derive(Clone, Debug)]
 pub enum CommunityAnswer {
     /// The community's manifest arrived and its requirements are now known.
     Manifest {
@@ -83,7 +87,7 @@ pub enum CommunityAnswer {
         /// The community.
         community: String,
         /// The page.
-        page: VetterListResponseBody,
+        page: vetters::list::v0_1::Response,
     },
     /// The community stored our vetter profile.
     ProfileStored {

--- a/openvtc-core/src/vetting/registry.rs
+++ b/openvtc-core/src/vetting/registry.rs
@@ -1,8 +1,8 @@
 //! The vetter registry: a vetter's published profile, the directory applicants
 //! search, and the forms both are typed into.
 //!
-//! A person types text; the community takes a `VetterProfileBody` or a
-//! `VetterListBody` and refuses anything that breaks its schema. This module
+//! A person types text; the community takes a `vetters/profile/0.1` payload or
+//! a `vetters/list/0.1` one and refuses anything that breaks its schema. This module
 //! sits between the two. It turns the text into the body, names the field a
 //! person got wrong in their own terms, and leaves every schema bound to the
 //! SDK's `check_shape`, so this client never disagrees with the community about
@@ -16,10 +16,12 @@
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use vta_sdk::protocols::vetting::{
-    ShapeError, VetterEvent, VetterListBody, VetterLocation, VetterProfileBody,
-    VetterProfileResponseBody, VettingMethod,
+use vta_sdk::protocols::vetting::vetters::list::v0_1 as list;
+use vta_sdk::protocols::vetting::vetters::profile::v0_1::{
+    self as profile, CalendarDate, CountryCode, LanguageTag, PlaceName, VetterAcceptsDocumentation,
+    VetterEvent, VetterLocation, VetterMethods, VettingDocumentation,
 };
+use vta_sdk::protocols::vetting::{CheckShape, ShapeError, VettingMethod};
 
 use super::book::{VetterPolicy, VettingBook};
 use crate::config::account::PersonaId;
@@ -69,6 +71,20 @@ fn date(field: &'static str, text: &str) -> Result<NaiveDate, DraftError> {
     NaiveDate::parse_from_str(text.trim(), "%Y-%m-%d").map_err(|_| DraftError::Date(field))
 }
 
+/// A value the published type refuses outright — a country that is not two
+/// letters, a place name past its bound, a documentation token that is not
+/// lowerCamelCase. The community refuses the same value, so it reads as a
+/// schema failure here too.
+fn refused(e: impl std::fmt::Display) -> DraftError {
+    DraftError::Shape(ShapeError::Schema(e.to_string()))
+}
+
+fn place(text: &str) -> Result<Option<PlaceName>, DraftError> {
+    optional(text)
+        .map(|t| PlaceName::try_from(t).map_err(refused))
+        .transpose()
+}
+
 fn location(
     what: &'static str,
     country: &str,
@@ -76,16 +92,45 @@ fn location(
     city: &str,
 ) -> Result<Option<VetterLocation>, DraftError> {
     match optional(country) {
-        Some(country) => Ok(Some(VetterLocation {
-            country: country.to_uppercase(),
-            region: optional(region),
-            city: optional(city),
-        })),
+        Some(country) => {
+            let country = CountryCode::try_from(country.to_uppercase()).map_err(refused)?;
+            let built = VetterLocation::try_from(
+                VetterLocation::builder()
+                    .country(country)
+                    .region(place(region)?)
+                    .city(place(city)?),
+            )
+            .map_err(refused)?;
+            Ok(Some(built))
+        }
         None if optional(region).is_some() || optional(city).is_some() => {
             Err(DraftError::LocationWithoutCountry(what))
         }
         None => Ok(None),
     }
+}
+
+/// Check one event the way the community checks it.
+///
+/// The published `VetterEvent` carries no check of its own: the rules no schema
+/// can state — `endDate` on or after `startDate`, a span of at most 31 days —
+/// and its `url` as an absolute https URI are checked over the whole profile.
+/// The event form runs one event through a profile that carries only it, so a
+/// bad date is still named while the form is open rather than at publish.
+fn check_event(event: &VetterEvent) -> Result<(), DraftError> {
+    let passport =
+        VettingDocumentation::try_from(vta_sdk::protocols::vetting::documentation::PASSPORT)
+            .map_err(refused)?;
+    let probe = profile::Payload::try_from(
+        profile::Payload::builder()
+            .listed(false)
+            .languages(Vec::new())
+            .methods(VetterMethods(vec![profile::VettingMethod::InPerson]))
+            .accepts_documentation(VetterAcceptsDocumentation(vec![passport]))
+            .events(vec![event.clone()]),
+    )
+    .map_err(refused)?;
+    probe.check_shape().map_err(DraftError::Shape)
 }
 
 /// One event, as typed.
@@ -106,12 +151,20 @@ impl EventDraft {
     pub fn from_event(event: &VetterEvent) -> Self {
         let place = event.location.as_ref();
         Self {
-            name: event.name.clone(),
-            start_date: event.start_date.format("%Y-%m-%d").to_string(),
-            end_date: event.end_date.format("%Y-%m-%d").to_string(),
-            country: place.map(|l| l.country.clone()).unwrap_or_default(),
-            region: place.and_then(|l| l.region.clone()).unwrap_or_default(),
-            city: place.and_then(|l| l.city.clone()).unwrap_or_default(),
+            name: event.name.as_str().to_string(),
+            start_date: event.start_date.0.format("%Y-%m-%d").to_string(),
+            end_date: event.end_date.0.format("%Y-%m-%d").to_string(),
+            country: place
+                .map(|l| l.country.as_str().to_string())
+                .unwrap_or_default(),
+            region: place
+                .and_then(|l| l.region.as_ref())
+                .map(|r| r.as_str().to_string())
+                .unwrap_or_default(),
+            city: place
+                .and_then(|l| l.city.as_ref())
+                .map(|c| c.as_str().to_string())
+                .unwrap_or_default(),
             url: event.url.clone().unwrap_or_default(),
         }
     }
@@ -121,17 +174,25 @@ impl EventDraft {
     /// # Errors
     ///
     /// A date that does not parse, a place without a country, or anything
-    /// `VetterEvent::check_shape` refuses — an end before the start, a span
-    /// over 31 days, a URL that is not `https`.
+    /// [`check_event`] refuses — an end before the start, a span over 31 days,
+    /// a URL that is not an absolute `https` one.
     pub fn to_event(&self) -> Result<VetterEvent, DraftError> {
-        let event = VetterEvent {
-            name: self.name.trim().to_string(),
-            start_date: date("the start date", &self.start_date)?,
-            end_date: date("the end date", &self.end_date)?,
-            location: location("the event", &self.country, &self.region, &self.city)?,
-            url: optional(&self.url),
-        };
-        event.check_shape()?;
+        let name = profile::VetterEventName::try_from(self.name.trim()).map_err(refused)?;
+        let event = VetterEvent::try_from(
+            VetterEvent::builder()
+                .name(name)
+                .start_date(CalendarDate(date("the start date", &self.start_date)?))
+                .end_date(CalendarDate(date("the end date", &self.end_date)?))
+                .location(location(
+                    "the event",
+                    &self.country,
+                    &self.region,
+                    &self.city,
+                )?)
+                .url(optional(&self.url)),
+        )
+        .map_err(refused)?;
+        check_event(&event)?;
         Ok(event)
     }
 }
@@ -189,22 +250,59 @@ impl ProfileDraft {
 
     /// The fields of a published profile, for editing.
     #[must_use]
-    pub fn from_body(body: &VetterProfileBody) -> Self {
+    pub fn from_body(body: &profile::Payload) -> Self {
         let place = body.location.as_ref();
+        let join = |items: Vec<String>| items.join(", ");
         Self {
             listed: body.listed,
-            display_name: body.display_name.clone().unwrap_or_default(),
-            languages: body.languages.join(", "),
-            country: place.map(|l| l.country.clone()).unwrap_or_default(),
-            region: place.and_then(|l| l.region.clone()).unwrap_or_default(),
-            city: place.and_then(|l| l.city.clone()).unwrap_or_default(),
+            display_name: body
+                .display_name
+                .as_ref()
+                .map(|n| n.as_str().to_string())
+                .unwrap_or_default(),
+            languages: join(
+                body.languages
+                    .iter()
+                    .map(|l| l.as_str().to_string())
+                    .collect(),
+            ),
+            country: place
+                .map(|l| l.country.as_str().to_string())
+                .unwrap_or_default(),
+            region: place
+                .and_then(|l| l.region.as_ref())
+                .map(|r| r.as_str().to_string())
+                .unwrap_or_default(),
+            city: place
+                .and_then(|l| l.city.as_ref())
+                .map(|c| c.as_str().to_string())
+                .unwrap_or_default(),
             methods: METHOD_ORDER
                 .into_iter()
-                .filter(|m| body.methods.contains(m))
+                .filter(|m| {
+                    body.methods
+                        .0
+                        .iter()
+                        .any(|published| published.to_string() == m.to_string())
+                })
                 .collect(),
-            accepts_documentation: body.accepts_documentation.join(", "),
-            availability: body.availability.clone().unwrap_or_default(),
-            contact_hint: body.contact_hint.clone().unwrap_or_default(),
+            accepts_documentation: join(
+                body.accepts_documentation
+                    .0
+                    .iter()
+                    .map(|d| d.as_str().to_string())
+                    .collect(),
+            ),
+            availability: body
+                .availability
+                .as_ref()
+                .map(|a| a.as_str().to_string())
+                .unwrap_or_default(),
+            contact_hint: body
+                .contact_hint
+                .as_ref()
+                .map(|c| c.as_str().to_string())
+                .unwrap_or_default(),
             events: body.events.iter().map(EventDraft::from_event).collect(),
         }
     }
@@ -227,28 +325,60 @@ impl ProfileDraft {
     ///
     /// # Errors
     ///
-    /// No method, a place without a country, a bad event, or anything
-    /// `VetterProfileBody::check_shape` refuses.
-    pub fn to_body(&self) -> Result<VetterProfileBody, DraftError> {
+    /// No method, a place without a country, a bad event, or anything the
+    /// published profile's `check_shape` refuses.
+    pub fn to_body(&self) -> Result<profile::Payload, DraftError> {
         if self.methods.is_empty() {
             return Err(DraftError::NoMethods);
         }
-        let body = VetterProfileBody {
-            listed: self.listed,
-            display_name: optional(&self.display_name),
-            languages: split_list(&self.languages),
-            location: location("your location", &self.country, &self.region, &self.city)?,
-            methods: self.methods.clone(),
-            accepts_documentation: split_list(&self.accepts_documentation),
-            availability: optional(&self.availability),
-            contact_hint: optional(&self.contact_hint),
-            events: self
-                .events
-                .iter()
-                .map(EventDraft::to_event)
-                .collect::<Result<_, _>>()?,
-            ext: None,
-        };
+        let languages = split_list(&self.languages)
+            .into_iter()
+            .map(|l| LanguageTag::try_from(l).map_err(refused))
+            .collect::<Result<Vec<_>, _>>()?;
+        let documentation = split_list(&self.accepts_documentation)
+            .into_iter()
+            .map(|d| VettingDocumentation::try_from(d).map_err(refused))
+            .collect::<Result<Vec<_>, _>>()?;
+        // The profile task has its own copy of the method vocabulary (see
+        // `super::same_token`), so the ticked methods are carried across by the
+        // token they both spell.
+        let methods = self
+            .methods
+            .iter()
+            .map(|m| super::same_token::<_, profile::VettingMethod>(m).map_err(refused))
+            .collect::<Result<Vec<_>, _>>()?;
+        let display_name = optional(&self.display_name)
+            .map(|n| profile::VetterDisplayName::try_from(n).map_err(refused))
+            .transpose()?;
+        let availability = optional(&self.availability)
+            .map(|a| profile::VetterAvailability::try_from(a).map_err(refused))
+            .transpose()?;
+        let contact_hint = optional(&self.contact_hint)
+            .map(|c| profile::VetterContactHint::try_from(c).map_err(refused))
+            .transpose()?;
+        let body = profile::Payload::try_from(
+            profile::Payload::builder()
+                .listed(self.listed)
+                .display_name(display_name)
+                .languages(languages)
+                .location(location(
+                    "your location",
+                    &self.country,
+                    &self.region,
+                    &self.city,
+                )?)
+                .methods(VetterMethods(methods))
+                .accepts_documentation(VetterAcceptsDocumentation(documentation))
+                .availability(availability)
+                .contact_hint(contact_hint)
+                .events(
+                    self.events
+                        .iter()
+                        .map(EventDraft::to_event)
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
+        )
+        .map_err(refused)?;
         body.check_shape()?;
         Ok(body)
     }
@@ -273,26 +403,55 @@ impl DirectoryFilter {
     ///
     /// # Errors
     ///
-    /// A date that does not parse, or anything `VetterListBody::check_shape`
-    /// refuses — an end before the start, a country that is not two letters.
-    pub fn to_body(&self, cursor: Option<String>) -> Result<VetterListBody, DraftError> {
-        let body = VetterListBody {
-            language: optional(&self.language),
-            country: optional(&self.country).map(|c| c.to_uppercase()),
-            region: optional(&self.region),
-            city: optional(&self.city),
-            method: self.method,
-            event_from: optional(&self.event_from)
-                .map(|d| date("the first event date", &d))
-                .transpose()?,
-            event_to: optional(&self.event_to)
-                .map(|d| date("the last event date", &d))
-                .transpose()?,
-            event_name: optional(&self.event_name),
-            limit: None,
-            cursor,
-            ext: None,
+    /// A date that does not parse, or anything the published list request's
+    /// `check_shape` refuses — an end before the start, a country that is not
+    /// two letters.
+    pub fn to_body(&self, cursor: Option<String>) -> Result<list::Payload, DraftError> {
+        // The listing task carries its own copy of every constrained string —
+        // `LanguageTag`, `CountryCode`, `PlaceName`, `CalendarDate` are all
+        // generated per specification (see `super::same_token`) — so these are
+        // the listing's, not the profile's.
+        let list_place = |text: &str| -> Result<Option<list::PlaceName>, DraftError> {
+            optional(text)
+                .map(|t| list::PlaceName::try_from(t).map_err(refused))
+                .transpose()
         };
+        let language = optional(&self.language)
+            .map(|l| list::LanguageTag::try_from(l).map_err(refused))
+            .transpose()?;
+        let country = optional(&self.country)
+            .map(|c| list::CountryCode::try_from(c.to_uppercase()).map_err(refused))
+            .transpose()?;
+        let event_name = optional(&self.event_name)
+            .map(|n| list::PayloadEventName::try_from(n).map_err(refused))
+            .transpose()?;
+        let cursor = cursor
+            .map(|c| list::PayloadCursor::try_from(c).map_err(refused))
+            .transpose()?;
+        // The listing task has its own copy of the method vocabulary.
+        let method = self
+            .method
+            .map(|m| super::same_token::<_, list::VettingMethod>(&m).map_err(refused))
+            .transpose()?;
+        let day =
+            |what: &'static str, text: &str| -> Result<Option<list::CalendarDate>, DraftError> {
+                optional(text)
+                    .map(|d| date(what, &d).map(list::CalendarDate))
+                    .transpose()
+            };
+        let body = list::Payload::try_from(
+            list::Payload::builder()
+                .language(language)
+                .country(country)
+                .region(list_place(&self.region)?)
+                .city(list_place(&self.city)?)
+                .method(method)
+                .event_from(day("the first event date", &self.event_from)?)
+                .event_to(day("the last event date", &self.event_to)?)
+                .event_name(event_name)
+                .cursor(cursor),
+        )
+        .map_err(refused)?;
         body.check_shape()?;
         Ok(body)
     }
@@ -330,7 +489,8 @@ pub struct VetterProfileRecord {
     pub community: String,
     /// Our member persona there.
     pub persona: PersonaId,
-    /// The `VetterProfileBody` we sent, as JSON (see the module docs).
+    /// The `vtc/vetting/vetters/profile/0.1` payload we sent, as JSON (see the
+    /// module docs).
     pub profile: Value,
     /// Where it stands.
     pub state: ProfileState,
@@ -341,7 +501,7 @@ impl VetterProfileRecord {
     /// by a newer one — starts from a first profile rather than failing.
     #[must_use]
     pub fn draft(&self, policy: &VetterPolicy) -> ProfileDraft {
-        serde_json::from_value::<VetterProfileBody>(self.profile.clone()).map_or_else(
+        serde_json::from_value::<profile::Payload>(self.profile.clone()).map_or_else(
             |_| ProfileDraft::new(policy),
             |b| ProfileDraft::from_body(&b),
         )
@@ -377,7 +537,7 @@ impl VettingBook {
         &mut self,
         community: &str,
         persona: PersonaId,
-        body: &VetterProfileBody,
+        body: &profile::Payload,
         now: DateTime<Utc>,
     ) -> Option<VetterProfileRecord> {
         let record = VetterProfileRecord {
@@ -412,7 +572,7 @@ impl VettingBook {
         &mut self,
         community: &str,
         persona: PersonaId,
-        response: &VetterProfileResponseBody,
+        response: &profile::Response,
     ) -> bool {
         match self.vetter_profile_mut(community, persona) {
             Some(record) => {
@@ -450,38 +610,76 @@ impl VettingBook {
 /// A place in a line: `Prague, Central Bohemia, CZ`.
 #[must_use]
 pub fn location_line(location: &VetterLocation) -> String {
-    [
-        location.city.as_deref(),
-        location.region.as_deref(),
-        Some(location.country.as_str()),
-    ]
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>()
-    .join(", ")
+    place_line(
+        location.city.as_ref().map(|c| c.as_str()),
+        location.region.as_ref().map(|r| r.as_str()),
+        location.country.as_str(),
+    )
+}
+
+/// [`location_line`] for a place as the **listing** publishes it.
+///
+/// The listing specification generates its own `VetterLocation`, distinct from
+/// the profile's (see `super::same_token`), so the same line is written from
+/// both rather than one being converted into the other to be displayed.
+#[must_use]
+pub fn listed_location_line(location: &list::VetterLocation) -> String {
+    place_line(
+        location.city.as_ref().map(|c| c.as_str()),
+        location.region.as_ref().map(|r| r.as_str()),
+        location.country.as_str(),
+    )
+}
+
+fn place_line(city: Option<&str>, region: Option<&str>, country: &str) -> String {
+    [city, region, Some(country)]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// An event in a line: `LPC — 2026-10-05 to 2026-10-07, Prague, CZ`.
 #[must_use]
 pub fn event_line(event: &VetterEvent) -> String {
-    let dates = if event.start_date == event.end_date {
-        event.start_date.format("%Y-%m-%d").to_string()
+    event_line_parts(
+        event.name.as_str(),
+        event.start_date.0,
+        event.end_date.0,
+        event.location.as_ref().map(location_line),
+    )
+}
+
+/// [`event_line`] for an event as the **listing** publishes it, which generates
+/// its own `VetterEvent`.
+#[must_use]
+pub fn listed_event_line(event: &list::VetterEvent) -> String {
+    event_line_parts(
+        event.name.as_str(),
+        event.start_date.0,
+        event.end_date.0,
+        event.location.as_ref().map(listed_location_line),
+    )
+}
+
+fn event_line_parts(name: &str, start: NaiveDate, end: NaiveDate, place: Option<String>) -> String {
+    let dates = if start == end {
+        start.format("%Y-%m-%d").to_string()
     } else {
-        format!(
-            "{} to {}",
-            event.start_date.format("%Y-%m-%d"),
-            event.end_date.format("%Y-%m-%d")
-        )
+        format!("{} to {}", start.format("%Y-%m-%d"), end.format("%Y-%m-%d"))
     };
-    match &event.location {
-        Some(place) => format!("{} — {dates}, {}", event.name, location_line(place)),
-        None => format!("{} — {dates}", event.name),
+    match place {
+        Some(place) => format!("{name} — {dates}, {place}"),
+        None => format!("{name} — {dates}"),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Whether a listing request filters on events at all is a free function on
+    // this line rather than a method on the request.
+    use vta_sdk::protocols::vetting::has_event_filter;
 
     fn event() -> EventDraft {
         EventDraft {
@@ -501,7 +699,13 @@ mod tests {
         let draft = ProfileDraft::new(&policy);
         assert!(!draft.listed, "being listed is opt-in");
         let body = draft.to_body().unwrap();
-        assert_eq!(body.accepts_documentation, policy.accepts_documentation);
+        let accepted: Vec<String> = body
+            .accepts_documentation
+            .0
+            .iter()
+            .map(|d| d.as_str().to_string())
+            .collect();
+        assert_eq!(accepted, policy.accepts_documentation);
         assert!(body.location.is_none());
     }
 
@@ -515,18 +719,39 @@ mod tests {
         draft.city = "Berlin".into();
         draft.events = vec![event()];
         let body = draft.to_body().unwrap();
-        assert_eq!(body.display_name.as_deref(), Some("Carol"));
-        assert_eq!(body.languages, vec!["en", "de-AT"]);
-        assert_eq!(body.location.as_ref().unwrap().country, "DE");
-        assert_eq!(body.events[0].location.as_ref().unwrap().country, "CZ");
-        assert_eq!(ProfileDraft::from_body(&body).to_body().unwrap(), body);
+        assert_eq!(
+            body.display_name.as_ref().map(|n| n.as_str()),
+            Some("Carol")
+        );
+        assert_eq!(
+            body.languages
+                .iter()
+                .map(|l| l.as_str())
+                .collect::<Vec<_>>(),
+            vec!["en", "de-AT"]
+        );
+        assert_eq!(body.location.as_ref().unwrap().country.as_str(), "DE");
+        assert_eq!(
+            body.events[0].location.as_ref().unwrap().country.as_str(),
+            "CZ"
+        );
+        // The generated payload has no `PartialEq`; a round trip is compared as
+        // what it puts on the wire.
+        assert_eq!(
+            serde_json::to_value(ProfileDraft::from_body(&body).to_body().unwrap()).unwrap(),
+            serde_json::to_value(&body).unwrap()
+        );
     }
 
     #[test]
     fn event_dates_are_checked_before_anything_is_sent() {
         let mut bad = event();
         bad.start_date = "5 Oct".into();
-        assert_eq!(bad.to_event(), Err(DraftError::Date("the start date")));
+        // The published event has no `PartialEq`, so the error is matched.
+        assert!(matches!(
+            bad.to_event(),
+            Err(DraftError::Date("the start date"))
+        ));
 
         let mut backwards = event();
         backwards.end_date = "2026-10-01".into();
@@ -545,14 +770,14 @@ mod tests {
     fn a_place_needs_a_country_and_a_method_is_required() {
         let mut draft = ProfileDraft::new(&VetterPolicy::default());
         draft.city = "Berlin".into();
-        assert_eq!(
+        assert!(matches!(
             draft.to_body(),
             Err(DraftError::LocationWithoutCountry("your location"))
-        );
+        ));
         let mut draft = ProfileDraft::new(&VetterPolicy::default());
         draft.toggle_method(VettingMethod::InPerson);
         draft.toggle_method(VettingMethod::Video);
-        assert_eq!(draft.to_body(), Err(DraftError::NoMethods));
+        assert!(matches!(draft.to_body(), Err(DraftError::NoMethods)));
         draft.toggle_method(VettingMethod::PriorAcquaintance);
         draft.toggle_method(VettingMethod::InPerson);
         assert_eq!(
@@ -564,9 +789,11 @@ mod tests {
 
     #[test]
     fn directory_filters_are_optional_and_checked() {
+        // Every filter empty is every member absent, which is the whole of an
+        // unfiltered listing request.
         assert_eq!(
-            DirectoryFilter::default().to_body(None).unwrap(),
-            VetterListBody::default()
+            serde_json::to_value(DirectoryFilter::default().to_body(None).unwrap()).unwrap(),
+            serde_json::json!({})
         );
         let filter = DirectoryFilter {
             country: "cz".into(),
@@ -575,9 +802,9 @@ mod tests {
             ..DirectoryFilter::default()
         };
         let body = filter.to_body(Some("next".into())).unwrap();
-        assert_eq!(body.country.as_deref(), Some("CZ"));
-        assert!(body.has_event_filter());
-        assert_eq!(body.cursor.as_deref(), Some("next"));
+        assert_eq!(body.country.as_ref().map(|c| c.as_str()), Some("CZ"));
+        assert!(has_event_filter(&body));
+        assert_eq!(body.cursor.as_ref().map(|c| c.as_str()), Some("next"));
 
         let backwards = DirectoryFilter {
             event_from: "2026-10-10".into(),
@@ -589,10 +816,10 @@ mod tests {
             event_to: "soon".into(),
             ..DirectoryFilter::default()
         };
-        assert_eq!(
+        assert!(matches!(
             bad_date.to_body(None),
             Err(DraftError::Date("the last event date"))
-        );
+        ));
     }
 
     #[test]
@@ -616,14 +843,10 @@ mod tests {
             "edited later from what was sent"
         );
 
-        assert!(book.on_profile_stored(
-            "did:web:a",
-            persona,
-            &VetterProfileResponseBody {
-                listed: false,
-                updated_at: now,
-            }
-        ));
+        let stored =
+            profile::Response::try_from(profile::Response::builder().listed(false).updated_at(now))
+                .unwrap();
+        assert!(book.on_profile_stored("did:web:a", persona, &stored));
         assert!(matches!(
             book.vetter_profile("did:web:a", persona).unwrap().state,
             ProfileState::Stored { listed: false, .. }

--- a/openvtc-core/src/vetting/registry.rs
+++ b/openvtc-core/src/vetting/registry.rs
@@ -173,9 +173,9 @@ impl EventDraft {
     ///
     /// # Errors
     ///
-    /// A date that does not parse, a place without a country, or anything
-    /// [`check_event`] refuses — an end before the start, a span over 31 days,
-    /// a URL that is not an absolute `https` one.
+    /// A date that does not parse, a place without a country, or anything the
+    /// event check refuses — an end before the start, a span over 31 days, a
+    /// URL that is not an absolute `https` one.
     pub fn to_event(&self) -> Result<VetterEvent, DraftError> {
         let name = profile::VetterEventName::try_from(self.name.trim()).map_err(refused)?;
         let event = VetterEvent::try_from(

--- a/openvtc-core/src/vetting/tests.rs
+++ b/openvtc-core/src/vetting/tests.rs
@@ -13,18 +13,13 @@ use dtg_credentials::DTGCredential;
 use serde_json::{Value, json};
 use trust_tasks_rs::TrustTask;
 use uuid::Uuid;
-use vta_sdk::protocols::join_requests::{
-    CommunityBranding, JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, JoinRequestManifestResponseBody,
-    ManifestCriterion,
-};
+use vta_sdk::protocols::join_requests::{JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE, manifest};
 use vta_sdk::protocols::vetting::{
-    COMMUNITY_ROLE_ENDORSEMENT_TYPE, CardClaim, DeclaredRelationship, DeclineCode,
-    IDENTITY_VETTING_ENDORSEMENT_TYPE, ListedVetter, RevocationReason, TicketPresentation,
-    VETTER_ROLE, VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_INVALID_TICKET,
-    VETTING_REQUEST_ERR_NOT_ELIGIBLE, VETTING_REQUEST_TYPE, VETTING_SESSION_TYPE,
-    VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE, VETTING_VETTER_RESEND_ERR_NOT_GRANTED, VetterListBody,
-    VetterListResponseBody, VetterProfileBody, VetterProfileResponseBody, VetterResendResponseBody,
-    VettingMethod, VettingRequirements, VettingSessionResponseBody,
+    COMMUNITY_ROLE_ENDORSEMENT_TYPE, IDENTITY_VETTING_ENDORSEMENT_TYPE, VETTER_ROLE,
+    VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_INVALID_TICKET, VETTING_REQUEST_ERR_NOT_ELIGIBLE,
+    VETTING_REQUEST_TYPE, VETTING_SESSION_TYPE, VETTING_VETTER_PROFILE_ERR_NOT_ELIGIBLE,
+    VETTING_VETTER_RESEND_ERR_NOT_GRANTED, VettingMethod, VettingRelationship, VettingRequirements,
+    decline, request, revoke_statement, session, vetters,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::card::sign_card;
@@ -53,6 +48,24 @@ use crate::persona::disclosure::ReleasedClaim;
 /// offline. [`the_community_is_its_key`] holds the two together.
 const COMMUNITY: &str = "did:key:z6MkkckEJvRiDoUSv2KFGPFuUoNjJbWTZUvWThqshF7g1u4p";
 const COMMUNITY_SEED: u8 = 0xC0;
+/// A `requirementsDigest` the published criterion accepts: base58btc, at least
+/// 16 characters.
+const DIGEST: &str = "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
+
+/// A listing request with no filters at all.
+fn unfiltered_list() -> vetters::list::v0_1::Payload {
+    vetters::list::v0_1::Payload::try_from(vetters::list::v0_1::Payload::builder()).unwrap()
+}
+
+/// A spoken ticket in the published form — upper-case Crockford base32.
+fn code_ticket(code: &str) -> request::v0_1::Ticket {
+    request::v0_1::Ticket::ShortCodeTicket(
+        request::v0_1::ShortCodeTicket::try_from(
+            request::v0_1::ShortCodeTicket::builder().code(code),
+        )
+        .expect("a Crockford code"),
+    )
+}
 
 #[test]
 fn the_community_is_its_key() {
@@ -188,18 +201,32 @@ fn requirements() -> VettingRequirements {
 }
 
 /// The community's manifest 0.2 body.
-fn manifest_body() -> JoinRequestManifestResponseBody {
-    JoinRequestManifestResponseBody {
-        community_did: COMMUNITY.into(),
-        criteria: vec![ManifestCriterion {
-            id: "vetted".into(),
-            description: None,
-            presentation_definition: json!({}),
-            vetting: Some(requirements()),
-            requirements_digest: Some("zRequirementsDigest".into()),
-        }],
-        branding: None,
-    }
+fn manifest_body() -> manifest::v0_2::Response {
+    manifest_with(Some(requirements()), None)
+}
+
+/// A manifest 0.2 body carrying `vetting` and `branding`.
+fn manifest_with(
+    vetting: Option<VettingRequirements>,
+    branding: Option<manifest::v0_2::CommunityBranding>,
+) -> manifest::v0_2::Response {
+    let criterion = manifest::v0_2::Criterion::try_from(
+        manifest::v0_2::Criterion::builder()
+            .id("vetted")
+            .presentation_definition(serde_json::Map::new())
+            .vetting(vetting)
+            .requirements_digest(Some(
+                manifest::v0_2::DigestMultibase::try_from(DIGEST).unwrap(),
+            )),
+    )
+    .unwrap();
+    manifest::v0_2::Response::try_from(
+        manifest::v0_2::Response::builder()
+            .community_did(COMMUNITY)
+            .criteria(vec![criterion])
+            .branding(branding),
+    )
+    .unwrap()
 }
 
 /// The community's manifest 0.2 reply, as its dispatcher sends it.
@@ -216,7 +243,7 @@ fn manifest_reply() -> Message {
 }
 
 /// An applicant with requirements in hand, and a vetter with a ticket for them.
-async fn ready() -> (Party, Party, TicketPresentation) {
+async fn ready() -> (Party, Party, request::v0_1::Ticket) {
     let mut applicant = Party::new(1);
     let mut vetter = Party::new(2).member_of(COMMUNITY);
     vetter.named_vetter().await;
@@ -231,12 +258,12 @@ async fn ready() -> (Party, Party, TicketPresentation) {
         Some(Notice::RequirementsUpdated { .. })
     ));
     let ticket = Ticket::issue(COMMUNITY, vetter.persona, vec![], 1, DEFAULT_VALIDITY, now);
-    let presented = ticket.code_presentation();
+    let presented = ticket.code_presentation().unwrap();
     vetter.book.tickets.push(ticket);
     (applicant, vetter, presented)
 }
 
-async fn request(applicant: &mut Party, vetter: &Party, ticket: TicketPresentation) -> Message {
+async fn request(applicant: &mut Party, vetter: &Party, ticket: request::v0_1::Ticket) -> Message {
     let id = wire::new_id();
     let vetter_did = vetter.did.clone();
     let body = applicant
@@ -256,7 +283,7 @@ async fn request(applicant: &mut Party, vetter: &Party, ticket: TicketPresentati
 /// Request, accept and open a session. Returns the vetter's request id and the
 /// session document.
 async fn in_session(applicant: &mut Party, vetter: &mut Party) -> (String, TrustTask<Value>) {
-    let ticket = vetter.book.tickets[0].code_presentation();
+    let ticket = vetter.book.tickets[0].code_presentation().unwrap();
     let message = request(applicant, vetter, ticket).await;
     let handled = vetter.receive(&message, &applicant.did).await;
     let Some(Notice::RequestAccepted { request_id, .. }) = handled.notice.clone() else {
@@ -336,11 +363,15 @@ async fn an_applicant_is_vetted_end_to_end() {
         .application()
         .card_draft(
             &session_id,
-            vec![CardClaim {
-                claim_type: "name.legal".into(),
-                value: json!("Alice Example"),
-                provenance: "selfAsserted".into(),
-            }],
+            vec![
+                session::v0_1::VettingCardClaim::try_from(
+                    session::v0_1::VettingCardClaim::builder()
+                        .type_("name.legal")
+                        .value(json!("Alice Example"))
+                        .provenance("selfAsserted"),
+                )
+                .unwrap(),
+            ],
             Utc::now(),
         )
         .unwrap();
@@ -350,11 +381,8 @@ async fn an_applicant_is_vetted_end_to_end() {
         .record_card(&session_id, &card, &resolver, Utc::now())
         .await
         .unwrap();
-    let doc = wire::response(
-        &session_doc,
-        &VettingSessionResponseBody { card, ext: None },
-    )
-    .unwrap();
+    // The card travels as it was signed: its digest is what the statement names.
+    let doc = wire::response(&session_doc, &json!({ "card": card })).unwrap();
     let message = signed(doc, &applicant.secret).await;
     let handled = vetter.receive(&message, &applicant.did).await;
     assert!(matches!(handled.notice, Some(Notice::CardReceived { .. })));
@@ -370,7 +398,7 @@ async fn an_applicant_is_vetted_end_to_end() {
                 document_classes: vec!["passport".into()],
                 claims_verified: vec!["name.legal".into()],
                 liveness_confirmed: true,
-                declared_relationship: DeclaredRelationship::None,
+                declared_relationship: VettingRelationship::None,
                 attestation_text_digest: None,
             },
             Utc::now(),
@@ -398,10 +426,7 @@ async fn an_applicant_is_vetted_end_to_end() {
     let application = applicant.application();
     assert!(application.checklist(Utc::now()).unwrap().satisfied());
     assert_eq!(application.presentable_statements(Utc::now()).len(), 1);
-    assert_eq!(
-        application.join_extensions()["requirementsDigest"],
-        "zRequirementsDigest"
-    );
+    assert_eq!(application.join_extensions()["requirementsDigest"], DIGEST);
 
     // Later, the vetter withdraws it.
     let notice_id = wire::new_id();
@@ -409,12 +434,15 @@ async fn an_applicant_is_vetted_end_to_end() {
         .book
         .withdrawal(
             &issued.id,
-            Some(RevocationReason::Mistake),
+            Some(revoke_statement::v0_1::PayloadReason::Mistake),
             &notice_id,
             Utc::now(),
         )
         .unwrap();
-    assert_eq!(body.statement_digest_multibase, issued.digest_multibase);
+    assert_eq!(
+        body.statement_digest_multibase.as_str(),
+        issued.digest_multibase
+    );
     assert!(
         vetter
             .book
@@ -483,7 +511,12 @@ async fn cards_come_from_the_face_and_keep_showing_the_same_identity() {
         .unwrap();
     app.record_sent_card(&session_id, sent, &claims, Utc::now())
         .unwrap();
-    assert_eq!(app.identity_claims, claims);
+    // The generated card claim has no `PartialEq`; what was kept is compared as
+    // what it serialises to.
+    assert_eq!(
+        serde_json::to_value(&app.identity_claims).unwrap(),
+        serde_json::to_value(&claims).unwrap()
+    );
 
     // The face has changed since: the next card is refused before it is signed.
     assert!(matches!(
@@ -495,14 +528,7 @@ async fn cards_come_from_the_face_and_keep_showing_the_same_identity() {
 #[tokio::test]
 async fn without_a_ticket_there_is_no_answer_at_all() {
     let (mut applicant, mut vetter, _) = ready().await;
-    let message = request(
-        &mut applicant,
-        &vetter,
-        TicketPresentation::Code {
-            code: "0000-0000".into(),
-        },
-    )
-    .await;
+    let message = request(&mut applicant, &vetter, code_ticket("0000-0000")).await;
     let handled = vetter.receive(&message, &applicant.did).await;
     assert!(handled.reply.is_none() && handled.notice.is_none());
     assert!(vetter.book.desk.is_empty());
@@ -512,15 +538,15 @@ async fn without_a_ticket_there_is_no_answer_at_all() {
 async fn a_bad_scanned_ticket_is_refused_and_the_applicant_hears_why() {
     let (mut applicant, mut vetter, _) = ready().await;
     let ticket_id = vetter.book.tickets[0].id.clone();
-    let message = request(
-        &mut applicant,
-        &vetter,
-        TicketPresentation::Scanned {
-            ticket_id,
-            secret: "A".repeat(43),
-        },
-    )
-    .await;
+    let scanned = request::v0_1::Ticket::QrTicket(
+        request::v0_1::QrTicket::try_from(
+            request::v0_1::QrTicket::builder()
+                .ticket_id(ticket_id)
+                .secret("A".repeat(43)),
+        )
+        .unwrap(),
+    );
+    let message = request(&mut applicant, &vetter, scanned).await;
     let handled = vetter.receive(&message, &applicant.did).await;
     let reply = handled.reply.expect("a scanned ticket is answered");
     assert_eq!(
@@ -548,7 +574,7 @@ async fn someone_who_is_not_a_member_cannot_vet() {
         DEFAULT_VALIDITY,
         Utc::now(),
     );
-    let presented = ticket.code_presentation();
+    let presented = ticket.code_presentation().unwrap();
     outsider.book.tickets.push(ticket);
     let message = request(&mut applicant, &outsider, presented).await;
     let handled = outsider.receive(&message, &applicant.did).await;
@@ -572,7 +598,7 @@ async fn a_member_the_community_has_not_named_cannot_vet() {
         DEFAULT_VALIDITY,
         Utc::now(),
     );
-    let presented = ticket.code_presentation();
+    let presented = ticket.code_presentation().unwrap();
     member.book.tickets.push(ticket);
     let message = request(&mut applicant, &member, presented).await;
     let handled = member.receive(&message, &applicant.did).await;
@@ -675,7 +701,7 @@ async fn a_vetter_can_decline_without_a_reason() {
         .book
         .decline(
             &request_id,
-            Some(DeclineCode::NotComfortable),
+            Some(decline::v0_1::PayloadCode::NotComfortable),
             None,
             Utc::now(),
         )
@@ -732,11 +758,17 @@ async fn a_vetter_asks_for_the_claims_the_community_requires() {
     );
     let handled = vetter.receive(&manifest_reply(), COMMUNITY).await;
     assert!(handled.changed, "the criteria are remembered");
-    let (claims, known) = vetter
-        .book
-        .required_claims_for(COMMUNITY, Some("zRequirementsDigest"));
+    let (claims, known) = vetter.book.required_claims_for(COMMUNITY, Some(DIGEST));
     assert!(known);
-    assert_eq!(claims, requirements().required_claims);
+    assert_eq!(
+        claims,
+        requirements()
+            .required_claims
+            .iter()
+            .flatten()
+            .map(|c| c.as_str().to_string())
+            .collect::<Vec<_>>()
+    );
     assert!(
         !vetter.receive(&manifest_reply(), COMMUNITY).await.changed,
         "the same manifest again changes nothing"
@@ -755,18 +787,8 @@ async fn the_communitys_decision_sla_is_known_once_its_manifest_is() {
         .start_application(COMMUNITY, with_sla.persona, &with_sla.did, Utc::now())
         .unwrap();
     let mut requirements = requirements();
-    requirements.decision_sla = Some("P21D".into());
-    let body = JoinRequestManifestResponseBody {
-        community_did: COMMUNITY.into(),
-        criteria: vec![ManifestCriterion {
-            id: "vetted".into(),
-            description: None,
-            presentation_definition: json!({}),
-            vetting: Some(requirements),
-            requirements_digest: Some("zOther".into()),
-        }],
-        branding: None,
-    };
+    requirements.decision_sla = Some("P21D".try_into().unwrap());
+    let body = manifest_with(Some(requirements), None);
     let reply = Message::build(
         wire::new_id(),
         JOIN_REQUEST_MANIFEST_0_2_RESPONSE_TYPE.to_string(),
@@ -806,7 +828,7 @@ fn asked(request: &TrustTask<Value>, persona: PersonaId, kind: QueryKind) -> Com
     }
 }
 
-fn listed_vetter() -> ListedVetter {
+fn listed_vetter() -> vetters::list::v0_1::ListedVetter {
     serde_json::from_value(json!({
         "vetterDid": "did:key:zCarol",
         "displayName": "Carol",
@@ -835,14 +857,19 @@ async fn a_vetter_publishes_a_profile_and_hears_the_communitys_answer() {
     // What the community receives is signed by the vetter and opens as a profile.
     let mut request = wire::vetter_profile_request(&vetter.did, COMMUNITY, &body).unwrap();
     wire::sign(&mut request, &vetter.secret).await.unwrap();
-    let opened: wire::Opened<VetterProfileBody> = wire::open(
+    let opened: wire::Opened<vetters::profile::v0_1::Payload> = wire::open(
         &wire::to_message(&request).unwrap(),
         &vetter.did,
         &TrustTaskVmResolver::did_key_only(),
     )
     .await
     .unwrap();
-    assert_eq!(opened.payload, body);
+    // The generated payload has no `PartialEq`; what was sent is compared as
+    // what it serialises to.
+    assert_eq!(
+        serde_json::to_value(&opened.payload).unwrap(),
+        serde_json::to_value(&body).unwrap()
+    );
 
     vetter
         .book
@@ -850,10 +877,12 @@ async fn a_vetter_publishes_a_profile_and_hears_the_communitys_answer() {
     vetter
         .book
         .ask(asked(&request, vetter.persona, QueryKind::VetterProfile));
-    let stored = VetterProfileResponseBody {
-        listed: true,
-        updated_at: now,
-    };
+    let stored = vetters::profile::v0_1::Response::try_from(
+        vetters::profile::v0_1::Response::builder()
+            .listed(true)
+            .updated_at(now),
+    )
+    .unwrap();
     let handled = vetter
         .receive(&community_answer(&request, &stored), COMMUNITY)
         .await;
@@ -909,12 +938,15 @@ async fn a_vetter_publishes_a_profile_and_hears_the_communitys_answer() {
 #[tokio::test]
 async fn the_directory_answers_only_what_was_asked() {
     let mut applicant = Party::new(1);
-    let page = VetterListResponseBody {
-        vetters: vec![listed_vetter()],
-        next_cursor: Some("page-2".into()),
-    };
-    let request =
-        wire::vetter_list_request(&applicant.did, COMMUNITY, &VetterListBody::default()).unwrap();
+    let page = vetters::list::v0_1::Response::try_from(
+        vetters::list::v0_1::Response::builder()
+            .vetters(vec![listed_vetter()])
+            .next_cursor(Some(
+                vetters::list::v0_1::ResponseNextCursor::try_from("page-2").unwrap(),
+            )),
+    )
+    .unwrap();
+    let request = wire::vetter_list_request(&applicant.did, COMMUNITY, &unfiltered_list()).unwrap();
 
     // Nobody asked: the page answers nothing.
     let handled = applicant
@@ -941,12 +973,14 @@ async fn the_directory_answers_only_what_was_asked() {
         panic!("the page is handed to whoever asked");
     };
     assert_eq!(query, request.id);
-    assert_eq!(got, page);
+    assert_eq!(
+        serde_json::to_value(&got).unwrap(),
+        serde_json::to_value(&page).unwrap()
+    );
     assert!(!handled.changed, "a directory page is never saved");
 
     // Refused: the community would not answer this caller.
-    let request =
-        wire::vetter_list_request(&applicant.did, COMMUNITY, &VetterListBody::default()).unwrap();
+    let request = wire::vetter_list_request(&applicant.did, COMMUNITY, &unfiltered_list()).unwrap();
     applicant
         .book
         .ask(asked(&request, applicant.persona, QueryKind::VetterList));
@@ -960,8 +994,7 @@ async fn the_directory_answers_only_what_was_asked() {
     ));
 
     // An error that answers nothing we asked is left for the join handler.
-    let stray =
-        wire::vetter_list_request(&applicant.did, COMMUNITY, &VetterListBody::default()).unwrap();
+    let stray = wire::vetter_list_request(&applicant.did, COMMUNITY, &unfiltered_list()).unwrap();
     let resolver = TrustTaskVmResolver::did_key_only();
     let ctx = Context {
         account: &applicant.account,
@@ -981,8 +1014,7 @@ async fn the_directory_answers_only_what_was_asked() {
     );
 
     // An answer this client cannot read says so, rather than timing out.
-    let request =
-        wire::vetter_list_request(&applicant.did, COMMUNITY, &VetterListBody::default()).unwrap();
+    let request = wire::vetter_list_request(&applicant.did, COMMUNITY, &unfiltered_list()).unwrap();
     applicant
         .book
         .ask(asked(&request, applicant.persona, QueryKind::VetterList));
@@ -1009,10 +1041,12 @@ async fn a_resend_is_answered_or_refused_in_plain_words() {
     member
         .book
         .ask(asked(&request, member.persona, QueryKind::VetterResend));
-    let resent = VetterResendResponseBody {
-        credential_id: "urn:uuid:grant".into(),
-        valid_until: Utc::now() + Duration::days(300),
-    };
+    let resent = vetters::resend::v0_1::Response::try_from(
+        vetters::resend::v0_1::Response::builder()
+            .credential_id("urn:uuid:grant")
+            .valid_until(Utc::now() + Duration::days(300)),
+    )
+    .unwrap();
     let handled = member
         .receive(&community_answer(&request, &resent), COMMUNITY)
         .await;
@@ -1050,12 +1084,18 @@ async fn a_manifest_answers_whoever_asked_and_brings_the_communitys_branding() {
     applicant
         .book
         .ask(asked(&request, applicant.persona, QueryKind::Manifest));
-    let mut body = manifest_body();
-    body.branding = Some(CommunityBranding {
-        display_name: Some("Kernel Developers".into()),
-        accent_color: Some("#336699".into()),
-        ..CommunityBranding::default()
-    });
+    let branding = manifest::v0_2::CommunityBranding::try_from(
+        manifest::v0_2::CommunityBranding::builder()
+            .display_name(Some(
+                manifest::v0_2::CommunityBrandingDisplayName::try_from("Kernel Developers")
+                    .unwrap(),
+            ))
+            .accent_color(Some(
+                manifest::v0_2::CommunityBrandingAccentColor::try_from("#336699").unwrap(),
+            )),
+    )
+    .unwrap();
+    let body = manifest_with(Some(requirements()), Some(branding));
     let handled = applicant
         .receive(&community_answer(&request, &body), COMMUNITY)
         .await;
@@ -1175,7 +1215,7 @@ async fn a_grant_that_names_no_status_list_is_not_called_unrevoked() {
 #[tokio::test]
 async fn a_scanned_ticket_link_is_enough_to_ask_and_another_communitys_is_refused() {
     let (mut applicant, mut vetter, _) = ready().await;
-    let link = vetter.book.tickets[0].uri(&vetter.did);
+    let link = vetter.book.tickets[0].uri(&vetter.did).unwrap();
     let ticket = applicant.application().ticket_from_uri(&link).unwrap();
     assert_eq!(ticket.vetter, vetter.did);
     let message = request(&mut applicant, &vetter, ticket.presentation).await;
@@ -1194,7 +1234,9 @@ async fn a_scanned_ticket_link_is_enough_to_ask_and_another_communitys_is_refuse
         Utc::now(),
     );
     assert!(matches!(
-        applicant.application().ticket_from_uri(&elsewhere.uri(&vetter.did)),
+        applicant
+            .application()
+            .ticket_from_uri(&elsewhere.uri(&vetter.did).unwrap()),
         Err(TicketUriError::OtherCommunity(c)) if c == "did:key:zOtherCommunity"
     ));
     assert!(matches!(

--- a/openvtc-core/src/vetting/tickets.rs
+++ b/openvtc-core/src/vetting/tickets.rs
@@ -22,9 +22,8 @@ use chrono::{DateTime, Duration, Utc};
 use rand::{RngCore, rngs::OsRng};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use vta_sdk::protocols::vetting::{
-    TicketPresentation, VETTING_REQUEST_ERR_INVALID_TICKET, VettingMethod,
-};
+use vta_sdk::protocols::vetting::request::v0_1 as request;
+use vta_sdk::protocols::vetting::{VETTING_REQUEST_ERR_INVALID_TICKET, VettingMethod};
 use vta_sdk::vetting::ticket_uri::{self, TicketUri};
 
 use crate::config::account::PersonaId;
@@ -116,20 +115,33 @@ impl Ticket {
     }
 
     /// The spoken form, as an applicant presents it.
-    #[must_use]
-    pub fn code_presentation(&self) -> TicketPresentation {
-        TicketPresentation::Code {
-            code: self.code.clone(),
-        }
+    ///
+    /// # Errors
+    ///
+    /// The published ticket refuses a code that breaks its pattern. Every code
+    /// [`Ticket::issue`] mints satisfies it, so this fails only for a ticket
+    /// read from a config some other build wrote.
+    pub fn code_presentation(&self) -> Result<request::Ticket, String> {
+        let code = request::ShortCodeTicket::try_from(
+            request::ShortCodeTicket::builder().code(self.code.clone()),
+        )
+        .map_err(|e| format!("ticket code: {e}"))?;
+        Ok(request::Ticket::ShortCodeTicket(code))
     }
 
     /// The scanned form, as an applicant presents it.
-    #[must_use]
-    pub fn scanned_presentation(&self) -> TicketPresentation {
-        TicketPresentation::Scanned {
-            ticket_id: self.id.clone(),
-            secret: self.secret.clone(),
-        }
+    ///
+    /// # Errors
+    ///
+    /// As [`Ticket::code_presentation`], for the ticket id and secret.
+    pub fn scanned_presentation(&self) -> Result<request::Ticket, String> {
+        let ticket = request::QrTicket::try_from(
+            request::QrTicket::builder()
+                .ticket_id(self.id.clone())
+                .secret(self.secret.clone()),
+        )
+        .map_err(|e| format!("scanned ticket: {e}"))?;
+        Ok(request::Ticket::QrTicket(ticket))
     }
 
     /// The ticket as a link — what its QR code carries. `vetter` is the DID of
@@ -138,13 +150,18 @@ impl Ticket {
     /// The link carries the scanned form: full-entropy, so it is refused
     /// outright when wrong rather than silently throttled, and nobody guesses
     /// it. The short code stays for reading aloud.
-    #[must_use]
-    pub fn uri(&self, vetter: &str) -> String {
+    ///
+    /// # Errors
+    ///
+    /// As [`Ticket::scanned_presentation`], or a ticket form the URI has no
+    /// members for — `ticket_uri::encode` returns a `Result` on this line.
+    pub fn uri(&self, vetter: &str) -> Result<String, String> {
         ticket_uri::encode(&TicketUri {
             community: self.community.clone(),
             vetter: vetter.to_string(),
-            presentation: self.scanned_presentation(),
+            presentation: self.scanned_presentation()?,
         })
+        .map_err(|e| e.to_string())
     }
 }
 
@@ -252,14 +269,15 @@ pub enum Redemption {
 pub fn check(
     tickets: &[Ticket],
     throttle: &mut GuessThrottle,
-    presented: &TicketPresentation,
+    presented: &request::Ticket,
     sender: &str,
     community: &str,
     persona: PersonaId,
     now: DateTime<Utc>,
 ) -> Redemption {
     match presented {
-        TicketPresentation::Code { code } => {
+        request::Ticket::ShortCodeTicket(spoken) => {
+            let code = spoken.code.as_str();
             throttle.prune(now);
             if !throttle.allows(sender) {
                 return Redemption::Silent;
@@ -282,10 +300,11 @@ pub fn check(
                 }
             }
         }
-        TicketPresentation::Scanned { ticket_id, secret } => {
+        request::Ticket::QrTicket(scanned) => {
+            let (ticket_id, secret) = (scanned.ticket_id.as_str(), scanned.secret.as_str());
             match tickets
                 .iter()
-                .find(|t| &t.id == ticket_id && t.persona == persona)
+                .find(|t| t.id == ticket_id && t.persona == persona)
             {
                 Some(ticket)
                     if ticket.community == community
@@ -299,6 +318,9 @@ pub fn check(
                 _ => Redemption::Refused(VETTING_REQUEST_ERR_INVALID_TICKET),
             }
         }
+        // The published ticket is `#[non_exhaustive]`: a form added by a later
+        // `vetting/request` is refused rather than silently admitted.
+        _ => Redemption::Refused(VETTING_REQUEST_ERR_INVALID_TICKET),
     }
 }
 
@@ -319,7 +341,7 @@ pub fn consume(tickets: &mut [Ticket], ticket_id: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vta_sdk::protocols::vetting::VettingRequestBody;
+    use vta_sdk::protocols::vetting::check_request;
 
     const COMMUNITY: &str = "did:web:vtc.example";
 
@@ -327,33 +349,55 @@ mod tests {
         Ticket::issue(COMMUNITY, persona, vec![], 1, DEFAULT_VALIDITY, now)
     }
 
+    /// A spoken ticket carrying `code`, which the published type refuses unless
+    /// it is Crockford base32 in upper case.
+    fn code_ticket(code: &str) -> Result<request::Ticket, String> {
+        request::ShortCodeTicket::try_from(request::ShortCodeTicket::builder().code(code))
+            .map(request::Ticket::ShortCodeTicket)
+            .map_err(|e| e.to_string())
+    }
+
     #[test]
     fn both_forms_satisfy_the_request_schema() {
         let t = ticket(PersonaId::new(), Utc::now());
-        for presented in [t.code_presentation(), t.scanned_presentation()] {
-            let body = VettingRequestBody {
-                community: COMMUNITY.into(),
-                requirements_digest: None,
-                join_did: "did:key:zApplicant".into(),
-                ticket: Some(presented),
-                introduction: None,
-                preferred_method: None,
-                languages: vec![],
-                message: None,
-                availability: None,
-                ext: None,
-            };
-            body.check_shape("did:key:zApplicant").unwrap();
+        for presented in [
+            t.code_presentation().unwrap(),
+            t.scanned_presentation().unwrap(),
+        ] {
+            let body = request::Payload::try_from(
+                request::Payload::builder()
+                    .community(COMMUNITY)
+                    .join_did("did:key:zApplicant")
+                    .ticket(Some(presented)),
+            )
+            .unwrap();
+            check_request(&body, "did:key:zApplicant").unwrap();
         }
+    }
+
+    /// The published code is upper-case Crockford base32. A code as a person
+    /// typed it is normalised before it is put on the wire; the type refuses it
+    /// otherwise, where the hand-written ticket carried whatever it was given.
+    #[test]
+    fn a_spoken_ticket_carries_the_code_in_the_published_form() {
+        let t = ticket(PersonaId::new(), Utc::now());
+        assert!(code_ticket(&t.code).is_ok());
+        assert!(code_ticket(&t.code.to_lowercase()).is_err());
+        assert!(code_ticket("K7QF2M9X").is_err(), "the dash is part of it");
     }
 
     #[test]
     fn a_ticket_link_carries_the_scanned_form() {
         let t = ticket(PersonaId::new(), Utc::now());
-        let decoded = ticket_uri::decode(&t.uri("did:key:zVetter")).unwrap();
+        let decoded = ticket_uri::decode(&t.uri("did:key:zVetter").unwrap()).unwrap();
         assert_eq!(decoded.community, COMMUNITY);
         assert_eq!(decoded.vetter, "did:key:zVetter");
-        assert_eq!(decoded.presentation, t.scanned_presentation());
+        // The published ticket has no `PartialEq`; its members are compared.
+        let request::Ticket::QrTicket(scanned) = &decoded.presentation else {
+            panic!("a link carries the scanned form");
+        };
+        assert_eq!(scanned.ticket_id.as_str(), t.id);
+        assert_eq!(scanned.secret.as_str(), t.secret);
     }
 
     #[test]
@@ -371,9 +415,7 @@ mod tests {
         let now = Utc::now();
         let mut tickets = vec![ticket(persona, now)];
         let mut throttle = GuessThrottle::default();
-        let presented = TicketPresentation::Code {
-            code: tickets[0].code.to_lowercase(),
-        };
+        let presented = code_ticket(&tickets[0].code).unwrap();
         let r = check(
             &tickets,
             &mut throttle,
@@ -409,9 +451,7 @@ mod tests {
         let now = Utc::now();
         let tickets = vec![ticket(persona, now)];
         let mut throttle = GuessThrottle::default();
-        let wrong = TicketPresentation::Code {
-            code: "0000-0000".into(),
-        };
+        let wrong = code_ticket("0000-0000").unwrap();
         for _ in 0..MAX_WRONG_CODES_PER_SENDER {
             assert_eq!(
                 check(
@@ -427,7 +467,7 @@ mod tests {
             );
         }
         // The throttled sender now gets silence even for the right code…
-        let right = tickets[0].code_presentation();
+        let right = tickets[0].code_presentation().unwrap();
         assert_eq!(
             check(
                 &tickets,
@@ -473,10 +513,14 @@ mod tests {
         let now = Utc::now();
         let tickets = vec![ticket(persona, now)];
         let mut throttle = GuessThrottle::default();
-        let presented = TicketPresentation::Scanned {
-            ticket_id: tickets[0].id.clone(),
-            secret: "A".repeat(43),
-        };
+        let presented = request::Ticket::QrTicket(
+            request::QrTicket::try_from(
+                request::QrTicket::builder()
+                    .ticket_id(tickets[0].id.clone())
+                    .secret("A".repeat(43)),
+            )
+            .unwrap(),
+        );
         assert_eq!(
             check(
                 &tickets,
@@ -497,7 +541,7 @@ mod tests {
         let persona = PersonaId::new();
         let now = Utc::now();
         let tickets = vec![ticket(persona, now)];
-        let right = tickets[0].scanned_presentation();
+        let right = tickets[0].scanned_presentation().unwrap();
         let mut throttle = GuessThrottle::default();
         let refused = Redemption::Refused(VETTING_REQUEST_ERR_INVALID_TICKET);
         let run = |throttle: &mut GuessThrottle, community, persona, at| {

--- a/openvtc-core/src/vetting/vetter.rs
+++ b/openvtc-core/src/vetting/vetter.rs
@@ -21,12 +21,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
 use vta_sdk::protocols::vetting::{
-    CardClaim, DeclaredRelationship, DeclineCode, IDENTITY_VETTING_ENDORSEMENT_TYPE,
-    IdentityVettingEndorsement, RevocationReason, RevokeStatementBody, ShapeError,
-    VETTING_REQUEST_ERR_CAPACITY, VETTING_REQUEST_ERR_DECLINED,
-    VETTING_REQUEST_ERR_METHOD_UNAVAILABLE, VETTING_REQUEST_ERR_NOT_ELIGIBLE, VettingDeclineBody,
-    VettingMethod, VettingRequestAcceptedBody, VettingRequestBody, VettingSessionBody,
-    VettingSessionResponseBody,
+    CheckShape, ClaimType, IDENTITY_VETTING_ENDORSEMENT_TYPE, IdentityVettingEndorsement,
+    ShapeError, VETTING_REQUEST_ERR_CAPACITY, VETTING_REQUEST_ERR_DECLINED,
+    VETTING_REQUEST_ERR_METHOD_UNAVAILABLE, VETTING_REQUEST_ERR_NOT_ELIGIBLE, VettingDocumentation,
+    VettingMethod, VettingRelationship, check_request, decline, documentation, request,
+    revoke_statement, session,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::VettingError;
@@ -74,7 +73,11 @@ pub enum VetterError {
 }
 
 /// One request at the desk.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+///
+/// No `PartialEq`: it keeps the applicant's request as the generated
+/// `vetting/request/0.1` payload, and the generated wire types derive only
+/// `Serialize`, `Deserialize`, `Clone` and `Debug`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeskEntry {
     /// Our handle, sent to the applicant.
     pub request_id: String,
@@ -90,7 +93,7 @@ pub struct DeskEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ticket_id: Option<String>,
     /// What they asked.
-    pub request: VettingRequestBody,
+    pub request: request::v0_1::Payload,
     /// Where it stands.
     pub state: DeskState,
     /// When it arrived.
@@ -100,7 +103,9 @@ pub struct DeskEntry {
 }
 
 /// Where a desk request stands.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+///
+/// No `PartialEq`: a received card carries the generated card claims.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
 pub enum DeskState {
     /// Waiting for the vetter to open a session.
@@ -130,7 +135,7 @@ pub enum DeskState {
     Declined {
         /// The reason code we gave, if any.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        code: Option<DeclineCode>,
+        code: Option<decline::v0_1::PayloadCode>,
         /// When.
         at: DateTime<Utc>,
         /// The card, if one had arrived.
@@ -161,7 +166,9 @@ pub struct DeskSession {
 
 /// A verified card. The claims and the card itself are forgotten after
 /// [`VetterPolicy::card_retention_days`]; the digest and commitment remain.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+///
+/// No `PartialEq`: the claims are the generated card's.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReceivedCard {
     /// `digestMultibase` of the card.
     pub digest_multibase: String,
@@ -169,7 +176,7 @@ pub struct ReceivedCard {
     pub identity_commitment: String,
     /// What the card showed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub claims: Vec<CardClaim>,
+    pub claims: Vec<session::v0_1::VettingCardClaim>,
     /// The signed card, exactly as received.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub card: Option<Value>,
@@ -208,7 +215,7 @@ pub struct Withdrawal {
     pub document_id: String,
     /// The reason we gave, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reason: Option<RevocationReason>,
+    pub reason: Option<revoke_statement::v0_1::PayloadReason>,
     /// When we sent it.
     pub sent_at: DateTime<Utc>,
     /// When the community recorded it.
@@ -226,17 +233,23 @@ pub struct IncomingRequest<'a> {
     /// Our persona it was addressed to.
     pub persona: PersonaId,
     /// The payload.
-    pub body: VettingRequestBody,
+    pub body: request::v0_1::Payload,
     /// `persona` is an active member of `body.community` and holds its live
     /// vetter role credential.
     pub eligible: bool,
 }
 
 /// What an inbound request earns.
-#[derive(Clone, Debug, PartialEq)]
+///
+/// No `PartialEq`: the acceptance is the generated `#response`.
+///
+/// The acceptance is boxed because it dwarfs the other two: the generated
+/// response carries an optional eligibility presentation, and a refusal is one
+/// `&'static str`.
+#[derive(Clone, Debug)]
 pub enum Intake {
     /// Accepted; answer with this `#response`.
-    Accepted(VettingRequestAcceptedBody),
+    Accepted(Box<request::v0_1::Response>),
     /// Refused; answer with a `trust-task-error` carrying this code.
     Refused(&'static str),
     /// No answer at all.
@@ -255,7 +268,7 @@ pub struct Attestation {
     /// The two people read the match code to each other.
     pub liveness_confirmed: bool,
     /// The vetter's declared relationship to the applicant.
-    pub declared_relationship: DeclaredRelationship,
+    pub declared_relationship: VettingRelationship,
     /// Digest of the attestation text the vetter was shown.
     pub attestation_text_digest: Option<String>,
 }
@@ -305,13 +318,41 @@ impl DeskEntry {
     }
 }
 
-fn accepted_reply(entry: &DeskEntry, policy: &VetterPolicy) -> VettingRequestAcceptedBody {
-    VettingRequestAcceptedBody {
-        request_id: entry.request_id.clone(),
-        eligibility_vp: None,
-        accepts_documentation: policy.accepts_documentation.clone(),
-        session_hint: None,
-        ext: None,
+/// The `#response` accepting `entry`.
+///
+/// `acceptsDocumentation` is `minItems: 1` and unique on this line, where it
+/// used to accept `[]`. A vetter who accepts no documentation at all — which V0
+/// allows, for someone they already know (D16) — therefore **omits** the member
+/// rather than sending an empty list the published response refuses, and a
+/// token repeated in the vetter's own policy is listed once.
+fn accepted_reply(
+    entry: &DeskEntry,
+    policy: &VetterPolicy,
+) -> Result<request::v0_1::Response, ShapeError> {
+    let schema = |e: &dyn std::fmt::Display| ShapeError::Schema(e.to_string());
+    let mut accepted: Vec<request::v0_1::VettingDocumentation> = Vec::new();
+    for token in &policy.accepts_documentation {
+        let parsed = request::v0_1::VettingDocumentation::try_from(token.as_str())
+            .map_err(|e| schema(&e))?;
+        if !accepted.iter().any(|d| d.as_str() == parsed.as_str()) {
+            accepted.push(parsed);
+        }
+    }
+    request::v0_1::Response::try_from(
+        request::v0_1::Response::builder()
+            .request_id(entry.request_id.as_str())
+            .accepts_documentation((!accepted.is_empty()).then_some(accepted)),
+    )
+    .map_err(|e| schema(&e))
+}
+
+/// [`accepted_reply`] as an [`Intake`]. A vetter whose own documentation list
+/// the published response cannot carry answers `declined` rather than going
+/// silent: the applicant learns their request arrived and was not taken.
+fn accept(entry: &DeskEntry, policy: &VetterPolicy) -> Intake {
+    match accepted_reply(entry, policy) {
+        Ok(body) => Intake::Accepted(Box::new(body)),
+        Err(_) => Intake::Refused(VETTING_REQUEST_ERR_DECLINED),
     }
 }
 
@@ -329,7 +370,7 @@ impl VettingBook {
             body,
             eligible,
         } = incoming;
-        if body.check_shape(sender).is_err() {
+        if check_request(&body, sender).is_err() {
             return Intake::Silent;
         }
         if let Some(existing) = self
@@ -337,14 +378,16 @@ impl VettingBook {
             .iter()
             .find(|e| e.request_document_id == document_id && e.applicant == sender)
         {
-            return Intake::Accepted(accepted_reply(existing, &self.policy));
+            return accept(existing, &self.policy);
         }
         let Some(ticket) = body.ticket.as_ref() else {
-            // Introductions are a vetter opt-in that V0 does not offer.
-            return if body.introduction.is_some() {
-                Intake::Refused(VETTING_REQUEST_ERR_DECLINED)
-            } else {
+            // Introductions are a vetter opt-in that V0 does not offer. The
+            // published payload makes `introduction` an object rather than an
+            // optional value, so "they sent one" is "it is not empty".
+            return if body.introduction.is_empty() {
                 Intake::Silent
+            } else {
+                Intake::Refused(VETTING_REQUEST_ERR_DECLINED)
             };
         };
         let ticket_id = match tickets::check(
@@ -352,7 +395,7 @@ impl VettingBook {
             &mut self.throttle,
             ticket,
             sender,
-            &body.community,
+            body.community.as_str(),
             persona,
             now,
         ) {
@@ -360,11 +403,17 @@ impl VettingBook {
             Redemption::Silent => return Intake::Silent,
             Redemption::Refused(code) => return Intake::Refused(code),
         };
+        // The request task has its own copy of the method vocabulary; a ticket
+        // holds the community's (see `super::same_token`).
+        let preferred = body
+            .preferred_method
+            .as_ref()
+            .and_then(|m| super::same_token::<_, VettingMethod>(m).ok());
         if !self
             .tickets
             .iter()
             .find(|t| t.id == ticket_id)
-            .is_some_and(|t| t.offers(body.preferred_method))
+            .is_some_and(|t| t.offers(preferred))
         {
             return Intake::Refused(VETTING_REQUEST_ERR_METHOD_UNAVAILABLE);
         }
@@ -379,7 +428,7 @@ impl VettingBook {
             request_id: Uuid::new_v4().to_string(),
             request_document_id: document_id.to_string(),
             applicant: sender.to_string(),
-            community: body.community.clone(),
+            community: body.community.as_str().to_string(),
             persona,
             ticket_id: Some(ticket_id),
             request: body,
@@ -387,9 +436,9 @@ impl VettingBook {
             received_at: now,
             updated_at: now,
         };
-        let reply = accepted_reply(&entry, &self.policy);
+        let reply = accept(&entry, &self.policy);
         self.desk.push(entry);
-        Intake::Accepted(reply)
+        reply
     }
 
     /// Open a session for `request_id` — with the person in front of us or on
@@ -407,7 +456,7 @@ impl VettingBook {
         optional_claims: Vec<String>,
         session_document_id: &str,
         now: DateTime<Utc>,
-    ) -> Result<VettingSessionBody, VetterError> {
+    ) -> Result<session::v0_1::Payload, VetterError> {
         let length = self.policy.session_length();
         let entry = self
             .desk_entry_mut(request_id)
@@ -415,24 +464,46 @@ impl VettingBook {
         if !entry.state.is_open() {
             return Err(VetterError::WrongState("open a session"));
         }
-        let body = VettingSessionBody {
-            request_id: request_id.to_string(),
-            challenge: new_commitment_salt()?,
-            domain: entry.community.clone(),
-            method,
-            required_claims,
-            optional_claims,
-            expires_at: now + length,
-            ext: None,
-        };
+        let schema = |e: &dyn std::fmt::Display| ShapeError::Schema(e.to_string());
+        let challenge = new_commitment_salt()?;
+        // The session task has its own copy of the method vocabulary and its
+        // own claim-type newtype, which is what refuses a claim that is not a
+        // claim type at all.
+        let task_method = super::same_token::<_, session::v0_1::VettingMethod>(&method)
+            .map_err(|e| schema(&e))?;
+        let required = required_claims
+            .iter()
+            .map(|c| {
+                session::v0_1::PayloadRequiredClaimsItem::try_from(c.as_str())
+                    .map_err(|e| schema(&e))
+            })
+            .collect::<Result<Vec<_>, ShapeError>>()?;
+        let optional = optional_claims
+            .iter()
+            .map(|c| {
+                session::v0_1::PayloadOptionalClaimsItem::try_from(c.as_str())
+                    .map_err(|e| schema(&e))
+            })
+            .collect::<Result<Vec<_>, ShapeError>>()?;
+        let body = session::v0_1::Payload::try_from(
+            session::v0_1::Payload::builder()
+                .request_id(request_id)
+                .challenge(challenge.as_str())
+                .domain(entry.community.as_str())
+                .method(task_method)
+                .required_claims(required)
+                .optional_claims((!optional.is_empty()).then_some(optional))
+                .expires_at(now + length),
+        )
+        .map_err(|e| schema(&e))?;
         body.check_shape()?;
         entry.state = DeskState::Session {
             session: DeskSession {
                 id: session_document_id.to_string(),
-                challenge: body.challenge.clone(),
+                challenge,
                 method,
-                required_claims: body.required_claims.clone(),
-                optional_claims: body.optional_claims.clone(),
+                required_claims: required_claims.clone(),
+                optional_claims: optional_claims.clone(),
                 expires_at: body.expires_at,
                 match_code: vetting_match_code(session_document_id),
             },
@@ -449,12 +520,15 @@ impl VettingBook {
     ///
     /// No open session from this applicant, a closed one, or a card that does
     /// not verify.
+    /// `card` is the card **as received** rather than a re-serialised one: its
+    /// `digestMultibase` is what the statement names, and a parsed card written
+    /// back out is not guaranteed to be the same bytes.
     pub async fn receive_card(
         &mut self,
         vetter_did: &str,
         applicant: &str,
         session_id: &str,
-        body: VettingSessionResponseBody,
+        card: &Value,
         resolver: &TrustTaskVmResolver,
         now: DateTime<Utc>,
     ) -> Result<&DeskEntry, VetterError> {
@@ -476,7 +550,7 @@ impl VettingBook {
             ));
         }
         let verified = verify_card(
-            &body.card,
+            card,
             &CardExpectations {
                 audience: vetter_did,
                 publisher: applicant,
@@ -489,14 +563,17 @@ impl VettingBook {
             resolver,
         )
         .await?;
-        let card = ReceivedCard {
+        let received = ReceivedCard {
             digest_multibase: verified.digest_multibase().to_string(),
-            identity_commitment: verified.card().identity_commitment.clone(),
+            identity_commitment: verified.card().identity_commitment.as_str().to_string(),
             claims: verified.card().claims.clone(),
-            card: Some(body.card),
+            card: Some(card.clone()),
             received_at: now,
         };
-        entry.state = DeskState::CardReceived { session, card };
+        entry.state = DeskState::CardReceived {
+            session,
+            card: received,
+        };
         entry.updated_at = now;
         Ok(entry)
     }
@@ -520,17 +597,27 @@ impl VettingBook {
         let DeskState::CardReceived { session, card } = &entry.state else {
             return Err(VetterError::WrongState("be attested"));
         };
+        let schema = |e: &dyn std::fmt::Display| ShapeError::Schema(e.to_string());
         let documentary = attestation.method != VettingMethod::PriorAcquaintance;
         if documentary && !attestation.liveness_confirmed {
             return Err(VetterError::LivenessNotConfirmed);
         }
-        if documentary && attestation.document_classes.is_empty() {
+        // The shared endorsement never lists `none`: no document is the empty
+        // list. So `none` is dropped here, and a documentary method left with
+        // nothing to rely on is the same as naming no documentation at all.
+        let document_classes = attestation
+            .document_classes
+            .iter()
+            .filter(|d| d.as_str() != documentation::NONE)
+            .map(|d| VettingDocumentation::try_from(d.as_str()).map_err(|e| schema(&e)))
+            .collect::<Result<Vec<_>, ShapeError>>()?;
+        if documentary && document_classes.is_empty() {
             return Err(VetterError::NoDocumentation);
         }
         if let Some(missing) = attestation
             .claims_verified
             .iter()
-            .find(|t| !card.claims.iter().any(|c| &c.claim_type == *t))
+            .find(|t| !card.claims.iter().any(|c| c.type_.as_str() == t.as_str()))
         {
             return Err(VetterError::ClaimNotOnCard(missing.clone()));
         }
@@ -541,12 +628,17 @@ impl VettingBook {
         {
             return Err(VetterError::RequiredClaimNotVerified(unverified.clone()));
         }
+        let claims_verified = attestation
+            .claims_verified
+            .iter()
+            .map(|c| ClaimType::try_from(c.as_str()).map_err(|e| schema(&e)))
+            .collect::<Result<Vec<_>, ShapeError>>()?;
         let endorsement = IdentityVettingEndorsement {
             endorsement_type: IDENTITY_VETTING_ENDORSEMENT_TYPE.into(),
             community: entry.community.clone(),
             method: attestation.method,
-            document_classes: attestation.document_classes,
-            claims_verified: attestation.claims_verified,
+            document_classes,
+            claims_verified,
             liveness_confirmed: attestation.liveness_confirmed,
             identity_commitment: card.identity_commitment.clone(),
             card_digest_multibase: card.digest_multibase.clone(),
@@ -614,22 +706,27 @@ impl VettingBook {
     pub fn decline(
         &mut self,
         request_id: &str,
-        code: Option<DeclineCode>,
+        code: Option<decline::v0_1::PayloadCode>,
         message: Option<String>,
         now: DateTime<Utc>,
-    ) -> Result<VettingDeclineBody, VetterError> {
+    ) -> Result<decline::v0_1::Payload, VetterError> {
         let entry = self
             .desk_entry_mut(request_id)
             .ok_or(VetterError::NoSuchRequest)?;
         if !entry.state.is_open() {
             return Err(VetterError::WrongState("be declined"));
         }
-        let body = VettingDeclineBody {
-            request_id: request_id.to_string(),
-            code,
-            message,
-            ext: None,
-        };
+        let schema = |e: &dyn std::fmt::Display| ShapeError::Schema(e.to_string());
+        let message = message
+            .map(|m| decline::v0_1::PayloadMessage::try_from(m).map_err(|e| schema(&e)))
+            .transpose()?;
+        let body = decline::v0_1::Payload::try_from(
+            decline::v0_1::Payload::builder()
+                .request_id(request_id)
+                .code(code)
+                .message(message),
+        )
+        .map_err(|e| schema(&e))?;
         body.check_shape()?;
         let card = match &entry.state {
             DeskState::CardReceived { card, .. } => Some(card.clone()),
@@ -654,10 +751,10 @@ impl VettingBook {
     pub fn withdrawal(
         &mut self,
         statement_id: &str,
-        reason: Option<RevocationReason>,
+        reason: Option<revoke_statement::v0_1::PayloadReason>,
         document_id: &str,
         now: DateTime<Utc>,
-    ) -> Result<(RevokeStatementBody, IssuedStatement), VetterError> {
+    ) -> Result<(revoke_statement::v0_1::Payload, IssuedStatement), VetterError> {
         let issued = self
             .issued
             .iter_mut()
@@ -670,12 +767,14 @@ impl VettingBook {
         {
             return Err(VetterError::AlreadyWithdrawn);
         }
-        let body = RevokeStatementBody {
-            statement_id: issued.id.clone(),
-            statement_digest_multibase: issued.digest_multibase.clone(),
-            reason,
-            ext: None,
-        };
+        let schema = |e: &dyn std::fmt::Display| ShapeError::Schema(e.to_string());
+        let body = revoke_statement::v0_1::Payload::try_from(
+            revoke_statement::v0_1::Payload::builder()
+                .statement_id(issued.id.as_str())
+                .statement_digest_multibase(issued.digest_multibase.as_str())
+                .reason(reason),
+        )
+        .map_err(|e| schema(&e))?;
         body.check_shape()?;
         issued.withdrawal = Some(Withdrawal {
             document_id: document_id.to_string(),

--- a/openvtc-core/src/vetting/wire.rs
+++ b/openvtc-core/src/vetting/wire.rs
@@ -208,7 +208,7 @@ pub fn manifest_request(
 pub fn vetter_list_request(
     issuer: &str,
     community_did: &str,
-    body: &vta_sdk::protocols::vetting::VetterListBody,
+    body: &vta_sdk::protocols::vetting::vetters::list::v0_1::Payload,
 ) -> Result<TrustTask<Value>, OpenVTCError> {
     document(
         vta_sdk::protocols::vetting::VETTING_VETTER_LIST_TYPE,
@@ -224,7 +224,7 @@ pub fn vetter_list_request(
 pub fn vetter_profile_request(
     vetter_did: &str,
     community_did: &str,
-    body: &vta_sdk::protocols::vetting::VetterProfileBody,
+    body: &vta_sdk::protocols::vetting::vetters::profile::v0_1::Payload,
 ) -> Result<TrustTask<Value>, OpenVTCError> {
     document(
         vta_sdk::protocols::vetting::VETTING_VETTER_PROFILE_TYPE,
@@ -246,7 +246,7 @@ pub fn vetter_resend_request(
         vetter_did,
         community_did,
         new_id(),
-        &vta_sdk::protocols::vetting::VetterResendBody::default(),
+        &vta_sdk::protocols::vetting::vetters::resend::v0_1::Payload::default(),
     )
 }
 
@@ -362,8 +362,7 @@ pub fn delivered_statement(body: &Value) -> Option<&Value> {
 pub(crate) mod tests {
     use super::*;
     use vta_sdk::protocols::vetting::{
-        VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_CAPACITY, VETTING_REQUEST_TYPE,
-        VettingDeclineBody,
+        VETTING_DECLINE_TYPE, VETTING_REQUEST_ERR_CAPACITY, VETTING_REQUEST_TYPE, decline, session,
     };
 
     /// A `did:key` Ed25519 secret from a fixed seed, `id` = `<did>#<multibase>`.
@@ -417,11 +416,15 @@ pub(crate) mod tests {
             domain: "did:webvh:QmScid:example.com:vtc".to_string(),
             issued_at: Utc::now(),
             validity: chrono::Duration::minutes(10),
-            claims: vec![vta_sdk::protocols::vetting::CardClaim {
-                claim_type: "name.legal".into(),
-                value: json!("Alice Example"),
-                provenance: "selfAsserted".into(),
-            }],
+            claims: vec![
+                session::v0_1::VettingCardClaim::try_from(
+                    session::v0_1::VettingCardClaim::builder()
+                        .type_("name.legal")
+                        .value(json!("Alice Example"))
+                        .provenance("selfAsserted"),
+                )
+                .unwrap(),
+            ],
             identity_types: vec!["name.legal".into()],
             salt: vta_sdk::vetting::card::new_commitment_salt().unwrap(),
         };
@@ -434,13 +437,9 @@ pub(crate) mod tests {
         );
     }
 
-    fn decline() -> VettingDeclineBody {
-        VettingDeclineBody {
-            request_id: "r1".into(),
-            code: None,
-            message: None,
-            ext: None,
-        }
+    fn decline() -> decline::v0_1::Payload {
+        decline::v0_1::Payload::try_from(decline::v0_1::Payload::builder().request_id("r1"))
+            .unwrap()
     }
 
     #[tokio::test]
@@ -459,12 +458,12 @@ pub(crate) mod tests {
         assert_eq!(message.id, doc.id);
 
         let resolver = TrustTaskVmResolver::did_key_only();
-        let opened: Opened<VettingDeclineBody> =
+        let opened: Opened<decline::v0_1::Payload> =
             open(&message, &did(&vetter), &resolver).await.unwrap();
-        assert_eq!(opened.payload.request_id, "r1");
+        assert_eq!(opened.payload.request_id.as_str(), "r1");
 
         assert!(matches!(
-            open::<VettingDeclineBody>(&message, &did(&other), &resolver).await,
+            open::<decline::v0_1::Payload>(&message, &did(&other), &resolver).await,
             Err(WireError::IssuerNotSender)
         ));
     }
@@ -482,7 +481,7 @@ pub(crate) mod tests {
         .unwrap();
         let message = to_message(&doc).unwrap();
         assert!(matches!(
-            open::<VettingDeclineBody>(
+            open::<decline::v0_1::Payload>(
                 &message,
                 &did(&vetter),
                 &TrustTaskVmResolver::did_key_only()

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -38,16 +38,19 @@ anyhow.workspace = true
 # own repo (OpenVTC/verifiable-git-infrastructure); openvtc is a downstream
 # consumer of the published crate.
 #
-# 0.4.9 is published and carries the vta-sdk 0.36 move, so the root manifest's
-# `[patch.crates-io]` entries for VGI are gone. Neither `did-git-sign` 0.4.9 nor
-# its `vgi-core` 0.4.9 dependency pulls `vta-sdk`, so there is no second sdk to
-# unify.
+# Floor is 0.4.9 — the release VGI cut from `chore/vta-sdk-036`, and the newest
+# there is. It resolves from crates.io, which is what let the patch block go.
 #
-# Floor is 0.4.8, and on the 0.35 line it was also where this actually resolved
-# from. 0.4.8 is published and requires `vta-sdk ^0.35`, so
-# the `[patch.crates-io]` redirect to VGI's unreleased `main` is deleted rather
-# than repointed — see the note where that block used to be, at the foot of the
-# root manifest.
+# **It is still a minor behind this workspace, and that cannot be fixed here.**
+# 0.4.9 requires `vta-sdk ^0.36` while the workspace is on 0.37, so the graph
+# holds two sdks. A `[patch]` is not the lever this time: 0.4.9 was cut from VGI
+# `main`, so there is no newer commit to redirect to. It closes when VGI takes
+# 0.37 and releases, and this floor moves to that release. See the `vta-sdk` note
+# in the root manifest for why two sdks are normally a build failure and why this
+# one is not.
+#
+# Naming 0.4.9 rather than a bare `"0.4"` is what stops a clean checkout
+# resolving further back and adding a *third* sdk line.
 #
 # Read the rule rather than the version, because the rule has not changed: when
 # the workspace's vta-sdk minor moves, VGI has to move with it, and until it

--- a/openvtc/Cargo.toml
+++ b/openvtc/Cargo.toml
@@ -41,13 +41,13 @@ anyhow.workspace = true
 # Floor is 0.4.9 — the release VGI cut from `chore/vta-sdk-036`, and the newest
 # there is. It resolves from crates.io, which is what let the patch block go.
 #
-# **It is still a minor behind this workspace, and that cannot be fixed here.**
-# 0.4.9 requires `vta-sdk ^0.36` while the workspace is on 0.37, so the graph
-# holds two sdks. A `[patch]` is not the lever this time: 0.4.9 was cut from VGI
-# `main`, so there is no newer commit to redirect to. It closes when VGI takes
-# 0.37 and releases, and this floor moves to that release. See the `vta-sdk` note
-# in the root manifest for why two sdks are normally a build failure and why this
-# one is not.
+# **It is still behind this workspace, and that cannot be fixed here.**
+# 0.4.9 requires `vta-sdk ^0.36` while the workspace is on 0.38, so the graph
+# holds two sdks. A `[patch]` is not the lever: 0.4.9 was cut from VGI `main`,
+# so there is no newer commit to redirect to. VGI `main` has since taken 0.38
+# (VGI #51), so the remaining step is a VGI *release* — when one is cut, this
+# floor moves to it and the second sdk goes. See the `vta-sdk` note in the root
+# manifest for why two sdks are normally a build failure and why this one is not.
 #
 # Naming 0.4.9 rather than a bare `"0.4"` is what stops a clean checkout
 # resolving further back and adding a *third* sdk line.

--- a/openvtc/src/state_handler/join_flow.rs
+++ b/openvtc/src/state_handler/join_flow.rs
@@ -2829,11 +2829,13 @@ mod tests {
 mod vetting_tests {
     use super::*;
     use crate::state_handler::dispatch_util::test_config;
-    use vta_sdk::protocols::join_requests::{JoinRequestManifestResponseBody, ManifestCriterion};
+    use vta_sdk::protocols::join_requests::manifest;
 
     const VTC: &str = "did:web:kernel.example";
+    /// Base58btc and at least 16 characters, as the published criterion asks.
+    const DIGEST: &str = "zQmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
 
-    fn manifest(vets: bool) -> JoinRequestManifestResponseBody {
+    fn manifest(vets: bool) -> manifest::v0_2::Response {
         let requirements = serde_json::from_value(serde_json::json!({
             "version": "0.1",
             "statementType": vta_sdk::protocols::vetting::IDENTITY_VETTING_ENDORSEMENT_TYPE,
@@ -2844,17 +2846,22 @@ mod vetting_tests {
             "eligibleVetters": { "role": "vetter" }
         }))
         .unwrap();
-        JoinRequestManifestResponseBody {
-            community_did: VTC.into(),
-            criteria: vec![ManifestCriterion {
-                id: "vetted".into(),
-                description: None,
-                presentation_definition: serde_json::json!({}),
-                vetting: vets.then_some(requirements),
-                requirements_digest: Some("zDigest".into()),
-            }],
-            branding: None,
-        }
+        let criterion = manifest::v0_2::Criterion::try_from(
+            manifest::v0_2::Criterion::builder()
+                .id("vetted")
+                .presentation_definition(serde_json::Map::new())
+                .vetting(vets.then_some(requirements))
+                .requirements_digest(Some(
+                    manifest::v0_2::DigestMultibase::try_from(DIGEST).unwrap(),
+                )),
+        )
+        .unwrap();
+        manifest::v0_2::Response::try_from(
+            manifest::v0_2::Response::builder()
+                .community_did(VTC)
+                .criteria(vec![criterion]),
+        )
+        .unwrap()
     }
 
     fn awaiting() -> AwaitingRequirements {

--- a/openvtc/src/state_handler/main_page/content.rs
+++ b/openvtc/src/state_handler/main_page/content.rs
@@ -8,9 +8,7 @@ use openvtc_core::config::community_context::{
     ContextDeletion, ContextDeletionPreview, ContextOption, PersonaTakenAlong,
 };
 use openvtc_core::vetting::registry::{DirectoryFilter, EventDraft, ProfileDraft};
-use vta_sdk::protocols::vetting::{
-    DeclaredRelationship, RevocationReason, TicketPresentation, VettingMethod,
-};
+use vta_sdk::protocols::vetting::{VettingMethod, VettingRelationship, request, revoke_statement};
 
 /// Lazily-rendered raw credential JSON for credential detail views.
 ///
@@ -1442,20 +1440,20 @@ pub const VETTING_METHODS: [VettingMethod; 3] = [
 ];
 
 /// Declared relationships, in the order the page cycles through them.
-pub const VETTING_RELATIONSHIPS: [DeclaredRelationship; 5] = [
-    DeclaredRelationship::None,
-    DeclaredRelationship::CommunityColleague,
-    DeclaredRelationship::SameEmployer,
-    DeclaredRelationship::Family,
-    DeclaredRelationship::OtherPersonal,
+pub const VETTING_RELATIONSHIPS: [VettingRelationship; 5] = [
+    VettingRelationship::None,
+    VettingRelationship::CommunityColleague,
+    VettingRelationship::SameEmployer,
+    VettingRelationship::Family,
+    VettingRelationship::OtherPersonal,
 ];
 
 /// Reasons a vetter may give for withdrawing a statement.
-pub const VETTING_WITHDRAWAL_REASONS: [RevocationReason; 4] = [
-    RevocationReason::Mistake,
-    RevocationReason::NewInformation,
-    RevocationReason::KeyCompromise,
-    RevocationReason::Other,
+pub const VETTING_WITHDRAWAL_REASONS: [revoke_statement::v0_1::PayloadReason; 4] = [
+    revoke_statement::v0_1::PayloadReason::Mistake,
+    revoke_statement::v0_1::PayloadReason::NewInformation,
+    revoke_statement::v0_1::PayloadReason::KeyCompromise,
+    revoke_statement::v0_1::PayloadReason::Other,
 ];
 
 /// How many requests a new ticket admits: one person, or a conference desk.
@@ -1502,24 +1500,24 @@ pub fn method_label(method: VettingMethod) -> &'static str {
 
 /// How a declared relationship reads on the page.
 #[must_use]
-pub fn relationship_label(relationship: DeclaredRelationship) -> &'static str {
+pub fn relationship_label(relationship: VettingRelationship) -> &'static str {
     match relationship {
-        DeclaredRelationship::None => "no prior relationship",
-        DeclaredRelationship::CommunityColleague => "we work together in the community",
-        DeclaredRelationship::SameEmployer => "same employer",
-        DeclaredRelationship::Family => "family",
-        DeclaredRelationship::OtherPersonal => "another personal relationship",
+        VettingRelationship::None => "no prior relationship",
+        VettingRelationship::CommunityColleague => "we work together in the community",
+        VettingRelationship::SameEmployer => "same employer",
+        VettingRelationship::Family => "family",
+        VettingRelationship::OtherPersonal => "another personal relationship",
         _ => "other",
     }
 }
 
 /// How a withdrawal reason reads on the page.
 #[must_use]
-pub fn reason_label(reason: RevocationReason) -> &'static str {
+pub fn reason_label(reason: revoke_statement::v0_1::PayloadReason) -> &'static str {
     match reason {
-        RevocationReason::Mistake => "I made a mistake",
-        RevocationReason::NewInformation => "I learned something new",
-        RevocationReason::KeyCompromise => "my signing key was compromised",
+        revoke_statement::v0_1::PayloadReason::Mistake => "I made a mistake",
+        revoke_statement::v0_1::PayloadReason::NewInformation => "I learned something new",
+        revoke_statement::v0_1::PayloadReason::KeyCompromise => "my signing key was compromised",
         _ => "another reason",
     }
 }
@@ -1622,7 +1620,7 @@ pub enum VettingMode {
         vetter: String,
         code: String,
         /// A scanned ticket from a pasted link, in place of the code.
-        ticket: Option<TicketPresentation>,
+        ticket: Option<request::v0_1::Ticket>,
         /// What the person should know before sending, e.g. how this vetter
         /// hands out tickets.
         note: Option<String>,

--- a/openvtc/src/state_handler/vetting_actions.rs
+++ b/openvtc/src/state_handler/vetting_actions.rs
@@ -29,7 +29,8 @@ use openvtc_core::vetting::queries::{
     CommunityAnswer, CommunityQuery, QUERY_TIMEOUT, QueryKind, refusal_words,
 };
 use openvtc_core::vetting::registry::{
-    EventDraft, ProfileDraft, ProfileState, VetterProfileRecord, event_line, location_line,
+    EventDraft, ProfileDraft, ProfileState, VetterProfileRecord, listed_event_line,
+    listed_location_line,
 };
 use openvtc_core::vetting::status::GrantCheck;
 use openvtc_core::vetting::tickets::{DEFAULT_VALIDITY, Ticket, normalise_code};
@@ -38,9 +39,9 @@ use openvtc_core::vetting::wire::{self, Document};
 use serde_json::Value;
 use vta_sdk::client::VtaClient;
 use vta_sdk::protocols::vetting::{
-    CardClaim, ListedVetter, TicketPresentation, VETTING_DECLINE_TYPE, VETTING_REQUEST_TYPE,
-    VETTING_REVOKE_STATEMENT_TYPE, VETTING_SESSION_RESPONSE_TYPE, VETTING_SESSION_TYPE,
-    VettingMethod, VettingRequirements, VettingSessionResponseBody, documentation,
+    VETTING_DECLINE_TYPE, VETTING_REQUEST_TYPE, VETTING_REVOKE_STATEMENT_TYPE,
+    VETTING_SESSION_RESPONSE_TYPE, VETTING_SESSION_TYPE, VettingMethod, VettingRequirements,
+    documentation, request, session, vetters,
 };
 use vta_sdk::trust_task_proof::TrustTaskVmResolver;
 use vta_sdk::vetting::card::sign_card;
@@ -170,7 +171,13 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
             let required: Vec<String> = app
                 .requirements
                 .as_ref()
-                .map(|r| r.required_claims.clone())
+                .map(|r| {
+                    r.required_claims
+                        .iter()
+                        .flatten()
+                        .map(|c| c.as_str().to_string())
+                        .collect::<Vec<_>>()
+                })
                 .filter(|claims| !claims.is_empty())
                 .unwrap_or_else(|| {
                     FALLBACK_REQUIRED_CLAIMS
@@ -184,7 +191,7 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
                     let value = app
                         .identity_claims
                         .iter()
-                        .find(|c| &c.claim_type == claim_type)
+                        .find(|c| c.type_.as_str() == claim_type.as_str())
                         .map(|c| claim_text(&c.value))
                         .unwrap_or_default();
                     (claim_type.clone(), value)
@@ -306,7 +313,7 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
                             .iter()
                             .map(|claim| {
                                 (
-                                    sanitize_display(&claim.claim_type, 64),
+                                    sanitize_display(claim.type_.as_str(), 64),
                                     sanitize_display(&claim_text(&claim.value), 256),
                                 )
                             })
@@ -336,7 +343,9 @@ pub(crate) fn sync(vetting: &mut VettingState, config: &Config) {
             uses_left: t.uses_left,
             expires: t.expires_at.format("%Y-%m-%d").to_string(),
             live: t.is_live(now),
-            uri: persona_did(config, t.persona).map(|did| t.uri(&did)),
+            // A ticket whose link the published URI cannot carry simply has no
+            // link; its code still reads aloud.
+            uri: persona_did(config, t.persona).and_then(|did| t.uri(&did).ok()),
         })
         .collect();
 
@@ -456,16 +465,19 @@ pub(crate) fn community_display(config: &Config, did: &str) -> String {
 }
 
 fn requirements_line(r: &VettingRequirements) -> String {
+    let n = r.min_statements.get();
     let mut line = format!(
-        "{} statement{} from distinct vetters",
-        r.min_statements,
-        if r.min_statements == 1 { "" } else { "s" }
+        "{n} statement{} from distinct vetters",
+        if n == 1 { "" } else { "s" }
     );
-    for (method, n) in &r.min_by_method {
-        line.push_str(&format!(", at least {n} {}", method_label(*method)));
+    for (method, floor) in &r.min_by_method {
+        line.push_str(&format!(", at least {floor} {}", method_label(*method)));
     }
     if let Some(age) = &r.max_statement_age {
-        line.push_str(&format!(", none older than {}", sanitize_display(age, 32)));
+        line.push_str(&format!(
+            ", none older than {}",
+            sanitize_display(age.as_str(), 32)
+        ));
     }
     line
 }
@@ -1138,7 +1150,7 @@ async fn request_vetter(
     application_id: &str,
     vetter: &str,
     code: &str,
-    ticket: Option<TicketPresentation>,
+    ticket: Option<request::v0_1::Ticket>,
 ) {
     // A link typed into the DID field is read the same as a pasted one.
     if vetter.to_ascii_lowercase().starts_with("vetting-ticket:") {
@@ -1149,8 +1161,16 @@ async fn request_vetter(
     }
     let presentation = match ticket {
         Some(ticket) if code.is_empty() => ticket,
-        _ => match normalise_code(code) {
-            Some(code) => TicketPresentation::Code { code },
+        // The published short code is upper-case Crockford base32, so the code
+        // is normalised into that form before the ticket is built rather than
+        // sent as it was typed.
+        _ => match normalise_code(code).and_then(|code| {
+            request::v0_1::ShortCodeTicket::try_from(
+                request::v0_1::ShortCodeTicket::builder().code(code),
+            )
+            .ok()
+        }) {
+            Some(code) => request::v0_1::Ticket::ShortCodeTicket(code),
             None => {
                 return status(
                     ctx,
@@ -1901,7 +1921,11 @@ async fn open_session(ctx: &mut ActionCtx<'_>, request_id: &str, method_index: u
     };
     let (required, known) = ctx.config.private.vetting.required_claims_for(
         &entry.community,
-        entry.request.requirements_digest.as_deref(),
+        entry
+            .request
+            .requirements_digest
+            .as_ref()
+            .map(|d| d.as_str()),
     );
     let asked = page(ctx).requirements_requested.contains(&entry.community);
     if !known && !asked {
@@ -2008,9 +2032,10 @@ async fn attest(ctx: &mut ActionCtx<'_>, request_id: &str, form: &AttestForm) {
         .get(form.documentation_index)
         .cloned()
         .unwrap_or_else(|| documentation::NONE.to_string());
-    let document_classes = if method == VettingMethod::PriorAcquaintance
-        && documentation_choice == documentation::NONE
-    {
+    // `none` is never listed in a statement: no document is the empty list. So
+    // choosing it means relying on nothing, whichever method was used — and a
+    // documentary method with nothing to rely on is refused by the desk.
+    let document_classes = if documentation_choice == documentation::NONE {
         Vec::new()
     } else {
         vec![documentation_choice]
@@ -2473,12 +2498,16 @@ impl CardJob {
                         .record_card(&session_id, &card, &resolver, now)
                         .await
                         .map_err(|e| failed(format!("the card did not verify: {e}")))?;
+                    // The card travels as it was signed. Parsing it into the
+                    // published response and writing it back out is not
+                    // guaranteed to be the same bytes, and its digest is what
+                    // the vetter's statement names.
                     let mut document = wire::document(
                         VETTING_SESSION_RESPONSE_TYPE,
                         &application.join_did,
                         &vetter,
                         wire::new_id(),
-                        &VettingSessionResponseBody { card, ext: None },
+                        &serde_json::json!({ "card": card }),
                     )
                     .map_err(failed)?;
                     document.thread_id = Some(session_id.clone());
@@ -2534,7 +2563,7 @@ pub(crate) enum VettingOutcome {
     CardSent {
         application_id: String,
         session_id: String,
-        result: Result<(SentCard, Vec<CardClaim>), CardFailure>,
+        result: Result<(SentCard, Vec<session::v0_1::VettingCardClaim>), CardFailure>,
     },
 }
 
@@ -2868,7 +2897,7 @@ pub(crate) fn apply_answers(state: &mut State, config: &Config, answers: Vec<Com
                         view.cursors = cursors;
                     }
                     view.results = page.vetters.iter().map(|l| listed_row(config, l)).collect();
-                    view.next_cursor = page.next_cursor;
+                    view.next_cursor = page.next_cursor.map(|c| c.as_str().to_string());
                     view.searched = true;
                     view.error = None;
                     view.field = if view.results.is_empty() {
@@ -2947,49 +2976,66 @@ fn directory_failed(v: &mut VettingState, query: &str, why: &str) {
 
 /// One listed vetter, ready to show. The name is the one they published — it
 /// is shown beside their DID, never instead of it.
-fn listed_row(config: &Config, listed: &ListedVetter) -> ListedVetterRow {
-    let join = |items: &[String], none: &str| {
+fn listed_row(config: &Config, listed: &vetters::list::v0_1::ListedVetter) -> ListedVetterRow {
+    let join = |items: Vec<String>, none: &str| {
         if items.is_empty() {
             none.to_string()
         } else {
             sanitize_display(&items.join(", "), 300)
         }
     };
+    let did = listed.vetter_did.as_str();
     ListedVetterRow {
-        did: listed.vetter_did.clone(),
+        did: did.to_string(),
         name: listed
             .display_name
-            .as_deref()
-            .or_else(|| config.agent_name_for(&listed.vetter_did))
+            .as_ref()
+            .map(|n| n.as_str())
+            .or_else(|| config.agent_name_for(did))
             .map(|n| sanitize_display(n, 128))
-            .unwrap_or_else(|| shorten_did(&listed.vetter_did, 48)),
-        languages: join(&listed.languages, "no language listed"),
+            .unwrap_or_else(|| shorten_did(did, 48)),
+        languages: join(
+            listed
+                .languages
+                .iter()
+                .map(|l| l.as_str().to_string())
+                .collect(),
+            "no language listed",
+        ),
         location: listed
             .location
             .as_ref()
-            .map(|l| sanitize_display(&location_line(l), 300)),
+            .map(|l| sanitize_display(&listed_location_line(l), 300)),
+        // The listing carries its own copy of the method vocabulary, so each is
+        // labelled by the token it spells.
         methods: listed
             .methods
+            .0
             .iter()
-            .map(|m| method_label(*m))
+            .map(|m| m.to_string())
             .collect::<Vec<_>>()
             .join(", "),
         documentation: join(
-            &listed.accepts_documentation,
+            listed
+                .accepts_documentation
+                .0
+                .iter()
+                .map(|d| d.as_str().to_string())
+                .collect(),
             "no documentation listed — ask them",
         ),
         availability: listed
             .availability
-            .as_deref()
-            .map(|a| sanitize_display(a, 500)),
+            .as_ref()
+            .map(|a| sanitize_display(a.as_str(), 500)),
         contact_hint: listed
             .contact_hint
-            .as_deref()
-            .map(|h| sanitize_display(h, 300)),
+            .as_ref()
+            .map(|h| sanitize_display(h.as_str(), 300)),
         events: listed
             .events
             .iter()
-            .map(|e| sanitize_display(&event_line(e), 300))
+            .map(|e| sanitize_display(&listed_event_line(e), 300))
             .collect(),
         grant_until: listed.grant_valid_until.format("%Y-%m-%d").to_string(),
     }
@@ -3127,11 +3173,9 @@ mod tests {
     use super::*;
     use crate::state_handler::dispatch_util::test_config;
     use openvtc_core::vetting::applicant::Application;
-    use vta_sdk::protocols::vetting::{
-        VETTING_VETTER_RESEND_ERR_NOT_GRANTED, VetterListResponseBody,
-    };
+    use vta_sdk::protocols::vetting::VETTING_VETTER_RESEND_ERR_NOT_GRANTED;
 
-    fn listed(did: &str) -> ListedVetter {
+    fn listed(did: &str) -> vetters::list::v0_1::ListedVetter {
         serde_json::from_value(serde_json::json!({
             "vetterDid": did,
             "displayName": "Carol",
@@ -3164,10 +3208,10 @@ mod tests {
     fn a_directory_page_lands_only_where_it_was_asked_for() {
         let config = test_config();
         let mut state = directory_waiting_on("q1");
-        let page = VetterListResponseBody {
-            vetters: vec![listed("did:key:zCarol")],
-            next_cursor: None,
-        };
+        let page = vetters::list::v0_1::Response::try_from(
+            vetters::list::v0_1::Response::builder().vetters(vec![listed("did:key:zCarol")]),
+        )
+        .unwrap();
         apply_answers(
             &mut state,
             &config,
@@ -3289,9 +3333,12 @@ mod tests {
         app.prepare_request(
             "urn:uuid:r1",
             "did:key:zVetter",
-            TicketPresentation::Code {
-                code: "K7QF-2M9X".into(),
-            },
+            request::v0_1::Ticket::ShortCodeTicket(
+                request::v0_1::ShortCodeTicket::try_from(
+                    request::v0_1::ShortCodeTicket::builder().code("K7QF-2M9X"),
+                )
+                .unwrap(),
+            ),
             RequestDraft::default(),
             Utc::now(),
         )
@@ -3458,9 +3505,12 @@ mod tests {
         app.prepare_request(
             "urn:uuid:r1",
             "did:key:zVetter",
-            TicketPresentation::Code {
-                code: "K7QF-2M9X".into(),
-            },
+            request::v0_1::Ticket::ShortCodeTicket(
+                request::v0_1::ShortCodeTicket::try_from(
+                    request::v0_1::ShortCodeTicket::builder().code("K7QF-2M9X"),
+                )
+                .unwrap(),
+            ),
             RequestDraft::default(),
             Utc::now(),
         )


### PR DESCRIPTION
## What moved

Everything this workspace was patching has been released, so the
`[patch.crates-io]` block — twenty VTI crates pinned by `rev`, plus two VGI
entries on a branch — is deleted, and both `allow-git` entries leave
`deny.toml` with it. The two files are edited together by design:
`unknown-git = "deny"` means a patch added in one without an entry in the other
fails `cargo deny check sources`.

| | was | now |
|---|---|---|
| `vta-sdk` | 0.36 (git `rev`) | **0.37** |
| `trust-tasks-rs`, `trust-tasks-capability-client` | 0.20.3 | **0.20.4** (what `vta-sdk` 0.37 declares) |
| `vta-service` (dev, `MockVta`) | 0.25.1 (git `rev`) | **0.26** |
| `did-git-sign` | 0.4.8 (git branch) | **0.4.9** |

`vtc-client` and `vti-common` had no direct requirement here — they were patch
entries only, reached through the graph — so they simply resolve from crates.io
at 0.6.1 and 0.18.4.

`Cargo.lock` holds **no git source** and exactly one copy of every VTI crate
**except `vta-sdk`**, which is the one thing the unwind did not buy.

### The second `vta-sdk`, stated plainly

`did-git-sign` 0.4.9 is the newest release there is and it requires
`vta-sdk ^0.36`, against this workspace's 0.37 — so the graph carries 0.36.0
beside 0.37.0. **A `[patch]` is no longer the lever**: 0.4.9 was cut from VGI
`main`, so there is no newer commit to point at. It costs a `cargo tree -d` row
rather than a build failure only because we use `did_git_sign::{config, init}`
and no sdk type crosses that boundary — one new import is all it would take. It
closes when VGI takes 0.37 and releases, and the floor in `openvtc/Cargo.toml`
moves to that release.

The `didwebvh-rs` 0.6/0.7 duplicate also survives, for a related reason:
`vta-sdk` 0.37 declares `^0.6` exactly as the patched checkout did. The manifest
notes now say so rather than promising the patch block's departure would
collapse it.

## The API changes that needed more than a rename

`vta-sdk` 0.37 deleted its hand-written vetting wire types and re-exports the
generated `trust_tasks_rs::specs` types. Beyond the old → new renames:

- **The generated wire types derive only `Serialize`, `Deserialize`, `Clone`
  and `Debug` — no `PartialEq`.** Every type that embeds one drops the derive:
  `Application`, `DeskEntry`, `DeskState`, `ReceivedCard`, `KnownCriterion`,
  `VettingBook`, `Knowledge`, `CommunityAnswer`, `Intake`. Where equality was
  load-bearing it became a comparison of what the value serialises to
  (`book::same_requirements`), which is what "the community changed what it
  asks" actually means; tests compare JSON rather than values.

- **The vocabulary is generated per specification.** `VettingMethod` exists
  five times over — the manifest's, the request's, the session's, the
  profile's and the listing's — with identical variants and wire tokens and no
  relation between the Rust types. `VettingDocumentation` is generated four
  times; `ClaimType`, `CountryCode`, `PlaceName`, `LanguageTag` and
  `CalendarDate` twice each. This client keeps the community's copy (the
  manifest's) in its own state and carries a value across each task boundary by
  the token both spell — `vetting::same_token`. It converts between two
  generated types; it does not restate either.

- **Two paths now read the JSON as received** rather than re-serialising a
  parsed value, because a digest and a proof are taken over bytes: the vetting
  card on its way to `verify_card` (its `digestMultibase` is what the vetter's
  statement names), and a vetter's `eligibilityVp` on its way to verification.
  `receive_card` therefore takes the raw card, and the inbound session response
  is opened as its payload rather than into the generated response.

- `Intake::Accepted` is boxed: the generated `#response` carries an optional
  eligibility presentation and dwarfs a refusal's `&'static str`.

- `ticket_uri::encode` returns a `Result`, so `Ticket::uri` and both ticket
  presentations are fallible; a ticket whose link cannot be built simply has no
  link, and its code still reads aloud.

- The event form validates one event through a profile carrying only it: the
  rules no schema can state (`endDate` ≥ `startDate`, a span ≤ 31 days, an
  absolute https `url`) live on the profile payload's `check_shape`, not on
  `VetterEvent`.

## What the stricter validation refused

Three values this client used to send are now refused, and are fixed at the
value rather than loosened:

1. **`acceptsDocumentation: []`** — a vetter who accepts no documentation sent
   an empty list. The published response makes it `minItems: 1` and unique, so
   the member is **omitted** instead. A vetter may still accept nothing, which
   is what V0 intends for someone they already know; a token repeated in the
   vetter's own policy is now listed once.
2. **A ticket code as typed** — the published short code is upper-case
   Crockford base32, so a typed code is normalised into that form before the
   request is built. A code that cannot be is refused with the same sentence as
   before.
3. **`none` among a statement's document classes** — no document is the empty
   list, so `none` is dropped, and a documentary method left with nothing to
   rely on is refused rather than attested.

Two fixtures also had to change, because the type now refuses what the old one
carried: a `requirementsDigest` must be a real multibase digest of at least 16
characters (`"zDigest"` is refused), and a branding accent must match
`^#[0-9a-fA-F]{6}$` — so the "bad branding is dropped whole" test now exercises
the case that can still reach a client, a `logoUrl` the schema admits and the
hand-written check refuses.

## Test evidence

Run on this branch, rebased onto `main`:

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, no warnings |
| `cargo test --workspace` | **1337 passed, 0 failed**, 17 ignored (17 binaries) |
| `cargo test --workspace --no-default-features` | **1337 passed, 0 failed**, 17 ignored (17 binaries) |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` | exit 0 |
| `grep -c 'git+https' Cargo.lock` | **0** |

`cargo deny check` **was not run: `cargo-deny` is not installed on this
machine.** `deny.toml`'s `allow-git` list is empty and no dependency resolves
from a git source, so `check sources` has nothing left to allow, but that is
reasoning rather than a run — please let CI make the call.

No advisory or licence entry in `deny.toml` existed only for a patched crate,
so the `[advisories].ignore` list and the licence allow-list are untouched.
