### PR TITLE
test(sec-4045): regression gates for the trust-anchor override and health probe SSRF findings

### DIFF
--- a/openvtc/src/env_overrides.rs
+++ b/openvtc/src/env_overrides.rs
@@ -300,7 +300,6 @@ pub(crate) fn surface(report: &OverrideReport, main_page: &mut MainPageState) {
 mod tests {
     use super::*;
     use affinidi_tdk::messaging::profiles::{ATMProfile, ATMProfileInner};
-    #[cfg(feature = "dev-overrides")]
     use openvtc_core::config::secured_config::SecuredConfig;
     use openvtc_core::config::{
         KeyBackend,
@@ -445,6 +444,49 @@ mod tests {
         );
         assert_eq!(config.runtime_trust_overrides, None);
         assert_eq!(report.banner(), None);
+    }
+
+    /// The persistence half of the same finding, in the build that ships.
+    ///
+    /// An override did not merely point the running process at another VTA: the
+    /// next save wrote it, through `Config::save` -> `SecuredConfig::from` ->
+    /// `SecuredConfig::save` -> the keyring, so one launch with the variable set
+    /// re-anchored the profile for every launch after it. That chain is why an
+    /// unchanged live config is only half the guarantee — what a save *would*
+    /// write has to carry the legitimate anchors too.
+    ///
+    /// Asserted on the two values a save reads, the coalesced-save snapshot and
+    /// the `SecuredConfig` built from the live config, rather than on the
+    /// keyring: the keyring is the operator's, and a test has no business in it.
+    #[cfg(not(feature = "dev-overrides"))]
+    #[test]
+    fn release_build_override_never_reaches_the_save_snapshot() {
+        let mut config = vta_config(LEGIT_URL, LEGIT_DID);
+
+        let report = apply_from(
+            &mut config,
+            env_of(&[(VTA_URL_VAR, OVERRIDE_URL), (VTA_DID_VAR, OVERRIDE_DID)]),
+        );
+        assert_eq!(ignored_vars(&report), vec![VTA_URL_VAR, VTA_DID_VAR]);
+
+        let snapshot = config.clone_for_save().expect("snapshot");
+        assert_eq!(
+            vta_of(&snapshot.key_backend),
+            (LEGIT_URL.to_string(), LEGIT_DID.to_string()),
+            "a save taken after an ignored override must still write the persisted anchor"
+        );
+
+        let secured = SecuredConfig::from(&config);
+        assert_eq!(
+            secured.vta_url.as_deref(),
+            Some(LEGIT_URL),
+            "the keyring record must keep the persisted VTA URL"
+        );
+        assert_eq!(
+            secured.vta_did.as_deref(),
+            Some(LEGIT_DID),
+            "the keyring record must keep the persisted VTA DID"
+        );
     }
 
     #[cfg(not(feature = "dev-overrides"))]

--- a/openvtc/src/health_cmd.rs
+++ b/openvtc/src/health_cmd.rs
@@ -121,22 +121,7 @@ pub async fn run(
         std::process::exit(1);
     }
 
-    // Probe URLs come from DID documents anyone can publish, so by default a
-    // plaintext or non-public one is listed rather than dialled. The opt-out is
-    // for dev stacks on loopback, and says so every time it is used.
-    let policy = if allow_private_probes {
-        eprintln!(
-            "{}",
-            style(
-                "warning: --allow-private-probes: plaintext and loopback/private/link-local \
-                 transport URLs from DID documents will be probed."
-            )
-            .themed(CLI_CAUTION)
-        );
-        ProbePolicy::AllowPrivate
-    } else {
-        ProbePolicy::PublicOnly
-    };
+    let policy = probe_policy(allow_private_probes);
 
     // Progress goes to stderr, the report to stdout. That keeps
     // `openvtc health --json > report.json` piping cleanly while still showing
@@ -448,6 +433,31 @@ fn short_tail(did: &str) -> String {
 /// took, because a chain that pauses nine seconds on one mediator and then
 /// succeeds has told you something the final report cannot: the outcome is fine
 /// and the host is struggling.
+/// Which transport URLs this run is willing to dial.
+///
+/// Probe URLs come from DID documents anyone can publish, so by default a
+/// plaintext or non-public one is listed rather than dialled. The opt-out is
+/// for dev stacks on loopback, and says so every time it is used.
+///
+/// Split out of [`run`] so the default is something a test can assert on: the
+/// guard itself lives in `openvtc_core::health`, but it only ever runs under
+/// the policy chosen here.
+fn probe_policy(allow_private_probes: bool) -> ProbePolicy {
+    if allow_private_probes {
+        eprintln!(
+            "{}",
+            style(
+                "warning: --allow-private-probes: plaintext and loopback/private/link-local \
+                 transport URLs from DID documents will be probed."
+            )
+            .themed(CLI_CAUTION)
+        );
+        ProbePolicy::AllowPrivate
+    } else {
+        ProbePolicy::PublicOnly
+    }
+}
+
 fn trace(step: &Step) {
     // `dim` rather than a palette colour: these lines are scaffolding the
     // operator reads past on a healthy run, and they must not compete with the
@@ -997,5 +1007,79 @@ mod tests {
              TSPTransport, and an operator comparing deployments must see which"
         );
         assert_eq!(fragment("no-fragment"), "no-fragment");
+    }
+
+    // ---- Probe egress policy -------------------------------------------------
+
+    /// The reproduced exploit, end to end through the command's own default.
+    ///
+    /// A `did:peer:2` carries its service inline and resolves offline, so a DID
+    /// pasted after `--vtc` is on its own enough to name an endpoint on this
+    /// machine's network — the PoC used
+    /// `{"t":"dm","s":"http://127.0.0.1:9098/latest/meta-data/"}` and watched
+    /// `health` GET it, reporting `reachable` and the status code back.
+    ///
+    /// `openvtc_core::health` refuses such a URL, but only under the policy this
+    /// command picks, so what is pinned here is the *default*: a run without
+    /// `--allow-private-probes` must report the endpoint as not probed and must
+    /// not open a connection to it. The listener is bound on an ephemeral
+    /// loopback port in-process; nothing leaves this machine.
+    #[tokio::test]
+    async fn the_default_run_never_dials_a_did_advertised_loopback_endpoint() {
+        use base64::Engine as _;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind a stand-in internal service");
+        let port = listener.local_addr().expect("listener address").port();
+
+        let service = serde_json::json!({
+            "t": "dm",
+            "s": format!("http://127.0.0.1:{port}/latest/meta-data/"),
+        })
+        .to_string();
+        let did = format!(
+            "did:peer:2.Vz6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK.S{}",
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(service)
+        );
+
+        assert_eq!(
+            probe_policy(false),
+            ProbePolicy::PublicOnly,
+            "the opt-out is a flag, so the flagless run must be the guarded one"
+        );
+
+        let report = build_report_with_progress(
+            &[Subject::new(Role::Vtc, "stand-in VTC", did.clone())],
+            &|_| {},
+            probe_policy(false),
+        )
+        .await;
+
+        let party = report
+            .parties
+            .iter()
+            .find(|p| p.did == did)
+            .expect("the subject is reported");
+        let resolved = party
+            .resolved
+            .as_ref()
+            .unwrap_or_else(|| panic!("did:peer resolves offline: {party:#?}"));
+        assert!(
+            matches!(resolved.probes.as_slice(), [Probe::Blocked { url, .. }]
+                if url.contains(&format!("127.0.0.1:{port}"))),
+            "the advertised internal endpoint must be listed, not dialled: {:?}",
+            resolved.probes
+        );
+
+        // The assertion the PoC's capture log is the negative of: no inbound
+        // connection at all, so the refusal happens before any I/O rather than
+        // after a connection that is then dropped.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(200), listener.accept())
+                .await
+                .is_err(),
+            "something connected to the stand-in internal service"
+        );
     }
 }

--- a/openvtc/src/health_cmd.rs
+++ b/openvtc/src/health_cmd.rs
@@ -423,16 +423,6 @@ fn short_tail(did: &str) -> String {
     did.rsplit(':').next().unwrap_or(did).to_string()
 }
 
-/// Render one [`Step`] to stderr, unbuffered.
-///
-/// `eprintln!` flushes per call, which is what makes this live rather than a
-/// batch dumped at exit — the whole point is that the operator sees the slow
-/// step *while* it is slow.
-///
-/// Each wait is announced before it starts and its result carries the time it
-/// took, because a chain that pauses nine seconds on one mediator and then
-/// succeeds has told you something the final report cannot: the outcome is fine
-/// and the host is struggling.
 /// Which transport URLs this run is willing to dial.
 ///
 /// Probe URLs come from DID documents anyone can publish, so by default a
@@ -458,6 +448,16 @@ fn probe_policy(allow_private_probes: bool) -> ProbePolicy {
     }
 }
 
+/// Render one [`Step`] to stderr, unbuffered.
+///
+/// `eprintln!` flushes per call, which is what makes this live rather than a
+/// batch dumped at exit — the whole point is that the operator sees the slow
+/// step *while* it is slow.
+///
+/// Each wait is announced before it starts and its result carries the time it
+/// took, because a chain that pauses nine seconds on one mediator and then
+/// succeeds has told you something the final report cannot: the outcome is fine
+/// and the host is struggling.
 fn trace(step: &Step) {
     // `dim` rather than a palette colour: these lines are scaffolding the
     // operator reads past on a healthy run, and they must not compete with the
@@ -1010,38 +1010,81 @@ mod tests {
     }
 
     // ---- Probe egress policy -------------------------------------------------
+    //
+    // `openvtc health --vtc <did>` takes a DID from whoever is being diagnosed,
+    // and a `did:peer:2` carries its service array inline and resolves offline —
+    // so the DID alone, with nothing misconfigured and no document served, is
+    // enough to name an endpoint on this machine's network. The PoC did exactly
+    // that with `{"t":"dm","s":"http://127.0.0.1:9098/latest/meta-data/"}` and
+    // watched `health` GET it, reporting `reachable` and `http_status: 200`
+    // back; a loopback listener logged the inbound request.
+    //
+    // `openvtc_core::health` refuses such a URL, but only under the
+    // `ProbePolicy` this command hands it, so what these pin is the choice made
+    // here. Both stand-in services are bound on ephemeral loopback ports in
+    // process — the listener pair the PoC ran as a script, with nothing leaving
+    // this machine and no port to collide on.
 
-    /// The reproduced exploit, end to end through the command's own default.
-    ///
-    /// A `did:peer:2` carries its service inline and resolves offline, so a DID
-    /// pasted after `--vtc` is on its own enough to name an endpoint on this
-    /// machine's network — the PoC used
-    /// `{"t":"dm","s":"http://127.0.0.1:9098/latest/meta-data/"}` and watched
-    /// `health` GET it, reporting `reachable` and the status code back.
-    ///
-    /// `openvtc_core::health` refuses such a URL, but only under the policy this
-    /// command picks, so what is pinned here is the *default*: a run without
-    /// `--allow-private-probes` must report the endpoint as not probed and must
-    /// not open a connection to it. The listener is bound on an ephemeral
-    /// loopback port in-process; nothing leaves this machine.
-    #[tokio::test]
-    async fn the_default_run_never_dials_a_did_advertised_loopback_endpoint() {
-        use base64::Engine as _;
-
+    /// An ephemeral loopback listener standing in for an internal service, and
+    /// the port it is on.
+    async fn loopback_listener() -> (tokio::net::TcpListener, u16) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind a stand-in internal service");
         let port = listener.local_addr().expect("listener address").port();
+        (listener, port)
+    }
 
-        let service = serde_json::json!({
-            "t": "dm",
-            "s": format!("http://127.0.0.1:{port}/latest/meta-data/"),
-        })
-        .to_string();
-        let did = format!(
+    /// A `did:peer:2` whose inline service array advertises `endpoint`, built
+    /// the way the PoC's DID was: one `Vz` key and one `S`-encoded service.
+    fn did_advertising(endpoint: &str) -> String {
+        use base64::Engine as _;
+
+        let service = serde_json::json!({ "t": "dm", "s": endpoint }).to_string();
+        format!(
             "did:peer:2.Vz6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK.S{}",
             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(service)
+        )
+    }
+
+    /// The probes the report recorded for `did`, which must have resolved.
+    fn probes_for(report: &HealthReport, did: &str) -> Vec<Probe> {
+        let party = report
+            .parties
+            .iter()
+            .find(|p| p.did == did)
+            .expect("a subject is reported whether or not it resolves");
+        party
+            .resolved
+            .as_ref()
+            .unwrap_or_else(|| panic!("did:peer resolves offline: {party:#?}"))
+            .probes
+            .clone()
+    }
+
+    /// Nothing connected to `listener`. This is the assertion the PoC's capture
+    /// log is the negative of: no inbound connection *at all*, so the refusal
+    /// happened before any I/O rather than after a connection that is dropped.
+    async fn assert_never_dialled(listener: &tokio::net::TcpListener) {
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(200), listener.accept())
+                .await
+                .is_err(),
+            "something connected to the stand-in internal service"
         );
+    }
+
+    /// The reproduced exploit, end to end through the command's own default.
+    ///
+    /// A run without `--allow-private-probes` must report the advertised
+    /// endpoint as not probed and must not open a connection to it. The default
+    /// is the whole point: the guard exists in `openvtc_core::health` either
+    /// way, and the only thing that can put this command outside it is passing
+    /// the wrong policy from [`probe_policy`].
+    #[tokio::test]
+    async fn the_default_run_never_dials_a_did_advertised_loopback_endpoint() {
+        let (listener, port) = loopback_listener().await;
+        let did = did_advertising(&format!("http://127.0.0.1:{port}/latest/meta-data/"));
 
         assert_eq!(
             probe_policy(false),
@@ -1056,30 +1099,73 @@ mod tests {
         )
         .await;
 
-        let party = report
-            .parties
-            .iter()
-            .find(|p| p.did == did)
-            .expect("the subject is reported");
-        let resolved = party
-            .resolved
-            .as_ref()
-            .unwrap_or_else(|| panic!("did:peer resolves offline: {party:#?}"));
         assert!(
-            matches!(resolved.probes.as_slice(), [Probe::Blocked { url, .. }]
+            matches!(probes_for(&report, &did).as_slice(), [Probe::Blocked { url, .. }]
                 if url.contains(&format!("127.0.0.1:{port}"))),
             "the advertised internal endpoint must be listed, not dialled: {:?}",
-            resolved.probes
+            probes_for(&report, &did)
         );
+        assert_never_dialled(&listener).await;
+    }
 
-        // The assertion the PoC's capture log is the negative of: no inbound
-        // connection at all, so the refusal happens before any I/O rather than
-        // after a connection that is then dropped.
-        assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(200), listener.accept())
-                .await
-                .is_err(),
-            "something connected to the stand-in internal service"
+    /// The second hop, which the URL guard cannot see.
+    ///
+    /// Under the default policy no loopback endpoint is dialled at all, so the
+    /// only run that reaches a first hop on this machine is the
+    /// `--allow-private-probes` dev opt-out — and that is precisely where a
+    /// redirect matters: a dev stack the operator chose to trust is not licence
+    /// to be handed on to the metadata service next door. The vetted URL is
+    /// checked once, before the request; a followed `Location` would be a
+    /// request to an address nothing ever vetted.
+    ///
+    /// So both halves of the PoC's listener pair are here: a redirector that
+    /// answers `302` toward an "internal" port, and that internal port, which
+    /// must record zero connections. `302` coming back as the probe result is
+    /// the positive half — the first hop really was dialled, so the absence of
+    /// the second is a refusal to follow rather than a probe that never ran.
+    #[tokio::test]
+    async fn a_dialled_endpoint_may_not_redirect_the_probe_onward() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        let (internal, internal_port) = loopback_listener().await;
+        let (redirector, redirector_port) = loopback_listener().await;
+
+        // A 302 to the internal port, answered once. Hand-rolled rather than
+        // mocked: one response is all this needs, and it keeps the CLI's
+        // dev-dependencies as they are.
+        let location = format!("http://127.0.0.1:{internal_port}/latest/meta-data/");
+        tokio::spawn(async move {
+            let (mut socket, _) = redirector.accept().await.expect("the probe connects");
+            let mut request = [0u8; 1024];
+            let _ = socket.read(&mut request).await;
+            let _ = socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 302 Found\r\nLocation: {location}\r\n\
+                         Content-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await;
+            let _ = socket.shutdown().await;
+        });
+
+        let did = did_advertising(&format!("http://127.0.0.1:{redirector_port}/"));
+        let report = build_report_with_progress(
+            &[Subject::new(Role::Vtc, "stand-in VTC", did.clone())],
+            &|_| {},
+            probe_policy(true),
+        )
+        .await;
+
+        assert_eq!(
+            probes_for(&report, &did),
+            vec![Probe::Reachable {
+                url: format!("http://127.0.0.1:{redirector_port}/"),
+                http_status: 302,
+            }],
+            "a 3xx is the answer; it already proves the host is up"
         );
+        assert_never_dialled(&internal).await;
     }
 }


### PR DESCRIPTION
Three regression gates for SEC-4045. Test-only, apart from extracting one
private function; no shipped behaviour changes, so there is no CHANGELOG
entry — the behaviour these pin was already described when it landed (#305
and the probe hardening).

Each gate below was proved by reverting the fix it guards, confirming RED,
restoring, and confirming GREEN. The reverts are not in this branch: the
working tree was clean and `git diff origin/main -- <file>` printed nothing
before anything was pushed.

## H5 — an ignored trust-anchor override must not reach a save

`openvtc/src/env_overrides.rs` ·
`release_build_override_never_reaches_the_save_snapshot`
(`#[cfg(not(feature = "dev-overrides"))]`, so it runs in the build that ships)

**The exploit.** `OPENVTC_VTA_URL` / `OPENVTC_VTA_DID` name the VTA this
client authenticates to. Before #305 any build applied them unvalidated and
the *next save persisted them* — `Config::save` → `SecuredConfig::from` →
`SecuredConfig::save` → the keyring. One launch with the variable set
re-anchored the profile for every launch after it, with nothing on screen to
say so.

**What it asserts.** After `apply_from` reports both variables ignored, the
two values a save actually reads still carry the legitimate anchor:

- `config.clone_for_save()` — the coalesced-save snapshot (R11 path);
- `SecuredConfig::from(&config)` — what `save` and `export` write.

An unchanged live config is only half the guarantee; `release_build_ignores
_trust_anchor_env` already covered that half. This covers what a save
*would* write. It stops at `SecuredConfig` deliberately: the keyring is the
operator's and a test has no business in it. The environment arrives through
the existing injectable `env_of(...)` closure — no `std::env::set_var`
anywhere.

**RED** — release-build `apply_trust_anchor` reverted to pre-#305 behaviour
(applied straight into the persisted key backend, no `runtime_trust_overrides`
record):

```
running 8 tests
test env_overrides::tests::release_build_ignores_trust_anchor_env ... FAILED
test env_overrides::tests::release_build_override_never_reaches_the_save_snapshot ... FAILED

---- env_overrides::tests::release_build_override_never_reaches_the_save_snapshot stdout ----

thread 'env_overrides::tests::release_build_override_never_reaches_the_save_snapshot' (550176) panicked at openvtc/src/env_overrides.rs:486:9:
assertion `left == right` failed: a save taken after an ignored override must still write the persisted anchor
  left: ("http://127.0.0.1:9099", "did:web:127.0.0.1%3A9099")
 right: ("https://legit-vta.affinidi.example", "did:webvh:legit-vta.example")

test result: FAILED. 6 passed; 2 failed; 0 ignored; 0 measured; 580 filtered out
```

Note the pre-existing test fails alongside it. In a release build nothing
ever sets `runtime_trust_overrides`, so live-config integrity and
save-snapshot integrity hang off the single `IgnoreReason::ReleaseBuild`
gate; there is no narrower revert that reds only the new test. Its
`dev-overrides` counterpart (`dev_build_applies_but_does_not_persist`) has
asserted the same two values since #305 — this is the shipping build's half,
which nothing covered.

## N1 — `openvtc health --vtc` must not probe attacker-advertised internals

`openvtc/src/health_cmd.rs`. `probe_policy(allow_private_probes)` is lifted
out of `run` unchanged, so the default is something a test can name.

**The exploit.** A `did:peer:2` carries its service array inline and resolves
offline, so the DID alone — nothing misconfigured, no document served — names
an endpoint on the operator's network. The PoC passed a DID encoding
`{"t":"dm","s":"http://127.0.0.1:9098/latest/meta-data/"}` and `openvtc
health` GET it, reporting `"status": "reachable", "http_status": 200` back to
the attacker; a loopback listener logged the inbound `GET /latest/meta-data/`.
`openvtc_core::health` refuses such a URL, but only under the `ProbePolicy`
this command hands it — and that choice was inline in `run` where nothing
could assert on it.

Both tests bind ephemeral loopback listeners in process. The evidence
bundle's `ssrf_listener.py` is ported, not shelled out to: no fixed port to
collide on, nothing leaves the machine, and `cargo test` stays
self-contained.

### `the_default_run_never_dials_a_did_advertised_loopback_endpoint`

- `probe_policy(false) == ProbePolicy::PublicOnly` — the opt-out is a flag,
  so the flagless run must be the guarded one;
- driving the report builder under that policy reports the advertised
  endpoint as `Probe::Blocked`, naming the refused host;
- **the listener records zero connections** — the refusal happens before any
  I/O, not after a connection that is then dropped. This is the assertion the
  PoC's `ssrf_capture.log` is the negative of.

**RED** — `probe_policy` reverted to return `AllowPrivate` unconditionally
(the pre-fix command had no egress policy at all):

```
test health_cmd::tests::the_default_run_never_dials_a_did_advertised_loopback_endpoint ... FAILED

thread '...' panicked at openvtc/src/health_cmd.rs:1091:9:
assertion `left == right` failed: the opt-out is a flag, so the flagless run must be the guarded one
  left: AllowPrivate
 right: PublicOnly
```

That assertion short-circuits, so it was run again with it temporarily
removed, to show the endpoint really is dialled:

```
thread '...' panicked at openvtc/src/health_cmd.rs:1098:9:
the advertised internal endpoint must be listed, not dialled: [Unreachable { url: "http://127.0.0.1:50653/latest/meta-data/", error: "error sending request for url (http://127.0.0.1:50653/latest/meta-data/)" }]
```

`Unreachable` rather than `Blocked` is the tell: a request was sent. The
stand-in service accepts the connection and never answers, which is why it
reads as a failed send rather than a 200.

### `a_dialled_endpoint_may_not_redirect_the_probe_onward`

The vetted URL is checked once, before the request. A `Location` header is
the hop that check cannot see — follow it and the probe issues a request to
an address nothing vetted.

Under the default policy no loopback first hop is dialled at all, so the run
that reaches one is the `--allow-private-probes` dev opt-out — which is
exactly where this matters: a dev stack the operator chose to trust is not
licence to be handed on to the metadata service next door. Both halves of the
PoC's listener pair are in process: a hand-rolled redirector answering `302`
toward an "internal" port, and that port.

- the probe result is `Probe::Reachable { http_status: 302 }` — the positive
  half, proving the first hop really was dialled;
- **the internal listener records zero connections**, so the missing second
  request is a refusal to follow rather than a probe that never ran.

**RED** — `probe_client`'s `redirect::Policy::none()` reverted to
`Policy::limited(10)`, and the two assertions ordered listener-first:

```
test health_cmd::tests::a_dialled_endpoint_may_not_redirect_the_probe_onward ... FAILED

thread '...' panicked at openvtc/src/health_cmd.rs:1069:9:
something connected to the stand-in internal service
```

With the assertions in their committed order the same revert reds the probe
result instead, which shows the chase from the other side:

```
assertion `left == right` failed: a 3xx is the answer; it already proves the host is up
  left: [Unreachable { url: "http://127.0.0.1:51200/", error: "error sending request for url (http://127.0.0.1:51200/)" }]
 right: [Reachable { url: "http://127.0.0.1:51200/", http_status: 302 }]
```

## Checks

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 588 `openvtc`, 660 `openvtc-core`, all integration suites and
  doctests pass
- `cargo clippy -p openvtc --features dev-overrides --all-targets -- -D warnings` — clean
- `cargo test -p openvtc --features dev-overrides` — 586 pass; both N1 tests
  run in this configuration too, and the H5 test correctly compiles out in
  favour of `dev_build_applies_but_does_not_persist`

`openvtc-core` is untouched by this branch: `git diff origin/main --
openvtc-core/` is empty.
